### PR TITLE
chore(ci): update docker build to include mainNet and esme for tagged releases

### DIFF
--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -48,8 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      TARI_NETWORK: ${{ steps.set-tari-network.outputs.TARI_NETWORK }}
-      TARI_TARGET_NETWORK: ${{ steps.set-tari-network.outputs.TARI_TARGET_NETWORK }}
 
     steps:
       - name: checkout tari
@@ -75,29 +73,11 @@ jobs:
           fi
 
           cd buildtools/docker_rig
-          source ./build-matrix.sh "${{ inputs.build_items }}" "${VERSION}" "${{ inputs.platforms }}"
+          source ./build-matrix.sh "${{ inputs.build_items }}" "${VERSION}" "${{ inputs.platforms }}" "${{ inputs.tari_network }}"
 
           echo "${matrix}"
           echo "${matrix}" | jq .
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
-
-      - name: Declare TestNet for tags/branches
-        id: set-tari-network
-        shell: bash
-        run: |
-          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] && [ -z "${{ inputs.tari_network }}" ]; then
-            # Case: A version tag push (e.g., v1.0.0), not manually triggered
-            echo "Using $GITHUB_REF_NAME for multinet_envs.sh"
-            source ./buildtools/multinet_envs.sh "$GITHUB_REF_NAME"
-          else
-            # Case: Manually triggered workflow, or non-tag
-            echo "Using ${{ inputs.tari_network }} for multinet_envs.sh"
-            source ./buildtools/multinet_envs.sh "${{ inputs.tari_network }}"
-          fi
-          echo "${TARI_NETWORK}"
-          echo "TARI_NETWORK=${TARI_NETWORK}" >> $GITHUB_OUTPUT
-          echo "${TARI_TARGET_NETWORK}"
-          echo "TARI_TARGET_NETWORK=${TARI_TARGET_NETWORK}" >> $GITHUB_OUTPUT
 
   docker_builds:
     name: Docker ${{ matrix.builds.arch }} ${{ matrix.builds.image_name }} build
@@ -114,10 +94,6 @@ jobs:
       packages: write
 
     runs-on: ${{ matrix.builds.runner }}
-
-    env:
-      TARI_NETWORK: ${{ needs.builds_envs_setup.outputs.TARI_NETWORK }}
-      TARI_TARGET_NETWORK: ${{ needs.builds_envs_setup.outputs.TARI_TARGET_NETWORK }}
 
     steps:
       - name: checkout tari
@@ -144,10 +120,10 @@ jobs:
 
             if [ ! -z "${{ inputs.tag_alias }}" ] ; then
               echo "Setup tag_alias with network"
-              echo "TAG_ALIASQ=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ env.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
-              echo "TAG_ALIASG=ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ env.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+              echo "TAG_ALIASQ=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ matrix.builds.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+              echo "TAG_ALIASG=ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ matrix.builds.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
             fi
