### PR TITLE
feat!: only scan in 10 block sections

### DIFF
--- a/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
+++ b/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
@@ -32,10 +32,6 @@ pub struct SyncUtxosByBlockQueryParams {
     #[param(value_type = String, example = "1a8da4213566e3cda06958c7ee46b87870a587fabb1c7f050f553b6da36cccb3"
     )]
     pub start_header_hash: Vec<u8>,
-    #[serde(deserialize_with = "from_hex")]
-    #[param(value_type = String, example = "7e0b29c48e46ca6805ef4593219641badc08f6c278e768e54220ecaa4a68e2a5"
-    )]
-    pub end_header_hash: Vec<u8>,
     #[param(value_type = u64, example = 5)]
     pub limit: u64,
     #[param(value_type = u64, example = 0)]
@@ -46,7 +42,6 @@ impl From<SyncUtxosByBlockQueryParams> for SyncUtxosByBlockRequest {
     fn from(params: SyncUtxosByBlockQueryParams) -> Self {
         Self {
             start_header_hash: params.start_header_hash,
-            end_header_hash: params.end_header_hash,
             limit: params.limit,
             page: params.page,
         }

--- a/base_layer/core/src/base_node/rpc/models/sync_utxos_by_block.rs
+++ b/base_layer/core/src/base_node/rpc/models/sync_utxos_by_block.rs
@@ -19,6 +19,7 @@ pub struct SyncUtxosByBlockRequest {
 pub struct SyncUtxosByBlockResponse {
     pub blocks: Vec<BlockUtxoInfo>,
     pub has_next_page: bool,
+    pub next_header_to_scan: Vec<u8>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone)]

--- a/base_layer/core/src/base_node/rpc/models/sync_utxos_by_block.rs
+++ b/base_layer/core/src/base_node/rpc/models/sync_utxos_by_block.rs
@@ -7,7 +7,6 @@ use utoipa::ToSchema;
 #[derive(Serialize, Deserialize, Validate)]
 pub struct SyncUtxosByBlockRequest {
     pub start_header_hash: Vec<u8>,
-    pub end_header_hash: Vec<u8>,
     #[validate(minimum = 1)]
     #[validate(maximum = 2000)]
     pub limit: u64,

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -293,7 +293,7 @@ impl<B: BlockchainBackend + 'static> Service<B> {
             }
         }
 
-        let has_next_page = (end_height - current_header.height) > 0;
+        let has_next_page = (end_height.saturating_sub(current_header.height)) > 0;
 
         Ok(SyncUtxosByBlockResponse {
             blocks: utxos,

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -1,8 +1,6 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::cmp;
-
 use log::trace;
 use serde_valid::{validation, Validate};
 use tari_common_types::{types, types::FixedHashSizeError};
@@ -176,15 +174,8 @@ impl<B: BlockchainBackend + 'static> Service<B> {
             .await?
             .ok_or_else(|| Error::StartHeaderHashNotFound)?;
 
-        let tip_header = self.db.fetch_tip_header().await?;
-        // we only allow wallets to ask for a max of 10 blocks at a time and we want to cache the queries to ensure they
-        // are in batch of 10 and we want to ensure they request goes to the nearest 10 block height so we can
-        // cache all wallet's queries
-        let increase = ((start_header.height + 10) / 10) * 10;
-        let end_height = cmp::min(tip_header.header().height, increase);
 
-        // pagination
-        let start_header_height = start_header.height + (request.page * request.limit);
+        let start_header_height = start_header.height;
         let start_header = self
             .db
             .fetch_header(start_header_height)
@@ -193,111 +184,79 @@ impl<B: BlockchainBackend + 'static> Service<B> {
                 height: start_header_height,
             })?;
 
-        if start_header.height > tip_header.header().height {
-            return Err(Error::HeaderHeightMismatch {
-                start_height: start_header.height,
-                end_height: tip_header.header().height,
-            });
-        }
-
         // fetch utxos
         let mut utxos = vec![];
-        let mut current_header = start_header;
-        let mut fetched_utxos = 0;
-        let next_header_to_request;
-        loop {
-            let current_header_hash = current_header.hash();
+        let current_header = start_header;
+        let current_header_hash = current_header.hash();
+        let next_header_to_request = match self.db.fetch_header(start_header_height).await? {
+            Some(header) => header.hash().to_vec(),
+            None => vec![],
+        };
 
-            trace!(
-                target: LOG_TARGET,
-                "current header = {} ({})",
-                current_header.height,
-                current_header_hash.to_hex()
-            );
+        trace!(
+            target: LOG_TARGET,
+            "current header = {} ({})",
+            current_header.height,
+            current_header_hash.to_hex()
+        );
 
-            let outputs_with_statuses = self
-                .db
-                .fetch_outputs_in_block_with_spend_state(current_header.hash(), None)
-                .await?;
-            let mut inputs = self
-                .db
-                .fetch_inputs_in_block(current_header.hash())
-                .await?
-                .into_iter()
-                .map(|input| input.output_hash().to_vec())
-                .collect::<Vec<Vec<u8>>>();
+        let outputs_with_statuses = self
+            .db
+            .fetch_outputs_in_block_with_spend_state(current_header.hash(), None)
+            .await?;
+        let mut inputs = self
+            .db
+            .fetch_inputs_in_block(current_header.hash())
+            .await?
+            .into_iter()
+            .map(|input| input.output_hash().to_vec())
+            .collect::<Vec<Vec<u8>>>();
 
-            let outputs = outputs_with_statuses
-                .into_iter()
-                .map(|(output, _spent)| output)
-                .collect::<Vec<TransactionOutput>>();
+        let outputs = outputs_with_statuses
+            .into_iter()
+            .map(|(output, _spent)| output)
+            .collect::<Vec<TransactionOutput>>();
 
-            for output_chunk in outputs.chunks(2000) {
-                let inputs_to_send = if inputs.is_empty() {
-                    Vec::new()
-                } else {
-                    let num_to_drain = inputs.len().min(2000);
-                    inputs.drain(..num_to_drain).collect()
-                };
+        for output_chunk in outputs.chunks(2000) {
+            let inputs_to_send = if inputs.is_empty() {
+                Vec::new()
+            } else {
+                let num_to_drain = inputs.len().min(2000);
+                inputs.drain(..num_to_drain).collect()
+            };
 
-                let output_block_response = BlockUtxoInfo {
-                    outputs: output_chunk
-                        .iter()
-                        .map(|output| MinimalUtxoSyncInfo {
-                            output_hash: output.hash().to_vec(),
-                            commitment: output.commitment().to_vec(),
-                            encrypted_data: output.encrypted_data().as_bytes().to_vec(),
-                            sender_offset_public_key: output.sender_offset_public_key.to_vec(),
-                        })
-                        .collect(),
-                    inputs: inputs_to_send,
-                    height: current_header.height,
-                    header_hash: current_header_hash.to_vec(),
-                    mined_timestamp: current_header.timestamp.as_u64(),
-                };
-                utxos.push(output_block_response);
-            }
-            // We might still have inputs left to send if they are more than the outputs
-            for input_chunk in inputs.chunks(2000) {
-                let output_block_response = BlockUtxoInfo {
-                    outputs: Vec::new(),
-                    inputs: input_chunk.to_vec(),
-                    height: current_header.height,
-                    header_hash: current_header_hash.to_vec(),
-                    mined_timestamp: current_header.timestamp.as_u64(),
-                };
-                utxos.push(output_block_response);
-            }
-
-            fetched_utxos += 1;
-
-            if current_header.height >= tip_header.header().height {
-                next_header_to_request = vec![];
-                break;
-            }
-            if fetched_utxos >= request.limit {
-                next_header_to_request = current_header.hash().to_vec();
-                break;
-            }
-
-            current_header =
-                self.db
-                    .fetch_header(current_header.height + 1)
-                    .await?
-                    .ok_or_else(|| Error::HeaderNotFound {
-                        height: current_header.height + 1,
-                    })?;
-            if current_header.height == end_height {
-                next_header_to_request = current_header.hash().to_vec();
-                break; // Stop if we reach the end height}
-            }
+            let output_block_response = BlockUtxoInfo {
+                outputs: output_chunk
+                    .iter()
+                    .map(|output| MinimalUtxoSyncInfo {
+                        output_hash: output.hash().to_vec(),
+                        commitment: output.commitment().to_vec(),
+                        encrypted_data: output.encrypted_data().as_bytes().to_vec(),
+                        sender_offset_public_key: output.sender_offset_public_key.to_vec(),
+                    })
+                    .collect(),
+                inputs: inputs_to_send,
+                height: current_header.height,
+                header_hash: current_header_hash.to_vec(),
+                mined_timestamp: current_header.timestamp.as_u64(),
+            };
+            utxos.push(output_block_response);
         }
-
-        let has_next_page = (end_height - current_header.height) > 0;
+        // We might still have inputs left to send if they are more than the outputs
+        for input_chunk in inputs.chunks(2000) {
+            let output_block_response = BlockUtxoInfo {
+                outputs: Vec::new(),
+                inputs: input_chunk.to_vec(),
+                height: current_header.height,
+                header_hash: current_header_hash.to_vec(),
+                mined_timestamp: current_header.timestamp.as_u64(),
+            };
+            utxos.push(output_block_response);
+        }
 
         Ok(SyncUtxosByBlockResponse {
             blocks: utxos,
-            has_next_page,
+            has_next_page: false,
             next_header_to_scan: next_header_to_request,
         })
     }

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::cmp;
+
 use log::trace;
 use serde_valid::{validation, Validate};
 use tari_common_types::{types, types::FixedHashSizeError};
@@ -174,8 +176,15 @@ impl<B: BlockchainBackend + 'static> Service<B> {
             .await?
             .ok_or_else(|| Error::StartHeaderHashNotFound)?;
 
+        let tip_header = self.db.fetch_tip_header().await?;
+        // we only allow wallets to ask for a max of 10 blocks at a time and we want to cache the queries to ensure they
+        // are in batch of 10 and we want to ensure they request goes to the nearest 10 block height so we can
+        // cache all wallet's queries
+        let increase = ((start_header.height + 10) / 10) * 10;
+        let end_height = cmp::min(tip_header.header().height, increase);
 
-        let start_header_height = start_header.height;
+        // pagination
+        let start_header_height = start_header.height + (request.page * request.limit);
         let start_header = self
             .db
             .fetch_header(start_header_height)
@@ -184,79 +193,111 @@ impl<B: BlockchainBackend + 'static> Service<B> {
                 height: start_header_height,
             })?;
 
