### PR TITLE
fix: refresh balances in wallet debouncer  more often to prevent invalid balance

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_debouncer.rs
@@ -193,6 +193,7 @@ impl WalletDebouncer {
                                     #[allow(clippy::collapsible_if)]
                                     if faux {
                                         let mut intial = self.initial_validation_done.lock().await;
+                                        self.set_refresh_needed(true).await;
                                         if !(*intial) {
                                             if *self.intial_scanning_done.lock().await{
                                                 // we should only set this after we completed initial scanning and then completed faux tx validation


### PR DESCRIPTION
Description
---
Wallet debouncer showed invalid balance while scanning. This was caused by race condition where  UTXO scanner picked up transaction before it was validated.

How Has This Been Tested?
---
Build minotari_wallet binary and used it in Tari Universe while importing wallet.



Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

