### PR TITLE
feat: add manual validation to peer db as command-line option

### DIFF
--- a/applications/minotari_console_wallet/src/cli.rs
+++ b/applications/minotari_console_wallet/src/cli.rs
@@ -107,6 +107,9 @@ pub struct Cli {
     /// Skip wallet recovery
     #[clap(long)]
     pub skip_recovery: bool,
+    /// This will validate the peer db, removing any invalid entries
+    #[clap(long, alias = "validate_peer_db")]
+    pub validate_peer_db: bool,
 }
 
 impl ConfigOverrideProvider for Cli {

--- a/applications/minotari_console_wallet/src/lib.rs
+++ b/applications/minotari_console_wallet/src/lib.rs
@@ -107,6 +107,7 @@ pub fn run_wallet(shutdown: &mut Shutdown, runtime: Runtime, config: &mut Applic
         birthday: None,
         libtor_data_dir: None,
         skip_recovery: false,
+        validate_peer_db: false,
     };
 
     run_wallet_with_cli(shutdown, runtime, config, cli)
@@ -194,6 +195,12 @@ pub fn run_wallet_with_cli(
         cli.non_interactive_mode,
         wallet_type,
     ))?;
+
+    if cli.validate_peer_db {
+        runtime
+            .block_on(wallet.dht_service.validate_all_peers())
+            .map_err(|e| ExitError::new(ExitCode::PeerDatabaseError, e))?;
+    }
 
     if !cli.non_interactive_mode &&
         config.wallet.transaction_service_config.transaction_routing_mechanism ==

--- a/applications/minotari_node/src/cli.rs
+++ b/applications/minotari_node/src/cli.rs
@@ -39,6 +39,9 @@ pub struct Cli {
     /// This will rebuild the db, adding block for block in
     #[clap(long, alias = "rebuild_db")]
     pub rebuild_db: bool,
+    /// This will validate the peer db, removing any invalid entries
+    #[clap(long, alias = "validate_peer_db")]
+    pub validate_peer_db: bool,
     /// Run in non-interactive mode, with no UI.
     #[clap(short, long, alias = "non-interactive", env = "TARI_NON_INTERACTIVE")]
     pub non_interactive_mode: bool,

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -95,6 +95,7 @@ pub async fn run_base_node(
         },
         init: true,
         rebuild_db: false,
+        validate_peer_db: false,
         non_interactive_mode: true,
         watch: None,
         profile_with_tokio_console: false,
@@ -153,6 +154,13 @@ pub async fn run_base_node_with_cli(
     let ctx =
         builder::configure_and_initialize_node(config.clone(), node_identity, shutdown.to_signal(), &readiness_handler)
             .await?;
+
+    if cli.validate_peer_db {
+        ctx.base_node_dht()
+            .validate_all_peers()
+            .await
+            .map_err(|e| ExitError::new(ExitCode::PeerDatabaseError, e))?;
+    }
 
     ctx.start()
         .map_err(|e| ExitError::new(ExitCode::DatabaseError, format!("Could not start database.{:?}", e)))?;

--- a/common/src/exit_codes.rs
+++ b/common/src/exit_codes.rs
@@ -132,6 +132,8 @@ pub enum ExitCode {
     TlsConfigurationError = 124,
     #[error("Unable to setup tari pulse")]
     TariPulseError = 125,
+    #[error("The application encountered a peer database error.")]
+    PeerDatabaseError = 126,
 }
 
 impl From<super::ConfigError> for ExitError {

--- a/comms/core/src/peer_manager/identity_signature.rs
+++ b/comms/core/src/peer_manager/identity_signature.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt::Display,
+};
 
 use blake2::Blake2b;
 use chrono::{DateTime, Utc};
@@ -29,7 +32,7 @@ use prost::Message;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use tari_crypto::hashing::DomainSeparatedHasher;
-use tari_utilities::{ByteArray, ByteArrayError};
+use tari_utilities::{hex::Hex, ByteArray, ByteArrayError};
 
 use super::hashing::{comms_core_peer_manager_domain, CommsCorePeerManagerDomain, IDENTITY_SIGNATURE};
 use crate::{
@@ -191,6 +194,19 @@ impl From<&IdentitySignature> for proto::identity::IdentitySignature {
             public_nonce: identity_sig.signature.get_compressed_public_nonce().to_vec(),
             updated_at: identity_sig.updated_at.timestamp(),
         }
+    }
+}
+
+impl Display for IdentitySignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "IdentitySignature {{ version: {}, updated_at: {}, signature: ({},{}) }}",
+            self.version,
+            self.updated_at,
+            self.signature.get_signature().to_hex(),
+            self.signature.get_compressed_public_nonce().to_hex()
+        )
     }
 }
 

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -92,6 +92,12 @@ impl PeerManager {
         Ok(())
     }
 
