### PR TITLE
feat: add network discovery timeouts

### DIFF
--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -703,8 +703,8 @@ impl PeerDatabaseSql {
                     .filter(multi_addresses::address.eq(address_update.address.clone()))
                     .filter(multi_addresses::peer_id.eq(peer_id)),
             )
-                .set(&address_update)
-                .execute(conn)?;
+            .set(&address_update)
+            .execute(conn)?;
             // If the address does not exist, add it
             if updated == 0 {
                 let new_address_sql = NewMultiaddrWithStatsSql::from((address_update.clone(), peer_id));

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -144,39 +144,36 @@ impl Discovering {
 
     async fn request_from_peers(&mut self, mut conn: PeerConnection) -> Result<(), NetworkDiscoveryError> {
         let rpc_connect_timeout = self.config().network_discovery.bootstrap_rpc_connect_timeout;
-        let rpc_result = tokio::time::timeout(rpc_connect_timeout, conn.connect_rpc::<DhtClient>()).await;
-        let client = match rpc_result {
-            Ok(Ok(client)) => {
-                trace!(
-                    target: LOG_TARGET,
-                    "Discovering: Successfully connected RPC client to sync peer '{}'",
-                    conn.peer_node_id()
-                );
-                client
-            },
-            Ok(Err(e)) => {
-                error!(
-                    target: LOG_TARGET,
-                    "Discovering: Failed to connect RPC client to sync peer {}: {}",
-                    conn.peer_node_id(),
-                    e
-                );
-                return Err(e.into());
-            },
-            Err(_) => {
+        let client = tokio::time::timeout(rpc_connect_timeout, conn.connect_rpc::<DhtClient>())
+            .await
+            .map_err(|_| {
                 error!(
                     target: LOG_TARGET,
                     "Discovering: RPC connect_rpc to sync peer '{}' timed out after {:?}",
                     conn.peer_node_id(),
                     rpc_connect_timeout,
                 );
-                return Err(NetworkDiscoveryError::Timeout {
+                NetworkDiscoveryError::Timeout {
                     operation: "connect_rpc".to_string(),
                     peer: conn.peer_node_id().to_hex(),
                     duration: format!("{:.2?}", rpc_connect_timeout),
-                });
-            },
-        };
+                }
+            })?
+            .inspect_err(|e| {
+                error!(
+                    target: LOG_TARGET,
+                    "Discovering: Failed to connect RPC client to sync peer {}: {}",
+                    conn.peer_node_id(),
+                    e
+                );
+            })?;
+
+        trace!(
+            target: LOG_TARGET,
+            "Discovering: Successfully connected RPC client to sync peer '{}'",
+            conn.peer_node_id()
+        );
+
         let peer_node_id = conn.peer_node_id();
 
         debug!(
@@ -195,7 +192,7 @@ impl Discovering {
         sync_peer: &NodeId,
     ) -> Result<ClientStreaming<GetPeersResponse>, NetworkDiscoveryError> {
         let rpc_get_peers_stream_timeout = self.config().network_discovery.bootstrap_rpc_get_peers_stream_timeout;
-        let stream_result = tokio::time::timeout(
+        let peer_stream = tokio::time::timeout(
             rpc_get_peers_stream_timeout,
             client.get_peers(GetPeersRequest {
                 n: self.params.num_peers_to_request,
@@ -221,40 +218,34 @@ impl Discovering {
                     }),
             }),
         )
-        .await;
+        .await
+        .map_err(|_| {
+            error!(
+                target: LOG_TARGET,
+                "Discovering: RPC get_peers from sync peer '{}' timed out after {:?}",
+                sync_peer, rpc_get_peers_stream_timeout
+            );
+            NetworkDiscoveryError::Timeout {
+                operation: "get_peers".to_string(),
+                peer: sync_peer.to_hex(),
+                duration: format!("{:.2?}", rpc_get_peers_stream_timeout),
+            }
+        })?
+        .inspect_err(|e| {
+            error!(
+                target: LOG_TARGET,
+                "Discovering: Failed to initiate get_peers stream from sync peer '{}': {}. This sync peer will be \
+                skipped.",
+                sync_peer,
+                e
+            );
+        })?;
 
-        let peer_stream = match stream_result {
-            Ok(Ok(stream)) => {
-                debug!(
-                    target: LOG_TARGET,
-                    "Discovering: Successfully initiated get_peers stream from sync peer '{}'",
-                    sync_peer
-                );
-                stream
-            },
-            Ok(Err(e)) => {
-                error!(
-                    target: LOG_TARGET,
-                    "Discovering: Failed to initiate get_peers stream from sync peer '{}': {}. This sync peer will be \
-                    skipped.",
-                    sync_peer,
-                    e
-                );
-                return Err(e.into());
-            },
-            Err(_) => {
-                error!(
-                    target: LOG_TARGET,
-                    "Discovering: RPC get_peers from sync '{}' timed out after {:?}",
-                    sync_peer, rpc_get_peers_stream_timeout
-                );
-                return Err(NetworkDiscoveryError::Timeout {
-                    operation: "get_peers".to_string(),
-                    peer: sync_peer.to_hex(),
-                    duration: format!("{:.2?}", rpc_get_peers_stream_timeout),
-                });
-            },
-        };
+        debug!(
+            target: LOG_TARGET,
+            "Discovering: Successfully initiated get_peers stream from sync peer '{}'",
+            sync_peer
+        );
 
         Ok(peer_stream)
     }
@@ -265,21 +256,21 @@ impl Discovering {
         sync_peer: &NodeId,
     ) -> Result<Option<Result<GetPeersResponse, RpcStatus>>, NetworkDiscoveryError> {
         let rpc_streaming_timeout = self.config().network_discovery.bootstrap_rpc_streaming_timeout;
-        match tokio::time::timeout(rpc_streaming_timeout, stream.next()).await {
-            Ok(response) => Ok(response),
-            Err(_) => {
+
+        tokio::time::timeout(rpc_streaming_timeout, stream.next())
+            .await
+            .map_err(|_| {
                 error!(
                     target: LOG_TARGET,
                     "Discovering: RPC get_peer_response from stream '{}' timed out after {:?}",
                     sync_peer, rpc_streaming_timeout
                 );
-                Err(NetworkDiscoveryError::Timeout {
+                NetworkDiscoveryError::Timeout {
                     operation: "get_peer_response".to_string(),
                     peer: sync_peer.to_hex(),
                     duration: format!("{:.2?}", rpc_streaming_timeout),
-                })
-            },
-        }
+                }
+            })
     }
 
     async fn request_peers(&mut self, sync_peer: &NodeId, client: rpc::DhtClient) -> Result<(), NetworkDiscoveryError> {
@@ -299,52 +290,45 @@ impl Discovering {
                 warn!(target: LOG_TARGET, "Discovering: Sync peer `{}` sent more peers than we requested.", sync_peer);
                 return Err(NetworkDiscoveryError::TooManyPeersReceived);
             }
-            let GetPeersResponse { peer } = match resp {
-                Ok(val) => val,
-                Err(err) => {
+            let GetPeersResponse { peer } = resp.map_err(|err| {
+                warn!(
+                    target: LOG_TARGET,
+                    "Discovering: Sync peer `{}` sent an error response: {:?}",
+                    sync_peer, err
+                );
+                NetworkDiscoveryError::from(err)
+            })?;
+            let peer = peer
+                .ok_or_else(|| NetworkDiscoveryError::EmptyPeerMessageReceived)
+                .inspect_err(|err| {
                     warn!(
                         target: LOG_TARGET,
-                        "Discovering: Sync peer `{}` sent invalid response: {:?}",
+                        "Discovering: Sync peer `{}` sent an empty peer message: {:?}",
                         sync_peer, err
                     );
-                    return Err(NetworkDiscoveryError::from(err));
-                },
-            };
-
-            let peer = match peer.ok_or_else(|| NetworkDiscoveryError::EmptyPeerMessageReceived) {
-                Ok(val) => val,
-                Err(err) => {
+                })?;
+            let new_peer: UnvalidatedPeerInfo = peer
+                .try_into()
+                .map_err(NetworkDiscoveryError::InvalidPeerDataReceived)
+                .inspect_err(|err| {
                     warn!(
-                        target: LOG_TARGET, "Discovering: Sync peer `{}` sent an empty peer message: {:?}",
+                        target: LOG_TARGET,
+                        "Discovering: Sync peer `{}` sent invalid peer data: {:?}",
                         sync_peer, err
                     );
-                    return Err(err);
-                },
-            };
-            let new_peer: UnvalidatedPeerInfo =
-                match peer.try_into().map_err(NetworkDiscoveryError::InvalidPeerDataReceived) {
-                    Ok(val) => val,
-                    Err(err) => {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Discovering: Sync peer `{}` sent invalid data: {:?}",
-                            sync_peer, err
-                        );
-                        return Err(err);
-                    },
-                };
+                })?;
+
             if !peers_received.insert(new_peer.public_key.clone()) {
                 let err = NetworkDiscoveryError::DuplicatePeerReceived;
                 warn!(target: LOG_TARGET, "Discovering: Sync peer `{}` sent duplicate peer: {:?}", sync_peer, err);
                 return Err(err);
             }
-            if let Err(err) = self.validate_and_add_peer(new_peer).await {
+            self.validate_and_add_peer(new_peer).await.inspect_err(|err| {
                 warn!(
                     target: LOG_TARGET,
                     "Discovering: Failed to validate and add peer from sync peer `{}`: {:?}", sync_peer, err
                 );
-                return Err(err);
-            }
+            })?;
         }
 
         Ok(())

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -27,9 +27,11 @@ use log::*;
 use tari_comms::{
     connectivity::ConnectivityError,
     peer_manager::{NodeDistance, NodeId, Peer, PeerFeatures, PeerId},
+    protocol::rpc::{ClientStreaming, RpcStatus},
     types::CommsPublicKey,
     PeerConnection,
 };
+use tari_utilities::hex::Hex;
 
 use super::{
     state_machine::{
@@ -46,7 +48,7 @@ use crate::{
     peer_validator::PeerValidator,
     proto::rpc::{GetPeersRequest, GetPeersResponse},
     rpc,
-    rpc::UnvalidatedPeerInfo,
+    rpc::{DhtClient, UnvalidatedPeerInfo},
     DhtConfig,
 };
 
@@ -112,7 +114,7 @@ impl Discovering {
     pub async fn next_event(&mut self) -> StateEvent {
         debug!(
             target: LOG_TARGET,
-            "Starting network discovery with params {}", self.params
+            "Discovering: Starting network discovery with params {}", self.params
         );
 
         if let Err(err) = self.initialize().await {
@@ -125,22 +127,14 @@ impl Discovering {
                 Ok(conn) => {
                     let peer_node_id = conn.peer_node_id().clone();
                     self.stats.sync_peers.push(peer_node_id.clone());
-                    debug!(target: LOG_TARGET, "Attempting to sync from peer `{}`", peer_node_id);
+                    debug!(target: LOG_TARGET, "Discovering: Attempting to sync from peer `{}`", peer_node_id);
 
-                    match self.request_from_peers(conn).await {
-                        Ok(_) => {
-                            self.stats.num_succeeded += 1;
-                        },
-                        Err(err) => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "Failed to request peers from `{}`: {}", peer_node_id, err
-                            );
-                        },
+                    if self.request_from_peers(conn).await.is_ok() {
+                        self.stats.num_succeeded += 1;
                     }
                 },
                 Err(err) => {
-                    debug!(target: LOG_TARGET, "Failed to connect to sync peer candidate: {}", err);
+                    debug!(target: LOG_TARGET, "Discovering: Failed to connect to sync peer candidate: {}", err);
                 },
             }
         }
@@ -149,12 +143,45 @@ impl Discovering {
     }
 
     async fn request_from_peers(&mut self, mut conn: PeerConnection) -> Result<(), NetworkDiscoveryError> {
-        let client = conn.connect_rpc::<rpc::DhtClient>().await?;
+        let rpc_connect_timeout = self.config().network_discovery.bootstrap_rpc_connect_timeout;
+        let rpc_result = tokio::time::timeout(rpc_connect_timeout, conn.connect_rpc::<DhtClient>()).await;
+        let client = match rpc_result {
+            Ok(Ok(client)) => {
+                trace!(
+                    target: LOG_TARGET,
+                    "Discovering: Successfully connected RPC client to sync peer '{}'",
+                    conn.peer_node_id()
+                );
+                client
+            },
+            Ok(Err(e)) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Discovering: Failed to connect RPC client to sync peer {}: {}",
+                    conn.peer_node_id(),
+                    e
+                );
+                return Err(e.into());
+            },
+            Err(_) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Discovering: RPC connect_rpc to sync peer '{}' timed out after {:?}",
+                    conn.peer_node_id(),
+                    rpc_connect_timeout,
+                );
+                return Err(NetworkDiscoveryError::Timeout {
+                    operation: "connect_rpc".to_string(),
+                    peer: conn.peer_node_id().to_hex(),
+                    duration: format!("{:.2?}", rpc_connect_timeout),
+                });
+            },
+        };
         let peer_node_id = conn.peer_node_id();
 
         debug!(
             target: LOG_TARGET,
-            "Established RPC connection to peer `{}`", peer_node_id
+            "Discovering: Established RPC connection to sync peer `{}`", peer_node_id
         );
         let result = self.request_peers(peer_node_id, client).await;
         self.ban_on_offence(peer_node_id.clone(), result).await?;
@@ -162,24 +189,22 @@ impl Discovering {
         Ok(())
     }
 
-    async fn request_peers(
+    async fn get_stream(
         &mut self,
-        sync_peer: &NodeId,
         mut client: rpc::DhtClient,
-    ) -> Result<(), NetworkDiscoveryError> {
-        debug!(
-            target: LOG_TARGET,
-            "Requesting {} peers from `{}`",
-            self.params
-                .num_peers_to_request,
-            sync_peer
-        );
-        let mut stream = client
-            .get_peers(GetPeersRequest {
+        sync_peer: &NodeId,
+    ) -> Result<ClientStreaming<GetPeersResponse>, NetworkDiscoveryError> {
+        let rpc_get_peers_stream_timeout = self.config().network_discovery.bootstrap_rpc_get_peers_stream_timeout;
+        let stream_result = tokio::time::timeout(
+            rpc_get_peers_stream_timeout,
+            client.get_peers(GetPeersRequest {
                 n: self.params.num_peers_to_request,
                 include_clients: true,
                 max_claims: self.config().max_permitted_peer_claims.try_into().unwrap_or_else(|_| {
-                    error!(target: LOG_TARGET, "Node configured to accept more than u32::MAX claims per peer");
+                    error!(
+                        target: LOG_TARGET,
+                        "Discovering: Node configured to accept more than u32::MAX claims per peer"
+                    );
                     u32::MAX
                 }),
                 max_addresses_per_claim: self
@@ -188,44 +213,147 @@ impl Discovering {
                     .max_permitted_peer_addresses_per_claim
                     .try_into()
                     .unwrap_or_else(|_| {
-                        error!(target: LOG_TARGET, "Node configured to accept more than u32::MAX addresses per claim");
+                        error!(
+                            target: LOG_TARGET,
+                            "Discovering: Node configured to accept more than u32::MAX addresses per claim"
+                        );
                         u32::MAX
                     }),
-            })
-            .await?;
+            }),
+        )
+        .await;
+
+        let peer_stream = match stream_result {
+            Ok(Ok(stream)) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Discovering: Successfully initiated get_peers stream from sync peer '{}'",
+                    sync_peer
+                );
+                stream
+            },
+            Ok(Err(e)) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Discovering: Failed to initiate get_peers stream from sync peer '{}': {}. This sync peer will be \
+                    skipped.",
+                    sync_peer,
+                    e
+                );
+                return Err(e.into());
+            },
+            Err(_) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Discovering: RPC get_peers from sync '{}' timed out after {:?}",
+                    sync_peer, rpc_get_peers_stream_timeout
+                );
+                return Err(NetworkDiscoveryError::Timeout {
+                    operation: "get_peers".to_string(),
+                    peer: sync_peer.to_hex(),
+                    duration: format!("{:.2?}", rpc_get_peers_stream_timeout),
+                });
+            },
+        };
+
+        Ok(peer_stream)
+    }
+
+    async fn get_peer_response(
+        &mut self,
+        stream: &mut ClientStreaming<GetPeersResponse>,
+        sync_peer: &NodeId,
+    ) -> Result<Option<Result<GetPeersResponse, RpcStatus>>, NetworkDiscoveryError> {
+        let rpc_streaming_timeout = self.config().network_discovery.bootstrap_rpc_streaming_timeout;
+        match tokio::time::timeout(rpc_streaming_timeout, stream.next()).await {
+            Ok(response) => Ok(response),
+            Err(_) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Discovering: RPC get_peer_response from stream '{}' timed out after {:?}",
+                    sync_peer, rpc_streaming_timeout
+                );
+                Err(NetworkDiscoveryError::Timeout {
+                    operation: "get_peer_response".to_string(),
+                    peer: sync_peer.to_hex(),
+                    duration: format!("{:.2?}", rpc_streaming_timeout),
+                })
+            },
+        }
+    }
+
+    async fn request_peers(&mut self, sync_peer: &NodeId, client: rpc::DhtClient) -> Result<(), NetworkDiscoveryError> {
+        debug!(
+            target: LOG_TARGET,
+            "Discovering: Requesting {} peers from `{}`",
+            self.params.num_peers_to_request,
+            sync_peer
+        );
+        let mut stream = self.get_stream(client, sync_peer).await?;
         let mut counter = 0;
         #[allow(clippy::mutable_key_type)]
         let mut peers_received = HashSet::new();
-        while let Some(resp) = stream.next().await {
+        while let Some(resp) = self.get_peer_response(&mut stream, sync_peer).await? {
             counter += 1;
             if counter > self.params.num_peers_to_request {
-                warn!(target: LOG_TARGET, "Remote peer sent more peers than we requested.");
+                warn!(target: LOG_TARGET, "Discovering: Sync peer `{}` sent more peers than we requested.", sync_peer);
                 return Err(NetworkDiscoveryError::TooManyPeersReceived);
             }
-            let GetPeersResponse { peer } = resp?;
+            let GetPeersResponse { peer } = match resp {
+                Ok(val) => val,
+                Err(err) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Discovering: Sync peer `{}` sent invalid response: {:?}",
+                        sync_peer, err
+                    );
+                    return Err(NetworkDiscoveryError::from(err));
+                },
+            };
 
-            let peer = peer.ok_or_else(|| NetworkDiscoveryError::EmptyPeerMessageReceived)?;
-            let new_peer: UnvalidatedPeerInfo = peer
-                .try_into()
-                .map_err(NetworkDiscoveryError::InvalidPeerDataReceived)?;
+            let peer = match peer.ok_or_else(|| NetworkDiscoveryError::EmptyPeerMessageReceived) {
+                Ok(val) => val,
+                Err(err) => {
+                    warn!(
+                        target: LOG_TARGET, "Discovering: Sync peer `{}` sent an empty peer message: {:?}",
+                        sync_peer, err
+                    );
+                    return Err(err);
+                },
+            };
+            let new_peer: UnvalidatedPeerInfo =
+                match peer.try_into().map_err(NetworkDiscoveryError::InvalidPeerDataReceived) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Discovering: Sync peer `{}` sent invalid data: {:?}",
+                            sync_peer, err
+                        );
+                        return Err(err);
+                    },
+                };
             if !peers_received.insert(new_peer.public_key.clone()) {
-                warn!(target: LOG_TARGET, "Remote peer sent duplicate peer.");
-                return Err(NetworkDiscoveryError::DuplicatePeerReceived);
+                let err = NetworkDiscoveryError::DuplicatePeerReceived;
+                warn!(target: LOG_TARGET, "Discovering: Sync peer `{}` sent duplicate peer: {:?}", sync_peer, err);
+                return Err(err);
             }
