### PR TITLE
feat!: add initial validation flag to wallet state

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1419,6 +1419,8 @@ message GetStateResponse {
   GetBalanceResponse balance = 2;
   // Status of the wallet's connection to the base node, based on the NetworkStatusResponse
   NetworkStatusResponse network = 3;
+  // Has the wallet since starting, completed a validation of all outputs after scanning
+  bool has_done_initial_validation = 4;
 }
 
 // Response message for GetUnspentAmounts RPC.

--- a/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
@@ -190,10 +190,11 @@ impl WalletDebouncer {
                                 },
                                 TransactionEvent::TransactionValidationStateChanged{faux, ..} => {
                                     self.set_refresh_needed(true).await;
+                                    #[allow(clippy::collapsible_if)]
                                     if faux {
                                         let mut intial = self.initial_validation_done.lock().await;
                                         if !(*intial) {
-                                            if self.intial_scanning_done.lock().await{
+                                            if *self.intial_scanning_done.lock().await{
                                                 // we should only set this after we completed initial scanning and then completed faux tx validation
                                                 *intial = true;
                                             }

--- a/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
@@ -192,7 +192,12 @@ impl WalletDebouncer {
                                     self.set_refresh_needed(true).await;
                                     if faux {
                                         let mut intial = self.initial_validation_done.lock().await;
-                                        *intial = true;
+                                        if !(*intial) {
+                                            if self.intial_scanning_done.lock().await{
+                                                // we should only set this after we completed initial scanning and then completed faux tx validation
+                                                *intial = true;
+                                            }
+                                        }
                                     }
                                 },
                                 _ => (),

--- a/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
@@ -48,6 +48,8 @@ pub struct WalletDebouncer {
     balance: Arc<Mutex<Balance>>,
     scanned_height: Arc<Mutex<u64>>,
     refresh_needed: Arc<Mutex<bool>>,
+    intial_scanning_done: Arc<Mutex<bool>>,
+    initial_validation_done: Arc<Mutex<bool>>,
     output_manager_service: OutputManagerHandle,
     transaction_service: TransactionServiceHandle,
     utxo_scanner_handle: UtxoScannerHandle,
@@ -72,6 +74,8 @@ impl WalletDebouncer {
                 time_locked_balance: None,
             })),
             refresh_needed: Arc::new(Mutex::new(true)),
+            intial_scanning_done: Arc::new(Mutex::new(false)),
+            initial_validation_done: Arc::new(Mutex::new(false)),
             scanned_height: Arc::new(Mutex::new(scanned_height)),
             output_manager_service,
             transaction_service,
@@ -133,6 +137,10 @@ impl WalletDebouncer {
         refresh_needed
     }
 
+    pub async fn is_initial_validation_done(&self) -> bool {
+        *self.initial_validation_done.lock().await
+    }
+
     async fn set_refresh_needed(&self, refresh_needed: bool) {
         let mut lock = self.refresh_needed.lock().await;
         if *lock != refresh_needed {
@@ -177,9 +185,15 @@ impl WalletDebouncer {
                                 TransactionEvent::DetectedTransactionConfirmed { .. } |
                                 TransactionEvent::TransactionMined { .. } |
                                 TransactionEvent::TransactionMinedUnconfirmed { .. } |
-                                TransactionEvent::TransactionImported(_)  |
-                                TransactionEvent::TransactionValidationStateChanged(..) => {
+                                TransactionEvent::TransactionImported(_)  => {
                                     self.set_refresh_needed(true).await;
+                                },
+                                TransactionEvent::TransactionValidationStateChanged{faux, ..} => {
+                                    self.set_refresh_needed(true).await;
+                                    if faux {
+                                        let mut intial = self.initial_validation_done.lock().await;
+                                        *intial = true;
+                                    }
                                 },
                                 _ => (),
                             }
@@ -215,6 +229,8 @@ impl WalletDebouncer {
                                     final_height,
                                     ..
                                 }=> {
+                                    let mut scanning_done = self.intial_scanning_done.lock().await;
+                                    *scanning_done = true;
                                     self.update_scanned_height(final_height).await;
                                 },
                                 _ => {}

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -401,14 +401,15 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
     async fn get_state(&self, _request: Request<GetStateRequest>) -> Result<Response<GetStateResponse>, Status> {
         let start = std::time::Instant::now();
-        let (balance, scanned_height) = {
+        let (balance, scanned_height, is_initial_validation_done) = {
             let mut debouncer = self.debouncer.lock().await;
             let balance = match debouncer.get_balance().await {
                 Ok(b) => b,
                 Err(e) => return Err(Status::not_found(format!("WalletDebouncer error! {}", e))),
             };
             let scanned_height = debouncer.get_scanned_height().await;
-            (Some(balance), scanned_height)
+            let is_initial_validation_done = debouncer.is_initial_validation_done().await;
+            (Some(balance), scanned_height, is_initial_validation_done)
         };
 
         let status = self
@@ -436,6 +437,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             scanned_height,
             balance,
             network,
+            has_done_initial_validation: is_initial_validation_done,
         }))
     }
 
@@ -1112,7 +1114,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                                         let event = if is_sent { SENT } else { QUEUED };
                                         handle_pending_outbound(tx_id, event, &mut transaction_service, &mut sender).await;
                                     },
-                                    TransactionValidationStateChanged(_t_operation_id) => {
+                                    TransactionValidationStateChanged{..} => {
                                         send_transaction_event(simple_event("unknown"), &mut sender).await;
                                     },
                                     ReceivedTransaction(_) | ReceivedTransactionReply(_)  | TransactionBroadcast(_) => {

--- a/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/minotari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -155,7 +155,7 @@ impl WalletEventMonitor {
                                     self.trigger_balance_refresh();
                                     notifier.transaction_sent_or_queued(tx_id, status.direct_send_result || status.store_and_forward_send_result);
                                 },
-                                TransactionEvent::TransactionValidationStateChanged(_) => {
+                                TransactionEvent::TransactionValidationStateChanged{..} => {
                                     self.trigger_full_tx_state_refresh().await;
                                     self.trigger_balance_refresh();
                                 },

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -623,7 +623,10 @@ pub enum TransactionEvent {
         is_valid: bool,
     },
     TransactionImported(TxId),
-    TransactionValidationStateChanged(OperationId),
+    TransactionValidationStateChanged {
+        faux: bool,
+        id: OperationId,
+    },
     TransactionValidationCompleted(OperationId),
     TransactionValidationFailed(OperationId, u64),
     Error(String),
@@ -690,7 +693,7 @@ impl fmt::Display for TransactionEvent {
             TransactionEvent::Error(error) => {
                 write!(f, "Error:{error}")
             },
-            TransactionEvent::TransactionValidationStateChanged(operation_id) => {
+            TransactionEvent::TransactionValidationStateChanged { id: operation_id, .. } => {
                 write!(f, "Transaction validation state changed: {operation_id}")
             },
             TransactionEvent::TransactionValidationCompleted(operation_id) => {

--- a/base_layer/wallet/src/transaction_service/protocols/check_faux_transaction_status.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/check_faux_transaction_status.rs
@@ -214,9 +214,10 @@ pub async fn check_detected_transactions<TBackend: 'static + TransactionBackend>
     }
     if state_changed {
         let _size = event_publisher
-            .send(Arc::new(TransactionEvent::TransactionValidationStateChanged(
-                OperationId::new_random(),
-            )))
+            .send(Arc::new(TransactionEvent::TransactionValidationStateChanged {
+                faux: true,
+                id: OperationId::new_random(),
+            }))
             .map_err(|e| {
                 trace!(
                     target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -102,7 +102,10 @@ where
         )
         .await;
         if state_changed {
-            self.publish_event(TransactionEvent::TransactionValidationStateChanged(self.operation_id));
+            self.publish_event(TransactionEvent::TransactionValidationStateChanged {
+                faux: false,
+                id: self.operation_id,
+            });
         }
         self.publish_event(TransactionEvent::TransactionValidationCompleted(self.operation_id));
         Ok(self.operation_id)
@@ -244,7 +247,7 @@ where
                 );
                 self.update_transaction_as_unmined(last_mined_transaction.tx_id, &last_mined_transaction.status)
                     .await?;
-                self.publish_event(TransactionEvent::TransactionValidationStateChanged(op_id));
+                self.publish_event(TransactionEvent::TransactionValidationStateChanged { faux: false, id: op_id });
             } else {
                 debug!(
                     target: LOG_TARGET,

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -313,7 +313,7 @@ where TBackend: TransactionBackend + 'static
                                     self.receive_faux_transaction_unconfirmed_event(tx_id, num_confirmations);
                                     self.trigger_balance_refresh().await;
                                 },
-                                TransactionEvent::TransactionValidationStateChanged(_request_key)  => {
+                                TransactionEvent::TransactionValidationStateChanged{..}  => {
                                     self.trigger_balance_refresh().await;
                                 },
                                 TransactionEvent::TransactionValidationCompleted(request_key)  => {

--- a/base_layer/wallet_ffi/src/callback_handler_tests.rs
+++ b/base_layer/wallet_ffi/src/callback_handler_tests.rs
@@ -758,15 +758,16 @@ mod test {
         assert_eq!(callback_balance_updated, 5);
 
         transaction_event_sender
-            .send(Arc::new(TransactionEvent::TransactionValidationStateChanged(
-                1u64.into(),
-            )))
+            .send(Arc::new(TransactionEvent::TransactionValidationStateChanged {
+                faux: false,
+                id: 1u64.into(),
+            }))
             .unwrap();
-
         transaction_event_sender
-            .send(Arc::new(TransactionEvent::TransactionValidationStateChanged(
-                2u64.into(),
-            )))
+            .send(Arc::new(TransactionEvent::TransactionValidationStateChanged {
+                faux: false,
+                id: 2u64.into(),
+            }))
             .unwrap();
 
         oms_event_sender


### PR DESCRIPTION
Description
---
Sets a flag if the wallet has completed a validation after its finished scanning

Breaking
---
changes grpc proto files by adding new field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new indicator to show whether the wallet has completed initial validation of all outputs after scanning since startup.

* **Bug Fixes**
  * Improved event handling and state tracking for wallet validation and scanning processes.

* **Tests**
  * Updated tests to reflect changes in event structure for transaction validation state.

* **Style**
  * Refined pattern matching for transaction validation events across the wallet interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->