+    /// The peers with the specified node ids will be permanently deleted from the database.
+    pub async fn hard_delete_peers(&self, node_ids: &[NodeId]) -> Result<(), PeerManagerError> {
+        self.peer_storage_sql.hard_delete_peers(node_ids)?;
+        Ok(())
+    }
+
     /// Get all peers based on a list of their node_ids
     pub async fn get_peers_by_node_ids(&self, node_ids: &[NodeId]) -> Result<Vec<Peer>, PeerManagerError> {
         self.peer_storage_sql.get_peers_by_node_ids(node_ids)

--- a/comms/core/src/peer_manager/peer_identity_claim.rs
+++ b/comms/core/src/peer_manager/peer_identity_claim.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt::Display,
+};
 
 use multiaddr::Multiaddr;
 use serde_derive::{Deserialize, Serialize};
@@ -81,5 +84,15 @@ impl TryFrom<PeerIdentityMsg> for PeerIdentityClaim {
         } else {
             Err(PeerManagerError::MissingIdentitySignature)
         }
+    }
+}
+
+impl Display for PeerIdentityClaim {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PeerIdentityClaim {{ addresses: {:?}, features: {:?}, signature: {} }}",
+            self.addresses, self.features, self.signature
+        )
     }
 }

--- a/comms/core/src/peer_manager/peer_storage_sql.rs
+++ b/comms/core/src/peer_manager/peer_storage_sql.rs
@@ -102,6 +102,12 @@ impl PeerStorageSql {
         Ok(())
     }
 
+    /// The peers with the specified node ids will be permanently deleted from the database.
+    pub fn hard_delete_peers(&self, node_ids: &[NodeId]) -> Result<(), PeerManagerError> {
+        self.peer_db.hard_delete_peers(node_ids)?;
+        Ok(())
+    }
+
     /// Find the peer with the provided NodeID
     pub fn get_peer_by_node_id(&self, node_id: &NodeId) -> Result<Option<Peer>, PeerManagerError> {
         Ok(self.peer_db.get_peer_by_node_id(node_id)?)

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -761,6 +761,33 @@ impl PeerDatabaseSql {
         })
     }
 
