### PR TITLE
feat: add borsh serialisation and deserialisation to peer_db peer claim source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7583,6 +7583,7 @@ dependencies = [
  "async-trait",
  "bitflags 2.6.0",
  "blake2",
+ "borsh",
  "bytes 1.9.0",
  "chrono",
  "cidr",

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -65,6 +65,7 @@ tower = { version = "0.4", features = ["util"] }
 tracing = "0.1.26"
 yamux = "0.13.2"
 zeroize = "1"
+borsh = "1.5.7"
 
 [dev-dependencies]
 tari_test_utils = { workspace = true }

--- a/comms/core/src/net_address/multiaddr_with_stats.rs
+++ b/comms/core/src/net_address/multiaddr_with_stats.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::{NaiveDateTime, Utc};
 use log::trace;
 use multiaddr::Multiaddr;
@@ -386,7 +387,7 @@ impl Display for MultiaddrWithStats {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PeerAddressSource {
     Config,
     FromNodeIdentity {
@@ -467,7 +468,11 @@ impl PartialEq for PeerAddressSource {
 }
 #[cfg(test)]
 mod test {
+    use borsh::{BorshDeserialize, BorshSerialize};
+    use multiaddr::Multiaddr;
+
     use super::*;
+    use crate::peer_manager::{create_test_peer_identity_claim, PeerFeatures};
 
     #[test]
     fn test_update_latency() {
@@ -561,5 +566,29 @@ mod test {
         assert_eq!(another_addr.quality_score, None);
 
         assert_eq!(another_addr.cmp(&address), Ordering::Less);
+    }
+
+    #[test]
+    fn test_borsh_serialize_deserialize() {
+        for _i in 0..1000 {
+            let claim = create_test_peer_identity_claim(PeerFeatures::COMMUNICATION_NODE);
+
+            let source = PeerAddressSource::FromDiscovery {
+                peer_identity_claim: claim,
+            };
+
+            // Serialize the claim
+            let mut serialized_data = Vec::new();
+            BorshSerialize::serialize(&source, &mut serialized_data).unwrap();
+
+            // Deserialize the claim
+            let deserialized_source = PeerAddressSource::deserialize_reader(&mut serialized_data.as_slice()).unwrap();
+
+            // Assert equality
+            assert_eq!(
+                source, deserialized_source,
+                "Deserialized object does not match the original"
+            );
+        }
     }
 }

--- a/comms/core/src/peer_manager/identity_signature.rs
+++ b/comms/core/src/peer_manager/identity_signature.rs
@@ -20,9 +20,13 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    io::{Error as IoError, ErrorKind, Read, Result as IoResult, Write},
+};
 
 use blake2::Blake2b;
+use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::{DateTime, Utc};
 use digest::consts::U64;
 use prost::Message;
@@ -194,6 +198,44 @@ impl From<&IdentitySignature> for proto::identity::IdentitySignature {
     }
 }
 
+impl BorshSerialize for IdentitySignature {
+    fn serialize<W: Write>(&self, writer: &mut W) -> IoResult<()> {
+        BorshSerialize::serialize(&self.version, writer)?;
+
+        BorshSerialize::serialize(&self.signature.get_compressed_public_nonce().as_bytes(), writer)?;
+        BorshSerialize::serialize(&self.signature.get_signature().as_bytes(), writer)?;
+
+        BorshSerialize::serialize(&self.updated_at.timestamp(), writer)?;
+        BorshSerialize::serialize(&self.updated_at.timestamp_subsec_nanos(), writer)?;
+
+        Ok(())
+    }
+}
+
+impl BorshDeserialize for IdentitySignature {
+    fn deserialize_reader<R: Read>(reader: &mut R) -> IoResult<Self> {
+        let version = u8::deserialize_reader(reader)?;
+
+        let public_nonce_bytes = <Vec<u8>>::deserialize_reader(reader)?;
+        let signature_bytes = <Vec<u8>>::deserialize_reader(reader)?;
+        let public_nonce = CommsPublicKey::from_canonical_bytes(&public_nonce_bytes)
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e.to_string()))?;
+        let signature = CommsSecretKey::from_canonical_bytes(&signature_bytes)
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e.to_string()))?;
+
+        let timestamp = i64::deserialize_reader(reader)?;
+        let nanos = u32::deserialize_reader(reader)?;
+        let updated_at = chrono::DateTime::<Utc>::from_timestamp(timestamp, nanos)
+            .ok_or_else(|| IoError::new(ErrorKind::InvalidData, "Invalid timestamp"))?;
+
+        Ok(Self {
+            version,
+            signature: CompressedSignature::new(public_nonce, signature),
+            updated_at,
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
@@ -201,6 +243,7 @@ mod test {
     use tari_crypto::keys::SecretKey;
 
     use super::*;
+    use crate::peer_manager::{create_test_peer_identity_claim, PeerIdentityClaim};
 
     mod is_valid_for_peer {
         use super::*;
@@ -253,6 +296,28 @@ mod test {
             assert!(
                 !identity.is_valid(&public_key, tampered, [&address]).unwrap(),
                 "Signature is not valid"
+            );
+        }
+    }
+
+    #[test]
+    fn test_borsh_serialize_deserialize() {
+        for _i in 0..1000 {
+            let PeerIdentityClaim {
+                signature: identity, ..
+            } = create_test_peer_identity_claim(PeerFeatures::COMMUNICATION_NODE);
+
+            // Serialize the identity
+            let mut serialized_data = Vec::new();
+            borsh::BorshSerialize::serialize(&identity, &mut serialized_data).unwrap();
+
+            // Deserialize the identity
+            let deserialized_identity = IdentitySignature::deserialize_reader(&mut serialized_data.as_slice()).unwrap();
+
+            // Assert equality
+            assert_eq!(
+                identity, deserialized_identity,
+                "Deserialized object does not match the original"
             );
         }
     }

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -24,6 +24,8 @@ use std::{fmt, time::Duration};
 
 use multiaddr::Multiaddr;
 
+#[cfg(test)]
+use crate::peer_manager::create_test_peer_identity_claim;
 #[cfg(feature = "metrics")]
 use crate::peer_manager::metrics;
 use crate::{
@@ -394,6 +396,53 @@ pub fn create_test_peer(ban_flag: bool, features: PeerFeatures) -> Peer {
 
     let good_addresses = peer.addresses.borrow_mut();
     let good_address = good_addresses.addresses()[0].address().clone();
+    good_addresses.mark_last_seen_now(&good_address);
+
+    peer
+}
+
+#[cfg(test)]
+pub fn create_test_peer_with_claim(ban_flag: bool, features: PeerFeatures) -> Peer {
+    use std::borrow::BorrowMut;
+
+    use rand::rngs::OsRng;
+
+    use crate::peer_manager::{PeerFlags, PeerIdentityClaim};
+    let (_sk, pk) = CommsPublicKey::random_keypair(&mut OsRng);
+    let node_id = NodeId::from_key(&pk);
+
+    let PeerIdentityClaim {
+        addresses,
+        features,
+        signature,
+    } = create_test_peer_identity_claim(features);
+    let peer_identity_claim = PeerIdentityClaim {
+        addresses: addresses.clone(),
+        features,
+        signature,
+    };
+    let net_addresses =
+        MultiaddressesWithStats::from_addresses_with_source(addresses, &PeerAddressSource::FromDiscovery {
+            peer_identity_claim,
+        });
+
+    let mut peer = Peer::new(
+        pk,
+        node_id,
+        net_addresses,
+        PeerFlags::default(),
+        features,
+        Default::default(),
+        Default::default(),
+    );
+    if ban_flag {
+        peer.ban_for(Duration::from_secs(1000), "".to_string());
+    }
+
+    let good_addresses = peer.addresses.borrow_mut();
+    let good_address = good_addresses.addresses()[0].address().clone();
+    good_addresses.mark_last_seen_now(&good_address);
+    let good_address = good_addresses.addresses()[good_addresses.len() - 1].address().clone();
     good_addresses.mark_last_seen_now(&good_address);
 
     peer

--- a/comms/core/src/peer_manager/mod.rs
+++ b/comms/core/src/peer_manager/mod.rs
@@ -97,14 +97,16 @@ mod peer_id;
 pub use peer_id::{generate_peer_id_as_i64, PeerId};
 
 mod manager;
-#[cfg(test)]
-pub use manager::create_test_peer;
 pub use manager::PeerManager;
+#[cfg(test)]
+pub use manager::{create_test_peer, create_test_peer_with_claim};
 
 mod peer_storage_sql;
 pub use peer_storage_sql::{PeerStorageSql as PeerStorage, STALE_PEER_THRESHOLD_DURATION};
 
 mod peer_identity_claim;
+#[cfg(test)]
+pub use peer_identity_claim::create_test_peer_identity_claim;
 pub use peer_identity_claim::PeerIdentityClaim;
 
 mod or_not_found;

--- a/comms/core/src/peer_manager/peer_identity_claim.rs
+++ b/comms/core/src/peer_manager/peer_identity_claim.rs
@@ -22,6 +22,7 @@
 
 use std::convert::{TryFrom, TryInto};
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use multiaddr::Multiaddr;
 use serde_derive::{Deserialize, Serialize};
 use tari_utilities::ByteArrayError;
@@ -80,6 +81,116 @@ impl TryFrom<PeerIdentityMsg> for PeerIdentityClaim {
             })
         } else {
             Err(PeerManagerError::MissingIdentitySignature)
+        }
+    }
+}
+
+impl BorshSerialize for PeerIdentityClaim {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let addr_strings: Vec<String> = self.addresses.iter().map(|a| a.to_string()).collect();
+        addr_strings.serialize(writer)?;
+
+        self.features.bits().serialize(writer)?;
+
+        self.signature.serialize(writer)?;
+
+        Ok(())
+    }
+}
+
+impl BorshDeserialize for PeerIdentityClaim {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let addr_strings = Vec::<String>::deserialize_reader(reader)?;
+        let addresses = addr_strings
+            .into_iter()
+            .map(|s| s.parse::<Multiaddr>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+
+        let feature_bits = u32::deserialize_reader(reader)?;
+        let features = PeerFeatures::from_bits(feature_bits)
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid PeerFeatures bits"))?;
+
+        let signature = IdentitySignature::deserialize_reader(reader)?;
+
+        Ok(Self {
+            addresses,
+            features,
+            signature,
+        })
+    }
+}
+
+#[cfg(test)]
+pub fn create_test_peer_identity_claim(features: PeerFeatures) -> PeerIdentityClaim {
+    use std::str::FromStr;
+
+    use chrono::Utc;
+    use multiaddr::Multiaddr;
+    use rand::{rngs::OsRng, Rng};
+    use tari_crypto::keys::SecretKey;
+
+    use crate::{
+        peer_manager::{IdentitySignature, PeerIdentityClaim},
+        types::CommsSecretKey,
+    };
+
+    let secret = CommsSecretKey::random(&mut OsRng);
+    let address_1 = Multiaddr::from_str(&format!(
+        "/ip4/127.0.0.1/tcp/{}",
+        rand::thread_rng().gen_range(5000..9000)
+    ))
+    .unwrap();
+    let address_2 = Multiaddr::from_str(&format!(
+        "/ip4/54.36.113.0/tcp/{}",
+        rand::thread_rng().gen_range(5000..9000)
+    ))
+    .unwrap();
+    let address_3 = Multiaddr::from_str(&format!(
+        "/ip6/2001:41d0:40d:4300::/tcp/{}",
+        rand::thread_rng().gen_range(5000..9000)
+    ))
+    .unwrap();
+    let address_4 = Multiaddr::from_str(&format!(
+        "/onion3/bukg4svrs4r3hdtx4s2vle6ekipi4v7bshenfwjalymvax7akivyhkyd:{}",
+        rand::thread_rng().gen_range(5000..9000)
+    ))
+    .unwrap();
+    let updated_at = Utc::now();
+    let addresses = vec![address_1, address_2, address_3, address_4];
+    let signature = IdentitySignature::sign_new(&secret, features, &addresses, updated_at);
+
+    PeerIdentityClaim {
+        addresses,
+        features,
+        signature,
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use borsh::{BorshDeserialize, BorshSerialize};
+
+    use crate::peer_manager::{create_test_peer_identity_claim, PeerFeatures, PeerIdentityClaim};
+
+    #[test]
+    fn test_borsh_serialize_deserialize() {
+        for _i in 0..1000 {
+            let claim = create_test_peer_identity_claim(PeerFeatures::COMMUNICATION_NODE);
+
+            // Serialize the claim
+            let mut serialized_data = Vec::new();
+            BorshSerialize::serialize(&claim, &mut serialized_data).unwrap();
+
+            // Deserialize the claim
+            let deserialized_claim = PeerIdentityClaim::deserialize_reader(&mut serialized_data.as_slice()).unwrap();
+
+            // Assert equality
+            assert_eq!(
+                claim, deserialized_claim,
+                "Deserialized object does not match the original"
+            );
         }
     }
 }

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -1749,7 +1749,13 @@ impl From<&MultiaddrWithStats> for UpdateMultiaddrWithStatsSql {
             quality_score: address.quality_score(),
             source: Some({
                 let mut serialized_data = Vec::new();
-                BorshSerialize::serialize(address.source(), &mut serialized_data).unwrap_or_default();
+                if let Err(e) = BorshSerialize::serialize(address.source(), &mut serialized_data) {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Could not serialize address source '{}', using default: {}",
+                        address.source(), e,
+                    );
+                }
                 serialized_data
             }),
         }

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -22,6 +22,7 @@
 
 use std::{cmp::min, collections::HashMap, str::FromStr, time::Duration};
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use bytes::Bytes;
 use chrono::{NaiveDateTime, TimeDelta};
 use diesel::{
@@ -562,8 +563,11 @@ impl PeerDatabaseSql {
                 last_attempted: address.last_attempted(),
                 last_failed_reason: address.last_failed_reason().map(|s| s.to_string()),
                 quality_score: address.quality_score(),
-                source: serde_json::to_string(&address.source())
-                    .map_err(|err| StorageError::UnexpectedResult(err.to_string()))?,
+                source: {
+                    let mut serialized_data = Vec::new();
+                    BorshSerialize::serialize(address.source(), &mut serialized_data)?;
+                    serialized_data
+                },
             });
         }
 
