### PR TITLE
feat: add seed peer exclusion to network discovery

### DIFF
--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -35,6 +35,7 @@ use crate::{
         NodeDistance,
         NodeId,
         PeerFeatures,
+        PeerFlags,
         PeerManagerError,
         ThisPeerIdentity,
     },
@@ -221,6 +222,7 @@ impl PeerManager {
         n: usize,
         excluded_peers: &[NodeId],
         features: Option<PeerFeatures>,
+        peer_flags: Option<PeerFlags>,
         stale_peer_threshold: Option<Duration>,
         exclude_if_all_address_failed: bool,
         exclusion_distance: Option<NodeDistance>,
@@ -231,6 +233,7 @@ impl PeerManager {
             n,
             excluded_peers,
             features,
+            peer_flags,
             stale_peer_threshold,
             exclude_if_all_address_failed,
             exclusion_distance,
@@ -248,8 +251,13 @@ impl PeerManager {
     }
 
     /// Fetch n random peers that are Communication Nodes and have at least one external address
-    pub async fn random_peers(&self, n: usize, excluded: &[NodeId]) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.random_peers(n, excluded)
+    pub async fn random_peers(
+        &self,
+        n: usize,
+        excluded: &[NodeId],
+        flags: Option<PeerFlags>,
+    ) -> Result<Vec<Peer>, PeerManagerError> {
+        self.peer_storage_sql.random_peers(n, excluded, flags)
     }
 
     /// Calculate the region threshold for a given number of peers and features
@@ -589,6 +597,7 @@ mod test {
                 3,
                 &[],
                 None,
+                None,
                 Some(STALE_PEER_THRESHOLD_DURATION),
                 true,
                 None,
@@ -624,6 +633,7 @@ mod test {
                 3,
                 &excluded_peers,
                 None,
+                None,
                 Some(STALE_PEER_THRESHOLD_DURATION),
                 true,
                 None,
@@ -654,8 +664,8 @@ mod test {
         }
 
         // Test Random
-        let identities1 = peer_manager.random_peers(10, &[]).await.unwrap();
-        let identities2 = peer_manager.random_peers(10, &[]).await.unwrap();
+        let identities1 = peer_manager.random_peers(10, &[], None).await.unwrap();
+        let identities2 = peer_manager.random_peers(10, &[], None).await.unwrap();
         assert_ne!(identities1, identities2);
     }
 
@@ -838,6 +848,7 @@ mod test {
                             &[],
                             Some(PeerFeatures::COMMUNICATION_NODE),
                             None,
+                            None,
                             false,
                             None,
                             false,
@@ -872,6 +883,7 @@ mod test {
                 n,
                 &[],
                 Some(PeerFeatures::COMMUNICATION_NODE),
+                None,
                 None,
                 false,
                 None,

--- a/comms/core/src/peer_manager/peer_storage_sql.rs
+++ b/comms/core/src/peer_manager/peer_storage_sql.rs
@@ -34,6 +34,7 @@ use crate::{
         NodeDistance,
         NodeId,
         PeerFeatures,
+        PeerFlags,
         PeerManagerError,
     },
     types::{CommsDatabase, CommsPublicKey},
@@ -207,6 +208,7 @@ impl PeerStorageSql {
             n,
             excluded_peers,
             features,
+            None,
             Some(STALE_PEER_THRESHOLD_DURATION),
             external_addresses_only,
         )?)
@@ -236,6 +238,7 @@ impl PeerStorageSql {
         n: usize,
         excluded_peers: &[NodeId],
         features: Option<PeerFeatures>,
+        peer_flags: Option<PeerFlags>,
         stale_peer_threshold: Option<Duration>,
         exclude_if_all_address_failed: bool,
         exclusion_distance: Option<NodeDistance>,
@@ -246,6 +249,7 @@ impl PeerStorageSql {
             n,
             excluded_peers,
             features,
+            peer_flags,
             stale_peer_threshold,
             exclude_if_all_address_failed,
             exclusion_distance,
@@ -259,8 +263,13 @@ impl PeerStorageSql {
 
     /// Compile a random list of communication node peers of size _n_ that are not banned or offline  and have at least
     /// one external address
-    pub fn random_peers(&self, n: usize, exclude_peers: &[NodeId]) -> Result<Vec<Peer>, PeerManagerError> {
-        Ok(self.peer_db.get_n_random_peers(n, exclude_peers)?)
+    pub fn random_peers(
+        &self,
+        n: usize,
+        exclude_peers: &[NodeId],
+        flags: Option<PeerFlags>,
+    ) -> Result<Vec<Peer>, PeerManagerError> {
+        Ok(self.peer_db.get_n_random_peers(n, exclude_peers, flags)?)
     }
 
     /// Get the closest `n` not failed, banned or deleted peers, ordered by their distance to the given node ID.

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -1383,6 +1383,7 @@ impl PeerDatabaseSql {
         &self,
         excluded_peers: &[NodeId],
         features: Option<PeerFeatures>,
+        peer_flags: Option<PeerFlags>,
         stale_peer_threshold: Option<Duration>,
         exclude_if_all_address_failed: bool,
         at_least_one_external_addresses: bool,
@@ -1403,6 +1404,10 @@ impl PeerDatabaseSql {
             .filter(peers::node_id.ne_all(excluded_node_ids_hex))
             .distinct()
             .into_boxed(); // Enables dynamic query building
+
+        if let Some(flags) = peer_flags {
+            query = query.filter(peers::flags.eq(flags.to_i32()));
+        }
 
         if exclude_if_all_address_failed {
             query = query
@@ -1464,6 +1469,7 @@ impl PeerDatabaseSql {
         n: usize,
         excluded_peers: &[NodeId],
         features: Option<PeerFeatures>,
+        peer_flags: Option<PeerFlags>,
         stale_peer_threshold: Option<Duration>,
         exclude_if_all_address_failed: bool,
         exclusion_distance: Option<NodeDistance>,
@@ -1479,6 +1485,7 @@ impl PeerDatabaseSql {
             let node_ids_hex = self.get_active_peer_node_ids(
                 excluded_peers,
                 features,
+                peer_flags,
                 stale_peer_threshold,
                 exclude_if_all_address_failed,
                 external_addresses_only,
@@ -1518,6 +1525,7 @@ impl PeerDatabaseSql {
         n: usize,
         excluded_peers: &[NodeId],
         features: Option<PeerFeatures>,
+        peer_flags: Option<PeerFlags>,
         stale_peer_threshold: Option<Duration>,
         external_addresses_only: bool,
     ) -> Result<Vec<Peer>, StorageError> {
@@ -1531,6 +1539,7 @@ impl PeerDatabaseSql {
             let node_ids_hex = self.get_active_peer_node_ids(
                 excluded_peers,
                 features,
+                peer_flags,
                 stale_peer_threshold,
                 true,
                 external_addresses_only,
@@ -1546,7 +1555,12 @@ impl PeerDatabaseSql {
 
     /// Get a random set of `n` peers from the database that are not banned and not deleted and have at least one
     /// external address
-    pub fn get_n_random_peers(&self, n: usize, exclude_node_ids: &[NodeId]) -> Result<Vec<Peer>, StorageError> {
+    pub fn get_n_random_peers(
+        &self,
+        n: usize,
+        exclude_node_ids: &[NodeId],
+        peer_flags: Option<PeerFlags>,
+    ) -> Result<Vec<Peer>, StorageError> {
         if n == 0 {
             return Ok(Vec::new());
         }
@@ -1556,7 +1570,7 @@ impl PeerDatabaseSql {
 
         conn.transaction::<_, StorageError, _>(|conn| {
             // Step 1: Filtered, random and truncated list of node_ids
-            let node_ids: Vec<String> = peers::table
+            let mut query = peers::table
                 .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
                 .filter(peers::deleted_at.is_null())
                 .filter(
@@ -1574,7 +1588,13 @@ impl PeerDatabaseSql {
                 .limit(i64::try_from(n).unwrap_or(i64::MAX))
                 .select(peers::node_id)
                 .distinct()
-                .load::<String>(conn)?;
+                .into_boxed(); // Enables dynamic query building
+
+            if let Some(flags) = peer_flags {
+                query = query.filter(peers::flags.eq(flags.to_i32()));
+            }
+
+            let node_ids: Vec<String> = query.load::<String>(conn)?;
 
             if node_ids.is_empty() {
                 return Ok(Vec::new());
@@ -2106,6 +2126,7 @@ mod tests {
                 5,
                 &[node_peers[6].node_id.clone(), node_peers[7].node_id.clone()],
                 Some(PeerFeatures::MESSAGE_PROPAGATION),
+                None,
                 Some(Duration::from_secs(60)),
                 true,
                 None,
@@ -2120,6 +2141,7 @@ mod tests {
                 5,
                 &[node_peers[6].node_id.clone(), node_peers[7].node_id.clone()],
                 Some(PeerFeatures::DHT_STORE_FORWARD),
+                None,
                 Some(Duration::from_secs(60)),
                 true,
                 None,
@@ -2134,6 +2156,7 @@ mod tests {
                 5,
                 &[node_peers[6].node_id.clone(), node_peers[7].node_id.clone()],
                 Some(PeerFeatures::COMMUNICATION_NODE),
+                None,
                 Some(Duration::from_secs(60)),
                 true,
                 None,
@@ -2149,6 +2172,7 @@ mod tests {
                 5,
                 &[wallet_peers[6].node_id.clone(), wallet_peers[7].node_id.clone()],
                 Some(PeerFeatures::COMMUNICATION_CLIENT),
+                None,
                 Some(Duration::from_secs(60)),
                 true,
                 None,
@@ -2156,6 +2180,132 @@ mod tests {
             )
             .unwrap();
         assert_eq!(closest_peers.len(), 5);
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_seed_peer_exclusion() {
+        let db_connection = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
+        let peers_db = PeerDatabaseSql::new(
+            db_connection,
+            &create_test_peer(false, PeerFeatures::COMMUNICATION_NODE),
+        )
+        .unwrap();
+
+        // Create new node peers
+        let mut node_peers = Vec::with_capacity(12);
+        for i in 0..12 {
+            let mut peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+            if i % 3 == 0 {
+                peer.flags = PeerFlags::SEED;
+            }
+            node_peers.push(peer.clone());
+            peers_db.add_or_update_peer(peer).unwrap();
+        }
+
+        // All peers as closest
+        let closest_nodes = peers_db
+            .get_closest_n_active_peers(
+                &node_peers[5].node_id,
+                12,
+                &[],
+                Some(PeerFeatures::COMMUNICATION_NODE),
+                None,
+                Some(Duration::from_secs(60)),
+                true,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(closest_nodes.len(), 12);
+
+        // All seed peers only as closest
+        let closest_nodes = peers_db
+            .get_closest_n_active_peers(
+                &node_peers[5].node_id,
+                12,
+                &[],
+                Some(PeerFeatures::COMMUNICATION_NODE),
+                Some(PeerFlags::SEED),
+                Some(Duration::from_secs(60)),
+                true,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(closest_nodes.len(), 4);
+        assert!(closest_nodes.iter().all(|p| p.flags == PeerFlags::SEED));
+
+        // One seed peer as closest
+        let closest_nodes = peers_db
+            .get_closest_n_active_peers(
+                &node_peers[5].node_id,
+                1,
+                &[],
+                Some(PeerFeatures::COMMUNICATION_NODE),
+                Some(PeerFlags::SEED),
+                Some(Duration::from_secs(60)),
+                true,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(closest_nodes[0].flags, PeerFlags::SEED);
+
+        // All normal peers only as closest
+        let closest_nodes = peers_db
+            .get_closest_n_active_peers(
+                &node_peers[5].node_id,
+                12,
+                &[],
+                Some(PeerFeatures::COMMUNICATION_NODE),
+                Some(PeerFlags::NONE),
+                Some(Duration::from_secs(60)),
+                true,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(closest_nodes.len(), 8);
+        assert!(closest_nodes.iter().all(|p| p.flags == PeerFlags::NONE));
+
+        // One normal peer as closest
+        let closest_nodes = peers_db
+            .get_closest_n_active_peers(
+                &node_peers[5].node_id,
+                1,
+                &[],
+                Some(PeerFeatures::COMMUNICATION_NODE),
+                Some(PeerFlags::NONE),
+                Some(Duration::from_secs(60)),
+                true,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(closest_nodes[0].flags, PeerFlags::NONE);
+
+        // All peers as random
+        let random_peers = peers_db.get_n_random_peers(12, &[], None).unwrap();
+        assert_eq!(random_peers.len(), 12);
+
+        // All seed peers only as random
+        let random_peers = peers_db.get_n_random_peers(12, &[], Some(PeerFlags::SEED)).unwrap();
+        assert_eq!(random_peers.len(), 4);
+        assert!(random_peers.iter().all(|p| p.flags == PeerFlags::SEED));
+
+        // One seed peer as random
+        let random_peers = peers_db.get_n_random_peers(1, &[], Some(PeerFlags::SEED)).unwrap();
+        assert_eq!(random_peers[0].flags, PeerFlags::SEED);
+
+        // All normal peers only as random
+        let random_peers = peers_db.get_n_random_peers(12, &[], Some(PeerFlags::NONE)).unwrap();
+        assert_eq!(random_peers.len(), 8);
+        assert!(random_peers.iter().all(|p| p.flags == PeerFlags::NONE));
+
+        // One normal peer as random
+        let random_peers = peers_db.get_n_random_peers(1, &[], Some(PeerFlags::NONE)).unwrap();
+        assert_eq!(random_peers[0].flags, PeerFlags::NONE);
     }
 
     #[test]
@@ -2300,6 +2450,7 @@ mod tests {
                 5,
                 &[node_peers[6].node_id.clone(), node_peers[7].node_id.clone()],
                 Some(PeerFeatures::COMMUNICATION_NODE),
+                None,
                 Some(Duration::from_secs(60)),
                 true,
                 None,
@@ -2334,6 +2485,7 @@ mod tests {
                 5,
                 &[node_peers[6].node_id.clone(), node_peers[7].node_id.clone()],
                 Some(PeerFeatures::COMMUNICATION_NODE),
+                None,
                 Some(Duration::from_secs(60)),
                 true,
                 None,
@@ -2371,6 +2523,7 @@ mod tests {
                 5,
                 &[wallet_peers[6].node_id.clone(), wallet_peers[7].node_id.clone()],
                 Some(PeerFeatures::COMMUNICATION_CLIENT),
+                None,
                 Some(Duration::from_secs(60)),
                 true,
                 None,
@@ -2407,7 +2560,7 @@ mod tests {
 
         // Test 'random_peers_sqlite'
         let random_peers = peers_db
-            .get_n_random_peers(5, &[node_peers[0].node_id.clone()])
+            .get_n_random_peers(5, &[node_peers[0].node_id.clone()], None)
             .unwrap();
         assert_eq!(random_peers.len(), 5);
         // Verify deleted & banned
@@ -2649,7 +2802,9 @@ mod tests {
         assert_eq!(peers_db.size(), 40);
 
         // Assert that retrieved peers have internal and external addresses
-        let nodes_with_all_addresses = peers_db.get_n_random_active_peers(100, &[], None, None, false).unwrap();
+        let nodes_with_all_addresses = peers_db
+            .get_n_random_active_peers(100, &[], None, None, None, false)
+            .unwrap();
         assert_eq!(nodes_with_all_addresses.len(), 40);
         // - Has external address
         assert!(nodes_with_all_addresses
@@ -2670,8 +2825,9 @@ mod tests {
         assert_eq!(peers_db.size(), 48);
 
         // Assert that retrieved peers have external addresses only
-        let nodes_with_external_addresses_only =
-            peers_db.get_n_random_active_peers(100, &[], None, None, true).unwrap();
+        let nodes_with_external_addresses_only = peers_db
+            .get_n_random_active_peers(100, &[], None, None, None, true)
+            .unwrap();
         assert_eq!(nodes_with_external_addresses_only.len(), 40);
         // - Has external address only
         assert!(nodes_with_external_addresses_only

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -610,7 +610,7 @@ impl DhtActor {
             Random(n, excluded) => {
                 // Send to a random set of peers of size n that are Communication Nodes
                 peer_manager
-                    .random_peers(n, &excluded)
+                    .random_peers(n, &excluded, None)
                     .await?
                     .into_iter()
                     .map(|p| p.node_id)
@@ -792,6 +792,7 @@ impl DhtActor {
                 n,
                 excluded_peers,
                 Some(features),
+                None,
                 Some(STALE_PEER_THRESHOLD_DURATION),
                 true,
                 None,

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -981,6 +981,7 @@ impl DhtConnectivity {
                 n,
                 &excluded,
                 Some(PeerFeatures::COMMUNICATION_NODE),
+                None,
                 stale_peer_threshold,
                 exclude_if_all_address_failed,
                 exclusion_distance,
@@ -995,7 +996,7 @@ impl DhtConnectivity {
     async fn fetch_random_peers(&mut self, n: usize, excluded: &[NodeId]) -> Result<Vec<NodeId>, DhtConnectivityError> {
         let mut excluded = excluded.to_vec();
         excluded.extend(self.peer_allow_list().await?);
-        let peers = self.peer_manager.random_peers(n, &excluded).await?;
+        let peers = self.peer_manager.random_peers(n, &excluded, None).await?;
         Ok(peers.into_iter().map(|p| p.node_id).collect())
     }
 

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -117,6 +117,7 @@ async fn initialize() {
             4,
             &[],
             Some(PeerFeatures::COMMUNICATION_NODE),
+            None,
             Some(STALE_PEER_THRESHOLD_DURATION),
             true,
             None,

--- a/comms/dht/src/network_discovery/ready.rs
+++ b/comms/dht/src/network_discovery/ready.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use log::*;
-use tari_comms::peer_manager::{PeerFeatures, STALE_PEER_THRESHOLD_DURATION};
+use tari_comms::peer_manager::{PeerFeatures, PeerFlags, STALE_PEER_THRESHOLD_DURATION};
 
 use super::{
     state_machine::{DiscoveryParams, NetworkDiscoveryContext, StateEvent},
@@ -37,7 +37,7 @@ pub(super) struct DiscoveryReady {
     last_discovery: Option<DhtNetworkDiscoveryRoundInfo>,
 }
 
-// New helper function to select peers for discovery
+// Helper function to select peers for discovery
 async fn select_peers_for_discovery_round(
     context: &NetworkDiscoveryContext,
     last_round_info: Option<&DhtNetworkDiscoveryRoundInfo>,
@@ -59,6 +59,7 @@ async fn select_peers_for_discovery_round(
                     config.network_discovery.max_sync_peers,
                     excluded_peers,
                     Some(PeerFeatures::COMMUNICATION_NODE),
+                    Some(PeerFlags::NONE),
                     Some(STALE_PEER_THRESHOLD_DURATION),
                     true,
                     None,
@@ -77,7 +78,11 @@ async fn select_peers_for_discovery_round(
             );
             context
                 .peer_manager
-                .random_peers(config.network_discovery.max_sync_peers, excluded_peers)
+                .random_peers(
+                    config.network_discovery.max_sync_peers,
+                    excluded_peers,
+                    Some(PeerFlags::NONE),
+                )
                 .await?
         },
     };

--- a/comms/dht/src/rpc/service.rs
+++ b/comms/dht/src/rpc/service.rs
@@ -163,6 +163,7 @@ impl DhtRpcService for DhtRpcServiceImpl {
                 message.n as usize,
                 &excluded,
                 features,
+                None,
                 Some(STALE_PEER_THRESHOLD_DURATION),
                 true,
                 None,


### PR DESCRIPTION
Description
---
Added seed peer exclusion to network discovery's `Discovering` mode (`impl DiscoveryReady`) when seed strap has been concluded.

Motivation and Context
---
It is counterproductive to dial seed peers to discover other peers after seed strap has been concluded, as this requires asking for the same information again.

How Has This Been Tested?
---
- System-level testing confirming that seed peers are not redialed as part of `Discovering` mode.

What process can a PR reviewer use to test or verify this change?
---
- Code review.
- System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering peers by flags when selecting closest or random peers, allowing more granular peer selection.

* **Bug Fixes**
  * Updated peer selection methods throughout the application to accept and handle the new optional peer flag parameter, ensuring consistent behavior.

* **Tests**
  * Introduced new tests to verify correct peer selection when filtering by specific flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->