+        if start_header.height > tip_header.header().height {
+            return Err(Error::HeaderHeightMismatch {
+                start_height: start_header.height,
+                end_height: tip_header.header().height,
+            });
+        }
+
         // fetch utxos
         let mut utxos = vec![];
-        let current_header = start_header;
-        let current_header_hash = current_header.hash();
-        let next_header_to_request = match self.db.fetch_header(start_header_height).await? {
-            Some(header) => header.hash().to_vec(),
-            None => vec![],
-        };
+        let mut current_header = start_header;
+        let mut fetched_utxos = 0;
+        let next_header_to_request;
+        loop {
+            let current_header_hash = current_header.hash();
 
-        trace!(
-            target: LOG_TARGET,
-            "current header = {} ({})",
-            current_header.height,
-            current_header_hash.to_hex()
-        );
+            trace!(
+                target: LOG_TARGET,
+                "current header = {} ({})",
+                current_header.height,
+                current_header_hash.to_hex()
+            );
 
-        let outputs_with_statuses = self
-            .db
-            .fetch_outputs_in_block_with_spend_state(current_header.hash(), None)
-            .await?;
-        let mut inputs = self
-            .db
-            .fetch_inputs_in_block(current_header.hash())
-            .await?
-            .into_iter()
-            .map(|input| input.output_hash().to_vec())
-            .collect::<Vec<Vec<u8>>>();
+            let outputs_with_statuses = self
+                .db
+                .fetch_outputs_in_block_with_spend_state(current_header.hash(), None)
+                .await?;
+            let mut inputs = self
+                .db
+                .fetch_inputs_in_block(current_header.hash())
+                .await?
+                .into_iter()
+                .map(|input| input.output_hash().to_vec())
+                .collect::<Vec<Vec<u8>>>();
 
-        let outputs = outputs_with_statuses
-            .into_iter()
-            .map(|(output, _spent)| output)
-            .collect::<Vec<TransactionOutput>>();
+            let outputs = outputs_with_statuses
+                .into_iter()
+                .map(|(output, _spent)| output)
+                .collect::<Vec<TransactionOutput>>();
 
-        for output_chunk in outputs.chunks(2000) {
-            let inputs_to_send = if inputs.is_empty() {
-                Vec::new()
-            } else {
-                let num_to_drain = inputs.len().min(2000);
-                inputs.drain(..num_to_drain).collect()
-            };
+            for output_chunk in outputs.chunks(2000) {
+                let inputs_to_send = if inputs.is_empty() {
+                    Vec::new()
+                } else {
+                    let num_to_drain = inputs.len().min(2000);
+                    inputs.drain(..num_to_drain).collect()
+                };
 
-            let output_block_response = BlockUtxoInfo {
-                outputs: output_chunk
-                    .iter()
-                    .map(|output| MinimalUtxoSyncInfo {
-                        output_hash: output.hash().to_vec(),
-                        commitment: output.commitment().to_vec(),
-                        encrypted_data: output.encrypted_data().as_bytes().to_vec(),
-                        sender_offset_public_key: output.sender_offset_public_key.to_vec(),
-                    })
-                    .collect(),
-                inputs: inputs_to_send,
-                height: current_header.height,
-                header_hash: current_header_hash.to_vec(),
-                mined_timestamp: current_header.timestamp.as_u64(),
-            };
-            utxos.push(output_block_response);
+                let output_block_response = BlockUtxoInfo {
+                    outputs: output_chunk
+                        .iter()
+                        .map(|output| MinimalUtxoSyncInfo {
+                            output_hash: output.hash().to_vec(),
+                            commitment: output.commitment().to_vec(),
+                            encrypted_data: output.encrypted_data().as_bytes().to_vec(),
+                            sender_offset_public_key: output.sender_offset_public_key.to_vec(),
+                        })
+                        .collect(),
+                    inputs: inputs_to_send,
+                    height: current_header.height,
+                    header_hash: current_header_hash.to_vec(),
+                    mined_timestamp: current_header.timestamp.as_u64(),
+                };
+                utxos.push(output_block_response);
+            }
+            // We might still have inputs left to send if they are more than the outputs
+            for input_chunk in inputs.chunks(2000) {
+                let output_block_response = BlockUtxoInfo {
+                    outputs: Vec::new(),
+                    inputs: input_chunk.to_vec(),
+                    height: current_header.height,
+                    header_hash: current_header_hash.to_vec(),
+                    mined_timestamp: current_header.timestamp.as_u64(),
+                };
+                utxos.push(output_block_response);
+            }
+
+            fetched_utxos += 1;
+
+            if current_header.height >= tip_header.header().height {
+                next_header_to_request = vec![];
+                break;
+            }
+            if fetched_utxos >= request.limit {
+                next_header_to_request = current_header.hash().to_vec();
+                break;
+            }
+
+            current_header =
+                self.db
+                    .fetch_header(current_header.height + 1)
+                    .await?
+                    .ok_or_else(|| Error::HeaderNotFound {
+                        height: current_header.height + 1,
+                    })?;
+            if current_header.height == end_height {
+                next_header_to_request = current_header.hash().to_vec();
+                break; // Stop if we reach the end height}
+            }
         }
-        // We might still have inputs left to send if they are more than the outputs
-        for input_chunk in inputs.chunks(2000) {
-            let output_block_response = BlockUtxoInfo {
-                outputs: Vec::new(),
-                inputs: input_chunk.to_vec(),
-                height: current_header.height,
-                header_hash: current_header_hash.to_vec(),
-                mined_timestamp: current_header.timestamp.as_u64(),
-            };
-            utxos.push(output_block_response);
-        }
+
+        let has_next_page = (end_height - current_header.height) > 0;
 
         Ok(SyncUtxosByBlockResponse {
             blocks: utxos,
-            has_next_page: false,
+            has_next_page,
             next_header_to_scan: next_header_to_request,
         })
     }

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -177,10 +177,10 @@ impl<B: BlockchainBackend + 'static> Service<B> {
             .ok_or_else(|| Error::StartHeaderHashNotFound)?;
 
         let tip_header = self.db.fetch_tip_header().await?;