@@ -664,10 +668,11 @@ impl PeerDatabaseSql {
                 last_attempted: address.last_attempted(),
                 last_failed_reason: address.last_failed_reason().map(|s| s.to_string()),
                 quality_score: address.quality_score(),
-                source: Some(
-                    serde_json::to_string(&address.source())
-                        .map_err(|err| StorageError::UnexpectedResult(err.to_string()))?,
-                ),
+                source: Some({
+                    let mut serialized_data = Vec::new();
+                    BorshSerialize::serialize(address.source(), &mut serialized_data)?;
+                    serialized_data
+                }),
             });
         }
 
@@ -1650,7 +1655,7 @@ pub struct NewMultiaddrWithStatsSql {
     pub last_attempted: Option<chrono::NaiveDateTime>,
     pub last_failed_reason: Option<String>,
     pub quality_score: Option<i32>,
-    pub source: String,
+    pub source: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Selectable, Queryable, AsChangeset, PartialEq, Eq)]
@@ -1666,7 +1671,7 @@ pub struct UpdateMultiaddrWithStatsSql {
     pub last_attempted: Option<chrono::NaiveDateTime>,
     pub last_failed_reason: Option<String>,
     pub quality_score: Option<i32>,
-    pub source: Option<String>,
+    pub source: Option<Vec<u8>>,
 }
 
 /// Serialize the protocols into a comma-separated string
