### PR TITLE
fix: prevent duplicate block insert

### DIFF
--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -535,7 +535,7 @@ where
                     scanned_block.height.saturating_sub(SCANNED_BLOCK_CACHE_SIZE),
                     true,
                 )?;
-                if !last_saved_hash.map_or(false, |h| h == scanned_block.header_hash) {
+                if last_saved_hash != Some(scanned_block.header_hash) {
                     self.resources.db.save_scanned_block(scanned_block)?;
                 }
             }

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -422,6 +422,7 @@ where
         let mut total_value_recovered = MicroMinotari::zero();
         let mut blocks_scanned = 0;
         let mut starting_header_vec = start_header_hash.to_vec();
+        let mut last_saved_hash = None;
         loop {
             let mut utxo_stream = client
                 .sync_utxos_by_block(starting_header_vec.clone(), self.shutdown_signal.clone())
@@ -502,11 +503,7 @@ where
                                 block_hash.to_hex()
                             );
                             self.resources.db.save_scanned_block(scanned_block)?;
-                            self.resources.db.clear_scanned_blocks_before_height(
-                                current_height.saturating_sub(SCANNED_BLOCK_CACHE_SIZE),
-                                true,
-                            )?;
-
+                            last_saved_hash = Some(block_hash);
                             if current_height % PROGRESS_REPORT_INTERVAL == 0 {
                                 debug!(
                                     target: LOG_TARGET,
@@ -538,8 +535,11 @@ where
                     scanned_block.height.saturating_sub(SCANNED_BLOCK_CACHE_SIZE),
                     true,
                 )?;
-                self.resources.db.save_scanned_block(scanned_block)?;
+                if !last_saved_hash.map_or(false, |h| h == scanned_block.header_hash) {
+                    self.resources.db.save_scanned_block(scanned_block)?;
+                }
             }
+
             if starting_header_vec.is_empty() {
                 // No more blocks to scan
                 break;


### PR DESCRIPTION
This seems to happen in Tari Universe more than when running locally. The wallet runs and inserts a duplicate scanned block hash, then stops and waits for the next round of utxo scanning. In some cases this happens every 10 blocks, making wallet sync incredibly slow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the scanning process to prevent saving the same scanned block multiple times, reducing redundant database operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->