-        // we only allow wallets to ask for a max of 10 blocks at a time and we want to cache the queries to ensure they
-        // are in batch of 10 and we want to ensure they request goes to the nearest 10 block height so we can
-        // cache all wallet's queries
-        let increase = ((start_header.height + 10) / 10) * 10;
+        // we only allow wallets to ask for a max of 100 blocks at a time and we want to cache the queries to ensure
+        // they are in batch of 100 and we want to ensure they request goes to the nearest 100 block height so
+        // we can cache all wallet's queries
+        let increase = ((start_header.height + 100) / 100) * 100;
         let end_height = cmp::min(tip_header.header().height, increase);
 
         // pagination

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::cmp;
+
 use log::trace;
 use serde_valid::{validation, Validate};
 use tari_common_types::{types, types::FixedHashSizeError};
@@ -174,13 +176,12 @@ impl<B: BlockchainBackend + 'static> Service<B> {
             .await?
             .ok_or_else(|| Error::StartHeaderHashNotFound)?;
 
-        let hash = request.end_header_hash.clone().try_into()?;
-
-        let end_header = self
-            .db
-            .fetch_header_by_block_hash(hash)
-            .await?
-            .ok_or_else(|| Error::EndHeaderHashNotFound)?;
+        let tip_header = self.db.fetch_tip_header().await?;
+        // we only allow wallets to ask for a max of 10 blocks at a time and we want to cache the queries to ensure they
+        // are in batch of 10 and we want to ensure they request goes to the nearest 10 block height so we can
+        // cache all wallet's queries
+        let increase = ((start_header.height + 10) / 10) * 10;
+        let end_height = cmp::min(tip_header.header().height, increase);
 
         // pagination
         let start_header_height = start_header.height + (request.page * request.limit);