-            echo "DSuffix=-${{ env.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+            echo "DSuffix=-${{ matrix.builds.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
           else
             echo "3rd Party builds - ${IMAGE_NAME}"
             echo "DOCKER_SUBTAG=${{ matrix.builds.build_args }}" >> $GITHUB_ENV
@@ -228,8 +204,8 @@ jobs:
             FEATURES=${{ inputs.features }}
             APP_NAME=${{ matrix.builds.app_name }}
             APP_EXEC=${{ matrix.builds.app_exec }}
-            TARI_NETWORK=${{ env.TARI_NETWORK }}
-            TARI_TARGET_NETWORK=${{ env.TARI_TARGET_NETWORK }}
+            TARI_NETWORK=${{ matrix.builds.TARI_NETWORK }}
+            TARI_TARGET_NETWORK=${{ matrix.builds.TARI_TARGET_NETWORK }}
             ${{ env.DOCKER_SUBTAG }}
           tags: |
             ${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ matrix.builds.version }}${{ env.DSuffix }}
@@ -262,20 +238,19 @@ jobs:
       - name: Pre for multi-arch image merge
         env:
           BMATRIX: ${{ needs.builds_envs_setup.outputs.matrix }}
-          TARI_NETWORK: ${{ needs.builds_envs_setup.outputs.TARI_NETWORK }}
         run: |
-          # set -xuo pipefail
+          set -xuo pipefail
           echo '${{ env.BMATRIX }}' | jq -r
 
           # Get all multi-arch image_names (have both amd64 and arm64), with version
           mapfile -t multiarch_images < <(
             echo '${{ env.BMATRIX }}' | jq -r '
               .builds
-                | group_by(.image_name)
+                | group_by([.image_name, .tari_network])
                 | map(select((map(.arch) | index("amd64")) and (map(.arch) | index("arm64"))))
-                | map({image_name: .[0].image_name, version: .[0].version})
+                | map({image_name: .[0].image_name, version: .[0].version, tari_network: .[0].tari_network})
                 | unique
-                | map("\(.image_name):\(.version)")
+                | map("\(.image_name):\(.version):\(.tari_network)")
                 | .[]
               '
             )
@@ -293,10 +268,13 @@ jobs:
             echo "Found ${#multiarch_images[@]} multi-arch Docker images."
             echo "${multiarch_images[*]}"
             for DENTRY in "${multiarch_images[@]}"; do
-              DNAME="${DENTRY%%:*}"
-              DVERSION="${DENTRY##*:}"
+              DNAME="${DENTRY%%:*}"             # before first :
+              REST="${DENTRY#*:}"               # drop first :
+              DVERSION="${REST%%:*}"            # version
+              DNETWORK="${REST##*:}"            # tari_network
+
               if [ "${DNAME:0:9}" = "minotari_" ] ; then
-                DSUFFIX=-${{ env.TARI_NETWORK }}
+                DSUFFIX=-${DNETWORK}
               else
                 DSUFFIX=
               fi

--- a/.github/workflows/build_dockers_workflow.yml
+++ b/.github/workflows/build_dockers_workflow.yml
@@ -120,10 +120,10 @@ jobs:
 
             if [ ! -z "${{ inputs.tag_alias }}" ] ; then
               echo "Setup tag_alias with network"
-              echo "TAG_ALIASQ=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ matrix.builds.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
-              echo "TAG_ALIASG=ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ matrix.builds.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+              echo "TAG_ALIASQ=${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ matrix.builds.tari_network }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+              echo "TAG_ALIASG=ghcr.io/${{ github.repository_owner }}/${{ matrix.builds.image_name }}:${{ inputs.tag_alias }}-${{ matrix.builds.tari_network }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
             fi
-            echo "DSuffix=-${{ matrix.builds.TARI_NETWORK }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
+            echo "DSuffix=-${{ matrix.builds.tari_network }}-${{ matrix.builds.arch }}" >> $GITHUB_ENV
           else
             echo "3rd Party builds - ${IMAGE_NAME}"
             echo "DOCKER_SUBTAG=${{ matrix.builds.build_args }}" >> $GITHUB_ENV
@@ -204,8 +204,8 @@ jobs:
             FEATURES=${{ inputs.features }}
             APP_NAME=${{ matrix.builds.app_name }}
             APP_EXEC=${{ matrix.builds.app_exec }}
-            TARI_NETWORK=${{ matrix.builds.TARI_NETWORK }}
-            TARI_TARGET_NETWORK=${{ matrix.builds.TARI_TARGET_NETWORK }}
+            TARI_NETWORK=${{ matrix.builds.tari_network }}
+            TARI_TARGET_NETWORK=${{ matrix.builds.tari_target_network }}
             ${{ env.DOCKER_SUBTAG }}
           tags: |
             ${{ secrets.DOCKER_PROVIDER }}/${{ secrets.DOCKER_REPO }}/${{ matrix.builds.image_name }}:${{ matrix.builds.version }}${{ env.DSuffix }}
@@ -300,7 +300,7 @@ jobs:
                 docker manifest push ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX} || true
 
                 if [[ "${{ inputs.tag_alias }}" =~ ^latest-.*$ ]]; then
-                  echo "Latest Alis Multi-Arch tag - ${{ inputs.tag_alias }}"
+                  echo "Latest Alias Multi-Arch tag - ${{ inputs.tag_alias }}"
                   docker manifest create \
                     ${DREGISTRY}/${REPO}/${DNAME}:${{ inputs.tag_alias }}${DSUFFIX} \
                       --amend ${DREGISTRY}/${REPO}/${DNAME}:${DVERSION}${DSUFFIX}-amd64 \

