### PR TITLE
fix(wallet): use minimum value promise in VN reg output

### DIFF
--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -100,6 +100,7 @@ pub enum OutputManagerRequest {
         fee_per_gram: MicroMinotari,
         lock_height: Option<u64>,
         payment_id: MemoField,
+        minimum_value_promise: MicroMinotari,
     },
     CreatePayToSelfWithOutputs {
         outputs: Vec<WalletOutputBuilder>,
@@ -916,6 +917,7 @@ where KM: TransactionKeyManagerInterface
         fee_per_gram: MicroMinotari,
         lock_height: Option<u64>,
         payment_id: MemoField,
+        minimum_value_promise: MicroMinotari,
     ) -> Result<(MicroMinotari, Transaction), OutputManagerError> {
         match self
             .handle
@@ -927,6 +929,7 @@ where KM: TransactionKeyManagerInterface
                 fee_per_gram,
                 lock_height,
                 payment_id,
+                minimum_value_promise,
             })
             .await??
         {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -370,6 +370,7 @@ where
                 fee_per_gram,
                 lock_height,
                 payment_id,
+                minimum_value_promise,
             } => self
                 .create_pay_to_self_transaction(
                     tx_id,
@@ -379,6 +380,7 @@ where
                     fee_per_gram,
                     lock_height,
                     payment_id,
+                    minimum_value_promise,
                 )
                 .await
                 .map(OutputManagerResponse::PayToSelfTransaction),
@@ -1638,6 +1640,7 @@ where
         fee_per_gram: MicroMinotari,
         lock_height: Option<u64>,
         payment_id: MemoField,
+        minimum_value_promise: MicroMinotari,
     ) -> Result<(MicroMinotari, Transaction), OutputManagerError> {
         let covenant = Covenant::default();
 
@@ -1691,6 +1694,7 @@ where
                 covenant,
                 payment_id,
                 input_selection.as_final_fee(),
+                minimum_value_promise,
             )
             .await?;
 
@@ -2165,6 +2169,7 @@ where
                     Covenant::default(),
                     MemoField::open_from_string(&format!("{number_of_splits} even coin splits"), TxType::CoinSplit),
                     fee,
+                    MicroMinotari::zero(),
                 )
                 .await?;
 
@@ -2325,6 +2330,7 @@ where
                     Covenant::default(),
                     payment_id.clone(),
                     final_fee,
+                    MicroMinotari::zero(),
                 )
                 .await?;
 
@@ -2399,6 +2405,7 @@ where
         covenant: Covenant,
         payment_id: MemoField,
         fee: MicroMinotari,
+        minimum_value_promise: MicroMinotari,
     ) -> Result<(DbWalletOutput, TariKeyId), OutputManagerError> {
         let (commitment_mask_key, script_key) = self
             .resources
@@ -2420,7 +2427,6 @@ where
             .key_manager
             .encrypt_data_for_recovery(&commitment_mask_key.key_id, None, amount.as_u64(), payment_id.clone())
             .await?;
-        let minimum_value_promise = MicroMinotari::zero();
         let metadata_message = TransactionOutput::metadata_signature_message_from_parts(
             &TransactionOutputVersion::get_current_version(),
             &script,
@@ -2548,6 +2554,7 @@ where
                 Covenant::default(),
                 payment_id.clone(),
                 fee,
+                MicroMinotari::zero(),
             )
             .await?;
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2099,6 +2099,9 @@ where
                 fee_per_gram,
                 None,
                 payment_id.clone(),
+                // Set minimum value promise to the amount provided. VN Reg outputs are required by validation to use
+                // this.
+                amount,
             )
             .await?;
 
@@ -2183,6 +2186,7 @@ where
                 fee_per_gram,
                 None,
                 payment_id.clone(),
+                MicroMinotari::zero(),
             )
             .await?;
 
@@ -2257,6 +2261,7 @@ where
                 fee_per_gram,
                 None,
                 payment_id.clone(),
+                MicroMinotari::zero(),
             )
             .await?;
 
@@ -2371,6 +2376,7 @@ where
                 fee_per_gram,
                 None,
                 payment_id.clone(),
+                MicroMinotari::zero(),
             )
             .await?;
         let template_output = transaction


### PR DESCRIPTION
Description
---
fix(wallet): use minimum value promise in VN reg output

Motivation and Context
---
Base node validation for VN reg requires the minimum value promise to be >= deposit amount

Ref https://github.com/tari-project/tari-ootle/pull/1560

How Has This Been Tested?
---
In PR https://github.com/tari-project/tari-ootle/pull/1560


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "minimum value promise" for pay-to-self transactions and UTXO aggregation.
  * Propagated across wallet transaction flows and advanced transaction options so it's available where outputs are constructed.
  * Defaults to zero when not specified, preserving existing behavior and workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->