### PR TITLE
fix: offline signing 0 fees

### DIFF
--- a/base_layer/transaction_components/src/transaction_builder/builder.rs
+++ b/base_layer/transaction_components/src/transaction_builder/builder.rs
@@ -17,7 +17,7 @@ use tari_common_types::{
         UncompressedSignature,
     },
 };
-use tari_script::{script, ExecutionStack};
+use tari_script::{push_pubkey_script, script, ExecutionStack};
 
 use crate::{
     consensus::ConsensusConstants,
@@ -31,6 +31,7 @@ use crate::{
     transaction_components::{
         covenants::Covenant,
         memo_field::{MemoField, TxType},
+        one_sided::{shared_secret_to_output_encryption_key, shared_secret_to_output_spending_key},
         CoreTransactionBuilder,
         KernelBuilder,
         KernelFeatures,
@@ -40,6 +41,7 @@ use crate::{
         TransactionOutput,
         TransactionOutputVersion,
         WalletOutput,
+        WalletOutputBuilder,
         MAX_TRANSACTION_INPUTS,
         MAX_TRANSACTION_OUTPUTS,
     },
@@ -159,6 +161,128 @@ where KM: TransactionKeyManagerInterface
         Ok(self)
     }
 
+    pub async fn add_stealth_recipient(
+        &mut self,
+        destination: TariAddress,
+        amount: MicroMinotari,
+        output_features: OutputFeatures,
+        memo_field: MemoField,
+    ) -> Result<WalletOutput, TransactionBuilderError> {
+        // This call is needed to advance the state from `SingleRoundMessageReady` to `SingleRoundMessageReady`,
+        // but the returned value is not used. We have to wait until the sender transaction protocol creates a
+        // sender_offset_private_key for us, so we can use it to create the shared secret
+        let sender_offset_private_key = self
+            .key_manager
+            .get_next_key(TransactionKeyManagerBranch::OneSidedSenderOffset.get_branch_key())
+            .await?;
+
+        // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is fed into
+        // KDFs to produce the spending, rewind, and encryption keys
+        let shared_secret = self
+            .key_manager
+            .get_diffie_hellman_shared_secret(
+                &sender_offset_private_key.key_id,
+                destination
+                    .public_view_key()
+                    .ok_or(TransactionBuilderError::InvalidAddressNoViewKey)?,
+            )
+            .await?;
+        let commitment_mask_private_key = shared_secret_to_output_spending_key(&shared_secret)?;
+        let commitment_mask_key_id = self.key_manager.import_key(commitment_mask_private_key.clone()).await?;
+
+        let script_spending_key = self
+            .key_manager
+            .stealth_address_script_spending_key(&commitment_mask_key_id, destination.public_spend_key())
+            .await?;
+        let script = push_pubkey_script(&script_spending_key);
+
+        let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret)?;
+        let encryption_key = self.key_manager.import_key(encryption_private_key).await?;
+
+        let sender_offset_public_key = self
+            .key_manager
+            .get_public_key_at_key_id(&sender_offset_private_key.key_id)
+            .await?;
+
+        let minimum_value_promise = MicroMinotari::zero();
+        let output = WalletOutputBuilder::new(amount, commitment_mask_key_id)
+            .with_features(output_features)
+            .with_script(script)
+            .encrypt_data_for_recovery(&self.key_manager, Some(&encryption_key), memo_field)
+            .await?
+            .with_input_data(Default::default())
+            .with_sender_offset_public_key(sender_offset_public_key)
+            .with_script_key(TariKeyId::Zero)
+            .with_minimum_value_promise(minimum_value_promise)
+            .sign_as_sender_and_receiver_verified(&self.key_manager, &sender_offset_private_key.key_id, &destination)
+            .await?
+            .try_build(&self.key_manager)
+            .await?;
+
+        self.add_recipient(destination, output.clone(), Some(sender_offset_private_key.key_id))
+            .await?;
+        Ok(output)
+    }
+
+    pub async fn add_depricated_one_sided_recipient(
+        &mut self,
+        destination: TariAddress,
+        amount: MicroMinotari,
+        output_features: OutputFeatures,
+        memo_field: MemoField,
+    ) -> Result<WalletOutput, TransactionBuilderError> {
+        // This call is needed to advance the state from `SingleRoundMessageReady` to `SingleRoundMessageReady`,
+        // but the returned value is not used. We have to wait until the sender transaction protocol creates a
+        // sender_offset_private_key for us, so we can use it to create the shared secret
+        let sender_offset_private_key = self
+            .key_manager
+            .get_next_key(TransactionKeyManagerBranch::OneSidedSenderOffset.get_branch_key())
+            .await?;
+
+        // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is fed into
+        // KDFs to produce the spending, rewind, and encryption keys
+        let shared_secret = self
+            .key_manager
+            .get_diffie_hellman_shared_secret(
+                &sender_offset_private_key.key_id,
+                destination
+                    .public_view_key()
+                    .ok_or(TransactionBuilderError::InvalidAddressNoViewKey)?,
+            )
+            .await?;
+        let commitment_mask_private_key = shared_secret_to_output_spending_key(&shared_secret)?;
+        let commitment_mask_key_id = self.key_manager.import_key(commitment_mask_private_key.clone()).await?;
+
+        let script = push_pubkey_script(destination.public_spend_key());
+
+        let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret)?;
+        let encryption_key = self.key_manager.import_key(encryption_private_key).await?;
+
+        let sender_offset_public_key = self
+            .key_manager
+            .get_public_key_at_key_id(&sender_offset_private_key.key_id)
+            .await?;
+
+        let minimum_value_promise = MicroMinotari::zero();
+        let output = WalletOutputBuilder::new(amount, commitment_mask_key_id)
+            .with_features(output_features)
+            .with_script(script)
+            .encrypt_data_for_recovery(&self.key_manager, Some(&encryption_key), memo_field)
+            .await?
+            .with_input_data(Default::default())
+            .with_sender_offset_public_key(sender_offset_public_key)
+            .with_script_key(TariKeyId::Zero)
+            .with_minimum_value_promise(minimum_value_promise)
+            .sign_as_sender_and_receiver_verified(&self.key_manager, &sender_offset_private_key.key_id, &destination)
+            .await?
+            .try_build(&self.key_manager)
+            .await?;
+
+        self.add_recipient(destination, output.clone(), Some(sender_offset_private_key.key_id))
+            .await?;
+        Ok(output)
+    }
+
     pub async fn with_input(&mut self, input: WalletOutput) -> Result<&mut Self, TransactionBuilderError> {
         let nonce = self
             .key_manager
@@ -217,8 +341,10 @@ where KM: TransactionKeyManagerInterface
         Ok(size)
     }
 