@@ -1742,7 +1747,11 @@ impl From<&MultiaddrWithStats> for UpdateMultiaddrWithStatsSql {
             last_attempted: address.last_attempted(),
             last_failed_reason: address.last_failed_reason().map(|v| v.to_string()),
             quality_score: address.quality_score(),
-            source: Some(serde_json::to_string(&address.source()).unwrap_or_default()),
+            source: Some({
+                let mut serialized_data = Vec::new();
+                BorshSerialize::serialize(address.source(), &mut serialized_data).unwrap_or_default();
+                serialized_data
+            }),
         }
     }
 }
@@ -1803,7 +1812,7 @@ impl TryFrom<Vec<NewMultiaddrWithStatsSql>> for MultiaddressesWithStats {
                 addr.last_attempted,
                 addr.last_failed_reason,
                 addr.quality_score,
-                serde_json::from_str(&addr.source).map_err(StorageError::JsonError)?,
+                PeerAddressSource::deserialize_reader(&mut addr.source.as_slice())?,
             );
             addresses.push(address);
         }
@@ -1844,6 +1853,7 @@ mod tests {
         net_address::{MultiaddressesWithStats, PeerAddressSource},
         peer_manager::{
             create_test_peer,
+            create_test_peer_with_claim,
             database::{NewMultiaddrWithStatsSql, NewPeerSql, PeerDatabaseSql, MIGRATIONS},
             storage::{
                 database::{duration_to_i64_ms_infallible, u32_to_i32_infallible},
@@ -2452,6 +2462,29 @@ mod tests {
         let peer = peers_db.get_peer_by_node_id(&node_peers[5].node_id).unwrap().unwrap();
         assert_eq!(peer.metadata.get(&111).unwrap(), &[1, 2, 3]);
         assert_eq!(peer.metadata.get(&222).unwrap(), &[4, 5, 6]);
+    }
+    #[test]
+    fn test_consistent_peer_claim_serialize_deserialize() {
+        let db_connection = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
+        let peers_db = PeerDatabaseSql::new(
+            db_connection,
+            &create_test_peer(false, PeerFeatures::COMMUNICATION_NODE),
+        )
+        .unwrap();
+
+        // Create new node peers
+        let mut original_peers = Vec::with_capacity(5);
+        for _i in 0..1000 {
+            let peer = create_test_peer_with_claim(false, PeerFeatures::COMMUNICATION_NODE);
+            original_peers.push(peer.clone());
+            peers_db.add_or_update_peer(peer).unwrap();
+        }
+
+        for peer in &mut original_peers {
+            let peer_from_db = peers_db.get_peer_by_node_id(&peer.node_id).unwrap().unwrap();
+            peer.id = peer_from_db.id;
+            assert_eq!(&peer_from_db, peer);
+        }
     }
 
     #[test]

--- a/comms/core/src/peer_manager/storage/migrations/2025-07-21-170500_peer_address_source/down.sql
+++ b/comms/core/src/peer_manager/storage/migrations/2025-07-21-170500_peer_address_source/down.sql
@@ -1,0 +1,4 @@
+-- Note: No rollback form this migration as `source -> Text,` could not reliably be converted to `source -> Binary`
+-- in the up migration.
+
+-- Nothing to do here

--- a/comms/core/src/peer_manager/storage/migrations/2025-07-21-170500_peer_address_source/up.sql
+++ b/comms/core/src/peer_manager/storage/migrations/2025-07-21-170500_peer_address_source/up.sql
@@ -1,0 +1,53 @@
+-- Note: `source -> Text,` cannot reliably be converted to `source -> Binary`, so we drop both tables and recreate them
+
+-- Table for Peer
+DROP TABLE peers;
+
+CREATE TABLE peers (
+    peer_id BIGINT PRIMARY KEY NOT NULL,
+    public_key TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    distance_to_self TEXT NOT NULL,
+    flags INTEGER NOT NULL,
+    banned_until TIMESTAMP,
+    banned_reason TEXT,
+    features INTEGER NOT NULL,
+    supported_protocols TEXT NOT NULL,
+    added_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_agent TEXT NOT NULL,
+    metadata BLOB,
+    deleted_at TIMESTAMP,
+
+    CONSTRAINT unique_public_key UNIQUE (public_key),
+    CONSTRAINT unique_node_id UNIQUE (node_id)
+);
+
+CREATE INDEX idx_node_id ON peers (node_id);
+CREATE INDEX idx_banned_until ON peers (banned_until);
+CREATE INDEX idx_deleted_at ON peers (deleted_at);
+CREATE INDEX idx_distance_to_self ON peers (distance_to_self);
+
+-- Table for MultiaddressesWithStats
+DROP TABLE multi_addresses;
+
+CREATE TABLE multi_addresses (
+    address_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    peer_id BIGINT NOT NULL,
+    address TEXT NOT NULL,
+    last_seen TIMESTAMP,
+    connection_attempts INTEGER,
+    avg_initial_dial_time BIGINT,
+    initial_dial_time_sample_count INTEGER,
+    avg_latency BIGINT,
+    latency_sample_count INTEGER,
+    last_attempted TIMESTAMP,
+    last_failed_reason TEXT,
+    quality_score INTEGER,
+    source BLOB NOT NULL,
+
+    FOREIGN KEY (peer_id) REFERENCES peers (peer_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_last_seen ON multi_addresses (last_seen);
+CREATE INDEX idx_last_failed_reason ON multi_addresses (last_failed_reason);
+CREATE INDEX idx_peer_id ON multi_addresses (peer_id);

--- a/comms/core/src/peer_manager/storage/schema.rs
+++ b/comms/core/src/peer_manager/storage/schema.rs
@@ -43,7 +43,7 @@ table! {
         last_attempted -> Nullable<Timestamp>,
         last_failed_reason -> Nullable<Text>,
         quality_score -> Nullable<Integer>,
-        source -> Text,
+        source -> Binary,
     }
 }
 


### PR DESCRIPTION
Description
---
Added Borsh serialisation/deserialisation to the peer_db's MultiaddrWithStats peer source field in favour of using `serde_json`. 

See #7306 - further system-level monitoring is needed to verify that this was the root cause.

Motivation and Context
---
Serde (`serde_json`) conversion was not always successful - validated peer info would be added to the database, then, very rarely, the data would be skewed when either written to or read from the database, so that peer validation fails due to claim signature validation failure, most likely the `updated_at: DateTime<Utc>` field. 

It was easy to detect invalid peer info sent over the wire from sync peers as the invalidated data is present in almost all peer dbs, but difficult to sumulate invalid data in the local test peer db. Starting with a fresh peer db each time, initial peer sync had to be done many times to capture a bad peer db instance where validation afterwards would fail. In the case presented here,  ~0.4% of the entries was invalid.

The example below shows a valid peer info added to the database, but when read back to validate, it fails with the 2nd address.
```rust
2025-07-21 12:06:42.378104700 [comms::dht] TRACE [Validate peer db] peer: '193cdfa4bda140a44b11785365' / '2225da7b8e01debb3bf65a263bcf47bd49f69773ce7b59c04ae43f5838bbd11b' __W MultiaddressesWithStats { addresses: [MultiaddrWithStats { address: "/ip4/127.0.0.1/tcp/41907", last_seen: None, connection_attempts: 0, avg_initial_dial_time: None, initial_dial_time_sample_count: 0, avg_latency: None, latency_sample_count: 0, last_attempted: None, last_failed_reason: None, quality_score: None, source: FromDiscovery { peer_identity_claim: PeerIdentityClaim { addresses: ["/ip4/127.0.0.1/tcp/41907"], features: PeerFeatures(0x0), signature: IdentitySignature { version: 0, signature: CompressedSchnorrSignature { public_nonce: 821e9d504cb756d64d2ed2f2612b5fdab8a627cbc1d7d7b24c5fc3ffb13e6a28, signature: RistrettoSecretKey(***), _phantom: PhantomData<tari_crypto::signatures::schnorr::SchnorrSigChallenge> }, updated_at: 2025-07-21T08:23:13Z } } } }, MultiaddrWithStats { address: "/ip4/127.0.0.1/tcp/43047", last_seen: None, connection_attempts: 0, avg_initial_dial_time: None, initial_dial_time_sample_count: 0, avg_latency: None, latency_sample_count: 0, last_attempted: None, last_failed_reason: None, quality_score: None, source: FromDiscovery { peer_identity_claim: PeerIdentityClaim { addresses: ["/ip4/127.0.0.1/tcp/43047"], features: PeerFeatures(0x0), signature: IdentitySignature { version: 0, signature: CompressedSchnorrSignature { public_nonce: 2e1b1a2dd32792a84ab6ee47baa5b66abe83ff950cd2410ff1ab2ecfedc05753, signature: RistrettoSecretKey(***), _phantom: PhantomData<tari_crypto::signatures::schnorr::SchnorrSigChallenge> }, updated_at: 2025-07-21T08:48:18Z } } } }] }
2025-07-21 12:06:42.378314700 [dht::network_discovery::peer_validator] TRACE Peer '193cdfa4bda140a44b11785365' / '2225da7b8e01debb3bf65a263bcf47bd49f69773ce7b59c04ae43f5838bbd11b' passed validation for claim: PeerIdentityClaim { addresses: ["/ip4/127.0.0.1/tcp/41907"], features: PeerFeatures(0x0), signature: IdentitySignature { version: 0, signature: CompressedSchnorrSignature { public_nonce: 821e9d504cb756d64d2ed2f2612b5fdab8a627cbc1d7d7b24c5fc3ffb13e6a28, signature: RistrettoSecretKey(***), _phantom: PhantomData<tari_crypto::signatures::schnorr::SchnorrSigChallenge> }, updated_at: 2025-07-21T08:23:13Z } }
2025-07-21 12:06:42.378393900 [dht::network_discovery::peer_validator] TRACE Peer '193cdfa4bda140a44b11785365' / '2225da7b8e01debb3bf65a263bcf47bd49f69773ce7b59c04ae43f5838bbd11b' FAILED validation for claim: PeerIdentityClaim { addresses: ["/ip4/127.0.0.1/tcp/43047"], features: PeerFeatures(0x0), signature: IdentitySignature { version: 0, signature: CompressedSchnorrSignature { public_nonce: 2e1b1a2dd32792a84ab6ee47baa5b66abe83ff950cd2410ff1ab2ecfedc05753, signature: RistrettoSecretKey(***), _phantom: PhantomData<tari_crypto::signatures::schnorr::SchnorrSigChallenge> }, updated_at: 2025-07-21T08:48:18Z } }, error: Peer signature was invalid for peer '193cdfa4bda140a44b11785365'
2025-07-21 12:06:42.378410300 [comms::dht] WARN  [Validate peer db] Peer validation failed for peer '193cdfa4bda140a44b11785365', deleting from peer db, Error: 'Peer signature was invalid for peer '193cdfa4bda140a44b11785365''
```

How Has This Been Tested?
---
Added unit tests.
System-level testing.
To be monitored.

What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for Borsh serialization and deserialization to peer identity and address data, improving data handling efficiency.
  * Introduced new test utilities for peer creation and identity claims to streamline testing.

* **Bug Fixes**
  * Ensured consistent serialization and deserialization of peer claims and addresses, verified by new automated tests.

* **Tests**
  * Added comprehensive tests validating Borsh serialization round-trips for peer-related entities.
  * Added tests verifying database serialization consistency for peer claims.

* **Chores**
  * Updated database schema and migration scripts to store peer address sources in binary format instead of text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->