### PR TITLE
fix: http wallet json_rpc route size limit

### DIFF
--- a/applications/minotari_node/src/http/server.rs
+++ b/applications/minotari_node/src/http/server.rs
@@ -77,7 +77,7 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
             .route("/get_utxos_by_block", get(handler::get_utxos_by_block::handle::<B>))
             .route(
                 "/json_rpc",
-                post(handler::json_rpc::handle::<B>).layer(DefaultBodyLimit::max(4096)),
+                post(handler::json_rpc::handle::<B>).layer(DefaultBodyLimit::max(4 * 1024 * 1024)), // 4 MiB
             )
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))
             .layer(Extension(self.query_service.clone()))


### PR DESCRIPTION
Description
---
Fixed http wallet json_rpc route size limit

Closes #7323 

Motivation and Context
---
See above

How Has This Been Tested?
---
System-level testing succeeds

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed request size for the `/json_rpc` endpoint from 4 KiB to 4 MiB, enabling support for larger JSON-RPC payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->