### PR TITLE
feat: add transport dial timeout

### DIFF
--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -523,22 +523,49 @@ where
             );
             let delay = time::sleep(backoff_duration).fuse();
             let cancel_signal = current_state.get_cancel_signal();
+
             tokio::select! {
                 _ = delay => {
-                    debug!(target: LOG_TARGET, "[Attempt {}] Connecting to peer '{}'", current_state.num_attempts(), current_state.peer().node_id.short_str());
-                    match Self::dial_peer(current_state, &noise_config, &current_transport, config.network_info.network_wire_byte, config.excluded_dial_addresses.clone()).await {
+                    debug!(
+                        target: LOG_TARGET,
+                        "[Attempt {}] Connecting to peer '{}'",
+                        current_state.num_attempts(), current_state.peer().node_id.short_str()
+                    );
+                    match Self::dial_peer(
+                        current_state,
+                        &noise_config,
+                        &current_transport,
+                        config.network_info.network_wire_byte,
+                        config.excluded_dial_addresses.clone(),
+                    )
+                    .await
+                    {
                         (state, Ok((socket, addr))) => {
-                            debug!(target: LOG_TARGET, "Dial succeeded for peer '{}' after {} attempt(s)", state.peer().node_id.short_str(), state.num_attempts());
+                            debug!(
+                                target: LOG_TARGET,
+                                "Dial succeeded for peer '{}' after {} attempt(s)",
+                                state.peer().node_id.short_str(), state.num_attempts()
+                            );
                             break (state, Ok((socket, addr)));
                         },
                         // Connection went stale, propagate error to enable starting a fresh connection
-                        (state, Err(ConnectionManagerError::NoiseHandshakeError(e))) => break (state, Err(ConnectionManagerError::NoiseHandshakeError(e))),
+                        (state, Err(ConnectionManagerError::NoiseHandshakeError(e))) => {
+                            break (state, Err(ConnectionManagerError::NoiseHandshakeError(e)))
+                        },
                         // Inflight dial was cancelled
-                        (state, Err(ConnectionManagerError::DialCancelled)) => break (state, Err(ConnectionManagerError::DialCancelled)),
+                        (state, Err(ConnectionManagerError::DialCancelled)) => {
+                            break (state, Err(ConnectionManagerError::DialCancelled))
+                        },
                         // All public addresses for this peer are excluded
-                        (state, Err(ConnectionManagerError::AllPeerAddressesAreExcluded(e))) => break (state, Err(ConnectionManagerError::AllPeerAddressesAreExcluded(e))),
+                        (state, Err(ConnectionManagerError::AllPeerAddressesAreExcluded(e))) => {
+                            break (state, Err(ConnectionManagerError::AllPeerAddressesAreExcluded(e)))
+                        },
                         (state, Err(err)) => {
-                            debug!(target: LOG_TARGET, "Failed to dial peer {} | Attempt {} | Error: {}", state.peer().node_id.short_str(), state.num_attempts(), err);
+                            debug!(
+                                target: LOG_TARGET,
+                                "Failed to dial peer {} | Attempt {} | Error: {}",
+                                state.peer().node_id.short_str(), state.num_attempts(), err
+                            );
                             if state.num_attempts() >= config.max_dial_attempts {
                                 break (state, Err(ConnectionManagerError::ConnectFailedMaximumAttemptsReached));
                             }
@@ -546,12 +573,16 @@ where
                             // Put the dial state and transport back for the retry
                             dial_state = Some(state);
                             transport = Some(current_transport);
-                        }
+                        },
                     }
                 },
                 // Delayed dial was cancelled
                 _ = cancel_signal => {
-                    warn!(target: LOG_TARGET, "[Attempt {}] Connection attempt cancelled for peer '{}'", current_state.num_attempts(), current_state.peer().node_id.short_str());
+                    warn!(
+                        target: LOG_TARGET,
+                        "[Attempt {}] Connection attempt cancelled for peer '{}'",
+                        current_state.num_attempts(), current_state.peer().node_id.short_str()
+                    );
                     break (current_state, Err(ConnectionManagerError::DialCancelled));
                 }
             }
