### PR TITLE
feat: add tolerance for invalid peer info while busy with peer sync

### DIFF
--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -332,8 +332,8 @@ database_url = "data/base_node/dht.db"
 #network_discovery.bootstrap_timeout = 300 # 5 * 60
 # The number of banable offenses this node will tolerate while syncing peers before the sync peer will be banned.
 # Any banable offense will be punished after syc completes or when the threshold is reached; this will let a node
-# accept valid peers in the presence of banable offenses. (Default: 15)
-#network_discovery.peer_sync_immediate_ban_threshold = 15
+# accept valid peers in the presence of banable offenses. (Default: 100)
+#network_discovery.peer_sync_immediate_ban_threshold = 100
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 #ban_duration = 21_600 # 6 * 60 * 60

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -330,6 +330,10 @@ database_url = "data/base_node/dht.db"
 #network_discovery.bootstrap_rpc_streaming_timeout = 5
 # Maximum time to wait for bootstrap to complete before forcing completion (Default: 5 minutes (300 second))
 #network_discovery.bootstrap_timeout = 300 # 5 * 60
+# The number of banable offenses this node will tolerate while syncing peers before the sync peer will be banned.
+# Any banable offense will be punished after syc completes or when the threshold is reached; this will let a node
+# accept valid peers in the presence of banable offenses. (Default: 15)
+#network_discovery.peer_sync_immediate_ban_threshold = 15
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 #ban_duration = 21_600 # 6 * 60 * 60

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -378,8 +378,8 @@ network_discovery.initial_peer_sync_delay = 25
 #network_discovery.bootstrap_timeout = 300 # 5 * 60
 # The number of banable offenses this node will tolerate while syncing peers before the sync peer will be banned.
 # Any banable offense will be punished after syc completes or when the threshold is reached; this will let a node
-# accept valid peers in the presence of banable offenses. (Default: 15)
-#network_discovery.peer_sync_immediate_ban_threshold = 15
+# accept valid peers in the presence of banable offenses. (Default: 100)
+#network_discovery.peer_sync_immediate_ban_threshold = 100
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 ban_duration = 120 # 2 mins

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -376,6 +376,10 @@ network_discovery.initial_peer_sync_delay = 25
 #network_discovery.bootstrap_rpc_streaming_timeout = 5
 # Maximum time to wait for bootstrap to complete before forcing completion (Default: 5 minutes (300 second))
 #network_discovery.bootstrap_timeout = 300 # 5 * 60
+# The number of banable offenses this node will tolerate while syncing peers before the sync peer will be banned.
+# Any banable offense will be punished after syc completes or when the threshold is reached; this will let a node
+# accept valid peers in the presence of banable offenses. (Default: 15)
+#network_discovery.peer_sync_immediate_ban_threshold = 15
 
 # Length of time to ban a peer if the peer misbehaves at the DHT-level. Default: 6 hrs
 ban_duration = 120 # 2 mins

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -136,17 +136,6 @@ pub enum OffenceSeverity {
     High,
 }
 
-impl OffenceSeverity {
-    /// Compare two OffenceSeverity values and return the maximum severity
-    pub fn max(self, other: OffenceSeverity) -> OffenceSeverity {
-        match (self, other) {
-            (OffenceSeverity::High, _) | (_, OffenceSeverity::High) => OffenceSeverity::High,
-            (OffenceSeverity::Medium, _) | (_, OffenceSeverity::Medium) => OffenceSeverity::Medium,
-            _ => OffenceSeverity::Low,
-        }
-    }
-}
-
 impl Display for DhtRequest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         #[allow(clippy::enum_glob_use)]

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -129,11 +129,22 @@ pub enum DhtRequest {
     },
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub enum OffenceSeverity {
     Low,
     Medium,
     High,
+}
+
+impl OffenceSeverity {
+    /// Compare two OffenceSeverity values and return the maximum severity
+    pub fn max(self, other: OffenceSeverity) -> OffenceSeverity {
+        match (self, other) {
+            (OffenceSeverity::High, _) | (_, OffenceSeverity::High) => OffenceSeverity::High,
+            (OffenceSeverity::Medium, _) | (_, OffenceSeverity::Medium) => OffenceSeverity::Medium,
+            _ => OffenceSeverity::Low,
+        }
+    }
 }
 
 impl Display for DhtRequest {

--- a/comms/dht/src/network_discovery/config.rs
+++ b/comms/dht/src/network_discovery/config.rs
@@ -101,6 +101,12 @@ pub struct NetworkDiscoveryConfig {
     #[serde(default)]
     #[serde(with = "serializers::seconds")]
     pub bootstrap_timeout: Duration,
+    /// The number of banable offenses this node will tolerate while syncing peers before the sync peer will be banned.
+    /// Any banable offense will be punished after syc completes or when the threshold is reached; this will let a node
+    /// accept valid peers in the presence of banable offenses.
+    /// Default: 15
+    #[serde(default)]
+    pub peer_sync_immediate_ban_threshold: usize,
 }
 
 impl Default for NetworkDiscoveryConfig {
@@ -122,6 +128,7 @@ impl Default for NetworkDiscoveryConfig {
             bootstrap_rpc_get_peers_stream_timeout: Duration::from_secs(5),
             bootstrap_rpc_streaming_timeout: Duration::from_secs(5),
             bootstrap_timeout: Duration::from_secs(300), // 5 minutes
+            peer_sync_immediate_ban_threshold: 15,
         }
     }
 }

--- a/comms/dht/src/network_discovery/config.rs
+++ b/comms/dht/src/network_discovery/config.rs
@@ -104,7 +104,7 @@ pub struct NetworkDiscoveryConfig {
     /// The number of banable offenses this node will tolerate while syncing peers before the sync peer will be banned.
     /// Any banable offense will be punished after syc completes or when the threshold is reached; this will let a node
     /// accept valid peers in the presence of banable offenses.
-    /// Default: 15
+    /// Default: 25
     #[serde(default)]
     pub peer_sync_immediate_ban_threshold: usize,
 }
@@ -128,7 +128,9 @@ impl Default for NetworkDiscoveryConfig {
             bootstrap_rpc_get_peers_stream_timeout: Duration::from_secs(5),
             bootstrap_rpc_streaming_timeout: Duration::from_secs(5),
             bootstrap_timeout: Duration::from_secs(300), // 5 minutes
-            peer_sync_immediate_ban_threshold: 15,
+            // This number is high to account for the big number of invalid peer info sets received from all sync peers
+            // due to an embedded error in the peer manager. When solved, this number can be reduced.
+            peer_sync_immediate_ban_threshold: 25,
         }
     }
 }