-            self.validate_and_add_peer(sync_peer, new_peer).await?;
+            if let Err(err) = self.validate_and_add_peer(new_peer).await {
+                warn!(
+                    target: LOG_TARGET,
+                    "Discovering: Failed to validate and add peer from sync peer `{}`: {:?}", sync_peer, err
+                );
+                return Err(err);
+            }
         }
 
         Ok(())
     }
 
-    async fn validate_and_add_peer(
-        &mut self,
-        sync_peer: &NodeId,
-        new_peer: UnvalidatedPeerInfo,
-    ) -> Result<(), NetworkDiscoveryError> {
+    async fn validate_and_add_peer(&mut self, new_peer: UnvalidatedPeerInfo) -> Result<(), NetworkDiscoveryError> {
         let node_id = NodeId::from_public_key(&new_peer.public_key);
         if self.context.node_identity.node_id() == &node_id {
-            debug!(target: LOG_TARGET, "Received our own node from peer sync. Ignoring.");
+            debug!(target: LOG_TARGET, "Discovering: Received our own node from peer sync. Ignoring.");
             return Ok(());
         }
 
@@ -243,13 +371,7 @@ impl Discovering {
                 self.add_peer(valid_peer).await?;
                 Ok(())
             },
-            Err(err) => {
-                info!(
-                    target: LOG_TARGET,
-                    "Received invalid peer from sync peer '{}': {}.", sync_peer, err
-                );
-                Err(err.into())
-            },
+            Err(err) => Err(err.into()),
         }
     }
 