+    /// Permanently remove peers from the database
+    pub fn hard_delete_peers(&self, node_ids: &[NodeId]) -> Result<Option<usize>, StorageError> {
+        if node_ids.is_empty() {
+            return Ok(None);
+        }
+        let mut conn = self.connection.get_pooled_connection()?;
+
+        let node_ids_hex = node_ids.iter().map(|id| id.to_hex()).collect::<Vec<_>>();
+
+        let deleted_count = conn.immediate_transaction::<_, StorageError, _>(|conn| {
+            diesel::delete(
+                multi_addresses::table.filter(
+                    multi_addresses::peer_id.eq_any(
+                        peers::table
+                            .filter(peers::node_id.eq_any(&node_ids_hex))
+                            .select(peers::peer_id),
+                    ),
+                ),
+            )
+            .execute(conn)?;
+
+            Ok(diesel::delete(peers::table.filter(peers::node_id.eq_any(&node_ids_hex))).execute(conn)?)
+        })?;
+
+        Ok(if deleted_count == 0 { None } else { Some(deleted_count) })
+    }
+
     /// Set the metadata for a peer, returning 'None' if the value was empty and the old value if the value was updated
     pub fn set_metadata(&self, node_id: &NodeId, key: u8, data: Vec<u8>) -> Result<Option<Vec<u8>>, StorageError> {
         let mut conn = self.connection.get_pooled_connection()?;
@@ -2496,6 +2523,53 @@ mod tests {
         let peer = peers_db.get_peer_by_node_id(&node_peers[5].node_id).unwrap().unwrap();
         assert_eq!(peer.metadata.get(&111).unwrap(), &[1, 2, 3]);
         assert_eq!(peer.metadata.get(&222).unwrap(), &[4, 5, 6]);
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_hard_delete_peers() {
+        let db_connection = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
+        let peers_db = PeerDatabaseSql::new(
+            db_connection,
+            &create_test_peer(false, PeerFeatures::COMMUNICATION_NODE),
+        )
+        .unwrap();
+
+        // Create new node peers
+        let mut node_peers = Vec::with_capacity(12);
+        for i in 0..12 {
+            let mut peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+            if i % 4 == 0 {
+                peer.flags = PeerFlags::SEED;
+            }
+            node_peers.push(peer.clone());
+            peers_db.add_or_update_peer(peer).unwrap();
+        }
+        // Create new wallet peers
+        let mut wallet_peers = Vec::with_capacity(12);
+        for _i in 0..12 {
+            let peer = create_test_peer(false, PeerFeatures::COMMUNICATION_CLIENT);
+            wallet_peers.push(peer.clone());
+            peers_db.add_or_update_peer(peer).unwrap();
+        }
+
+        // Hard delete some node peers
+        let peers_to_delete = vec![
+            node_peers[0].node_id.clone(),
+            node_peers[3].node_id.clone(),
+            node_peers[6].node_id.clone(),
+            node_peers[9].node_id.clone(),
+            wallet_peers[5].node_id.clone(),
+            wallet_peers[10].node_id.clone(),
+        ];
+
+        // Verify the peers were deleted
+        let number_deleted = peers_db.hard_delete_peers(&peers_to_delete).unwrap();
+        assert_eq!(number_deleted.unwrap(), peers_to_delete.len());
+        let all_peers = peers_db.get_all_peers(None).unwrap();
+        all_peers.iter().for_each(|peer| {
+            assert!(!peers_to_delete.contains(&peer.node_id));
+        });
     }
 
     #[test]

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -28,7 +28,7 @@ use tari_common_sqlite::{connection::DbConnection, error::StorageError};
 use tari_comms::{
     connectivity::ConnectivityRequester,
     message::{InboundMessage, OutboundMessage},
-    peer_manager::{NodeIdentity, PeerFeatures, PeerManager},
+    peer_manager::{NodeIdentity, PeerFeatures, PeerManager, PeerManagerError},
     pipeline::PipelineError,
 };
 use tari_shutdown::ShutdownSignal;
@@ -51,7 +51,9 @@ use crate::{
     network_discovery::DhtNetworkDiscovery,
     outbound,
     outbound::DhtOutboundRequest,
+    peer_validator::PeerValidator,
     rpc,
+    rpc::UnvalidatedPeerInfo,
     storage::MIGRATIONS,
     DedupLayer,
     DhtActorError,
@@ -72,6 +74,8 @@ pub enum DhtInitializationError {
     DhtActorInitializationError(#[from] DhtActorError),
     #[error("Builder error: no outbound message sender set")]
     BuilderNoOutboundMessageSender,
+    #[error("Peer manager error: {0}")]
+    PeerManagerError(#[from] PeerManagerError),
 }
 
 /// Responsible for starting the DHT actor, building the DHT middleware stack and as a factory
@@ -136,6 +140,58 @@ impl Dht {
         debug!(target: LOG_TARGET, "Dht initialization complete.");
 
         Ok(dht)
+    }
+
+    /// This function ensures that all peers in the peer manager database are valid
+    pub async fn validate_all_peers(&self) -> Result<(), DhtInitializationError> {
+        let peers = self.peer_manager.all(None).await?;
+        let peers_count = peers.len();
+        debug!(
+            target: LOG_TARGET,
+            "[Validate peer db] Starting peer validation for all ({}) peers in the peer db.",
+            peers_count,
+        );
+        let validator = PeerValidator::new(&self.config);
+        let mut invalid_peers = Vec::new();
+        for peer in peers {
+            trace!(
+                target: LOG_TARGET, "[Validate peer db] peer: '{}' / '{}' {}{} {:?}",
+                peer.node_id,
+                peer.public_key,
+                if peer.is_seed() { "S"} else { "_" },
+                if peer.features.is_node() { "N_"} else { "_W" },
+                peer.addresses,
+            );
+            let node_id = peer.node_id.clone();
+
+            if peer.addresses.addresses().iter().all(|addr| !addr.source().is_config()) {
+                let peer_to_validate = UnvalidatedPeerInfo::from_peer_limited_claims(
+                    peer,
+                    self.config.max_permitted_peer_claims,
+                    self.config.peer_validator_config.max_permitted_peer_addresses_per_claim,
+                );
+                if let Err(e) = validator.validate_peer(peer_to_validate, None) {
+                    warn!(
+                        target: LOG_TARGET,
+                        "[Validate peer db] Peer validation failed for peer '{}', deleting from peer db, Error: '{}'",
+                        node_id, e
+                    );
+                    invalid_peers.push(node_id);
+                }
+            }
+        }
+        if invalid_peers.is_empty() {
+            debug!(target: LOG_TARGET, "[Validate peer db] All ({}) peers in the peer db are valid.", peers_count);
+        } else {
+            self.peer_manager.hard_delete_peers(&invalid_peers).await?;
+            debug!(
+                target: LOG_TARGET,
+                "[Validate peer db] Removed {} invalid peers from the peer db: [{}]",
+                invalid_peers.len(),
+                invalid_peers.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", "),
+            );
+        }
+        Ok(())
     }
 
     pub fn builder() -> DhtBuilder {

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -55,8 +55,8 @@ impl<'a> PeerValidator<'a> {
         Self { config }
     }
 
-    /// Validates the new peer against the current peer database. Returning true if a new peer was added and false if
-    /// the peer already exists.
+    /// Validates a new peer candidate's peer information, optionally verifying against an existing peer. Returns a
+    /// Peer item if validation is successful, error otherwise.
     pub fn validate_peer(
         &self,
         new_peer: UnvalidatedPeerInfo,
@@ -106,21 +106,35 @@ impl<'a> PeerValidator<'a> {
         });
 
         for claim in new_peer.claims {
-            peer_validator::validate_peer_identity_claim(
+            match peer_validator::validate_peer_identity_claim(
                 &self.config.peer_validator_config,
                 &new_peer.public_key,
                 &claim,
-            )?;
-            peer.update_addresses(&claim.addresses, &PeerAddressSource::FromDiscovery {
-                peer_identity_claim: claim.clone(),
-            });
-            trace!(
-                target: LOG_TARGET,
-                "Peer '{}' / '{}' added with address(es) from claim: {:?}",
-                node_id,
-                new_peer.public_key.to_hex(),
-                claim.addresses
-            );
+            ) {
+                Ok(_) => {
+                    peer.update_addresses(&claim.addresses, &PeerAddressSource::FromDiscovery {
+                        peer_identity_claim: claim.clone(),
+                    });
+                    trace!(
+                        target: LOG_TARGET,
+                        "Peer '{}' / '{}' passed validation for claim: {:?}",
+                        node_id,
+                        new_peer.public_key.to_hex(),
+                        claim
+                    );
+                },
+                Err(e) => {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Peer '{}' / '{}' FAILED validation for claim: {:?}, error: {}",
+                        node_id,
+                        new_peer.public_key.to_hex(),
+                        claim,
+                        e
+                    );
+                    return Err(DhtPeerValidatorError::ValidatorError(e));
+                },
+            }
         }
 
         Ok(peer)

--- a/integration_tests/src/wallet_process.rs
+++ b/integration_tests/src/wallet_process.rs
@@ -235,6 +235,7 @@ pub fn get_default_cli() -> Cli {
         spend_key: None,
         libtor_data_dir: None,
         skip_recovery: false,
+        validate_peer_db: false,
     }
 }
 


### PR DESCRIPTION
Description
---
Added manual validation to the peer db upon base node or wallet startup using the `--validate-peer-db` command-line option. 

Motivation and Context
---
This allows a node to cleanse its peer db from invalid entries.

How Has This Been Tested?
---
Performed system-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to validate and clean the peer database in both the console wallet and node applications.
  * Peer database validation removes invalid peer entries before the application starts.

* **Improvements**
  * Enhanced error reporting with a new exit code for peer database errors.
  * Added user-friendly string representations for peer identity claims and signatures.

* **Bug Fixes**
  * Corrected parameter naming in peer information handling for improved clarity.

* **Tests**
  * Added tests to ensure permanent deletion of peers from the database works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->