### PR TITLE
chore: new release v5.0.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.13.1",
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_utilities"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "clap 3.2.25",
  "dialoguer 0.10.4",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_console_wallet"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "blake2",
  "chrono",
@@ -4256,14 +4256,14 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "bs58 0.5.1",
 ]
 
 [[package]]
 name = "minotari_ledger_wallet_comms"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "borsh",
  "dialoguer 0.11.0",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_merge_mining_proxy"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4330,7 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_miner"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_node"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "minotari_app_grpc",
  "tokio",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_utils"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "argon2 0.4.1",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet_ffi"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "borsh",
  "cbindgen",
@@ -7486,7 +7486,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -7512,7 +7512,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -7529,7 +7529,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.21.7",
@@ -7567,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7618,7 +7618,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -7660,7 +7660,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "futures 0.3.31",
  "proc-macro2",
@@ -7675,7 +7675,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7766,11 +7766,11 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 
 [[package]]
 name = "tari_hashing"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "blake2",
  "borsh",
@@ -7826,7 +7826,7 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "borsh",
  "digest",
@@ -7839,7 +7839,7 @@ dependencies = [
 
 [[package]]
 name = "tari_libtor"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "derivative",
  "libtor",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "borsh",
  "serde",
@@ -7862,7 +7862,7 @@ dependencies = [
 
 [[package]]
 name = "tari_metrics"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "bincode",
  "blake2",
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -7928,7 +7928,7 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "blake2",
  "borsh",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7963,7 +7963,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "futures 0.3.31",
  "tokio",
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "borsh",
  "hex",
@@ -7988,7 +7988,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -8001,7 +8001,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "futures 0.3.31",
  "futures-test",
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8062,7 +8062,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_key_manager"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "chacha20poly1305",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari"

--- a/applications/minotari_ledger_wallet/comms/Cargo.toml
+++ b/applications/minotari_ledger_wallet/comms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minotari_ledger_wallet_comms"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 authors = ["The Tari Development Community"]
 license = "BSD-3-Clause"
 edition = "2021"

--- a/applications/minotari_ledger_wallet/wallet/Cargo.lock
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "blake2",
  "borsh",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 dependencies = [
  "bs58",
 ]

--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minotari_ledger_wallet"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 authors = ["The Tari Development Community"]
 license = "BSD-3-Clause"
 edition = "2021"

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari miner implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 edition = "2018"
 
 [dependencies]

--- a/changelog-development.md
+++ b/changelog-development.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.0.0-pre.5](https://github.com/tari-project/tari/compare/v5.0.0-pre.4...v5.0.0-pre.5) (2025-08-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* update c29 fork block (#7434)
+
+### Features
+
+* update c29 fork block ([#7434](https://github.com/tari-project/tari/issues/7434)) ([344dde7](https://github.com/tari-project/tari/commit/344dde703fbb06314a39566c425a8f6715810783))
+
+
+### Bug Fixes
+
+* siphash calcs for c29 ([#7433](https://github.com/tari-project/tari/issues/7433)) ([80e0528](https://github.com/tari-project/tari/commit/80e0528bfecc602132d531af3e0e755a632bd63e))
+* tari address serialization ([#7424](https://github.com/tari-project/tari/issues/7424)) ([e5e40ab](https://github.com/tari-project/tari/commit/e5e40abea087053bd1f36b98f512f9cb1050168f))
+
 ## [5.0.0-pre.4](https://github.com/tari-project/tari/compare/v5.0.0-pre.3...v5.0.0-pre.4) (2025-08-20)
 
 

--- a/clients/ffi_client/package-lock.json
+++ b/clients/ffi_client/package-lock.json
@@ -18,11 +18,11 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "ms": "5.0.0-pre.4"
+            "ms": "5.0.0-pre.5"
           }
         },
         "ms": {
-          "version": "5.0.0-pre.4",
+          "version": "5.0.0-pre.5",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
@@ -180,11 +180,11 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "ms": "5.0.0-pre.4"
+            "ms": "5.0.0-pre.5"
           }
         },
         "ms": {
-          "version": "5.0.0-pre.4",
+          "version": "5.0.0-pre.5",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 edition = "2018"
 
 [lib]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "5.0.0-pre.4"
+version = "5.0.0-pre.5"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tari",
-  "version": "5.0.0-pre.4",
+  "version": "5.0.0-pre.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
Description
---
new release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 5.0.0-pre.5 across the workspace packages.

* **Documentation**
  * Added changelog entry for 5.0.0-pre.5, noting:
    - Breaking change: updated c29 fork block.
    - Feature: c29 fork block update.
    - Bug fixes: corrected siphash calculations for c29 and Tari address serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->