### PR TITLE
chore: moves more hashing

### DIFF
--- a/base_layer/common_types/src/types/mod.rs
+++ b/base_layer/common_types/src/types/mod.rs
@@ -19,7 +19,7 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+use tari_hashing::BulletRangeProofHashDomain;
 mod bullet_rangeproofs;
 mod fixed_hash;
 use blake2::Blake2b;
@@ -27,7 +27,6 @@ pub use bullet_rangeproofs::BulletRangeProof;
 use digest::consts::{U32, U64};
 use tari_crypto::{
     compressed_key::CompressedKey,
-    hasher,
     ristretto::{
         bulletproofs_plus::BulletproofsPlusService,
         pedersen::{extended_commitment_factory::ExtendedPedersenCommitmentFactory, CompressedPedersenCommitment},
@@ -89,24 +88,9 @@ pub type CommsDHKE = DiffieHellmanSharedSecret<RistrettoPublicKey>;
 
 use tari_crypto::{
     dhke::DiffieHellmanSharedSecret,
-    hash_domain,
     hashing::DomainSeparatedHasher,
     ristretto::{pedersen::PedersenCommitment, RistrettoSchnorr},
 };
-
-hasher!(
-    Blake2b<U64>,
-    WalletHasher,
-    "com.tari.base_layer.wallet",
-    1,
-    wallet_hasher
-);
-
-hash_domain!(
-    BulletRangeProofHashDomain,
-    "com.tari.base_layer.common_types.bullet_rangeproofs",
-    1
-);
 
 pub type BulletRangeProofHasherBlake256 = DomainSeparatedHasher<Blake2b<U32>, BulletRangeProofHashDomain>;
 

--- a/base_layer/transaction_components/src/transaction_components/one_sided.rs
+++ b/base_layer/transaction_components/src/transaction_components/one_sided.rs
@@ -19,15 +19,14 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use blake2::Blake2b;
 use digest::consts::U64;
-use tari_common_types::types::{CommsDHKE, CompressedPublicKey, PrivateKey, WalletHasher};
+use tari_common_types::types::{CommsDHKE, CompressedPublicKey, PrivateKey};
 use tari_crypto::{
     hashing::{DomainSeparatedHash, DomainSeparatedHasher},
     keys::SecretKey as SKtrait,
 };
-use tari_hashing::{WalletOutputEncryptionKeysDomain, WalletOutputSpendingKeysDomain};
+use tari_hashing::{WalletHasher, WalletOutputEncryptionKeysDomain, WalletOutputSpendingKeysDomain};
 use tari_utilities::{byte_array::ByteArrayError, ByteArray};
 
 type WalletOutputEncryptionKeysDomainHasher = DomainSeparatedHasher<Blake2b<U64>, WalletOutputEncryptionKeysDomain>;

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -19,7 +19,6 @@ pub mod storage;
 pub mod test_utils;
 pub mod transaction_service;
 
-pub use tari_common_types::types::WalletHasher;
 use tari_transaction_components::key_manager::TransactionKeyManagerWrapper;
 pub mod util;
 pub mod wallet;

--- a/hashing/src/domains.rs
+++ b/hashing/src/domains.rs
@@ -1,7 +1,8 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
-
-use tari_crypto::hash_domain;
+use blake2::Blake2b;
+use digest::consts::U64;
+use tari_crypto::{hash_domain, hasher};
 
 // These are the hash domains that are also used in tari-dan.
 
@@ -69,5 +70,19 @@ hash_domain!(
 hash_domain!(
     WalletMessageSigningDomain,
     "com.tari.base_layer.wallet.message_signing",
+    1
+);
+
+hasher!(
+    Blake2b<U64>,
+    WalletHasher,
+    "com.tari.base_layer.wallet",
+    1,
+    wallet_hasher
+);
+
+hash_domain!(
+    BulletRangeProofHashDomain,
+    "com.tari.base_layer.common_types.bullet_rangeproofs",
     1
 );


### PR DESCRIPTION
Description
---
hasing domains should all  be in a single package, not spread out over the code base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated hashing domains into a shared module and replaced macro-based definitions with explicit domain-separated hashing. No user-facing behavior changes.
- Chores
  - Cleaned up imports and removed a redundant public re-export to streamline the API surface.
- New Features
  - Added dedicated, domain-separated hashers for wallet and bullet range proof components to improve consistency across the system (internal change, no impact on existing workflows).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->