### PR TITLE
feat: add cli payref search for minotari node

### DIFF
--- a/applications/minotari_node/src/commands/command/mod.rs
+++ b/applications/minotari_node/src/commands/command/mod.rs
@@ -50,6 +50,7 @@ mod quit;
 mod reset_offline_peers;
 mod rewind_blockchain;
 mod search_kernel;
+mod search_payref;
 mod search_utxo;
 mod status;
 mod test_peer_liveness;
@@ -136,6 +137,7 @@ pub enum Command {
     DiscoverPeer(discover_peer::Args),
     GetBlock(get_block::Args),
     SearchUtxo(search_utxo::Args),
+    SearchPayref(search_payref::Args),
     SearchKernel(search_kernel::Args),
     GetMempoolStats(get_mempool_stats::Args),
     GetMempoolState(get_mempool_state::Args),
@@ -234,6 +236,7 @@ impl CommandContext {
                 Command::ListHeaders(_) |
                 Command::HeaderStats(_) |
                 Command::SearchUtxo(_) |
+                Command::SearchPayref(_) |
                 Command::SearchKernel(_) |
                 Command::GetMempoolStats(_) |
                 Command::GetMempoolState(_) |
@@ -301,6 +304,7 @@ impl HandleCommand<Command> for CommandContext {
             Command::DiscoverPeer(args) => self.handle_command(args).await,
             Command::GetBlock(args) => self.handle_command(args).await,
             Command::SearchUtxo(args) => self.handle_command(args).await,
+            Command::SearchPayref(args) => self.handle_command(args).await,
             Command::SearchKernel(args) => self.handle_command(args).await,
             Command::ListConnections(args) => self.handle_command(args).await,
             Command::GetMempoolStats(args) => self.handle_command(args).await,

--- a/applications/minotari_node/src/commands/command/search_payref.rs
+++ b/applications/minotari_node/src/commands/command/search_payref.rs
@@ -24,6 +24,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
 use tari_common_types::types::FixedHash;
+use tari_utilities::hex::Hex;
 
 use super::{CommandContext, HandleCommand};
 use crate::commands::parser::FromHex;
@@ -54,7 +55,7 @@ impl CommandContext {
         }
         println!(
             "Found output for payref, commitment: {}",
-            mined_info.output.as_ref().unwrap().output.commitment()
+            mined_info.output.as_ref().unwrap().output.commitment().to_hex()
         );
 
         println!("---- Mined info ----");

--- a/applications/minotari_node/src/commands/command/search_payref.rs
+++ b/applications/minotari_node/src/commands/command/search_payref.rs
@@ -1,0 +1,65 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use anyhow::Error;
+use async_trait::async_trait;
+use clap::Parser;
+use tari_common_types::types::FixedHash;
+
+use super::{CommandContext, HandleCommand};
+use crate::commands::parser::FromHex;
+
+/// This will search the main chain for the utxo.
+/// If the utxo is found, it will print out
+/// the block it was found in.
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// hex of commitment of the utxo
+    payref: FromHex<FixedHash>,
+}
+
+#[async_trait]
+impl HandleCommand<Args> for CommandContext {
+    async fn handle_command(&mut self, args: Args) -> Result<(), Error> {
+        self.search_payref(args.payref.0).await
+    }
+}
+
+impl CommandContext {
+    /// Function to process the search utxo command
+    pub async fn search_payref(&mut self, payref: FixedHash) -> Result<(), Error> {
+        let mined_info = self.node_service.fetch_mined_info_by_payref(&payref).await?;
+        if mined_info.output.is_none() {
+            println!("No output found for {}", payref);
+            return Ok(());
+        }
+        println!(
+            "Found output for payref, commitment: {}",
+            mined_info.output.as_ref().unwrap().output.commitment()
+        );
+
+        println!("---- Mined info ----");
+        println!("{mined_info}");
+
+        Ok(())
+    }
+}

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -242,11 +242,11 @@ where B: BlockchainBackend + 'static
                         Ok(Some(block)) => blocks.push(block),
                         Ok(None) => warn!(
                             target: LOG_TARGET,
-                            "Could not provide requested block with commitment {commitment_hex} to peer because not stored"
+                            "Could not provide requested block with commitment {commitment_hex} to because not stored"
                         ),
                         Err(e) => warn!(
                             target: LOG_TARGET,
-                            "Could not provide requested block with commitment {commitment_hex} to peer because: {e}"
+                            "Could not provide requested block with commitment {commitment_hex} to because: {e}"
                         ),
                     }
                 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -242,11 +242,11 @@ where B: BlockchainBackend + 'static
                         Ok(Some(block)) => blocks.push(block),
                         Ok(None) => warn!(
                             target: LOG_TARGET,
-                            "Could not provide requested block with commitment {commitment_hex} to because not stored"
+                            "Could not provide requested block with commitment {commitment_hex} because not stored"
                         ),
                         Err(e) => warn!(
                             target: LOG_TARGET,
-                            "Could not provide requested block with commitment {commitment_hex} to because: {e}"
+                            "Could not provide requested block with commitment {commitment_hex} because: {e}"
                         ),
                     }
                 }

