### PR TITLE
fix!: revert grpc message deletion for wallet proto message and deprecate it instead

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1706,6 +1706,12 @@ message ValidateRequest{}
 
 message ValidateResponse{}
 
+message SetBaseNodeRequest {
+  string public_key_hex = 1;
+  string net_address = 2;
+  option deprecated = true;
+}
+
 message SetBaseNodeResponse{}
 
 // Empty request for CheckConnectivity


### PR DESCRIPTION
Description
---
Reverted gRPC message deletion for `message SetBaseNodeRequest` and deprecated it instead.

Motivation and Context
---
This was an oversight.

How Has This Been Tested?
---
Compile test.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
BREAKING CHANGE: 
- The gRPC `wallet.proto` interface changed back to what it was before #7353, but is now just marked deprecated.
- The `WalletConfig` struct changed in #7353 in that `custom_base_node` is no longer included. Any config of config overrides still referencing it will break.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new (deprecated) message type for setting base node information in the wallet API. 

* **Documentation**
  * Updated API documentation to reflect the addition of the deprecated message type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->