-    pub async fn get_pre_build_change_output(&self) -> Result<Option<OutputPair>, TransactionBuilderError> {
-        Ok(self.add_change_if_required().await?.1)
+    pub async fn get_pre_build_change_output(
+        &self,
+    ) -> Result<(MicroMinotari, Option<OutputPair>), TransactionBuilderError> {
+        self.add_change_if_required().await
     }
 
     pub fn get_total_input_value(&self) -> Result<MicroMinotari, TransactionBuilderError> {
@@ -852,13 +978,15 @@ impl<KM> Debug for TransactionBuilder<KM> {
 
 #[cfg(test)]
 mod test {
+    use chacha20poly1305::aead::OsRng;
     use tari_common_types::key_branches::TransactionKeyManagerBranch;
+    use tari_crypto::keys::SecretKey;
     use tari_script::{script, TariScript};
 
     use super::*;
     use crate::{
         crypto_factories::CryptoFactories,
-        key_manager::create_memory_key_manager,
+        key_manager::{create_memory_key_manager, SecretTransactionKeyManagerInterface},
         tari_amount::{uT, MicroMinotari},
         test_helpers::{
             create_consensus_constants,
@@ -1243,6 +1371,184 @@ mod test {
             .add_recipient(Default::default(), bob_output, Some(bob_sender_offset.key_id))
             .await
             .unwrap();
+        let finalized = builder.build().await.unwrap();
+
+        let tx = finalized.transaction;
+        assert_eq!(tx.body.inputs().len(), 3);
+        assert_eq!(tx.body.outputs().len(), 2);
+        let validator = TransactionInternalConsistencyValidator::new(false, rules, factories);
+        assert!(validator.validate(&tx, None, None, u64::MAX).is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_stealth_recipient() {
+        let rules = create_consensus_manager();
+        let key_manager = create_memory_key_manager().await.unwrap();
+        let factories = CryptoFactories::default();
+        let input = create_test_input(MicroMinotari(10000), 0, &key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &key_manager, vec![], None).await;
+        let consensus_constants = create_consensus_constants(0);
+        let mut builder = TransactionBuilder::new(consensus_constants.clone(), key_manager.clone(), Network::LocalNet)
+            .await
+            .unwrap();
+        builder
+            .with_lock_height(0)
+            .with_fee_per_gram(MicroMinotari(20))
+            .with_input(input)
+            .await
+            .unwrap()
+            .with_input(input2)
+            .await
+            .unwrap()
+            .with_input(input3)
+            .await
+            .unwrap();
+        let bob_address = TariAddress::new_dual_address_with_default_features(
+            CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        )
+        .unwrap();
+
+        let bob_output = builder
+            .add_stealth_recipient(
+                bob_address.clone(),
+                MicroMinotari(5000),
+                OutputFeatures::default(),
+                MemoField::new_empty(),
+            )
+            .await
+            .unwrap();
+        let bob_sender_offset = builder
+            .recipient_outputs
+            .last()
+            .unwrap()
+            .output
+            .sender_offset_key_id
+            .clone()
+            .unwrap();
+        let shared_secret = key_manager
+            .get_diffie_hellman_shared_secret(&bob_sender_offset, bob_address.public_view_key().unwrap())
+            .await
+            .unwrap();
+        let commitment_mask_private_key = shared_secret_to_output_spending_key(&shared_secret).unwrap();
+        let commitment_mask_pvt = key_manager
+            .get_private_key(&bob_output.commitment_mask_key_id)
+            .await
+            .unwrap();
+        assert_eq!(commitment_mask_private_key, commitment_mask_pvt);
+
+        let script_spending_key = key_manager
+            .stealth_address_script_spending_key(&bob_output.commitment_mask_key_id, bob_address.public_spend_key())
+            .await
+            .unwrap();
+        let script = push_pubkey_script(&script_spending_key);
+
+        assert_eq!(bob_output.script, script);
+
+        let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret).unwrap();
+        let encryption_public_key = CompressedPublicKey::from_secret_key(&encryption_private_key);
+        let encryption_key_id = TariKeyId::Imported {
+            key: encryption_public_key,
+        };
+        let bob_tx_output = bob_output.to_transaction_output(&key_manager).await.unwrap();
+        assert!(key_manager
+            .is_this_output_ours(
+                &bob_tx_output.commitment,
+                &bob_output.encrypted_data,
+                Some(&encryption_key_id)
+            )
+            .await
+            .unwrap());
+
+        let finalized = builder.build().await.unwrap();
+
+        let tx = finalized.transaction;
+        assert_eq!(tx.body.inputs().len(), 3);
+        assert_eq!(tx.body.outputs().len(), 2);
+        let validator = TransactionInternalConsistencyValidator::new(false, rules, factories);
+        assert!(validator.validate(&tx, None, None, u64::MAX).is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_depricated_one_sided_recipient() {
+        let rules = create_consensus_manager();
+        let key_manager = create_memory_key_manager().await.unwrap();
+        let factories = CryptoFactories::default();
+        let input = create_test_input(MicroMinotari(10000), 0, &key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &key_manager, vec![], None).await;
+        let consensus_constants = create_consensus_constants(0);
+        let mut builder = TransactionBuilder::new(consensus_constants.clone(), key_manager.clone(), Network::LocalNet)
+            .await
+            .unwrap();
+        builder
+            .with_lock_height(0)
+            .with_fee_per_gram(MicroMinotari(20))
+            .with_input(input)
+            .await
+            .unwrap()
+            .with_input(input2)
+            .await
+            .unwrap()
+            .with_input(input3)
+            .await
+            .unwrap();
+        let bob_address = TariAddress::new_dual_address_with_default_features(
+            CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            CompressedPublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+            Network::LocalNet,
+        )
+        .unwrap();
+
+        let bob_output = builder
+            .add_depricated_one_sided_recipient(
+                bob_address.clone(),
+                MicroMinotari(5000),
+                OutputFeatures::default(),
+                MemoField::new_empty(),
+            )
+            .await
+            .unwrap();
+        let bob_sender_offset = builder
+            .recipient_outputs
+            .last()
+            .unwrap()
+            .output
+            .sender_offset_key_id
+            .clone()
+            .unwrap();
+        let shared_secret = key_manager
+            .get_diffie_hellman_shared_secret(&bob_sender_offset, bob_address.public_view_key().unwrap())
+            .await
+            .unwrap();
+        let commitment_mask_private_key = shared_secret_to_output_spending_key(&shared_secret).unwrap();
+        let commitment_mask_pvt = key_manager
+            .get_private_key(&bob_output.commitment_mask_key_id)
+            .await
+            .unwrap();
+        assert_eq!(commitment_mask_private_key, commitment_mask_pvt);
+
+        let script = push_pubkey_script(bob_address.public_spend_key());
+
+        assert_eq!(bob_output.script, script);
+
+        let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret).unwrap();
+        let encryption_public_key = CompressedPublicKey::from_secret_key(&encryption_private_key);
+        let encryption_key_id = TariKeyId::Imported {
+            key: encryption_public_key,
+        };
+        let bob_tx_output = bob_output.to_transaction_output(&key_manager).await.unwrap();
+        assert!(key_manager
+            .is_this_output_ours(
+                &bob_tx_output.commitment,
+                &bob_output.encrypted_data,
+                Some(&encryption_key_id)
+            )
+            .await
+            .unwrap());
+
         let finalized = builder.build().await.unwrap();
 
         let tx = finalized.transaction;

--- a/base_layer/transaction_components/src/transaction_builder/error.rs
+++ b/base_layer/transaction_components/src/transaction_builder/error.rs
@@ -18,6 +18,8 @@ pub enum TransactionBuilderError {
     FeeNotSet,
     #[error("No outputs for transaction")]
     NoRecipients,
+    #[error("Invalid address, address does not contain a view key")]
+    InvalidAddressNoViewKey,
     #[error("No inputs provided for transaction")]
     NoInputs,
     #[error("Transaction exceeds maximum inputs limit of {0}")]

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -875,7 +875,6 @@ where
 
     /// Prepare a Sender Transaction Protocol for the amount and fee_per_gram specified. If required a change output
     /// will be produced.
-    #[allow(clippy::too_many_lines)]
     pub async fn prepare_transaction_to_send(
         &mut self,
         tx_id: TxId,

--- a/base_layer/wallet/src/transaction_service/offline_signing/mod.rs
+++ b/base_layer/wallet/src/transaction_service/offline_signing/mod.rs
@@ -23,3 +23,378 @@ pub mod marshal_output_pair;
 pub mod models;
 pub mod offline_signer;
 pub mod one_sided_signer;
+
+#[cfg(test)]
+mod test {
+    #![allow(clippy::indexing_slicing)]
+    use std::sync::Arc;
+
+    use argon2::password_hash::rand_core::OsRng;
+    use chacha20poly1305::Key;
+    use rand::RngCore;
+    use tari_common::configuration::Network;
+    use tari_common_types::{
+        seeds::cipher_seed::CipherSeed,
+        tari_address::{TariAddress, TariAddressFeatures},
+        transaction::TxId,
+        wallet_types::{ProvidedKeysWallet, WalletType},
+    };
+    use tari_transaction_components::{
+        crypto_factories::CryptoFactories,
+        key_manager::{
+            create_memory_key_manager,
+            error::KeyManagerServiceError,
+            memory_key_manager::MemoryKeyManagerBackend,
+            MemoryKeyManager,
+            TransactionKeyManagerInterface,
+            TransactionKeyManagerWrapper,
+        },
+        tari_amount::MicroMinotari,
+        test_helpers::{create_consensus_manager, create_test_input},
+        transaction_components::{
+            memo_field::MemoField,
+            one_sided::shared_secret_to_output_encryption_key,
+            EncryptedData,
+            OutputFeatures,
+        },
+        validation::transaction::TransactionInternalConsistencyValidator,
+        TransactionBuilder,
+    };
+    use zeroize::Zeroizing;
+
+    use crate::transaction_service::offline_signing::offline_signer::OfflineSigner;
+
+    async fn create_view_key_manager(keys: ProvidedKeysWallet) -> Result<MemoryKeyManager, KeyManagerServiceError> {
+        let cipher = CipherSeed::new();
+        let mut key = Zeroizing::new([0u8; size_of::<Key>()]);
+        OsRng.fill_bytes(key.as_mut());
+        let factory = CryptoFactories::new(64);
+
+        let backend = MemoryKeyManagerBackend::new();
+        TransactionKeyManagerWrapper::new(cipher, backend, factory, Arc::new(WalletType::ProvidedKeys(keys))).await
+    }
+    #[tokio::test]
+    async fn offline_sign_is_valid() {
+        let rules = create_consensus_manager();
+        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let keys = ProvidedKeysWallet {
+            public_spend_key: alice_key_manager.get_spend_key().await.unwrap().pub_key,
+            private_spend_key: None,
+            private_comms_key: None,
+            view_key: alice_key_manager.get_private_view_key().await.unwrap(),
+            birthday: None,
+        };
+        let alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
+        let bob_key_manager = create_memory_key_manager().await.unwrap();
+
+        let input = create_test_input(MicroMinotari(10000), 0, &alice_view_key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &alice_view_key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &alice_view_key_manager, vec![], None).await;
+        // this replicates the behaviour od the oms that selects the inputs and starts the build tx process.
+        let mut tx_builder = TransactionBuilder::new(
+            rules.consensus_constants(0).clone(),
+            alice_view_key_manager.clone(),
+            Network::LocalNet,
+        )
+        .await
+        .unwrap();
+        tx_builder
+            .with_lock_height(0)
+            .with_fee_per_gram(MicroMinotari(20))
+            .with_input(input)
+            .await
+            .unwrap()
+            .with_input(input2)
+            .await
+            .unwrap()
+            .with_input(input3)
+            .await
+            .unwrap();
+
+        // now we start the offline process
+        let mut offline_signing = OfflineSigner::new(alice_view_key_manager.clone());
+        let tx_id = TxId::new_random();
+        let payment_id = MemoField::new_empty();
+        let output_features = OutputFeatures::default();
+        let amount = MicroMinotari(5000);
+
+        let spend_key = bob_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = bob_key_manager.get_view_key().await.unwrap().pub_key;
+        let bob_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+        let spend_key = alice_view_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = alice_view_key_manager.get_view_key().await.unwrap().pub_key;
+        let alice_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+
+        let spend_key = alice_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = alice_key_manager.get_view_key().await.unwrap().pub_key;
+        let alice_address_s = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(alice_address, alice_address_s);
+
+        let init = offline_signing
+            .prepare_one_sided_transaction_for_signing(
+                tx_id,
+                tx_builder,
+                bob_address,
+                amount,
+                output_features,
+                payment_id,
+                alice_address,
+            )
+            .await
+            .unwrap();
+
+        assert!(init.info.change_output.is_some());
+        assert_eq!(init.info.metadata.fee, MicroMinotari(2960));
+        assert_eq!(init.info.inputs.len(), 3);
+        assert_eq!(init.info.outputs.len(), 0);
+
+        let signer = OfflineSigner::new(alice_key_manager.clone());
+        let signed = signer.sign_locked_transaction(init).await.unwrap();
+        assert!(signed.signed_transaction.change_output.is_some());
+        assert_eq!(
+            signed.signed_transaction.transaction.body.kernels()[0].fee,
+            MicroMinotari(2960)
+        );
+        assert_eq!(signed.signed_transaction.transaction.body.inputs().len(), 3);
+        assert_eq!(signed.signed_transaction.transaction.body.outputs().len(), 2);
+        assert_eq!(signed.signed_transaction.sent_hashes.len(), 1);
+        let tx = signed.signed_transaction.transaction.clone();
+
+        let factories = CryptoFactories::default();
+        let validator = TransactionInternalConsistencyValidator::new(false, rules, factories);
+        assert!(validator.validate(&tx, None, None, u64::MAX).is_ok());
+    }
+
+    #[tokio::test]
+    async fn offline_sign_can_be_claimed() {
+        let rules = create_consensus_manager();
+        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let keys = ProvidedKeysWallet {
+            public_spend_key: alice_key_manager.get_spend_key().await.unwrap().pub_key,
+            private_spend_key: None,
+            private_comms_key: None,
+            view_key: alice_key_manager.get_private_view_key().await.unwrap(),
+            birthday: None,
+        };
+        let alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
+        let bob_key_manager = create_memory_key_manager().await.unwrap();
+
+        let input = create_test_input(MicroMinotari(100000), 0, &alice_view_key_manager, vec![], None).await;
+        // this replicates the behaviour od the oms that selects the inputs and starts the build tx process.
+        let mut tx_builder = TransactionBuilder::new(
+            rules.consensus_constants(0).clone(),
+            alice_view_key_manager.clone(),
+            Network::LocalNet,
+        )
+        .await
+        .unwrap();
+        tx_builder
+            .with_lock_height(0)
+            .with_fee_per_gram(MicroMinotari(20))
+            .with_input(input)
+            .await
+            .unwrap();
+
+        // now we start the offline process
+        let mut offline_signing = OfflineSigner::new(alice_view_key_manager.clone());
+        let spend_key = bob_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = bob_key_manager.get_view_key().await.unwrap().pub_key;
+        let bob_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+        let spend_key = alice_view_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = alice_view_key_manager.get_view_key().await.unwrap().pub_key;
+        let alice_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+
+        let init = offline_signing
+            .prepare_one_sided_transaction_for_signing(
+                TxId::new_random(),
+                tx_builder,
+                bob_address,
+                MicroMinotari(5000),
+                OutputFeatures::default(),
+                MemoField::new_empty(),
+                alice_address,
+            )
+            .await
+            .unwrap();
+
+        let signer = OfflineSigner::new(alice_key_manager.clone());
+        let signed = signer.sign_locked_transaction(init).await.unwrap();
+        let tx = signed.signed_transaction.transaction.clone();
+
+        let factories = CryptoFactories::default();
+        let validator = TransactionInternalConsistencyValidator::new(false, rules, factories);
+        assert!(validator.validate(&tx, None, None, u64::MAX).is_ok());
+
+        let outputs = signed.signed_transaction.transaction.body.outputs();
+        let mut sent_index = 99;
+        for (i, output) in outputs.iter().enumerate() {
+            if output.hash() == signed.signed_transaction.sent_hashes[0] {
+                sent_index = i;
+            }
+        }
+        let change_index = if sent_index == 0 { 1 } else { 0 };
+
+        let change_output = &signed.signed_transaction.transaction.body.outputs()[change_index].clone();
+
+        // let see if alice's view wallet can claim the change:
+        assert!(alice_view_key_manager
+            .is_this_output_ours(&change_output.commitment, &change_output.encrypted_data, None,)
+            .await
+            .unwrap());
+        // lets test the hot wallet
+        assert!(alice_key_manager
+            .is_this_output_ours(&change_output.commitment, &change_output.encrypted_data, None,)
+            .await
+            .unwrap());
+
+        // lets see if bob's wallet can claim the sent:
+        let sent_output = &signed.signed_transaction.transaction.body.outputs()[sent_index].clone();
+        let view_key = bob_key_manager.get_view_key().await.unwrap();
+        let shared_secret = bob_key_manager
+            .get_diffie_hellman_shared_secret(&view_key.key_id, &sent_output.sender_offset_public_key)
+            .await
+            .unwrap();
+
+        let recovery_key = shared_secret_to_output_encryption_key(&shared_secret).unwrap();
+        let res =
+            EncryptedData::decrypt_data(&recovery_key, &sent_output.commitment, &sent_output.encrypted_data).unwrap();
+        assert_eq!(res.0, MicroMinotari(5000));
+    }
+
+    #[tokio::test]
+    async fn view_only_cannot_sign_offline() {
+        let rules = create_consensus_manager();
+        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let keys = ProvidedKeysWallet {
+            public_spend_key: alice_key_manager.get_spend_key().await.unwrap().pub_key,
+            private_spend_key: None,
+            private_comms_key: None,
+            view_key: alice_key_manager.get_private_view_key().await.unwrap(),
+            birthday: None,
+        };
+        let alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
+        let bob_key_manager = create_memory_key_manager().await.unwrap();
+
+        let input = create_test_input(MicroMinotari(10000), 0, &alice_view_key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &alice_view_key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &alice_view_key_manager, vec![], None).await;
+        // this replicates the behaviour od the oms that selects the inputs and starts the build tx process.
+        let mut tx_builder = TransactionBuilder::new(
+            rules.consensus_constants(0).clone(),
+            alice_view_key_manager.clone(),
+            Network::LocalNet,
+        )
+        .await
+        .unwrap();
+        tx_builder
+            .with_lock_height(0)
+            .with_fee_per_gram(MicroMinotari(20))
+            .with_input(input)
+            .await
+            .unwrap()
+            .with_input(input2)
+            .await
+            .unwrap()
+            .with_input(input3)
+            .await
+            .unwrap();
+
+        // now we start the offline process
+        let mut offline_signing = OfflineSigner::new(alice_view_key_manager.clone());
+        let tx_id = TxId::new_random();
+        let payment_id = MemoField::new_empty();
+        let output_features = OutputFeatures::default();
+        let amount = MicroMinotari(5000);
+
+        let spend_key = bob_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = bob_key_manager.get_view_key().await.unwrap().pub_key;
+        let bob_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+        let spend_key = alice_view_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = alice_view_key_manager.get_view_key().await.unwrap().pub_key;
+        let alice_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+
+        let spend_key = alice_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = alice_key_manager.get_view_key().await.unwrap().pub_key;
+        let alice_address_s = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(alice_address, alice_address_s);
+
+        let init = offline_signing
+            .prepare_one_sided_transaction_for_signing(
+                tx_id,
+                tx_builder,
+                bob_address,
+                amount,
+                output_features,
+                payment_id,
+                alice_address,
+            )
+            .await
+            .unwrap();
+
+        assert!(init.info.change_output.is_some());
+        assert_eq!(init.info.metadata.fee, MicroMinotari(2960));
+        assert_eq!(init.info.inputs.len(), 3);
+        assert_eq!(init.info.outputs.len(), 0);
+
+        let signer = OfflineSigner::new(alice_view_key_manager.clone());
+        let _signed = signer.sign_locked_transaction(init).await.is_err();
+    }
+}

--- a/base_layer/wallet/src/transaction_service/offline_signing/mod.rs
+++ b/base_layer/wallet/src/transaction_service/offline_signing/mod.rs
@@ -395,6 +395,6 @@ mod test {
         assert_eq!(init.info.outputs.len(), 0);
 
         let signer = OfflineSigner::new(alice_view_key_manager.clone());
-        let _signed = signer.sign_locked_transaction(init).await.is_err();
+        assert!(signer.sign_locked_transaction(init).await.is_err());
     }
 }

--- a/base_layer/wallet/src/transaction_service/offline_signing/offline_signer.rs
+++ b/base_layer/wallet/src/transaction_service/offline_signing/offline_signer.rs
@@ -21,107 +21,58 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use std::str::FromStr;
 
-use log::*;
-use tari_common_types::{
-    tari_address::{TariAddress, TariAddressFeatures},
-    transaction::TxId,
-    types::CompressedPublicKey,
-};
-use tari_script::push_pubkey_script;
+use tari_common_types::{tari_address::TariAddress, transaction::TxId, types::CompressedPublicKey};
 use tari_transaction_components::{
     key_manager::{TariKeyId, TransactionKeyManagerInterface},
-    transaction_components::{
-        covenants::Covenant,
-        memo_field::{MemoField, TxType},
-        OutputFeatures,
-    },
+    transaction_components::{memo_field::MemoField, OutputFeatures},
     MicroMinotari,
+    TransactionBuilder,
 };
 
-use crate::{
-    connectivity_service::WalletConnectivityInterface,
-    output_manager_service::UtxoSelectionCriteria,
-    transaction_service::{
-        error::{TransactionServiceError, TransactionServiceProtocolError},
-        offline_signing::{
-            marshal_output_pair::MarshalOutputPair,
-            models::{
-                get_supported_version,
-                OneSidedTransactionInfo,
-                PaymentRecipient,
-                PrepareOneSidedTransactionForSigningResult,
-                SignedOneSidedTransactionResult,
-                TransactionMetadata,
-            },
-            one_sided_signer::OneSidedSigner,
+use crate::transaction_service::{
+    error::TransactionServiceError,
+    offline_signing::{
+        marshal_output_pair::MarshalOutputPair,
+        models::{
+            get_supported_version,
+            OneSidedTransactionInfo,
+            PaymentRecipient,
+            PrepareOneSidedTransactionForSigningResult,
+            SignedOneSidedTransactionResult,
+            TransactionMetadata,
         },
-        service::TransactionServiceResources,
-        storage::database::TransactionBackend,
+        one_sided_signer::OneSidedSigner,
     },
 };
-const LOG_TARGET: &str = "wallet::transaction_service::offline_signing::offline_signer";
 
-pub struct OfflineSigner<TBackend, TWalletConnectivity, TKeyManagerInterface> {
-    resources: TransactionServiceResources<TBackend, TWalletConnectivity, TKeyManagerInterface>,
+pub struct OfflineSigner<TKeyManagerInterface> {
+    key_manager: TKeyManagerInterface,
 }
 
-impl<TBackend, TWalletConnectivity, TKeyManagerInterface>
-    OfflineSigner<TBackend, TWalletConnectivity, TKeyManagerInterface>
-where
-    TBackend: TransactionBackend + 'static,
-    TWalletConnectivity: WalletConnectivityInterface,
-    TKeyManagerInterface: TransactionKeyManagerInterface,
+impl<TKeyManagerInterface> OfflineSigner<TKeyManagerInterface>
+where TKeyManagerInterface: TransactionKeyManagerInterface
 {
-    pub fn new(resources: TransactionServiceResources<TBackend, TWalletConnectivity, TKeyManagerInterface>) -> Self {
-        OfflineSigner { resources }
+    pub fn new(key_manager: TKeyManagerInterface) -> Self {
+        OfflineSigner { key_manager }
     }
 
     pub async fn prepare_one_sided_transaction_for_signing(
         &mut self,
+        tx_id: TxId,
+        mut tx_builder: TransactionBuilder<TKeyManagerInterface>,
         dest_address: TariAddress,
         amount: MicroMinotari,
-        selection_criteria: UtxoSelectionCriteria,
         output_features: OutputFeatures,
-        fee_per_gram: MicroMinotari,
-        mut payment_id: MemoField,
+        payment_id: MemoField,
+        sender_address: TariAddress,
     ) -> Result<PrepareOneSidedTransactionForSigningResult, TransactionServiceError> {
-        debug!(target: LOG_TARGET, "Locking one sided transaction to {dest_address} with {amount}");
-        let tx_id = TxId::new_random();
-
-        // let override the payment_id if the address says we should
-        if dest_address.features().contains(TariAddressFeatures::PAYMENT_ID) {
-            debug!(target: LOG_TARGET, "Address contains memo, overriding memo {} with {:?}", payment_id, dest_address.get_memo_field_payment_id_bytes());
-            payment_id = MemoField::open(dest_address.get_memo_field_payment_id_bytes(), TxType::PaymentToOther);
-        }
-        let payment_id = payment_id
-            .clone()
-            .add_sender_address(
-                self.resources.one_sided_tari_address.clone(),
-                true,
-                fee_per_gram,
-                if dest_address == self.resources.one_sided_tari_address ||
-                    dest_address == self.resources.interactive_tari_address
-                {
-                    Some(TxType::PaymentToSelf)
-                } else {
-                    Some(TxType::PaymentToOther)
-                },
-            )
-            .unwrap_or(payment_id);
-
-        let script = push_pubkey_script(&Default::default());
-        // Prepare sender part of the transaction
-        let tx_builder = self
-            .resources
-            .output_manager_service
-            .prepare_transaction_to_send(
-                tx_id,
+        // we do this to ensure the fee is calculated correctly
+        tx_builder
+            .add_stealth_recipient(
+                dest_address.clone(),
                 amount,
-                selection_criteria,
                 output_features.clone(),
-                fee_per_gram,
-                script,
-                Covenant::default(),
+                payment_id.clone(),
             )
             .await?;
 
@@ -132,29 +83,35 @@ where
                 .make_key_id_export_safe(&input.output.script_key_id)
                 .await
                 .map_err(TransactionServiceError::NotSupported)?;
-            inputs.push(MarshalOutputPair::marshal(&self.resources.transaction_key_manager_service, input).await?);
+            inputs.push(MarshalOutputPair::marshal(&self.key_manager, input).await?);
         }
         let mut outputs = Vec::new();
-        for output_pair in tx_builder.recipient_outputs() {
-            let mut output = output_pair.output.clone();
+        for output_pair in tx_builder.custom_outputs() {
+            let mut output = output_pair.clone();
             output.output.script_key_id = self
                 .make_key_id_export_safe(&output.output.script_key_id)
                 .await
                 .map_err(TransactionServiceError::NotSupported)?;
-            outputs.push(MarshalOutputPair::marshal(&self.resources.transaction_key_manager_service, output).await?);
+            outputs.push(MarshalOutputPair::marshal(&self.key_manager, output).await?);
         }
 
-        let change_output = match tx_builder.get_pre_build_change_output().await? {
-            Some(mut change_output) => {
+        let (fee, change_output) = match tx_builder.get_pre_build_change_output().await? {
+            (fee, Some(mut change_output)) => {
                 change_output.output.script_key_id = self
                     .make_key_id_export_safe(&change_output.output.script_key_id)
                     .await
                     .map_err(TransactionServiceError::NotSupported)?;
-                Some(MarshalOutputPair::marshal(&self.resources.transaction_key_manager_service, change_output).await?)
+                (
+                    fee,
+                    Some(MarshalOutputPair::marshal(&self.key_manager, change_output).await?),
+                )
             },
-            None => None,
+            (fee, None) => (fee, None),
         };
-        let metadata = TransactionMetadata::default();
+        let metadata = TransactionMetadata {
+            fee,
+            ..Default::default()
+        };
         let info = OneSidedTransactionInfo {
             payment_id,
             recipient: PaymentRecipient {
@@ -166,14 +123,8 @@ where
             inputs,
             outputs,
             metadata,
-            sender_address: self.resources.one_sided_tari_address.clone(),
+            sender_address,
         };
-
-        self.resources
-            .output_manager_service
-            .confirm_pending_transaction(tx_id, None)
-            .await
-            .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 
         Ok(PrepareOneSidedTransactionForSigningResult {
             version: get_supported_version(),
@@ -186,7 +137,7 @@ where
         &self,
         request: PrepareOneSidedTransactionForSigningResult,
     ) -> Result<SignedOneSidedTransactionResult, TransactionServiceError> {
-        let signer = OneSidedSigner::new(&self.resources.transaction_key_manager_service);
+        let signer = OneSidedSigner::new(&self.key_manager);
         let signed_transaction = signer.sign_transaction(request.tx_id, request.info.clone()).await?;
 
         Ok(SignedOneSidedTransactionResult {
@@ -198,8 +149,7 @@ where
 
     async fn make_key_id_export_safe(&self, key_id: &TariKeyId) -> Result<TariKeyId, String> {
         if *key_id ==
-            self.resources
-                .transaction_key_manager_service
+            self.key_manager
                 .get_spend_key()
                 .await
                 .map_err(|err| err.to_string())?
@@ -208,8 +158,7 @@ where
             return Ok(key_id.clone());
         }
         if *key_id ==
-            self.resources
-                .transaction_key_manager_service
+            self.key_manager
                 .get_view_key()
                 .await
                 .map_err(|err| err.to_string())?
@@ -227,8 +176,7 @@ where
             TariKeyId::Derived { key } => {
                 let inner_key = TariKeyId::from_str(key.to_string().as_str())?;
                 let public_key = self
-                    .resources
-                    .transaction_key_manager_service
+                    .key_manager
                     .get_public_key_at_key_id(&inner_key)
                     .await
                     .map_err(|err| err.to_string())?;
@@ -242,8 +190,7 @@ where
             },
             TariKeyId::Managed { .. } => {
                 let key = self
-                    .resources
-                    .transaction_key_manager_service
+                    .key_manager
                     .get_public_key_at_key_id(key_id)
                     .await
                     .map_err(|err| err.to_string())?;

--- a/base_layer/wallet/src/transaction_service/offline_signing/one_sided_signer.rs
+++ b/base_layer/wallet/src/transaction_service/offline_signing/one_sided_signer.rs
@@ -54,7 +54,6 @@ use crate::transaction_service::{
     error::{TransactionServiceError, TransactionServiceProtocolError},
     offline_signing::models::{OneSidedTransactionInfo, SignedTransaction, TransactionMetadata},
 };
-
 /// This is the message containing the public data that the Receiver will send back to the Sender
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecipientSignedMessage {
@@ -347,7 +346,6 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
             &info.metadata.kernel_features,
             &burn_commitment.clone(),
         );
-
         for input in &info.inputs {
             tx_builder.add_input(input.output_pair.output.to_transaction_input(self.key_manager).await?);
             signature = &signature +
@@ -451,7 +449,6 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
             },
             None => None,
         };
-
         tx_builder.add_output(signed_message.output.clone());
         let script_offset = self
             .key_manager

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -62,14 +62,7 @@ use tari_crypto::{
     tari_utilities::ByteArray,
 };
 use tari_max_size::MaxSizeString;
-use tari_script::{
-    push_pubkey_script,
-    script,
-    CompressedCheckSigSchnorrSignature,
-    ExecutionStack,
-    ScriptContext,
-    TariScript,
-};
+use tari_script::{push_pubkey_script, script, CompressedCheckSigSchnorrSignature, ExecutionStack, ScriptContext};
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_shutdown::ShutdownSignal;
 use tari_sidechain::EvictionProof;
@@ -405,24 +398,71 @@ where
                 selection_criteria,
                 output_features,
                 fee_per_gram,
-                payment_id,
+                mut payment_id,
             } => {
                 self.verify_send(&destination, TariAddressFeatures::create_one_sided_only())?;
-                let mut offline_signing = OfflineSigner::new(self.resources.clone());
-                offline_signing
-                    .prepare_one_sided_transaction_for_signing(
-                        destination,
+                debug!(target: LOG_TARGET, "Locking one sided transaction to {destination} with {amount}");
+                let tx_id = TxId::new_random();
+
+                // let override the payment_id if the address says we should
+                if destination.features().contains(TariAddressFeatures::PAYMENT_ID) {
+                    debug!(target: LOG_TARGET, "Address contains memo, overriding memo {} with {:?}", payment_id, destination.get_memo_field_payment_id_bytes());
+                    payment_id = MemoField::open(destination.get_memo_field_payment_id_bytes(), TxType::PaymentToOther);
+                }
+                let payment_id = payment_id
+                    .clone()
+                    .add_sender_address(
+                        self.resources.one_sided_tari_address.clone(),
+                        true,
+                        fee_per_gram,
+                        if destination == self.resources.one_sided_tari_address ||
+                            destination == self.resources.interactive_tari_address
+                        {
+                            Some(TxType::PaymentToSelf)
+                        } else {
+                            Some(TxType::PaymentToOther)
+                        },
+                    )
+                    .unwrap_or(payment_id);
+
+                let script = push_pubkey_script(&Default::default());
+                // Prepare sender part of the transaction
+                let tx_builder = self
+                    .resources
+                    .output_manager_service
+                    .prepare_transaction_to_send(
+                        tx_id,
                         amount,
                         selection_criteria,
-                        *output_features,
+                        *output_features.clone(),
                         fee_per_gram,
-                        payment_id,
+                        script,
+                        Covenant::default(),
                     )
+                    .await?;
+                let mut offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
+                let res = offline_signing
+                    .prepare_one_sided_transaction_for_signing(
+                        tx_id,
+                        tx_builder,
+                        destination,
+                        amount,
+                        *output_features,
+                        payment_id,
+                        self.resources.one_sided_tari_address.clone(),
+                    )
+                    .await?;
+                self.resources
+                    .output_manager_service
+                    .confirm_pending_transaction(res.tx_id, None)
                     .await
-                    .map(|v| TransactionServiceResponse::OneSidedTransactionPreparedForSigning(Box::new(v)))
+                    .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+                Ok(TransactionServiceResponse::OneSidedTransactionPreparedForSigning(
+                    Box::new(res),
+                ))
             },
             TransactionServiceRequest::SignOneSidedTransaction { request } => {
-                let offline_signing = OfflineSigner::new(self.resources.clone());
+                let offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
                 offline_signing
                     .sign_locked_transaction(request)
                     .await
@@ -1489,7 +1529,7 @@ where
         transaction_broadcast_join_handles: &mut FuturesUnordered<
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
-        recipient_script: Option<TariScript>,
+        use_stealth_one_sided: bool,
         mut payment_id: MemoField,
     ) -> Result<TxId, TransactionServiceError> {
         debug!(target: LOG_TARGET, "Sending one sided transaction to {dest_address} with {amount}");
@@ -1515,13 +1555,6 @@ where
             .map_err(TransactionServiceError::InvalidPaymentId)?;
         self.verify_send(&dest_address, TariAddressFeatures::create_one_sided_only())?;
 
-        // For a stealth transaction, the script is not provided because the public key that should be included
-        // is not known at this stage. This will only be known later. For now,
-        // we include a default public key to ensure that the script size is correct.
-        let (mut script, use_stealth_address) = match recipient_script {
-            Some(s) => (s, false),
-            None => (push_pubkey_script(&Default::default()), true),
-        };
         // Prepare sender part of the transaction
         let mut tx_builder = self
             .resources
@@ -1532,101 +1565,30 @@ where
                 selection_criteria,
                 output_features.clone(),
                 fee_per_gram,
-                script.clone(),
+                push_pubkey_script(&Default::default()),
                 Covenant::default(),
             )
             .await?;
 
-        // This call is needed to advance the state from `SingleRoundMessageReady` to `SingleRoundMessageReady`,
-        // but the returned value is not used. We have to wait until the sender transaction protocol creates a
-        // sender_offset_private_key for us, so we can use it to create the shared secret
-        let sender_offset_private_key = self
-            .resources
-            .transaction_key_manager_service
-            .get_next_key(TransactionKeyManagerBranch::OneSidedSenderOffset.get_branch_key())
-            .await?;
-
-        // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is fed into
-        // KDFs to produce the spending, rewind, and encryption keys
-        let shared_secret = self
-            .resources
-            .transaction_key_manager_service
-            .get_diffie_hellman_shared_secret(
-                &sender_offset_private_key.key_id,
-                dest_address
-                    .public_view_key()
-                    .ok_or(TransactionServiceProtocolError::new(
-                        tx_id,
-                        TransactionServiceError::OneSidedTransactionError("Missing public view key".to_string()),
-                    ))?,
-            )
-            .await?;
-        let commitment_mask_private_key = shared_secret_to_output_spending_key(&shared_secret)
-            .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
-        let commitment_mask_key_id = &self
-            .resources
-            .transaction_key_manager_service
-            .import_key(commitment_mask_private_key.clone())
-            .await?;
-
-        if use_stealth_address {
-            let script_spending_key = self
-                .resources
-                .transaction_key_manager_service
-                .stealth_address_script_spending_key(commitment_mask_key_id, dest_address.public_spend_key())
-                .await?;
-            script = push_pubkey_script(&script_spending_key);
-        }
-
-        let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret)?;
-        let encryption_key = self
-            .resources
-            .transaction_key_manager_service
-            .import_key(encryption_private_key)
-            .await?;
-
-        let spending_key_id = self
-            .resources
-            .transaction_key_manager_service
-            .import_key(commitment_mask_private_key)
-            .await?;
-
-        let sender_offset_public_key = self
-            .resources
-            .transaction_key_manager_service
-            .get_public_key_at_key_id(&sender_offset_private_key.key_id)
-            .await?;
-
-        let minimum_value_promise = MicroMinotari::zero();
-        let output = WalletOutputBuilder::new(amount, spending_key_id)
-            .with_features(output_features)
-            .with_script(script)
-            .encrypt_data_for_recovery(
-                &self.resources.transaction_key_manager_service,
-                Some(&encryption_key),
-                payment_id.clone(),
-            )
-            .await?
-            .with_input_data(Default::default())
-            .with_sender_offset_public_key(sender_offset_public_key)
-            .with_script_key(TariKeyId::Zero)
-            .with_minimum_value_promise(minimum_value_promise)
-            .sign_as_sender_and_receiver_verified(
-                &self.resources.transaction_key_manager_service,
-                &sender_offset_private_key.key_id,
-                &dest_address,
-            )
-            .await?
-            .try_build(&self.resources.transaction_key_manager_service)
-            .await?;
-
-        tx_builder
-            .add_recipient(
-                dest_address.clone(),
-                output.clone(),
-                Some(sender_offset_private_key.key_id),
-            )
-            .await?;
+        let _output = if use_stealth_one_sided {
+            tx_builder
+                .add_stealth_recipient(
+                    dest_address.clone(),
+                    amount,
+                    output_features.clone(),
+                    payment_id.clone(),
+                )
+                .await?
+        } else {
+            tx_builder
+                .add_depricated_one_sided_recipient(
+                    dest_address.clone(),
+                    amount,
+                    output_features.clone(),
+                    payment_id.clone(),
+                )
+                .await?
+        };
 
         let finalized = tx_builder.build().await?;
 
@@ -1862,7 +1824,6 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<TxId, TransactionServiceError> {
-        let dest_pubkey = destination.public_spend_key().clone();
         self.send_one_sided_or_stealth(
             destination,
             amount,
@@ -1870,7 +1831,7 @@ where
             output_features,
             fee_per_gram,
             transaction_broadcast_join_handles,
-            Some(push_pubkey_script(&dest_pubkey)),
+            false,
             payment_id,
         )
         .await
@@ -2460,7 +2421,7 @@ where
             output_features,
             fee_per_gram,
             transaction_broadcast_join_handles,
-            None, // The stealth address for the script will be calculated in the next step
+            true,
             payment_id,
         )
         .await


### PR DESCRIPTION
Description
---
Fix offline signing fee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for sending to stealth addresses while preserving the deprecated one-sided recipient path.
  - Transaction preparation now returns the calculated network fee alongside any change output.

- Bug Fixes / Improvements
  - One-sided/offline signing flows and transaction metadata now include the computed fee.
  - Added explicit address validation for addresses missing a view key.

- Refactor
  - Recipient construction and signing flows simplified and unified behind recipient-builder APIs; signing now threads an explicit tx builder and tx id.

- Tests
  - Added end-to-end and unit tests covering stealth/one-sided paths and fee/change handling.

- Chores
  - Linting enforcement re-enabled for a long function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->