--- a/base_layer/core/src/chain_storage/utxo_mined_info.rs
+++ b/base_layer/core/src/chain_storage/utxo_mined_info.rs
@@ -22,6 +22,7 @@
 
 use std::fmt::Display;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::BlockHash;
 
@@ -52,19 +53,29 @@ pub struct MinedInfo {
 impl Display for MinedInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(output) = &self.output {
+            let time =
+                DateTime::<Utc>::from_timestamp(i64::try_from(output.mined_timestamp.as_u64()).unwrap_or(i64::MAX), 0)
+                    .unwrap_or(DateTime::<Utc>::MAX_UTC);
             writeln!(
                 f,
                 "Output mined at height {} in block {} at timestamp {}",
-                output.mined_height, output.header_hash, output.mined_timestamp
+                output.mined_height,
+                output.header_hash,
+                time.to_rfc2822()
             )?;
         } else {
             writeln!(f, "Output not mined ")?;
         }
         if let Some(input) = &self.input {
+            let time =
+                DateTime::<Utc>::from_timestamp(i64::try_from(input.spent_timestamp.as_u64()).unwrap_or(i64::MAX), 0)
+                    .unwrap_or(DateTime::<Utc>::MAX_UTC);
             writeln!(
                 f,
                 "Output spent at height {} in block {} at timestamp {}",
-                input.spent_height, input.header_hash, input.spent_timestamp
+                input.spent_height,
+                input.header_hash,
+                time.to_rfc2822()
             )?;
         } else {
             writeln!(f, "Output not spent")?;

--- a/base_layer/core/src/chain_storage/utxo_mined_info.rs
+++ b/base_layer/core/src/chain_storage/utxo_mined_info.rs
@@ -53,9 +53,8 @@ pub struct MinedInfo {
 impl Display for MinedInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(output) = &self.output {
-            let time =
-                DateTime::<Utc>::from_timestamp(i64::try_from(output.mined_timestamp.as_u64()).unwrap_or(i64::MAX), 0)
-                    .unwrap_or(DateTime::<Utc>::MAX_UTC);
+            let time = DateTime::<Utc>::from_timestamp(i64::try_from(output.mined_timestamp).unwrap_or(i64::MAX), 0)
+                .unwrap_or(DateTime::<Utc>::MAX_UTC);
             writeln!(
                 f,
                 "Output mined at height {} in block {} at timestamp {}",
@@ -67,9 +66,8 @@ impl Display for MinedInfo {
             writeln!(f, "Output not mined ")?;
         }
         if let Some(input) = &self.input {
-            let time =
-                DateTime::<Utc>::from_timestamp(i64::try_from(input.spent_timestamp.as_u64()).unwrap_or(i64::MAX), 0)
-                    .unwrap_or(DateTime::<Utc>::MAX_UTC);
+            let time = DateTime::<Utc>::from_timestamp(i64::try_from(input.spent_timestamp).unwrap_or(i64::MAX), 0)
+                .unwrap_or(DateTime::<Utc>::MAX_UTC);
             writeln!(
                 f,
                 "Output spent at height {} in block {} at timestamp {}",

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -416,6 +416,9 @@ impl CompletedTransaction {
     }
 
     pub fn calculate_received_payment_references(&self) -> Vec<PaymentReference> {
+        if !self.status.is_confirmed() {
+            return vec![];
+        }
         if let Some(block_hash) = self.mined_in_block.as_ref() {
             return self
                 .received_output_hashes
@@ -427,6 +430,9 @@ impl CompletedTransaction {
     }
 
     pub fn calculate_sent_payment_references(&self) -> Vec<PaymentReference> {
+        if !self.status.is_confirmed() {
+            return vec![];
+        }
         if let Some(block_hash) = self.mined_in_block.as_ref() {
             return self
                 .sent_output_hashes
@@ -438,6 +444,9 @@ impl CompletedTransaction {
     }
 
     pub fn calculate_change_payment_references(&self) -> Vec<PaymentReference> {
+        if !self.status.is_confirmed() {
+            return vec![];
+        }
         if let Some(block_hash) = self.mined_in_block.as_ref() {
             return self
                 .change_output_hashes


### PR DESCRIPTION
Description
---
Added a payref search option for cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a CLI command to search mined info by hex-encoded payment reference; displays output commitment and mined details or a clear "not found" message.

- Bug Fixes
  - Payment-reference calculations now return empty lists for unconfirmed transactions to avoid incorrect references until confirmed.

- Style
  - Clarified UTXO fetch log messages and standardized mined/spent timestamps to RFC 2822 for human-friendly display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->