@@ -192,10 +193,10 @@ impl<B: BlockchainBackend + 'static> Service<B> {
                 height: start_header_height,
             })?;
 
-        if start_header.height > end_header.height {
+        if start_header.height > tip_header.header().height {
             return Err(Error::HeaderHeightMismatch {
                 start_height: start_header.height,
-                end_height: end_header.height,
+                end_height: tip_header.header().height,
             });
         }
 
@@ -203,6 +204,7 @@ impl<B: BlockchainBackend + 'static> Service<B> {
         let mut utxos = vec![];
         let mut current_header = start_header;
         let mut fetched_utxos = 0;
+        let next_header_to_request;
         loop {
             let current_header_hash = current_header.hash();
 
@@ -269,7 +271,12 @@ impl<B: BlockchainBackend + 'static> Service<B> {
 
             fetched_utxos += 1;
 
-            if current_header.height >= end_header.height || fetched_utxos >= request.limit {
+            if current_header.height >= tip_header.header().height {
+                next_header_to_request = vec![];
+                break;
+            }
+            if fetched_utxos >= request.limit {
+                next_header_to_request = current_header.hash().to_vec();
                 break;
             }
 
@@ -280,13 +287,18 @@ impl<B: BlockchainBackend + 'static> Service<B> {
                     .ok_or_else(|| Error::HeaderNotFound {
                         height: current_header.height + 1,
                     })?;
+            if current_header.height == end_height {
+                next_header_to_request = current_header.hash().to_vec();
+                break; // Stop if we reach the end height}
+            }
         }
 
-        let has_next_page = (end_header.height - current_header.height) > 0;
+        let has_next_page = (end_height - current_header.height) > 0;
 
         Ok(SyncUtxosByBlockResponse {
             blocks: utxos,
             has_next_page,
+            next_header_to_scan: next_header_to_request,
         })
     }
 }

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -290,12 +290,7 @@ where
             );
 
             let scan_result = self