--- a/comms/dht/src/network_discovery/config.rs
+++ b/comms/dht/src/network_discovery/config.rs
@@ -103,8 +103,8 @@ pub struct NetworkDiscoveryConfig {
     pub bootstrap_timeout: Duration,
     /// The number of banable offenses this node will tolerate while syncing peers before the sync peer will be banned.
     /// Any banable offense will be punished after syc completes or when the threshold is reached; this will let a node
-    /// accept valid peers in the presence of banable offenses.
-    /// Default: 25
+    /// accept valid peers in the presence of ban-able offenses.
+    /// Default: 100
     #[serde(default)]
     pub peer_sync_immediate_ban_threshold: usize,
 }
@@ -128,9 +128,10 @@ impl Default for NetworkDiscoveryConfig {
             bootstrap_rpc_get_peers_stream_timeout: Duration::from_secs(5),
             bootstrap_rpc_streaming_timeout: Duration::from_secs(5),
             bootstrap_timeout: Duration::from_secs(300), // 5 minutes
-            // This number is high to account for the big number of invalid peer info sets received from all sync peers
-            // due to an embedded error in the peer manager. When solved, this number can be reduced.
-            peer_sync_immediate_ban_threshold: 25,
+            // Note: This number is high to account for the big number of invalid peer info sets received from all sync
+            //       peers due to an embedded error in the peer manager. When solved, this number can be reduced.
+            //       See: https://github.com/tari-project/tari/issues/7306
+            peer_sync_immediate_ban_threshold: 100,
         }
     }
 }

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -115,7 +115,7 @@ impl Discovering {
     pub async fn next_event(&mut self) -> StateEvent {
         debug!(
             target: LOG_TARGET,
-            "Starting network discovery with params {}", self.params
+            "Discovering: Starting network discovery with params {}", self.params
         );
 
         if let Err(err) = self.initialize().await {
@@ -128,14 +128,14 @@ impl Discovering {
                 Ok(conn) => {
                     let peer_node_id = conn.peer_node_id().clone();
                     self.stats.sync_peers.push(peer_node_id.clone());
-                    debug!(target: LOG_TARGET, "Attempting to sync from peer `{}`", peer_node_id);
+                    debug!(target: LOG_TARGET, "Discovering: Attempting to sync from peer `{}`", peer_node_id);
 
                     if self.request_from_peers(conn).await.is_ok() {
                         self.stats.num_succeeded += 1;
                     }
                 },
                 Err(err) => {
-                    debug!(target: LOG_TARGET, "Failed to connect to sync peer candidate: {}", err);
+                    debug!(target: LOG_TARGET, "Discovering: Failed to connect to sync peer candidate: {}", err);
                 },
             }
         }
@@ -150,7 +150,7 @@ impl Discovering {
             Ok(Ok(client)) => {
                 trace!(
                     target: LOG_TARGET,
-                    "Successfully connected RPC client to sync peer '{}'",
+                    "Discovering: Successfully connected RPC client to sync peer '{}'",
                     conn.peer_node_id()
                 );
                 client
@@ -158,7 +158,7 @@ impl Discovering {
             Ok(Err(e)) => {
                 error!(
                     target: LOG_TARGET,
-                    "Failed to connect RPC client to sync peer {}: {}",
+                    "Discovering: Failed to connect RPC client to sync peer {}: {}",
                     conn.peer_node_id(),
                     e
                 );
@@ -167,7 +167,7 @@ impl Discovering {
             Err(_) => {
                 error!(
                     target: LOG_TARGET,
-                    "RPC connect_rpc to seed '{}' timed out after {:?}",
+                    "Discovering: RPC connect_rpc to sync peer '{}' timed out after {:?}",
                     conn.peer_node_id(),
                     rpc_connect_timeout,
                 );
@@ -182,7 +182,7 @@ impl Discovering {
 
         debug!(
             target: LOG_TARGET,
-            "Established RPC connection to peer `{}`", peer_node_id
+            "Discovering: Established RPC connection to sync peer `{}`", peer_node_id
         );
         let result = self.request_peers(peer_node_id, client).await;
         self.ban_on_offence(peer_node_id.clone(), result).await?;
@@ -202,7 +202,10 @@ impl Discovering {
                 n: self.params.num_peers_to_request,
                 include_clients: true,
                 max_claims: self.config().max_permitted_peer_claims.try_into().unwrap_or_else(|_| {
-                    error!(target: LOG_TARGET, "Node configured to accept more than u32::MAX claims per peer");
+                    error!(
+                        target: LOG_TARGET,
+                        "Discovering: Node configured to accept more than u32::MAX claims per peer"
+                    );
                     u32::MAX
                 }),
                 max_addresses_per_claim: self
@@ -211,7 +214,10 @@ impl Discovering {
                     .max_permitted_peer_addresses_per_claim
                     .try_into()
                     .unwrap_or_else(|_| {
-                        error!(target: LOG_TARGET, "Node configured to accept more than u32::MAX addresses per claim");
+                        error!(
+                            target: LOG_TARGET,
+                            "Discovering: Node configured to accept more than u32::MAX addresses per claim"
+                        );
                         u32::MAX
                     }),
             }),
@@ -222,7 +228,7 @@ impl Discovering {
             Ok(Ok(stream)) => {
                 debug!(
                     target: LOG_TARGET,
-                    "Successfully initiated get_peers stream from sync peer '{}'",
+                    "Discovering: Successfully initiated get_peers stream from sync peer '{}'",
                     sync_peer
                 );
                 stream
@@ -230,7 +236,8 @@ impl Discovering {
             Ok(Err(e)) => {
                 error!(
                     target: LOG_TARGET,
-                    "Failed to initiate get_peers stream from sync peer '{}': {}. This sync peer will be skipped.",
+                    "Discovering: Failed to initiate get_peers stream from sync peer '{}': {}. This sync peer will be \
+                    skipped.",
                     sync_peer,
                     e
                 );
@@ -239,7 +246,7 @@ impl Discovering {
             Err(_) => {
                 error!(
                     target: LOG_TARGET,
-                    "RPC get_peers from sunc '{}' timed out after {:?}",
+                    "Discovering: RPC get_peers from sync '{}' timed out after {:?}",
                     sync_peer, rpc_get_peers_stream_timeout
                 );
                 return Err(NetworkDiscoveryError::Timeout {
@@ -272,7 +279,7 @@ impl Discovering {
     async fn request_peers(&mut self, sync_peer: &NodeId, client: rpc::DhtClient) -> Result<(), NetworkDiscoveryError> {
         debug!(
             target: LOG_TARGET,
-            "Requesting {} peers from `{}`",
+            "Discovering: Requesting {} peers from `{}`",
             self.params.num_peers_to_request,
             sync_peer
         );
@@ -285,13 +292,14 @@ impl Discovering {
         while let Some(resp) = self.get_peer_response(&mut stream, sync_peer).await? {
             counter += 1;
             if counter > self.params.num_peers_to_request {
-                warn!(target: LOG_TARGET, "Sync peer `{}` sent more peers than we requested.", sync_peer);
+                warn!(target: LOG_TARGET, "Discovering: Sync peer `{}` sent more peers than we requested.", sync_peer);
                 return Err(NetworkDiscoveryError::TooManyPeersReceived);
             }
             if invalid_peer_signatures >= peer_sync_immediate_ban_threshold {
                 warn!(
                       target: LOG_TARGET,
-                     "Too many ban-able offences ({} of {}) received from peer `{}`. Stopping further processing.",
+                     "Discovering: Too many ban-able offences ({} of {}) received from peer `{}`. Stopping further \
+                     processing.",
                       peer_sync_immediate_ban_threshold, counter, sync_peer
                 );
                 return Err(NetworkDiscoveryError::BanableOffencesWhileSyncing(
@@ -301,7 +309,11 @@ impl Discovering {
             let GetPeersResponse { peer } = match resp {
                 Ok(val) => val,
                 Err(err) => {
-                    warn!(target: LOG_TARGET, "Sync peer `{}` sent invalid response: {:?}", sync_peer, err);
+                    warn!(
+                        target: LOG_TARGET,
+                        "Discovering: Sync peer `{}` sent invalid response: {:?}",
+                        sync_peer, err
+                    );
                     return Err(NetworkDiscoveryError::from(err));
                 },
             };
@@ -309,7 +321,10 @@ impl Discovering {
             let peer = match peer.ok_or_else(|| NetworkDiscoveryError::EmptyPeerMessageReceived) {
                 Ok(val) => val,
                 Err(err) => {
-                    warn!(target: LOG_TARGET, "Sync peer `{}` sent an empty peer message: {:?}", sync_peer, err);
+                    warn!(
+                        target: LOG_TARGET, "Discovering: Sync peer `{}` sent an empty peer message: {:?}",
+                        sync_peer, err
+                    );
                     return Err(err);
                 },
             };
@@ -317,19 +332,23 @@ impl Discovering {
                 match peer.try_into().map_err(NetworkDiscoveryError::InvalidPeerDataReceived) {
                     Ok(val) => val,
                     Err(err) => {
-                        warn!(target: LOG_TARGET, "Sync peer `{}` sent invalid data: {:?}", sync_peer, err);
+                        warn!(
+                            target: LOG_TARGET,
+                            "Discovering: Sync peer `{}` sent invalid data: {:?}",
+                            sync_peer, err
+                        );
                         return Err(err);
                     },
                 };
             if !peers_received.insert(new_peer.public_key.clone()) {
                 let err = NetworkDiscoveryError::DuplicatePeerReceived;
-                warn!(target: LOG_TARGET, "Sync peer `{}` sent duplicate peer: {:?}", sync_peer, err);
+                warn!(target: LOG_TARGET, "Discovering: Sync peer `{}` sent duplicate peer: {:?}", sync_peer, err);
                 return Err(err);
             }
             if let Err(err) = self.validate_and_add_peer(new_peer).await {
                 warn!(
                     target: LOG_TARGET,
-                    "Failed to validate and add peer from sync peer `{}`: {:?}", sync_peer, err
+                    "Discovering: Failed to validate and add peer from sync peer `{}`: {:?}", sync_peer, err
                 );
                 // Note: Currently we allow invalid peer signature errors to accumulate up to a threshold without
                 //       banning the sync peer due to an embedded problem, however, the invalid peer info sets are not
@@ -342,7 +361,7 @@ impl Discovering {
                     invalid_peer_signatures += 1;
                     debug!(
                         target: LOG_TARGET,
-                        "Sync peer `{}` committed {} of {} ban offences",
+                        "Discovering: Sync peer `{}` committed {} of {} ban offences",
                         sync_peer, invalid_peer_signatures, peer_sync_immediate_ban_threshold
                     );
                     continue;
@@ -358,7 +377,7 @@ impl Discovering {
     async fn validate_and_add_peer(&mut self, new_peer: UnvalidatedPeerInfo) -> Result<(), NetworkDiscoveryError> {
         let node_id = NodeId::from_public_key(&new_peer.public_key);
         if self.context.node_identity.node_id() == &node_id {
-            debug!(target: LOG_TARGET, "Received our own node from peer sync. Ignoring.");
+            debug!(target: LOG_TARGET, "Discovering: Received our own node from peer sync. Ignoring.");
             return Ok(());
         }
 
@@ -431,14 +450,14 @@ impl Discovering {
             Ok(_) => {
                 warn!(
                     target: LOG_TARGET,
-                    "Banned peer `{}` for {:.2?} due to '{}'",
+                    "Discovering: Banned peer `{}` for {:.2?} due to '{}'",
                     peer, self.config().ban_duration_from_severity(severity), err.to_string()
                 );
             },
             Err(e) => {
                 warn!(
                     target: LOG_TARGET,
-                    "Failed to ban peer `{}`: {}", peer, e
+                    "Discovering: Failed to ban peer `{}`: {}", peer, e
                 );
             },
         }
@@ -462,7 +481,7 @@ impl Discovering {
 
         debug!(
             target: LOG_TARGET,
-            "Dialing {} candidate peer(s) for peer sync",
+            "Discovering: Dialing {} candidate peer(s) for peer sync",
             pending_dials.len()
         );
         pending_dials

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -127,16 +127,8 @@ impl Discovering {
                     self.stats.sync_peers.push(peer_node_id.clone());
                     debug!(target: LOG_TARGET, "Attempting to sync from peer `{}`", peer_node_id);
 
-                    match self.request_from_peers(conn).await {
-                        Ok(_) => {
-                            self.stats.num_succeeded += 1;
-                        },
-                        Err(err) => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "Failed to request peers from `{}`: {}", peer_node_id, err
-                            );
-                        },
+                    if self.request_from_peers(conn).await.is_ok() {
+                        self.stats.num_succeeded += 1;
                     }
                 },
                 Err(err) => {
@@ -162,6 +154,7 @@ impl Discovering {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn request_peers(
         &mut self,
         sync_peer: &NodeId,
@@ -170,8 +163,7 @@ impl Discovering {
         debug!(
             target: LOG_TARGET,
             "Requesting {} peers from `{}`",
-            self.params
-                .num_peers_to_request,
+            self.params.num_peers_to_request,
             sync_peer
         );
         let mut stream = client
@@ -196,33 +188,92 @@ impl Discovering {
         let mut counter = 0;
         #[allow(clippy::mutable_key_type)]
         let mut peers_received = HashSet::new();
+        let mut ban_offences = Vec::new();
+        let peer_sync_immediate_ban_threshold = self.config().network_discovery.peer_sync_immediate_ban_threshold;
         while let Some(resp) = stream.next().await {
             counter += 1;
             if counter > self.params.num_peers_to_request {
-                warn!(target: LOG_TARGET, "Remote peer sent more peers than we requested.");
+                warn!(target: LOG_TARGET, "Sync peer `{}` sent more peers than we requested.", sync_peer);
                 return Err(NetworkDiscoveryError::TooManyPeersReceived);
             }
-            let GetPeersResponse { peer } = resp?;
-
-            let peer = peer.ok_or_else(|| NetworkDiscoveryError::EmptyPeerMessageReceived)?;
-            let new_peer: UnvalidatedPeerInfo = peer
-                .try_into()
-                .map_err(NetworkDiscoveryError::InvalidPeerDataReceived)?;
-            if !peers_received.insert(new_peer.public_key.clone()) {
-                warn!(target: LOG_TARGET, "Remote peer sent duplicate peer.");
-                return Err(NetworkDiscoveryError::DuplicatePeerReceived);
+            if Self::count_banable_offences(&ban_offences) >= peer_sync_immediate_ban_threshold {
+                warn!(
+                    target: LOG_TARGET,
+                    "Too many banable offences ({}) received from peer `{}`. Stopping further processing.",
+                    peer_sync_immediate_ban_threshold, sync_peer
+                );
+                break;
             }
-            self.validate_and_add_peer(sync_peer, new_peer).await?;
+            let GetPeersResponse { peer } = match resp {
+                Ok(val) => val,
+                Err(err) => {
+                    warn!(target: LOG_TARGET, "Sync peer `{}` sent invalid response: {:?}", sync_peer, err);
+                    let err = NetworkDiscoveryError::from(err);
+                    let severity = Self::determine_offence_severity(&err);
+                    ban_offences.push((severity, err));
+                    continue;
+                },
+            };
+
+            let peer = match peer.ok_or_else(|| NetworkDiscoveryError::EmptyPeerMessageReceived) {
+                Ok(val) => val,
+                Err(err) => {
+                    warn!(target: LOG_TARGET, "Sync peer `{}` sent an empty peer message: {:?}", sync_peer, err);
+                    let severity = Self::determine_offence_severity(&err);
+                    ban_offences.push((severity, err));
+                    continue;
+                },
+            };
+            let new_peer: UnvalidatedPeerInfo =
+                match peer.try_into().map_err(NetworkDiscoveryError::InvalidPeerDataReceived) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        warn!(target: LOG_TARGET, "Sync peer `{}` sent invalid data: {:?}", sync_peer, err);
+                        let severity = Self::determine_offence_severity(&err);
+                        ban_offences.push((severity, err));
+                        continue;
+                    },
+                };
+            if !peers_received.insert(new_peer.public_key.clone()) {
+                let err = NetworkDiscoveryError::DuplicatePeerReceived;
+                warn!(target: LOG_TARGET, "Sync peer `{}` sent duplicate peer: {:?}", sync_peer, err);
+                let severity = Self::determine_offence_severity(&err);
+                ban_offences.push((severity, err));
+                continue;
+            }
+            if let Err(err) = self.validate_and_add_peer(new_peer).await {
+                warn!(
+                    target: LOG_TARGET,
+                    "Failed to validate and add peer from sync peer `{}`: {:?}", sync_peer, err
+                );
+                let severity = Self::determine_offence_severity(&err);
+                ban_offences.push((severity, err));
+                continue;
+            }
+        }
+
+        // Return any error that has the highest severity offence if any were recorded
+        if !ban_offences.is_empty() {
+            // Sort the offences by severity, from highest to lowest
+            ban_offences.sort_by(|a, b| b.0.cmp(&a.0));
+            if let Some((severity, err)) = ban_offences.into_iter().next() {
+                trace!(
+                    target: LOG_TARGET,
+                    "Request peers from: `{}`, returning error: {:?}, severity: {:?}", sync_peer, err, severity
+                );
+                return Err(err);
+            }
         }
 
         Ok(())
     }
 
-    async fn validate_and_add_peer(
-        &mut self,
-        sync_peer: &NodeId,
-        new_peer: UnvalidatedPeerInfo,
-    ) -> Result<(), NetworkDiscoveryError> {
+    // Helper function to calculate the number of banable offences in ban_offences vec that are not None
+    fn count_banable_offences(ban_offences: &[(Option<OffenceSeverity>, NetworkDiscoveryError)]) -> usize {
+        ban_offences.iter().filter(|(severity, _)| severity.is_some()).count()
+    }
+
+    async fn validate_and_add_peer(&mut self, new_peer: UnvalidatedPeerInfo) -> Result<(), NetworkDiscoveryError> {
         let node_id = NodeId::from_public_key(&new_peer.public_key);
         if self.context.node_identity.node_id() == &node_id {
             debug!(target: LOG_TARGET, "Received our own node from peer sync. Ignoring.");
@@ -243,13 +294,7 @@ impl Discovering {
                 self.add_peer(valid_peer).await?;
                 Ok(())
             },
-            Err(err) => {
-                info!(
-                    target: LOG_TARGET,
-                    "Received invalid peer from sync peer '{}': {}.", sync_peer, err
-                );
-                Err(err.into())
-            },
+            Err(err) => Err(err.into()),
         }
     }
 
@@ -261,36 +306,37 @@ impl Discovering {
         match result {
             Ok(t) => Ok(t),
             Err(err) => {
-                match &err {
-                    NetworkDiscoveryError::EmptyPeerMessageReceived |
-                    NetworkDiscoveryError::InvalidPeerDataReceived(_) |
-                    NetworkDiscoveryError::DuplicatePeerReceived |
-                    NetworkDiscoveryError::TooManyPeersReceived => {
-                        self.ban_peer(peer, OffenceSeverity::High, &err).await;
-                    },
-                    NetworkDiscoveryError::RpcError(rpc_err) if rpc_err.is_caused_by_server() => {
-                        self.ban_peer(peer, OffenceSeverity::High, &err).await;
-                    },
-                    NetworkDiscoveryError::RpcStatus(status) if !status.is_ok() => {
-                        self.ban_peer(peer, OffenceSeverity::Low, &err).await;
-                    },
-                    // Other errors - no banning needed
-                    NetworkDiscoveryError::RpcStatus(_) |
-                    NetworkDiscoveryError::NoSyncPeers |
-                    NetworkDiscoveryError::PeerManagerError(_) |
-                    NetworkDiscoveryError::RpcError(_) |
-                    NetworkDiscoveryError::ConnectivityError(_) |
-                    NetworkDiscoveryError::PeerValidationError(_) |
-                    NetworkDiscoveryError::JoinError(_) |
-                    NetworkDiscoveryError::Timeout { .. } => {},
+                let severity = Self::determine_offence_severity(&err);
+                if let Some(val) = severity {
+                    self.ban_peer(peer, val, &err).await
                 }
                 Err(err)
             },
         }
     }
 
+    fn determine_offence_severity(err: &NetworkDiscoveryError) -> Option<OffenceSeverity> {
+        match err {
+            NetworkDiscoveryError::EmptyPeerMessageReceived |
+            NetworkDiscoveryError::InvalidPeerDataReceived(_) |
+            NetworkDiscoveryError::DuplicatePeerReceived |
+            NetworkDiscoveryError::PeerValidationError(_) |
+            NetworkDiscoveryError::TooManyPeersReceived => Some(OffenceSeverity::High),
+            NetworkDiscoveryError::RpcError(rpc_err) if rpc_err.is_caused_by_server() => Some(OffenceSeverity::High),
+            NetworkDiscoveryError::RpcStatus(status) if !status.is_ok() => Some(OffenceSeverity::Low),
+            // Other errors - no banning needed
+            NetworkDiscoveryError::RpcStatus(_) |
+            NetworkDiscoveryError::NoSyncPeers |
+            NetworkDiscoveryError::PeerManagerError(_) |
+            NetworkDiscoveryError::RpcError(_) |
+            NetworkDiscoveryError::ConnectivityError(_) |
+            NetworkDiscoveryError::JoinError(_) |
+            NetworkDiscoveryError::Timeout { .. } => None,
+        }
+    }
+
     async fn ban_peer<T: ToString>(&mut self, peer: NodeId, severity: OffenceSeverity, err: T) {
-        if let Err(e) = self
+        match self
             .context
             .connectivity
             .ban_peer_until(
@@ -300,10 +346,19 @@ impl Discovering {
             )
             .await
         {
-            warn!(
-                target: LOG_TARGET,
-                "Failed to ban peer `{}`: {}", peer, e
-            );
+            Ok(_) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Banned peer `{}` for {:.2?} due to '{}'",
+                    peer, self.config().ban_duration_from_severity(severity), err.to_string()
+                );
+            },
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Failed to ban peer `{}`: {}", peer, e
+                );
+            },
         }
     }
 

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -154,7 +154,6 @@ impl Discovering {
         Ok(())
     }
 
-    #[allow(clippy::too_many_lines)]
     async fn request_peers(
         &mut self,
         sync_peer: &NodeId,
@@ -186,21 +185,21 @@ impl Discovering {
             })
             .await?;
         let mut counter = 0;
+        let mut ban_offenses = 0;
+        let peer_sync_immediate_ban_threshold = self.config().network_discovery.peer_sync_immediate_ban_threshold;
         #[allow(clippy::mutable_key_type)]
         let mut peers_received = HashSet::new();
-        let mut ban_offences = Vec::new();
-        let peer_sync_immediate_ban_threshold = self.config().network_discovery.peer_sync_immediate_ban_threshold;
         while let Some(resp) = stream.next().await {
             counter += 1;
             if counter > self.params.num_peers_to_request {
                 warn!(target: LOG_TARGET, "Sync peer `{}` sent more peers than we requested.", sync_peer);
                 return Err(NetworkDiscoveryError::TooManyPeersReceived);
             }
-            if Self::count_banable_offences(&ban_offences) >= peer_sync_immediate_ban_threshold {
+            if ban_offenses >= peer_sync_immediate_ban_threshold {
                 warn!(
-                    target: LOG_TARGET,
-                    "Too many banable offences ({}) received from peer `{}`. Stopping further processing.",
-                    peer_sync_immediate_ban_threshold, sync_peer
+                      target: LOG_TARGET,
+                     "Too many banable offences ({}) received from peer `{}`. Stopping further processing.",
+                      peer_sync_immediate_ban_threshold, sync_peer
                 );
                 break;
             }
@@ -208,9 +207,7 @@ impl Discovering {
                 Ok(val) => val,
                 Err(err) => {
                     warn!(target: LOG_TARGET, "Sync peer `{}` sent invalid response: {:?}", sync_peer, err);
-                    let err = NetworkDiscoveryError::from(err);
-                    let severity = Self::determine_offence_severity(&err);
-                    ban_offences.push((severity, err));
+                    ban_offenses += 1;
                     continue;
                 },
             };
@@ -219,8 +216,7 @@ impl Discovering {
                 Ok(val) => val,
                 Err(err) => {
                     warn!(target: LOG_TARGET, "Sync peer `{}` sent an empty peer message: {:?}", sync_peer, err);
-                    let severity = Self::determine_offence_severity(&err);
-                    ban_offences.push((severity, err));
+                    ban_offenses += 1;
                     continue;
                 },
             };
@@ -229,16 +225,14 @@ impl Discovering {
                     Ok(val) => val,
                     Err(err) => {
                         warn!(target: LOG_TARGET, "Sync peer `{}` sent invalid data: {:?}", sync_peer, err);
-                        let severity = Self::determine_offence_severity(&err);
-                        ban_offences.push((severity, err));
+                        ban_offenses += 1;
                         continue;
                     },
                 };
             if !peers_received.insert(new_peer.public_key.clone()) {
                 let err = NetworkDiscoveryError::DuplicatePeerReceived;
                 warn!(target: LOG_TARGET, "Sync peer `{}` sent duplicate peer: {:?}", sync_peer, err);
-                let severity = Self::determine_offence_severity(&err);
-                ban_offences.push((severity, err));
+                ban_offenses += 1;
                 continue;
             }
             if let Err(err) = self.validate_and_add_peer(new_peer).await {
@@ -246,31 +240,17 @@ impl Discovering {
                     target: LOG_TARGET,
                     "Failed to validate and add peer from sync peer `{}`: {:?}", sync_peer, err
                 );
-                let severity = Self::determine_offence_severity(&err);
-                ban_offences.push((severity, err));
+                ban_offenses += 1;
                 continue;
             }
         }
 
         // Return any error that has the highest severity offence if any were recorded
-        if !ban_offences.is_empty() {
-            // Sort the offences by severity, from highest to lowest
-            ban_offences.sort_by(|a, b| b.0.cmp(&a.0));
-            if let Some((severity, err)) = ban_offences.into_iter().next() {
-                trace!(
-                    target: LOG_TARGET,
-                    "Request peers from: `{}`, returning error: {:?}, severity: {:?}", sync_peer, err, severity
-                );
-                return Err(err);
-            }
+        if ban_offenses > 0 {
+            return Err(NetworkDiscoveryError::TooManyBanableOffences(ban_offenses));
         }
 
         Ok(())
-    }
-
-    // Helper function to calculate the number of banable offences in ban_offences vec that are not None
-    fn count_banable_offences(ban_offences: &[(Option<OffenceSeverity>, NetworkDiscoveryError)]) -> usize {
-        ban_offences.iter().filter(|(severity, _)| severity.is_some()).count()
     }
 
     async fn validate_and_add_peer(&mut self, new_peer: UnvalidatedPeerInfo) -> Result<(), NetworkDiscoveryError> {
@@ -306,32 +286,32 @@ impl Discovering {
         match result {
             Ok(t) => Ok(t),
             Err(err) => {
-                let severity = Self::determine_offence_severity(&err);
-                if let Some(val) = severity {
-                    self.ban_peer(peer, val, &err).await
+                match &err {
+                    NetworkDiscoveryError::EmptyPeerMessageReceived |
+                    NetworkDiscoveryError::InvalidPeerDataReceived(_) |
+                    NetworkDiscoveryError::DuplicatePeerReceived |
+                    NetworkDiscoveryError::TooManyPeersReceived |
+                    NetworkDiscoveryError::TooManyBanableOffences(_) => {
+                        self.ban_peer(peer, OffenceSeverity::High, &err).await;
+                    },
+                    NetworkDiscoveryError::RpcError(rpc_err) if rpc_err.is_caused_by_server() => {
+                        self.ban_peer(peer, OffenceSeverity::High, &err).await;
+                    },
+                    NetworkDiscoveryError::RpcStatus(status) if !status.is_ok() => {
+                        self.ban_peer(peer, OffenceSeverity::Low, &err).await;
+                    },
+                    // Other errors - no banning needed
+                    NetworkDiscoveryError::RpcStatus(_) |
+                    NetworkDiscoveryError::NoSyncPeers |
+                    NetworkDiscoveryError::PeerManagerError(_) |
+                    NetworkDiscoveryError::RpcError(_) |
+                    NetworkDiscoveryError::ConnectivityError(_) |
+                    NetworkDiscoveryError::PeerValidationError(_) |
+                    NetworkDiscoveryError::JoinError(_) |
+                    NetworkDiscoveryError::Timeout { .. } => {},
                 }
                 Err(err)
             },
-        }
-    }
-
-    fn determine_offence_severity(err: &NetworkDiscoveryError) -> Option<OffenceSeverity> {
-        match err {
-            NetworkDiscoveryError::EmptyPeerMessageReceived |
-            NetworkDiscoveryError::InvalidPeerDataReceived(_) |
-            NetworkDiscoveryError::DuplicatePeerReceived |
-            NetworkDiscoveryError::PeerValidationError(_) |
-            NetworkDiscoveryError::TooManyPeersReceived => Some(OffenceSeverity::High),
-            NetworkDiscoveryError::RpcError(rpc_err) if rpc_err.is_caused_by_server() => Some(OffenceSeverity::High),
-            NetworkDiscoveryError::RpcStatus(status) if !status.is_ok() => Some(OffenceSeverity::Low),
-            // Other errors - no banning needed
-            NetworkDiscoveryError::RpcStatus(_) |
-            NetworkDiscoveryError::NoSyncPeers |
-            NetworkDiscoveryError::PeerManagerError(_) |
-            NetworkDiscoveryError::RpcError(_) |
-            NetworkDiscoveryError::ConnectivityError(_) |
-            NetworkDiscoveryError::JoinError(_) |
-            NetworkDiscoveryError::Timeout { .. } => None,
         }
     }
 

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -27,9 +27,12 @@ use log::*;
 use tari_comms::{
     connectivity::ConnectivityError,
     peer_manager::{NodeDistance, NodeId, Peer, PeerFeatures, PeerId},
+    peer_validator::PeerValidatorError,
+    protocol::rpc::{ClientStreaming, RpcStatus},
     types::CommsPublicKey,
     PeerConnection,
 };
+use tari_utilities::hex::Hex;
 
 use super::{
     state_machine::{
@@ -43,10 +46,10 @@ use super::{
 };
 use crate::{
     actor::OffenceSeverity,
-    peer_validator::PeerValidator,
+    peer_validator::{DhtPeerValidatorError, PeerValidator},
     proto::rpc::{GetPeersRequest, GetPeersResponse},
     rpc,
-    rpc::UnvalidatedPeerInfo,
+    rpc::{DhtClient, UnvalidatedPeerInfo},
     DhtConfig,
 };
 
@@ -141,7 +144,40 @@ impl Discovering {
     }
 
     async fn request_from_peers(&mut self, mut conn: PeerConnection) -> Result<(), NetworkDiscoveryError> {
-        let client = conn.connect_rpc::<rpc::DhtClient>().await?;
+        let rpc_connect_timeout = self.config().network_discovery.bootstrap_rpc_connect_timeout;
+        let rpc_result = tokio::time::timeout(rpc_connect_timeout, conn.connect_rpc::<DhtClient>()).await;
+        let client = match rpc_result {
+            Ok(Ok(client)) => {
+                trace!(
+                    target: LOG_TARGET,
+                    "Successfully connected RPC client to sync peer '{}'",
+                    conn.peer_node_id()
+                );
+                client
+            },
+            Ok(Err(e)) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Failed to connect RPC client to sync peer {}: {}",
+                    conn.peer_node_id(),
+                    e
+                );
+                return Err(e.into());
+            },
+            Err(_) => {
+                error!(
+                    target: LOG_TARGET,
+                    "RPC connect_rpc to seed '{}' timed out after {:?}",
+                    conn.peer_node_id(),
+                    rpc_connect_timeout,
+                );
+                return Err(NetworkDiscoveryError::Timeout {
+                    operation: "connect_rpc".to_string(),
+                    peer: conn.peer_node_id().to_hex(),
+                    duration: format!("{:.2?}", rpc_connect_timeout),
+                });
+            },
+        };
         let peer_node_id = conn.peer_node_id();
 
         debug!(
@@ -154,19 +190,15 @@ impl Discovering {
         Ok(())
     }
 
-    async fn request_peers(
+    async fn get_stream(
         &mut self,
-        sync_peer: &NodeId,
         mut client: rpc::DhtClient,
-    ) -> Result<(), NetworkDiscoveryError> {
-        debug!(
-            target: LOG_TARGET,
-            "Requesting {} peers from `{}`",
-            self.params.num_peers_to_request,
-            sync_peer
-        );
-        let mut stream = client
-            .get_peers(GetPeersRequest {
+        sync_peer: &NodeId,
+    ) -> Result<ClientStreaming<GetPeersResponse>, NetworkDiscoveryError> {
+        let rpc_get_peers_stream_timeout = self.config().network_discovery.bootstrap_rpc_get_peers_stream_timeout;
+        let stream_result = tokio::time::timeout(
+            rpc_get_peers_stream_timeout,
+            client.get_peers(GetPeersRequest {
                 n: self.params.num_peers_to_request,
                 include_clients: true,
                 max_claims: self.config().max_permitted_peer_claims.try_into().unwrap_or_else(|_| {
@@ -182,33 +214,95 @@ impl Discovering {
                         error!(target: LOG_TARGET, "Node configured to accept more than u32::MAX addresses per claim");
                         u32::MAX
                     }),
-            })
-            .await?;
+            }),
+        )
+        .await;
+
+        let peer_stream = match stream_result {
+            Ok(Ok(stream)) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Successfully initiated get_peers stream from sync peer '{}'",
+                    sync_peer
+                );
+                stream
+            },
+            Ok(Err(e)) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Failed to initiate get_peers stream from sync peer '{}': {}. This sync peer will be skipped.",
+                    sync_peer,
+                    e
+                );
+                return Err(e.into());
+            },
+            Err(_) => {
+                error!(
+                    target: LOG_TARGET,
+                    "RPC get_peers from sunc '{}' timed out after {:?}",
+                    sync_peer, rpc_get_peers_stream_timeout
+                );
+                return Err(NetworkDiscoveryError::Timeout {
+                    operation: "get_peers".to_string(),
+                    peer: sync_peer.to_hex(),
+                    duration: format!("{:.2?}", rpc_get_peers_stream_timeout),
+                });
+            },
+        };
+
+        Ok(peer_stream)
+    }
+
+    async fn get_peer_response(
+        &mut self,
+        stream: &mut ClientStreaming<GetPeersResponse>,
+        sync_peer: &NodeId,
+    ) -> Result<Option<Result<GetPeersResponse, RpcStatus>>, NetworkDiscoveryError> {
+        let rpc_streaming_timeout = self.config().network_discovery.bootstrap_rpc_streaming_timeout;
+        match tokio::time::timeout(rpc_streaming_timeout, stream.next()).await {
+            Ok(response) => Ok(response),
+            Err(_) => Err(NetworkDiscoveryError::Timeout {
+                operation: "get_peer_response".to_string(),
+                peer: sync_peer.to_hex(),
+                duration: format!("{:.2?}", rpc_streaming_timeout),
+            }),
+        }
+    }
+
+    async fn request_peers(&mut self, sync_peer: &NodeId, client: rpc::DhtClient) -> Result<(), NetworkDiscoveryError> {
+        debug!(
+            target: LOG_TARGET,
+            "Requesting {} peers from `{}`",
+            self.params.num_peers_to_request,
+            sync_peer
+        );
+        let mut stream = self.get_stream(client, sync_peer).await?;
         let mut counter = 0;
-        let mut ban_offenses = 0;
+        let mut invalid_peer_signatures = 0;
         let peer_sync_immediate_ban_threshold = self.config().network_discovery.peer_sync_immediate_ban_threshold;
         #[allow(clippy::mutable_key_type)]
         let mut peers_received = HashSet::new();
-        while let Some(resp) = stream.next().await {
+        while let Some(resp) = self.get_peer_response(&mut stream, sync_peer).await? {
             counter += 1;
             if counter > self.params.num_peers_to_request {
                 warn!(target: LOG_TARGET, "Sync peer `{}` sent more peers than we requested.", sync_peer);
                 return Err(NetworkDiscoveryError::TooManyPeersReceived);
             }
-            if ban_offenses >= peer_sync_immediate_ban_threshold {
+            if invalid_peer_signatures >= peer_sync_immediate_ban_threshold {
                 warn!(
                       target: LOG_TARGET,
-                     "Too many banable offences ({}) received from peer `{}`. Stopping further processing.",
-                      peer_sync_immediate_ban_threshold, sync_peer
+                     "Too many ban-able offences ({} of {}) received from peer `{}`. Stopping further processing.",
+                      peer_sync_immediate_ban_threshold, counter, sync_peer
                 );
-                break;
+                return Err(NetworkDiscoveryError::BanableOffencesWhileSyncing(
+                    invalid_peer_signatures,
+                ));
             }
             let GetPeersResponse { peer } = match resp {
                 Ok(val) => val,
                 Err(err) => {
                     warn!(target: LOG_TARGET, "Sync peer `{}` sent invalid response: {:?}", sync_peer, err);
-                    ban_offenses += 1;
-                    continue;
+                    return Err(NetworkDiscoveryError::from(err));
                 },
             };
 
@@ -216,8 +310,7 @@ impl Discovering {
                 Ok(val) => val,
                 Err(err) => {
                     warn!(target: LOG_TARGET, "Sync peer `{}` sent an empty peer message: {:?}", sync_peer, err);
-                    ban_offenses += 1;
-                    continue;
+                    return Err(err);
                 },
             };
             let new_peer: UnvalidatedPeerInfo =
@@ -225,29 +318,38 @@ impl Discovering {
                     Ok(val) => val,
                     Err(err) => {
                         warn!(target: LOG_TARGET, "Sync peer `{}` sent invalid data: {:?}", sync_peer, err);
-                        ban_offenses += 1;
-                        continue;
+                        return Err(err);
                     },
                 };
             if !peers_received.insert(new_peer.public_key.clone()) {
                 let err = NetworkDiscoveryError::DuplicatePeerReceived;
                 warn!(target: LOG_TARGET, "Sync peer `{}` sent duplicate peer: {:?}", sync_peer, err);
-                ban_offenses += 1;
-                continue;
+                return Err(err);
             }
             if let Err(err) = self.validate_and_add_peer(new_peer).await {
                 warn!(
                     target: LOG_TARGET,
                     "Failed to validate and add peer from sync peer `{}`: {:?}", sync_peer, err
                 );
-                ban_offenses += 1;
-                continue;
+                // Note: Currently we allow invalid peer signature errors to accumulate up to a threshold without
+                //       banning the sync peer due to an embedded problem, however, the invalid peer info sets are not
+                //       added to the peer database. This allowance must be removed when the issue is solved.
+                //       See: https://github.com/tari-project/tari/issues/7306
+                if let NetworkDiscoveryError::PeerValidationError(DhtPeerValidatorError::ValidatorError(
+                    PeerValidatorError::InvalidPeerSignature { .. },
+                )) = err
+                {
+                    invalid_peer_signatures += 1;
+                    debug!(
+                        target: LOG_TARGET,
+                        "Sync peer `{}` committed {} of {} ban offences",
+                        sync_peer, invalid_peer_signatures, peer_sync_immediate_ban_threshold
+                    );
+                    continue;
+                } else {
+                    return Err(err);
+                }
             }
-        }
-
-        // Return any error that has the highest severity offence if any were recorded
-        if ban_offenses > 0 {
-            return Err(NetworkDiscoveryError::TooManyBanableOffences(ban_offenses));
         }
 
         Ok(())
@@ -291,7 +393,7 @@ impl Discovering {
                     NetworkDiscoveryError::InvalidPeerDataReceived(_) |
                     NetworkDiscoveryError::DuplicatePeerReceived |
                     NetworkDiscoveryError::TooManyPeersReceived |
-                    NetworkDiscoveryError::TooManyBanableOffences(_) => {
+                    NetworkDiscoveryError::BanableOffencesWhileSyncing(_) => {
                         self.ban_peer(peer, OffenceSeverity::High, &err).await;
                     },
                     NetworkDiscoveryError::RpcError(rpc_err) if rpc_err.is_caused_by_server() => {

--- a/comms/dht/src/network_discovery/error.rs
+++ b/comms/dht/src/network_discovery/error.rs
@@ -47,8 +47,8 @@ pub enum NetworkDiscoveryError {
     EmptyPeerMessageReceived,
     #[error("Sync peer sent too many peers")]
     TooManyPeersReceived,
-    #[error("Sync peer committed too many ban-able offences: {0}")]
-    TooManyBanableOffences(usize),
+    #[error("Sync peer committed {0} ban-able offences")]
+    BanableOffencesWhileSyncing(usize),
     #[error("Sync peer sent duplicate peer")]
     DuplicatePeerReceived,
     #[error("Sync peer sent invalid peer data: {0}")]
@@ -76,7 +76,10 @@ impl PartialEq for NetworkDiscoveryError {
                 (Self::PeerValidationError(_), Self::PeerValidationError(_)) |
                 (Self::EmptyPeerMessageReceived, Self::EmptyPeerMessageReceived) |
                 (Self::TooManyPeersReceived, Self::TooManyPeersReceived) |
-                (Self::TooManyBanableOffences(_), Self::TooManyBanableOffences(_)) |
+                (
+                    Self::BanableOffencesWhileSyncing(_),
+                    Self::BanableOffencesWhileSyncing(_)
+                ) |
                 (Self::DuplicatePeerReceived, Self::DuplicatePeerReceived) |
                 (Self::InvalidPeerDataReceived(_), Self::InvalidPeerDataReceived(_))
         )

--- a/comms/dht/src/network_discovery/error.rs
+++ b/comms/dht/src/network_discovery/error.rs
@@ -47,6 +47,8 @@ pub enum NetworkDiscoveryError {
     EmptyPeerMessageReceived,
     #[error("Sync peer sent too many peers")]
     TooManyPeersReceived,
+    #[error("Sync peer committed too many ban-able offences: {0}")]
+    TooManyBanableOffences(usize),
     #[error("Sync peer sent duplicate peer")]
     DuplicatePeerReceived,
     #[error("Sync peer sent invalid peer data: {0}")]
@@ -74,6 +76,7 @@ impl PartialEq for NetworkDiscoveryError {
                 (Self::PeerValidationError(_), Self::PeerValidationError(_)) |
                 (Self::EmptyPeerMessageReceived, Self::EmptyPeerMessageReceived) |
                 (Self::TooManyPeersReceived, Self::TooManyPeersReceived) |
+                (Self::TooManyBanableOffences(_), Self::TooManyBanableOffences(_)) |
                 (Self::DuplicatePeerReceived, Self::DuplicatePeerReceived) |
                 (Self::InvalidPeerDataReceived(_), Self::InvalidPeerDataReceived(_))
         )


### PR DESCRIPTION
Description
---
~~Added tolerance for banable offences while busy with peer sync. A sync session will be interrupted after a configurable number of banable offences has been committed. When the sync session ends due to this threshold or otherwise, the peer will be banned for the most severe ban offence. This scheme enables a local node to accumulate good peer info sets optimally.~~

**Update:** _All sync peers emit invalid peer info sets due to random embedded invalid peer signature errors in the peer identity claims. This PR is an interim measure to combat large scale banning of peers and to collect good peer info sets from peers that send up to a threshold number of bad peer identity claims. Those sync peers will not be banned during peer sync._
_(See linked issue #7306.)_


**Note:** This does not apply to the seedstrap phase as seed peer ban offences are ignored then.

Motivation and Context
---
Peer sync efficiency can be improved if good peer info sets are accepted from sync peers in the midst of having committed ~~a~~ _this specific_ banable offence.

How Has This Been Tested?
---
System-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable threshold (default 100) for the number of offenses tolerated during peer syncing before banning a peer.
* **Bug Fixes**
  * Improved timeout handling, error logging, and peer validation to accumulate multiple offenses before banning during peer sync.
* **Refactor**
  * Enhanced offense severity comparison with ordering and equality traits.
  * Unified and simplified peer banning logic and error handling for better robustness and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->