### PR TITLE
chore: condense MiningHelperError and easier to read

### DIFF
--- a/base_layer/tari_mining_helper_ffi/src/error.rs
+++ b/base_layer/tari_mining_helper_ffi/src/error.rs
@@ -59,51 +59,23 @@ pub struct MiningHelperError {
 
 impl From<InterfaceError> for MiningHelperError {
     fn from(v: InterfaceError) -> Self {
-        match v {
-            InterfaceError::NullError(_) => Self {
-                code: 1,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::Conversion(_) => Self {
-                code: 2,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::InvalidHash(_) => Self {
-                code: 3,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::LowDifficulty(_) => Self {
-                code: 4,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::AllocationError => Self {
-                code: 5,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::PositionInvalidError => Self {
-                code: 6,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::TokioError(_) => Self {
-                code: 7,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::CoinbaseBuildError(_) => Self {
-                code: 8,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::InvalidAddress(_) => Self {
-                code: 9,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::InvalidNetwork(_) => Self {
-                code: 10,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::KeyManager(_) => Self {
-                code: 11,
-                message: format!("{:?}", v),
-            },
+        let code = match &v {
+            InterfaceError::NullError(_) => 1,
+            InterfaceError::Conversion(_) => 2,
+            InterfaceError::InvalidHash(_) => 3,
+            InterfaceError::LowDifficulty(_) => 4,
+            InterfaceError::AllocationError => 5,
+            InterfaceError::PositionInvalidError => 6,
+            InterfaceError::TokioError(_) => 7,
+            InterfaceError::CoinbaseBuildError(_) => 8,
+            InterfaceError::InvalidAddress(_) => 9,
+            InterfaceError::InvalidNetwork(_) => 10,
+            InterfaceError::KeyManager(_) => 11,
+        };
+
+        Self {
+            code,
+            message: format!("{v:?}"),
         }
     }
 }

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -377,6 +377,7 @@ impl DhtNetworkDiscovery {
             (State::Ready(_), StateEvent::OnConnectMode) => State::OnConnect(OnConnect::new(self.context.clone())),
             (State::Ready(_), StateEvent::Idle) => State::Waiting(config.idle_period.into()),
             (State::OnConnect(_), StateEvent::Ready) => State::Ready(DiscoveryReady::new(self.context.clone())),
+            (State::Waiting(_), StateEvent::Ready) => State::Ready(DiscoveryReady::new(self.context.clone())), // <-- ADDED
             (_, StateEvent::Shutdown) => State::Shutdown,
             (_state, StateEvent::Errored(err)) => {
                 error!(


### PR DESCRIPTION
Description
MiningHelperError had a lot of repetition so I made it condensed it.

Motivation and Context
Looked through the code and thought that it could have some improvement.

How Has This Been Tested?
It's the same and I ran it and it didn't cause any errors

What process can a PR reviewer use to test or verify this change?
Make sure it doesn't cause any errors and it has the same functionality as the previous code.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
[x]

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined error handling in the mining helper, reducing duplication and unifying error message formatting; no public API changes.
* **Bug Fix**
  * Network discovery now progresses from Waiting to Ready when appropriate, enabling discovery readiness to be reached directly and improving connection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->