### PR TITLE
fix: blocking main tokio thread when reading last latency

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -248,7 +248,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         _: Request<GetConnectivityRequest>,
     ) -> Result<Response<CheckConnectivityResponse>, Status> {
         let connectivity = self.wallet.wallet_connectivity.clone();
-        let status = connectivity.get_connectivity_status();
+        let status = connectivity.get_connectivity_status().await;
         Ok(Response::new(CheckConnectivityResponse { status: status as i32 }))
     }
 

--- a/base_layer/wallet/src/connectivity_service/handle.rs
+++ b/base_layer/wallet/src/connectivity_service/handle.rs
@@ -62,8 +62,8 @@ impl<TWalletClientFactory: HttpClientFactory> WalletConnectivityInterface
         self.client_factory.create_http_client()
     }
 
-    fn get_connectivity_status(&self) -> OnlineStatus {
-        if self.client_factory.create_http_client().is_online() {
+    async fn get_connectivity_status(&self) -> OnlineStatus {
+        if self.client_factory.create_http_client().is_online().await {
             OnlineStatus::Online
         } else {
             OnlineStatus::Offline

--- a/base_layer/wallet/src/connectivity_service/interface.rs
+++ b/base_layer/wallet/src/connectivity_service/interface.rs
@@ -37,7 +37,7 @@ pub trait WalletConnectivityInterface: Clone + Send + Sync + 'static {
     /// BaseNodeWalletRpcClient RPC session.
     async fn obtain_base_node_wallet_rpc_client(&mut self) -> Self::BaseNodeClient;
 
-    fn get_connectivity_status(&self) -> OnlineStatus;
+    async fn get_connectivity_status(&self) -> OnlineStatus;
 
     fn get_connectivity_status_watch(&self) -> watch::Receiver<OnlineStatus>;
 }

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -100,7 +100,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
         todo!()
     }
 
-    fn is_online(&self) -> bool {
+    async fn is_online(&self) -> bool {
         todo!()
     }
 

--- a/clients/rust/base_node_wallet_client/src/client/http.rs
+++ b/clients/rust/base_node_wallet_client/src/client/http.rs
@@ -114,9 +114,10 @@ impl BaseNodeWalletClient for Client {
         }
     }
 
-    fn is_online(&self) -> bool {
+    async fn is_online(&self) -> bool {
         self.last_latency
-            .blocking_read()
+            .read()
+            .await
             .map(|latency| latency.1.elapsed() < std::time::Duration::from_secs(60))
             .unwrap_or(false)
     }

--- a/clients/rust/base_node_wallet_client/src/client/mod.rs
+++ b/clients/rust/base_node_wallet_client/src/client/mod.rs
@@ -24,7 +24,7 @@ use crate::client::models::TxSubmissionResponse;
 #[async_trait::async_trait]
 pub trait BaseNodeWalletClient: Send + Sync + Clone + 'static {
     async fn get_address(&self) -> String;
-    fn is_online(&self) -> bool;
+    async fn is_online(&self) -> bool;
     async fn get_tip_info(&self) -> Result<models::TipInfoResponse, Error>;
 
     async fn get_header_by_height(&self, height: u64) -> Result<Option<BlockHeader>, Error>;


### PR DESCRIPTION
Description
---
Fix minotari_console_wallet panic when attempting to block main tokio thread with error message:
 ```
 Cannot block the current thread from within a runtime. This happens because a function attempted to block the current thread while the thread is being used to drive asynchronous tasks
 ```
 This happens because function `is_online` which was not async tried to do blocking read on the `tokio::sync::RwLock` on main tokio thread. This is not allowed since it would also block every other async action causing in thread panic.

Motivation and Context
---
Fix sporadic wallet failures when repeatedly  called `is_online` mostly seen when bridging tokens.

How Has This Been Tested?
---
Just ran `cargo check` and verified that changing all functions definition to `async` causes not error even so other functions in the same trait were also `async`. 

What process can a PR reviewer use to test or verify this change?
---
Basic code review of changes.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved wallet connectivity checks to use asynchronous operations for better performance and responsiveness. No user-facing changes in functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->