@@ -613,25 +644,37 @@ where
             let node_id = dial_state.peer().node_id.clone();
             let dial_fut = async move {
                 let mut timer = Instant::now();
-                let mut socket =
-                    transport
-                        .dial(&moved_address)
-                        .await
-                        .map_err(|err| ConnectionManagerError::TransportError {
+
+                let socket_res =
+                    tokio::time::timeout(noise_config.dial_timeout(), transport.dial(&moved_address)).await;
+                let mut socket = match socket_res {
+                    Ok(Ok(value)) => value,
+                    Ok(Err(err)) => {
+                        return Err(ConnectionManagerError::TransportError {
                             address: moved_address.to_string(),
                             details: err.to_string(),
-                        })?;
+                        })
+                    },
+                    Err(_) => {
+                        trace!(
+                            target: LOG_TARGET,
+                            "Dial - Timed out while dialing peer '{}' on address '{}' after {:.2?}",
+                            node_id.short_str(),
+                            moved_address,
+                            noise_config.dial_timeout(),
+                        );
+                        return Err(ConnectionManagerError::DialTimeout {
+                            address: moved_address.to_string(),
+                            timeout: format!("{:.2?}", noise_config.dial_timeout()),
+                        });
+                    },
+                };
                 let initial_dial_time = timer.elapsed();
 
                 trace!(
-                    "Dial - Dialed peer: {} on address: {} on tcp after: {}",
-                    node_id.short_str(),
-                    moved_address,
-                    timer.elapsed().as_millis()
-                );
-                trace!(
                     target: LOG_TARGET,
-                    "Dial - Socket established on '{}'. Performing noise upgrade protocol", moved_address
+                    "Dial - Socket established for '{}' on '{}' after {:.2?}. Performing noise upgrade protocol",
+                    node_id.short_str(), moved_address, timer.elapsed()
                 );
                 timer = Instant::now();
 

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -56,6 +56,8 @@ pub enum ConnectionManagerError {
     ListenerError { address: String, details: String },
     #[error("Transport error for {address}: {details}")]
     TransportError { address: String, details: String },
+    #[error("Dial timeout dialing {address} after {timeout}")]
+    DialTimeout { address: String, timeout: String },
     #[error(
         "The peer authenticated to public key '{authenticated_pk}' which did not match the dialed peer's public key \
          '{expected_pk}'"

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -123,6 +123,9 @@ pub struct ConnectionManagerConfig {
     /// the responder will wait 2 x this value (1 per receive) before timing out.
     /// Default: 3s
     pub noise_handshake_recv_timeout: Duration,
+    /// The maximum time to wait for a peer to respond on a noise protocol dial.
+    /// Default: 60s
+    pub noise_dial_timeout: Duration,
     /// The number of liveness check sessions to allow. Default: 0
     pub liveness_max_sessions: usize,
     /// CIDR blocks that allowlist liveness checks. Default: Localhost only (127.0.0.1/32)
@@ -157,6 +160,7 @@ impl Default for ConnectionManagerConfig {
             auxiliary_tcp_listener_address: None,
             peer_validation_config: PeerValidatorConfig::default(),
             noise_handshake_recv_timeout: Duration::from_secs(6),
+            noise_dial_timeout: Duration::from_secs(60),
             excluded_dial_addresses: vec![],
         }
     }
@@ -218,8 +222,9 @@ where
         let (internal_event_tx, internal_event_rx) = mpsc::channel(EVENT_CHANNEL_SIZE);
         let (dialer_tx, dialer_rx) = mpsc::channel(DIALER_REQUEST_CHANNEL_SIZE);
 
-        let noise_config =
-            NoiseConfig::new(node_identity.clone()).with_recv_timeout(config.noise_handshake_recv_timeout);
+        let noise_config = NoiseConfig::new(node_identity.clone())
+            .with_recv_timeout(config.noise_handshake_recv_timeout)
+            .with_dial_timeout(config.noise_dial_timeout);
 
         let listener = PeerListener::new(
             config.clone(),

--- a/comms/core/src/noise/config.rs
+++ b/comms/core/src/noise/config.rs
@@ -49,6 +49,7 @@ pub struct NoiseConfig {
     node_identity: Arc<NodeIdentity>,
     parameters: NoiseParams,
     recv_timeout: Duration,
+    dial_timeout: Duration,
 }
 
 impl NoiseConfig {
@@ -59,6 +60,7 @@ impl NoiseConfig {
             node_identity,
             parameters,
             recv_timeout: Duration::from_secs(3),
+            dial_timeout: Duration::from_secs(60),
         }
     }
 
@@ -66,6 +68,17 @@ impl NoiseConfig {
     pub fn with_recv_timeout(mut self, recv_timeout: Duration) -> Self {
         self.recv_timeout = recv_timeout;
         self
+    }
+
+    /// Sets a custom dial timeout when dialing on the transport layer.
+    pub fn with_dial_timeout(mut self, dial_timeout: Duration) -> Self {
+        self.dial_timeout = dial_timeout;
+        self
+    }
+
+    /// Returns the custom dial timeout when dialing on the transport layer.
+    pub fn dial_timeout(&self) -> Duration {
+        self.dial_timeout
     }
 
     /// Upgrades the given socket to using the noise protocol. The upgraded socket and the peer's static key


### PR DESCRIPTION
Description
---
Added a dial timeout on the transport layer for comms. This enables dials to be dropped where enough feedback is given to the code to indicate that a dial is in progress, but not enough feedback to indicate that it has stalled.

Motivation and Context
---
See https://github.com/tari-project/tari/issues/7199#issuecomment-3069486135

How Has This Been Tested?
---
- General system-level testing performed well.
- Big wallet recovery system-level testing performed well.

What process can a PR reviewer use to test or verify this change?
---
- Code review
- System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout for peer connection attempts, allowing users to set a maximum wait time when connecting to peers.
  * Improved error reporting by providing specific messages when a connection attempt exceeds the configured timeout.

* **Bug Fixes**
  * Enhanced error handling to distinguish between general connection errors and connection timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->