### PR TITLE
chore(ci): disable cargo vet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
           cargo install cargo-machete@0.7.0
           cargo machete
       - name: cargo vet
+        # Disable cargo vet
+        if: ${{ false }}
         run: |
           cargo install cargo-vet@0.10.0 --locked
           cargo vet


### PR DESCRIPTION
Description
Disable CI cargo vet

Motivation and Context
Get CI working again, until we fix cargo vet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the "cargo vet" step in the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->