### PR TITLE
fix: grpc server not respecting base_node.grpc_enabled flag

### DIFF
--- a/applications/minotari_node/src/cli.rs
+++ b/applications/minotari_node/src/cli.rs
@@ -48,9 +48,6 @@ pub struct Cli {
     /// Run in test profile mode
     #[clap(long, alias = "profile")]
     pub profile_with_tokio_console: bool,
-    /// Enable gRPC
-    #[clap(long, env = "MINOTARI_NODE_ENABLE_GRPC", alias = "enable-grpc")]
-    pub grpc_enabled: bool,
     /// Enable mining
     #[clap(long, env = "MINOTARI_NODE_ENABLE_MINING", alias = "enable-mining")]
     pub mining_enabled: bool,
@@ -81,11 +78,7 @@ impl ConfigOverrideProvider for Cli {
             replace_or_add_override(&mut overrides, k, v);
         });
         // Logical overrides based on command-line flags
-        if self.grpc_enabled {
-            replace_or_add_override(&mut overrides, "base_node.grpc_enabled", "true");
-        }
         if self.mining_enabled {
-            replace_or_add_override(&mut overrides, "base_node.grpc_enabled", "true");
             replace_or_add_override(&mut overrides, "base_node.mining_enabled", "true");
         }
         if self.second_layer_grpc_enabled {

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -60,7 +60,10 @@ use tari_common::{
 use tari_common_types::grpc_authentication::GrpcAuthentication;
 use tari_comms::{multiaddr::Multiaddr, utils::multiaddr::multiaddr_to_socketaddr, NodeIdentity};
 use tari_shutdown::{Shutdown, ShutdownSignal};
-use tokio::{task, time::timeout};
+use tokio::{
+    task::{self, JoinHandle},
+    time::timeout,
+};
 use tonic::{
     codegen::InterceptedService,
     transport::{Identity, Server, ServerTlsConfig},
@@ -98,7 +101,6 @@ pub async fn run_base_node(
         non_interactive_mode: true,
         watch: None,
         profile_with_tokio_console: false,
-        grpc_enabled: false,
         mining_enabled: false,
         second_layer_grpc_enabled: false,
         disable_splash_screen: true,
@@ -129,13 +131,18 @@ pub async fn run_base_node_with_cli(
 
     let (readiness_grpc_server, readiness_handler) = ReadinessGrpcServer::new();
     let mut readiness_grpc_shutdown = Shutdown::new();
-    let readiness_task = task::spawn(run_grpc(
-        readiness_grpc_server,
-        grpc_address.clone(),
-        auth.clone(),
-        tls_identity.clone(),
-        readiness_grpc_shutdown.to_signal(),
-    ));
+    let mut readiness_task: Option<JoinHandle<Result<(), anyhow::Error>>> = None;
+    if config.base_node.grpc_enabled {
+        readiness_task = Some(task::spawn(run_grpc(
+            readiness_grpc_server,
+            grpc_address.clone(),
+            auth.clone(),
+            tls_identity.clone(),
+            readiness_grpc_shutdown.to_signal(),
+        )));
+    } else {
+        info!(target: LOG_TARGET, "base_node.grpc_enabled is set to false. gRPC server is disabled.");
+    }
     readiness_handler.send_readiness_status(ReadinessState::StartingUp);
 
     if cli.rebuild_db {
@@ -165,10 +172,15 @@ pub async fn run_base_node_with_cli(
     let grpc = grpc::base_node_grpc_server::BaseNodeGrpcServer::from_base_node_context(&ctx, config.base_node.clone());
 
     readiness_grpc_shutdown.trigger();
-    if let Err(e) = timeout(std::time::Duration::from_millis(500), readiness_task).await {
-        error!("Readiness task failed to shutdown: {e}");
+    if let Some(task) = readiness_task {
+        if let Err(e) = timeout(std::time::Duration::from_millis(500), task).await {
+            error!("Readiness task failed to shutdown: {e}");
+        }
     }
-    task::spawn(run_grpc(grpc, grpc_address, auth, tls_identity, shutdown.to_signal()));
+
+    if config.base_node.grpc_enabled {
+        task::spawn(run_grpc(grpc, grpc_address, auth, tls_identity, shutdown.to_signal()));
+    }
 
     let main_loop = CliLoop::new(context, cli.watch, cli.non_interactive_mode);
     if cli.non_interactive_mode {


### PR DESCRIPTION
Description
---
Fixes: #7447 

Fixes both the normal and readiness gRPC servers to respect the base_node.grpc_enabled flag. Also removes the duplicate enabled_grpc flag, since having two flags for the same configuration option was confusing, especially when one took precedence over the other.

Motivation and Context
---
Fix a bug and improve UX by removes duplicated flag to enable gRPC.


How Has This Been Tested?
---
Build `minotari_node` and launch it twice - once with `-p base_node.grpc_enabled=false` and second time with gRPC enabled.
Then test each time if gRPC server is up by querying anything like this:
```
grpcurl -plaintext --emit-defaults -import-path /home/maciej/projects/tari/tari/applications/minotari_app_grpc/proto/ -proto /home/maciej/projects/tari/tari/applications/minotari_app_grpc/proto/base_node.proto 127.0.0.1:45227 tari.rpc.BaseNode/GetTipInfo
```

What process can a PR reviewer use to test or verify this change?
---
Same as above.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed CLI flag to enable gRPC; enablement now only via second-layer setting. Mining toggle no longer affects gRPC. The related env var/alias is no longer used.
  - gRPC server and readiness task start only when enabled; shutdown awaits the task only if running.
- Bug Fixes
  - Prevents unnecessary spawning/awaiting of gRPC readiness when disabled and adds clearer logs indicating gRPC is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->