--- a/buildtools/docker_rig/build-matrix.sh
+++ b/buildtools/docker_rig/build-matrix.sh
@@ -7,7 +7,7 @@
 # ./build-matrix.sh tor "4.4.1" "linux/arm64"
 #
 
-set -euxo pipefail
+# set -euxo pipefail
 
 build_items=${1:-minotari_all}
 echo "Building with ${build_items}."
@@ -119,11 +119,12 @@ build_networks=${4:-"esme, mainnet"}
 mapfile -t networks_list < <(echo "${build_networks}" | tr ',' '\n'| awk '{$1=$1; print}')
 # Convert platform list to JSON array
 networks_json=$(jq -n --argjson p "$(printf '%s\n' "${networks_list[@]}" | jq -R . | jq -s .)" '$p')
-# Final merged matrix
+
+# Networks merged matrix
 matrix_final="[]"
 
 for net in "${networks_list[@]}"; do
-  source ../multinet_envs.sh ${net}
+  source ../multinet_envs.sh "${net}"
   # Add tari_network and tari_target_network for this network
   matrix_network=$(echo "${matrix_platforms}" | \
     jq --arg tn "${net}" --arg ttn "${TARI_TARGET_NETWORK}" 'map(. + {"tari_network": $tn, "tari_target_network": $ttn})')
@@ -132,7 +133,6 @@ for net in "${networks_list[@]}"; do
   matrix_final=$(echo "${matrix_final} ${matrix_network}" | jq -s 'add')
 done
 
-#matrix=$(echo "${matrix_platforms}" | jq -s -c '{"builds": .[]}')
 matrix=$(echo "${matrix_final}" | jq -s -c '{"builds": .[]}')
 
 echo "${matrix}"

--- a/buildtools/docker_rig/build-matrix.sh
+++ b/buildtools/docker_rig/build-matrix.sh
@@ -2,8 +2,8 @@
 #
 # prep json build matrix from args
 #
-# ./build-matrix.sh all "4.4.1" "linux/amd64,linux/arm64"
-# ./build-matrix.sh minotari_sha3_miner "4.4.1" "linux/arm64"
+# ./build-matrix.sh all "4.4.1" "linux/amd64,linux/arm64" mainnet
+# ./build-matrix.sh minotari_sha3_miner "4.4.1" "linux/arm64" igor
 # ./build-matrix.sh tor "4.4.1" "linux/arm64"
 #
 
@@ -114,7 +114,26 @@ matrix_platforms=$(jq --argjson platforms "$platforms_json" '
   ]
 ' <<< "${matrix_details}")
 
-matrix=$(echo "${matrix_platforms}" | jq -s -c '{"builds": .[]}')
+# Prep multTest setups
+build_networks=${4:-"esme, mainnet"}
+mapfile -t networks_list < <(echo "${build_networks}" | tr ',' '\n'| awk '{$1=$1; print}')
+# Convert platform list to JSON array
+networks_json=$(jq -n --argjson p "$(printf '%s\n' "${networks_list[@]}" | jq -R . | jq -s .)" '$p')
+# Final merged matrix
+matrix_final="[]"
+
+for net in "${networks_list[@]}"; do
+  source ../multinet_envs.sh ${net}
+  # Add tari_network and tari_target_network for this network
+  matrix_network=$(echo "${matrix_platforms}" | \
+    jq --arg tn "${net}" --arg ttn "${TARI_TARGET_NETWORK}" 'map(. + {"tari_network": $tn, "tari_target_network": $ttn})')
+
+  # Merge into final matrix
+  matrix_final=$(echo "${matrix_final} ${matrix_network}" | jq -s 'add')
+done
+
+#matrix=$(echo "${matrix_platforms}" | jq -s -c '{"builds": .[]}')
+matrix=$(echo "${matrix_final}" | jq -s -c '{"builds": .[]}')
 
 echo "${matrix}"
 echo "${matrix}" | jq .


### PR DESCRIPTION
Description
update docker build to include mainNet and esme for tagged releases

Motivation and Context
update docker builds to match binary releases

How Has This Been Tested?
Builds in local fork for branched and tagged releases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker images and multi-arch manifests are fully network-aware with network-specific tags and grouping.

* **Chores**
  * Build matrix now includes per-network entries so each build is scoped by network.
  * Removed legacy global network env exposure; steps consume matrix-provided network values.
  * Eliminated separate TestNet declaration step.
  * Enabled verbose shell in a key prep step to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->