### PR TITLE
fix: add missing c29 parsers

### DIFF
--- a/base_layer/core/src/proof_of_work/proof_of_work_algorithm.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work_algorithm.rs
@@ -69,6 +69,7 @@ impl TryFrom<u64> for PowAlgorithm {
             0 => Ok(PowAlgorithm::RandomXM),
             1 => Ok(PowAlgorithm::Sha3x),
             2 => Ok(PowAlgorithm::RandomXT),
+            3 => Ok(PowAlgorithm::Cuckaroo),
             _ => Err("Invalid PoWAlgorithm".into()),
         }
     }
@@ -85,6 +86,7 @@ impl FromStr for PowAlgorithm {
             },
             "SHA" | "SHA3" | "SHA3X" => Ok(Self::Sha3x),
             "RANDOMXT" | "RANDOM_XT" | "TARI_RANDOM_X" | "RANDOMXTARI" => Ok(Self::RandomXT),
+            "CUCKAROO" | "CUCKAROO29" | "C29" => Ok(Self::Cuckaroo),
             _ => Err(anyhow::Error::msg(format!("Unknown pow algorithm type: {}", s))),
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Cuckaroo proof-of-work algorithm.
  * You can now select this algorithm using the identifiers “cuckaroo”, “cuckaroo29”, “c29”, or the numeric value 3 in configuration or CLI options.
  * Enhances compatibility with configurations and tools that reference this algorithm by these names or ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->