### PR TITLE
fix: view wallet scan height

### DIFF
--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -216,7 +216,7 @@ where
             // wallet birthday
             self.resources.db.clear_scanned_blocks()?;
             let wallet_birthday = match self.resources.db.get_wallet_type()? {
-                Some(WalletType::ProvidedKeys(wallet)) => wallet.birthday,
+                Some(WalletType::ProvidedKeys(wallet)) => Some(wallet.birthday.unwrap_or_default()),
                 _ => None,
             };
             let scanning_start_height_hash = self


### PR DESCRIPTION
Description
---
if a view wallet does not have birthday as a start, it should start at 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing wallet birthday information to ensure a default value is used when necessary, enhancing reliability during scanning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->