-                .scan_utxos(
-                    &wallet_service_client,
-                    next_block_to_scan.header_hash,
-                    tip_hash,
-                    tip_height,
-                )
+                .scan_utxos_to_tip(&wallet_service_client, next_block_to_scan.header_hash, tip_height)
                 .await?;
             scanned_blocks += scan_result.blocks_scanned;
             total_num_recovered += scan_result.total_num_recovered;
@@ -407,18 +402,16 @@ where
     }
 
     #[allow(clippy::too_many_lines)]
-    async fn scan_utxos(
+    async fn scan_utxos_to_tip(
         &mut self,
         client: &TWalletClientFactory::Client,
         start_header_hash: HashOutput,
-        end_header_hash: HashOutput,
         tip_height: u64,
     ) -> Result<ScanUtxosResult, anyhow::Error> {
         info!(
             target: LOG_TARGET,
-            "Starting UTXO scanning from header hash {} to header hash {} at tip height {}",
+            "Starting UTXO scanning from header hash {} to tip height {}",
             start_header_hash.to_hex(),
-            end_header_hash.to_hex(),
             tip_height
         );
         // Setting how often the progress event and log should occur during scanning. Defined in blocks
@@ -428,120 +421,123 @@ where
         let mut total_num_recovered = 0;
         let mut total_value_recovered = MicroMinotari::zero();
         let mut blocks_scanned = 0;
+        let mut starting_header_vec = start_header_hash.to_vec();
+        loop {
+            let mut utxo_stream = client
+                .sync_utxos_by_block(starting_header_vec.clone(), self.shutdown_signal.clone())
+                .await?;
 
-        let mut utxo_stream = client
-            .sync_utxos_by_block(
-                start_header_hash.to_vec(),
-                end_header_hash.to_vec(),
-                self.shutdown_signal.clone(),
-            )
-            .await?;
-
-        let mut prev_scanned_block: Option<ScannedBlock> = None;
-        while let Some(response) = utxo_stream.recv().await {
-            if self.shutdown_signal.is_triggered() {
-                let result = ScanUtxosResult {
-                    total_scanned,
-                    total_num_recovered,
-                    total_value_recovered,
-                    blocks_scanned,
-                };
-                return Ok(result);
-            }
-
-            let response = response?;
-            #[allow(clippy::cast_possible_wrap)]
-            for response in response.blocks {
-                blocks_scanned += 1;
-                let current_height = response.height;
-                let current_header_hash = response.header_hash;
-                let mined_timestamp = DateTime::<Utc>::from_timestamp(response.mined_timestamp as i64, 0)
-                    .unwrap_or(DateTime::<Utc>::MIN_UTC);
-                let outputs = response.outputs;
-                total_scanned += outputs.len();
-
-                let found_outputs = self.search_for_owned_outputs(outputs).await?;
-
-                if found_outputs.is_empty() {
-                    debug!(
-                        target: LOG_TARGET,
-                        "No recoverable outputs found in block at height {} with header hash {}",
-                        current_height,
-                        current_header_hash.to_hex()
-                    );
-                } else {
-                    // Now download the whole block and import the outputs
-                    info!(
-                        target: LOG_TARGET,
-                        "Found {} recoverable outputs in block at height {} with header hash {}",
-                        found_outputs.len(),
-                        current_height,
-                        current_header_hash.to_hex()
-                    );
-                    let block = client.get_utxos_by_block(current_header_hash.to_vec()).await?;
-
-                    let outputs = block
-                        .outputs
-                        .iter()
-                        .filter(|o| found_outputs.iter().any(|f| f.commitment == o.commitment.as_bytes()))
-                        .cloned()
-                        .collect::<Vec<_>>();
-
-                    let imported_outputs = self.scan_for_outputs(outputs).await?;
-
-                    let (num_recovered, amount) = self
-                        .import_utxos_to_transaction_service(&imported_outputs, current_height, mined_timestamp)
-                        .await?;
-                    total_num_recovered += num_recovered;
-                    total_value_recovered += amount;
+            let mut prev_scanned_block: Option<ScannedBlock> = None;
+            while let Some(response) = utxo_stream.recv().await {
+                if self.shutdown_signal.is_triggered() {
+                    let result = ScanUtxosResult {
+                        total_scanned,
+                        total_num_recovered,
+                        total_value_recovered,
+                        blocks_scanned,
+                    };
+                    return Ok(result);
                 }
 
-                let block_hash: FixedHash = current_header_hash.try_into()?;
-                if let Some(scanned_block) = prev_scanned_block {
-                    if block_hash != scanned_block.header_hash {
+                let response = response?;
+                #[allow(clippy::cast_possible_wrap)]
+                for response in response.blocks {
+                    blocks_scanned += 1;
+                    let current_height = response.height;
+                    let current_header_hash = response.header_hash;
+                    let mined_timestamp = DateTime::<Utc>::from_timestamp(response.mined_timestamp as i64, 0)
+                        .unwrap_or(DateTime::<Utc>::MIN_UTC);
+                    let outputs = response.outputs;
+                    total_scanned += outputs.len();
+
+                    let found_outputs = self.search_for_owned_outputs(outputs).await?;
+
+                    if found_outputs.is_empty() {
                         debug!(
                             target: LOG_TARGET,
-                            "Saving scanned block at height {} with header hash {}",
+                            "No recoverable outputs found in block at height {} with header hash {}",
                             current_height,
-                            block_hash.to_hex()
+                            current_header_hash.to_hex()
                         );
-                        self.resources.db.save_scanned_block(scanned_block)?;
-                        self.resources.db.clear_scanned_blocks_before_height(
-                            current_height.saturating_sub(SCANNED_BLOCK_CACHE_SIZE),
-                            true,
-                        )?;
+                    } else {
+                        // Now download the whole block and import the outputs
+                        info!(
+                            target: LOG_TARGET,
+                            "Found {} recoverable outputs in block at height {} with header hash {}",
+                            found_outputs.len(),
+                            current_height,
+                            current_header_hash.to_hex()
+                        );
+                        let block = client.get_utxos_by_block(current_header_hash.to_vec()).await?;
 
-                        if current_height % PROGRESS_REPORT_INTERVAL == 0 {
+                        let outputs = block
+                            .outputs
+                            .iter()
+                            .filter(|o| found_outputs.iter().any(|f| f.commitment == o.commitment.as_bytes()))
+                            .cloned()
+                            .collect::<Vec<_>>();
+
+                        let imported_outputs = self.scan_for_outputs(outputs).await?;
+
+                        let (num_recovered, amount) = self
+                            .import_utxos_to_transaction_service(&imported_outputs, current_height, mined_timestamp)
+                            .await?;
+                        total_num_recovered += num_recovered;
+                        total_value_recovered += amount;
+                    }
+
+                    let block_hash: FixedHash = current_header_hash.try_into()?;
+                    if let Some(scanned_block) = prev_scanned_block {
+                        if block_hash != scanned_block.header_hash {
                             debug!(
                                 target: LOG_TARGET,
-                                "Scanned up to block {} with a current tip_height of {}", current_height, tip_height
-                            );
-
-                            let latency = client.get_last_request_latency().await.unwrap_or_default();
-                            let node = client.get_address().await;
-                            self.publish_event(UtxoScannerEvent::Progress {
+                                "Saving scanned block at height {} with header hash {}",
                                 current_height,
-                                tip_height,
-                                current_node: node,
-                                latency,
-                            });
+                                block_hash.to_hex()
+                            );
+                            self.resources.db.save_scanned_block(scanned_block)?;
+                            self.resources.db.clear_scanned_blocks_before_height(
+                                current_height.saturating_sub(SCANNED_BLOCK_CACHE_SIZE),
+                                true,
+                            )?;
+
+                            if current_height % PROGRESS_REPORT_INTERVAL == 0 {
+                                debug!(
+                                    target: LOG_TARGET,
+                                    "Scanned up to block {} with a current tip_height of {}", current_height, tip_height
+                                );
+
+                                let latency = client.get_last_request_latency().await.unwrap_or_default();
+                                let node = client.get_address().await;
+                                self.publish_event(UtxoScannerEvent::Progress {
+                                    current_height,
+                                    tip_height,
+                                    current_node: node,
+                                    latency,
+                                });
+                            }
                         }
                     }
+                    prev_scanned_block = Some(ScannedBlock {
+                        header_hash: block_hash,
+                        height: current_height,
+                        timestamp: Utc::now().naive_utc(),
+                    });
                 }
-                prev_scanned_block = Some(ScannedBlock {
-                    header_hash: block_hash,
-                    height: current_height,
-                    timestamp: Utc::now().naive_utc(),
-                });
+                starting_header_vec = response.next_header_to_scan;
             }
-        }
-        // We need to update the last one
-        if let Some(scanned_block) = prev_scanned_block {
-            self.resources.db.clear_scanned_blocks_before_height(
-                scanned_block.height.saturating_sub(SCANNED_BLOCK_CACHE_SIZE),
-                true,
-            )?;
-            self.resources.db.save_scanned_block(scanned_block)?;
+            // We need to update the last one
+            if let Some(scanned_block) = prev_scanned_block {
+                self.resources.db.clear_scanned_blocks_before_height(
+                    scanned_block.height.saturating_sub(SCANNED_BLOCK_CACHE_SIZE),
+                    true,
+                )?;
+                self.resources.db.save_scanned_block(scanned_block)?;
+            }
+            if starting_header_vec.is_empty() {
+                // No more blocks to scan
+                break;
+            }
         }
         let result = ScanUtxosResult {
             total_scanned,

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -487,6 +487,12 @@ where
                     }
 
                     let block_hash: FixedHash = current_header_hash.try_into()?;
+                    debug!(
+                        target: LOG_TARGET,
+                        "Scanned block at height {} with header hash {}, :{:?}",
+                        current_height,
+                        block_hash.to_hex(), prev_scanned_block
+                    );
                     if let Some(scanned_block) = prev_scanned_block {
                         if block_hash != scanned_block.header_hash {
                             debug!(

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -201,7 +201,6 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
     async fn sync_utxos_by_block(
         &self,
         start_header_hash: Vec<u8>,
-        end_header_hash: Vec<u8>,
         shutdown: ShutdownSignal,
     ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponse, Error>>, Error> {
         let (tx, rx) = mpsc::channel(100);
@@ -213,11 +212,9 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
             .find(|b| b.hash().to_vec() == start_header_hash)
             .map_or(0, |b| b.height);
 
-        let end_height = state2
-            .blocks
-            .values()
-            .find(|b| b.hash().to_vec() == end_header_hash)
-            .map_or(0, |b| b.height);
+        let end_height = state2.tip_info.as_ref().map_or(0, |tip| {
+            tip.metadata.as_ref().map_or(0, |meta| meta.best_block_height())
+        });
         let state = self.state.clone();
         tokio::spawn(async move {
             let state = state.read().await;
@@ -254,6 +251,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
                     let response = SyncUtxosByBlockResponse {
                         blocks: blocks.clone(),
                         has_next_page,
+                        next_header_to_scan: vec![],
                     };
                     blocks.clear();
 

--- a/clients/rust/base_node_wallet_client/src/client/http.rs
+++ b/clients/rust/base_node_wallet_client/src/client/http.rs
@@ -252,18 +252,16 @@ impl BaseNodeWalletClient for Client {
     async fn sync_utxos_by_block(
         &self,
         start_header_hash: Vec<u8>,
-        end_header_hash: Vec<u8>,
         shutdown: ShutdownSignal,
     ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponse, anyhow::Error>>, anyhow::Error> {
         debug!(
             target: LOG_TARGET,
-            "Starting UTXO sync from {} to {}",
-            start_header_hash.to_hex(), end_header_hash.to_hex()
+            "Starting UTXO sync from {}",
+            start_header_hash.to_hex()
         );
         let mut target_url = self.http_server_address().await?.join("/sync_utxos_by_block")?;
         let (resp_tx, resp_rx) = mpsc::channel(1000);
         let start_header_hash_hex = start_header_hash.to_hex();
-        let end_header_hash_hex = end_header_hash.to_hex();
         let client = self.http_client.clone();
 
         let limit = 10;
@@ -277,8 +275,8 @@ impl BaseNodeWalletClient for Client {
                 }
                 target_url.set_query(Some(
                     format!(
-                        "start_header_hash={}&end_header_hash={}&limit={}&page={}",
-                        &start_header_hash_hex, &end_header_hash_hex, limit, page
+                        "start_header_hash={}&limit={}&page={}",
+                        &start_header_hash_hex, limit, page
                     )
                     .as_str(),
                 ));

--- a/clients/rust/base_node_wallet_client/src/client/mod.rs
+++ b/clients/rust/base_node_wallet_client/src/client/mod.rs
@@ -36,7 +36,6 @@ pub trait BaseNodeWalletClient: Send + Sync + Clone + 'static {
     async fn sync_utxos_by_block(
         &self,
         start_header_hash: Vec<u8>,
-        end_header_hash: Vec<u8>,
         shutdown: ShutdownSignal,
     ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponse, Error>>, Error>;
 


### PR DESCRIPTION
Description
---
we need to ensure the wallets scan in 10 block sections so that we can cache the results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved UTXO scanning with dynamic pagination, enabling smoother and more efficient wallet synchronization to the blockchain tip.
  * Added progress reporting and enhanced block caching during UTXO scanning.
  * Introduced a new pagination token to enhance synchronization continuity.

* **Refactor**
  * Simplified UTXO sync APIs by removing the need for an explicit end header, streamlining integration and usage for clients.
  * Updated scanning logic to iteratively sync to the tip, improving reliability and resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->