### PR TITLE
docs: update recovery event callback in the ffi wallet recovery method

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -9697,15 +9697,15 @@ pub unsafe extern "C" fn wallet_is_recovery_in_progress(wallet: *mut TariWallet,
 /// that triggered the callback, as follows:
 /// ```
 /// enum RecoveryEvent {
-///     ScanningRoundFailed,        // 0
-///        num_retries: u64,                - 1st argument
-///        retry_limit: u64,                - 2nd argument
-///     Progress,                   // 1
+///     Progress,                   // 3
 ///        current_height: u64,             - 1st argument
 ///        tip_height: u64,                 - 2nd argument
-///     Completed,                  // 2
+///     Completed,                  // 4
 ///        num_recovered: u64,              - 1st argument
 ///        value_recovered: u64,            - 2nd argument (representing MicroMinotari)
+///     ScanningRoundFailed,        // 5
+///        num_retries: u64,                - 1st argument
+///        retry_limit: u64,                - 2nd argument
 /// }
 /// ```
 ///

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -9697,13 +9697,13 @@ pub unsafe extern "C" fn wallet_is_recovery_in_progress(wallet: *mut TariWallet,
 /// that triggered the callback, as follows:
 /// ```
 /// enum RecoveryEvent {
-///     Progress,                   // 3
+///     Progress,                   // 0
 ///        current_height: u64,             - 1st argument
 ///        tip_height: u64,                 - 2nd argument
-///     Completed,                  // 4
+///     Completed,                  // 1
 ///        num_recovered: u64,              - 1st argument
 ///        value_recovered: u64,            - 2nd argument (representing MicroMinotari)
-///     ScanningRoundFailed,        // 5
+///     ScanningRoundFailed,        // 2
 ///        num_retries: u64,                - 1st argument
 ///        retry_limit: u64,                - 2nd argument
 /// }

--- a/base_layer/wallet_ffi/src/tasks.rs
+++ b/base_layer/wallet_ffi/src/tasks.rs
@@ -32,9 +32,9 @@ const LOG_TARGET: &str = "wallet_ffi";
 
 /// Events that the recovery process will report via the callback
 enum RecoveryEvent {
-    Progress = 3,            // 3
-    Completed = 4,           // 4
-    ScanningRoundFailed = 5, // 5
+    Progress = 0,            // 0
+    Completed = 1,           // 1
+    ScanningRoundFailed = 2, // 2
 }
 
 #[allow(clippy::too_many_lines)]

--- a/base_layer/wallet_ffi/src/tasks.rs
+++ b/base_layer/wallet_ffi/src/tasks.rs
@@ -32,9 +32,9 @@ const LOG_TARGET: &str = "wallet_ffi";
 
 /// Events that the recovery process will report via the callback
 enum RecoveryEvent {
-    Progress,            // 3
-    Completed,           // 4
-    ScanningRoundFailed, // 5
+    Progress = 3,            // 3
+    Completed = 4,           // 4
+    ScanningRoundFailed = 5, // 5
 }
 
 #[allow(clippy::too_many_lines)]

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -4298,15 +4298,15 @@ bool wallet_is_recovery_in_progress(struct TariWallet *wallet,
  * that triggered the callback, as follows:
  * ```
  * enum RecoveryEvent {
- *     ScanningRoundFailed,        // 0
- *        num_retries: u64,                - 1st argument
- *        retry_limit: u64,                - 2nd argument
- *     Progress,                   // 1
+ *     Progress,                   // 3
  *        current_height: u64,             - 1st argument
  *        tip_height: u64,                 - 2nd argument
- *     Completed,                  // 2
+ *     Completed,                  // 4
  *        num_recovered: u64,              - 1st argument
  *        value_recovered: u64,            - 2nd argument (representing MicroMinotari)
+ *     ScanningRoundFailed,        // 5
+ *        num_retries: u64,                - 1st argument
+ *        retry_limit: u64,                - 2nd argument
  * }
  * ```
  *


### PR DESCRIPTION
Description
---
- ~~Fixed `RecoveryEvent` callback values to be in line with the original FFI implementation of v4.9.1, thus no breaking change to previous use.~~
- Updated documentation to be in line with the callback.
- Updated comments for `enum RecoveryEvent {` to be in line with recent enum value changes

Motivation and Context
---
~~The latter release broke the FFI, and the recent documentation update was wrong.~~
The previous FFI recent documentation update was wrong.

How Has This Been Tested?
---
Not tested - just compiled

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify and correct the numeric values and order of the `RecoveryEvent` enum variants in the wallet recovery process.
  * Improved consistency in documentation comments related to wallet recovery callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->