### PR TITLE
fix: unwrap when sending readiness status

### DIFF
--- a/applications/minotari_node/src/grpc/readiness_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/readiness_grpc_server.rs
@@ -58,7 +58,7 @@ impl ReadinessStatusHandler {
             status: Some(ReadinessStatusEnum::State(status_state.into())),
             timestamp: Utc::now().timestamp_millis() as u64,
         };
-        self.readiness_tx.send(status).unwrap();
+        let _unused = self.readiness_tx.send(status);
     }
 }
 


### PR DESCRIPTION
Description
---
Fixes: #7447 

How Has This Been Tested?
---
Launch 2 nodes: one on mainnet and second on esmeralda with same gRPC port set (different networks so they don't try to acquire same lock to database).
2nd node reported that port was already in use but didn't crash.
```
16:30 ERROR GRPC encountered an error: tonic::transport::Error(Transport, Os { code: 98, kind: AddrInUse, message: "Address already in use" })
```

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of readiness status handling to avoid crashes when internal message delivery fails. Previously, rare send failures could trigger a panic; these are now handled safely, preventing unexpected shutdowns during load spikes or shutdown races. No changes to configuration or APIs; overall stability and uptime are improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->