### PR TITLE
fix: increase http server limit

### DIFF
--- a/applications/minotari_node/src/http/server.rs
+++ b/applications/minotari_node/src/http/server.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use axum::{
+    extract::DefaultBodyLimit,
     routing::{get, post},
     Extension,
     Router,
@@ -74,7 +75,10 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
             .route("/transactions", get(handler::transaction_query::handle::<B>))
             .route("/sync_utxos_by_block", get(handler::sync_utxos_by_block::handle::<B>))
             .route("/get_utxos_by_block", get(handler::get_utxos_by_block::handle::<B>))
-            .route("/json_rpc", post(handler::json_rpc::handle::<B>))
+            .route(
+                "/json_rpc",
+                post(handler::json_rpc::handle::<B>).layer(DefaultBodyLimit::max(4096)),
+            )
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))
             .layer(Extension(self.query_service.clone()))
             .layer(Extension(self.mempool_handle.clone()));


### PR DESCRIPTION
Description
---
fixes http limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a maximum request body size limit of 4096 bytes for the POST `/json_rpc` endpoint to enhance request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->