### PR TITLE
feat: add output hash of inputs to scanning stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,6 +4436,7 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tonic 0.13.1",
+ "tower-http",
  "url",
  "utoipa",
  "utoipa-swagger-ui",
@@ -8611,15 +8612,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.6.0",
  "bytes 1.9.0",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.2",

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -73,6 +73,7 @@ axum = { version = "0.8.4", features = ["default", "http2"] }
 http = "0.2.12"
 utoipa = "5.3.1"
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
+tower-http = { version = "0.6", features = ["limit"] }
 
 [features]
 default = ["libtor"]

--- a/applications/minotari_node/src/http/server.rs
+++ b/applications/minotari_node/src/http/server.rs
@@ -18,6 +18,7 @@ use tari_core::{
 use tari_shutdown::ShutdownSignal;
 use thiserror::Error;
 use tokio::{io, net::TcpListener};
+use tower_http::limit::RequestBodyLimitLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -77,8 +78,9 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
             .route("/get_utxos_by_block", get(handler::get_utxos_by_block::handle::<B>))
             .route(
                 "/json_rpc",
-                post(handler::json_rpc::handle::<B>).layer(DefaultBodyLimit::max(4 * 1024 * 1024)), // 4 MiB
+                post(handler::json_rpc::handle::<B>).layer(DefaultBodyLimit::disable()), // 4 MiB
             )
+            .layer(RequestBodyLimitLayer::new(4 * 1024 * 1024))
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))
             .layer(Extension(self.query_service.clone()))
             .layer(Extension(self.mempool_handle.clone()));

--- a/applications/minotari_node/src/http/server.rs
+++ b/applications/minotari_node/src/http/server.rs
@@ -71,14 +71,23 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
             .route("/get_utxos_mined_info", get(handler::get_utxos_mined_info::handle::<B>))
             .route(
                 "/get_utxos_deleted_info",
-                get(handler::get_utxos_deleted_info::handle::<B>),
+                get(handler::get_utxos_deleted_info::handle::<B>).layer(DefaultBodyLimit::disable()),
             )
-            .route("/transactions", get(handler::transaction_query::handle::<B>))
-            .route("/sync_utxos_by_block", get(handler::sync_utxos_by_block::handle::<B>))
-            .route("/get_utxos_by_block", get(handler::get_utxos_by_block::handle::<B>))
+            .route(
+                "/transactions",
+                get(handler::transaction_query::handle::<B>).layer(DefaultBodyLimit::disable()),
+            )
+            .route(
+                "/sync_utxos_by_block",
+                get(handler::sync_utxos_by_block::handle::<B>).layer(DefaultBodyLimit::disable()),
+            )
+            .route(
+                "/get_utxos_by_block",
+                get(handler::get_utxos_by_block::handle::<B>).layer(DefaultBodyLimit::disable()),
+            )
             .route(
                 "/json_rpc",
-                post(handler::json_rpc::handle::<B>).layer(DefaultBodyLimit::disable()), // 4 MiB
+                post(handler::json_rpc::handle::<B>).layer(DefaultBodyLimit::disable()),
             )
             .layer(RequestBodyLimitLayer::new(4 * 1024 * 1024))
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))

--- a/base_layer/core/src/base_node/rpc/models/sync_utxos_by_block.rs
+++ b/base_layer/core/src/base_node/rpc/models/sync_utxos_by_block.rs
@@ -26,6 +26,7 @@ pub struct BlockUtxoInfo {
     pub header_hash: Vec<u8>,
     pub height: u64,
     pub outputs: Vec<MinimalUtxoSyncInfo>,
+    pub inputs: Vec<Vec<u8>>,
     pub mined_timestamp: u64,
 }
 
@@ -33,7 +34,6 @@ pub struct BlockUtxoInfo {
 pub struct MinimalUtxoSyncInfo {
     pub output_hash: Vec<u8>,
     pub commitment: Vec<u8>,
-    // pub script: Vec<u8>,
     pub encrypted_data: Vec<u8>,
     pub sender_offset_public_key: Vec<u8>,
 }

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -161,6 +161,7 @@ impl<B: BlockchainBackend + 'static> Service<B> {
         Ok(utxo_block_response)
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn fetch_utxos(&self, request: SyncUtxosByBlockRequest) -> Result<SyncUtxosByBlockResponse, Error> {
         // validate and fetch inputs
         request.validate()?;
@@ -216,6 +217,13 @@ impl<B: BlockchainBackend + 'static> Service<B> {
                 .db
                 .fetch_outputs_in_block_with_spend_state(current_header.hash(), None)
                 .await?;
+            let mut inputs = self
+                .db
+                .fetch_inputs_in_block(current_header.hash())
+                .await?
+                .into_iter()
+                .map(|input| input.output_hash().to_vec())
+                .collect::<Vec<Vec<u8>>>();
 
             let outputs = outputs_with_statuses
                 .into_iter()
@@ -223,6 +231,13 @@ impl<B: BlockchainBackend + 'static> Service<B> {
                 .collect::<Vec<TransactionOutput>>();
 
             for output_chunk in outputs.chunks(2000) {
+                let inputs_to_send = if inputs.is_empty() {
+                    Vec::new()
+                } else {
+                    let num_to_drain = inputs.len().min(2000);
+                    inputs.drain(..num_to_drain).collect()
+                };
+
                 let output_block_response = BlockUtxoInfo {
                     outputs: output_chunk
                         .iter()
@@ -233,21 +248,23 @@ impl<B: BlockchainBackend + 'static> Service<B> {
                             sender_offset_public_key: output.sender_offset_public_key.to_vec(),
                         })
                         .collect(),
+                    inputs: inputs_to_send,
                     height: current_header.height,
                     header_hash: current_header_hash.to_vec(),
                     mined_timestamp: current_header.timestamp.as_u64(),
                 };
                 utxos.push(output_block_response);
             }
-            if outputs.is_empty() {
-                // if its empty, we need to send an empty vec of outputs.
-                let utxo_block_response = BlockUtxoInfo {
+            // We might still have inputs left to send if they are more than the outputs
+            for input_chunk in inputs.chunks(2000) {
+                let output_block_response = BlockUtxoInfo {
                     outputs: Vec::new(),
+                    inputs: input_chunk.to_vec(),
                     height: current_header.height,
                     header_hash: current_header_hash.to_vec(),
                     mined_timestamp: current_header.timestamp.as_u64(),
                 };
-                utxos.push(utxo_block_response);
+                utxos.push(output_block_response);
             }
 
             fetched_utxos += 1;

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -244,6 +244,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
                                     sender_offset_public_key: o.sender_offset_public_key.to_vec(),
                                 })
                                 .collect(),
+                            inputs: Vec::new(),
                             mined_timestamp: header.timestamp.as_u64(),
                         });
                     }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -3100,6 +3100,10 @@ criteria = "safe-to-deploy"
 version = "0.6.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.tower-http]]
+version = "0.6.6"
+criteria = "safe-to-deploy"
+
 [[exemptions.tower-layer]]
 version = "0.3.3"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Description
---
adds spent output hashes to the stream by utxo block for the utxpo scanner
fixes limites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `inputs` field to UTXO sync responses, allowing clients to receive input data alongside outputs when syncing by block.

* **Improvements**
  * Enhanced UTXO sync logic to ensure all inputs are included and chunked appropriately, even if their count exceeds outputs.
  * Applied a global request body size limit of 4 MiB to the HTTP server for improved consistency.

* **Tests**
  * Updated test mocks to include the new `inputs` field in UTXO sync responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->