@@ -290,7 +412,7 @@ impl Discovering {
     }
 
     async fn ban_peer<T: ToString>(&mut self, peer: NodeId, severity: OffenceSeverity, err: T) {
-        if let Err(e) = self
+        match self
             .context
             .connectivity
             .ban_peer_until(
@@ -300,10 +422,19 @@ impl Discovering {
             )
             .await
         {
-            warn!(
-                target: LOG_TARGET,
-                "Failed to ban peer `{}`: {}", peer, e
-            );
+            Ok(_) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Discovering: Banned peer `{}` for {:.2?} due to '{}'",
+                    peer, self.config().ban_duration_from_severity(severity), err.to_string()
+                );
+            },
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Discovering: Failed to ban peer `{}`: {}", peer, e
+                );
+            },
         }
     }
 
@@ -325,7 +456,7 @@ impl Discovering {
 
         debug!(
             target: LOG_TARGET,
-            "Dialing {} candidate peer(s) for peer sync",
+            "Discovering: Dialing {} candidate peer(s) for peer sync",
             pending_dials.len()
         );
         pending_dials


### PR DESCRIPTION
Description
---
Added network discovery timeouts - this enhances discovery performance.

Fixes #7379.

Motivation and Context
---
Network discovery times out in the presence of bad/hanging RPC connections or operations, stopping it from working properly.

How Has This Been Tested?
---
System-level tests.

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling and error reporting during network peer discovery, reducing the likelihood of hanging or unresponsive operations.
  * Enhanced error and warning messages for failed peer connections, duplicate peers, and banning actions, making issues easier to identify.

* **Refactor**
  * Streamlined peer discovery logic for more robust and clear error handling, with improved log message consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->