### PR TITLE
chore(ci): remove minotari_mining_helper_ffi from builds

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -24,7 +24,7 @@ env:
   ## Must be a JSon string
   TS_FILES: '["minotari_node","minotari_console_wallet","minotari_miner","minotari_merge_mining_proxy"]'
   TS_FEATURES: "default, safe"
-  TS_LIBRARIES: "minotari_mining_helper_ffi"
+  TS_LIBRARIES: ""
   TS_DESCRIPTION: "Tari Suite"
   TS_URL: "https://tari.com"
   # For debug builds


### PR DESCRIPTION
Description
remove minotari_mining_helper_ffi from ci builds process

Motivation and Context
Fix binary builds

How Has This Been Tested?
Builds in local fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to stop packaging optional library binaries in release artifacts.
  * Core application binaries remain unaffected; no changes to runtime behavior.
  * Results in leaner artifacts and a simplified release package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->