### PR TITLE
feat: add prometheus difficulty gauges for expanded metrics export

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -57,7 +57,7 @@ use crate::{
             NodeCommsResponse,
             OutboundNodeCommsInterface,
         },
-        metrics::{log2_u128, log2_u512, milli_bits, u512_exp2_sig53},
+        metrics::{approximate_u512_with_f64, log2_u128, log2_u512, milli_bits, u512_exp2_sig53},
     },
     blocks::ChainBlock,
     chain_storage::{async_db::AsyncBlockchainDb, BlockAddResult, BlockchainBackend, ChainStorageError},
@@ -1102,6 +1102,8 @@ where B: BlockchainBackend + 'static
             .unwrap_or(0);
         let (acc_diff_exp2, acc_diff_sig53) =
             u512_exp2_sig53(&chain_header.accumulated_data().total_accumulated_difficulty).unwrap_or((0, 0));
+        let acc_diff_as_f64 =
+            approximate_u512_with_f64(&chain_header.accumulated_data().total_accumulated_difficulty).unwrap_or(0.0);
 
         // Publish
         metrics::accumulated_difficulty_indicator().set(acc_diff_milli_bits);
@@ -1113,6 +1115,7 @@ where B: BlockchainBackend + 'static
             .set(i64::try_from(chain_header.accumulated_data().target_difficulty.as_u64()).unwrap_or(i64::MAX));
         metrics::accumulated_difficulty_exp2().set(acc_diff_exp2);
         metrics::accumulated_difficulty_sig53().set(acc_diff_sig53);
+        metrics::accumulated_difficulty_as_f64().set(acc_diff_as_f64);
 
         Ok(())
     }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -1081,9 +1081,9 @@ where B: BlockchainBackend + 'static
         // Use canonical height from tip where reorgs are highly unlikely
         if tip <= DIFF_INDICATOR_LAG {
             // Not enough history yet; clear or skip
-            metrics::difficulty_indicator_height().set(0);
             metrics::accumulated_difficulty_indicator().set(0);
             metrics::target_difficulty_indicator().set(0);
+            metrics::difficulty_indicator_height().set(0);
             metrics::target_difficulty().set(0);
             metrics::accumulated_difficulty_exp2().set(0);
             metrics::accumulated_difficulty_sig53().set(0);
@@ -1109,7 +1109,7 @@ where B: BlockchainBackend + 'static
         #[allow(clippy::cast_possible_wrap)]
         metrics::difficulty_indicator_height().set(height as i64);
         #[allow(clippy::cast_possible_wrap)]
-        metrics::target_difficulty_indicator().set(chain_header.accumulated_data().target_difficulty.as_u64() as i64);
+        metrics::target_difficulty().set(chain_header.accumulated_data().target_difficulty.as_u64() as i64);
         metrics::accumulated_difficulty_exp2().set(acc_diff_exp2);
         metrics::accumulated_difficulty_sig53().set(acc_diff_sig53);
 

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -47,14 +47,17 @@ use tokio::sync::RwLock;
 #[cfg(feature = "metrics")]
 use crate::base_node::metrics;
 use crate::{
-    base_node::comms_interface::{
-        comms_response::ValidatorNodeChange,
-        error::CommsInterfaceError,
-        local_interface::BlockEventSender,
-        FetchMempoolTransactionsResponse,
-        NodeCommsRequest,
-        NodeCommsResponse,
-        OutboundNodeCommsInterface,
+    base_node::{
+        comms_interface::{
+            comms_response::ValidatorNodeChange,
+            error::CommsInterfaceError,
+            local_interface::BlockEventSender,
+            FetchMempoolTransactionsResponse,
+            NodeCommsRequest,
+            NodeCommsResponse,
+            OutboundNodeCommsInterface,
+        },
+        metrics::{log2_u128, log2_u512, milli_bits, u512_exp2_sig53},
     },
     blocks::ChainBlock,
     chain_storage::{async_db::AsyncBlockchainDb, BlockAddResult, BlockchainBackend, ChainStorageError},
@@ -69,11 +72,13 @@ use crate::{
     },
     validation::{helpers, tari_rx_vm_key_height, ValidationError},
 };
+
 const LOG_TARGET: &str = "c::bn::comms_interface::inbound_handler";
 const MAX_REQUEST_BY_BLOCK_HASHES: usize = 100;
 const MAX_REQUEST_BY_KERNEL_EXCESS_SIGS: usize = 100;
 const MAX_REQUEST_BY_UTXO_HASHES: usize = 100;
 const MAX_MEMPOOL_TIMEOUT: u64 = 150;
+const DIFF_INDICATOR_LAG: u64 = 25;
 
 /// Events that can be published on the Validated Block Event Stream
 /// Broadcast is to notify subscribers if this is a valid propagated block event
@@ -1043,6 +1048,7 @@ where B: BlockchainBackend + 'static
         match block_add_result {
             BlockAddResult::Ok(ref block) => {
                 update_target_difficulty(block);
+                self.update_difficulty_indicators(block.height()).await?;
                 #[allow(clippy::cast_possible_wrap)]
                 metrics::tip_height().set(block.height() as i64);
                 let utxo_set_size = self.blockchain_db.utxo_count().await?;
@@ -1059,6 +1065,7 @@ where B: BlockchainBackend + 'static
                 }
                 for block in added {
                     update_target_difficulty(block);
+                    self.update_difficulty_indicators(block.height()).await?;
                 }
             },
             BlockAddResult::OrphanBlock => {
@@ -1066,6 +1073,46 @@ where B: BlockchainBackend + 'static
             },
             _ => {},
         }
+        Ok(())
+    }
+
+    #[cfg(feature = "metrics")]
+    async fn update_difficulty_indicators(&self, tip: u64) -> Result<(), CommsInterfaceError> {
+        // Use canonical height from tip where reorgs are highly unlikely
+        if tip <= DIFF_INDICATOR_LAG {
+            // Not enough history yet; clear or skip
+            metrics::difficulty_indicator_height().set(0);
+            metrics::accumulated_difficulty_indicator().set(0);
+            metrics::target_difficulty_indicator().set(0);
+            metrics::target_difficulty().set(0);
+            metrics::accumulated_difficulty_exp2().set(0);
+            metrics::accumulated_difficulty_sig53().set(0);
+            return Ok(());
+        }
+        let height = tip - DIFF_INDICATOR_LAG;
+        let chain_header = self.blockchain_db.fetch_chain_header(height).await?;
+
+        // Compute indicators in millibits as `log₂(value) * 1000` to make huge numbers fathomable in a time-series
+        // graph with enough granularity
+        let acc_diff_milli_bits = log2_u512(&chain_header.accumulated_data().total_accumulated_difficulty)
+            .map(milli_bits)
+            .unwrap_or(0);
+        let target_diff_milli_bits = log2_u128(u128::from(chain_header.accumulated_data().target_difficulty.as_u64()))
+            .map(milli_bits)
+            .unwrap_or(0);
+        let (acc_diff_exp2, acc_diff_sig53) =
+            u512_exp2_sig53(&chain_header.accumulated_data().total_accumulated_difficulty).unwrap_or((0, 0));
+
+        // Publish
+        metrics::accumulated_difficulty_indicator().set(acc_diff_milli_bits);
+        metrics::target_difficulty_indicator().set(target_diff_milli_bits);
+        #[allow(clippy::cast_possible_wrap)]
+        metrics::difficulty_indicator_height().set(height as i64);
+        #[allow(clippy::cast_possible_wrap)]
+        metrics::target_difficulty_indicator().set(chain_header.accumulated_data().target_difficulty.as_u64() as i64);
+        metrics::accumulated_difficulty_exp2().set(acc_diff_exp2);
+        metrics::accumulated_difficulty_sig53().set(acc_diff_sig53);
+
         Ok(())
     }
 

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -47,17 +47,14 @@ use tokio::sync::RwLock;
 #[cfg(feature = "metrics")]
 use crate::base_node::metrics;
 use crate::{
-    base_node::{
-        comms_interface::{
-            comms_response::ValidatorNodeChange,
-            error::CommsInterfaceError,
-            local_interface::BlockEventSender,
-            FetchMempoolTransactionsResponse,
-            NodeCommsRequest,
-            NodeCommsResponse,
-            OutboundNodeCommsInterface,
-        },
-        metrics::{approximate_u512_with_f64, log2_u128, log2_u512, milli_bits, u512_exp2_sig53},
+    base_node::comms_interface::{
+        comms_response::ValidatorNodeChange,
+        error::CommsInterfaceError,
+        local_interface::BlockEventSender,
+        FetchMempoolTransactionsResponse,
+        NodeCommsRequest,
+        NodeCommsResponse,
+        OutboundNodeCommsInterface,
     },
     blocks::ChainBlock,
     chain_storage::{async_db::AsyncBlockchainDb, BlockAddResult, BlockchainBackend, ChainStorageError},
@@ -1087,6 +1084,7 @@ where B: BlockchainBackend + 'static
             metrics::target_difficulty().set(0);
             metrics::accumulated_difficulty_exp2().set(0);
             metrics::accumulated_difficulty_sig53().set(0);
+            metrics::accumulated_difficulty_as_f64().set(0.0);
             return Ok(());
         }
         let height = tip - DIFF_INDICATOR_LAG;
@@ -1094,16 +1092,18 @@ where B: BlockchainBackend + 'static
 
         // Compute indicators in millibits as `log₂(value) * 1000` to make huge numbers fathomable in a time-series
         // graph with enough granularity
-        let acc_diff_milli_bits = log2_u512(&chain_header.accumulated_data().total_accumulated_difficulty)
-            .map(milli_bits)
+        let acc_diff_milli_bits = metrics::log2_u512(&chain_header.accumulated_data().total_accumulated_difficulty)
+            .map(metrics::milli_bits)
             .unwrap_or(0);
-        let target_diff_milli_bits = log2_u128(u128::from(chain_header.accumulated_data().target_difficulty.as_u64()))
-            .map(milli_bits)
-            .unwrap_or(0);
+        let target_diff_milli_bits =
+            metrics::log2_u128(u128::from(chain_header.accumulated_data().target_difficulty.as_u64()))
+                .map(metrics::milli_bits)
+                .unwrap_or(0);
         let (acc_diff_exp2, acc_diff_sig53) =
-            u512_exp2_sig53(&chain_header.accumulated_data().total_accumulated_difficulty).unwrap_or((0, 0));
+            metrics::u512_exp2_sig53(&chain_header.accumulated_data().total_accumulated_difficulty).unwrap_or((0, 0));
         let acc_diff_as_f64 =
-            approximate_u512_with_f64(&chain_header.accumulated_data().total_accumulated_difficulty).unwrap_or(0.0);
+            metrics::approximate_u512_with_f64(&chain_header.accumulated_data().total_accumulated_difficulty)
+                .unwrap_or(0.0);
 
         // Publish
         metrics::accumulated_difficulty_indicator().set(acc_diff_milli_bits);

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -1109,7 +1109,8 @@ where B: BlockchainBackend + 'static
         #[allow(clippy::cast_possible_wrap)]
         metrics::difficulty_indicator_height().set(height as i64);
         #[allow(clippy::cast_possible_wrap)]
-        metrics::target_difficulty().set(chain_header.accumulated_data().target_difficulty.as_u64() as i64);
+        metrics::target_difficulty()
+            .set(i64::try_from(chain_header.accumulated_data().target_difficulty.as_u64()).unwrap_or(i64::MAX));
         metrics::accumulated_difficulty_exp2().set(acc_diff_exp2);
         metrics::accumulated_difficulty_sig53().set(acc_diff_sig53);
 

--- a/base_layer/core/src/base_node/metrics.rs
+++ b/base_layer/core/src/base_node/metrics.rs
@@ -320,6 +320,26 @@ pub fn u512_exp2_sig53(value: &U512) -> Option<(i64, i64)> {
     Some((i64::from(total_bits) - 1, i64::try_from(sig53).unwrap_or(i64::MAX)))
 }
 
+// Approximate a U512 as f64 using a 53-bit significand and exponent as `(sig53 / 2^52) * 2^exp2`.
+//   - exp2 = floor(log2(value)) (i64)
+//   - sig53 = top 53 bits (i64, always positive, safe up to 2^53-1)
+//   - Returns None if value == 0.
+#[allow(clippy::cast_possible_truncation)]
+#[cfg(test)]
+fn approximate_u512_with_f64(value: &U512) -> Option<f64> {
+    if value.is_zero() {
+        return None;
+    }
+    let (exp2, sig53) = u512_exp2_sig53(value).unwrap();
+
+    // Grafana-style reconstruction: (sig53 / 2^52) * 2^exp2
+    // This is not exact (limited by f64), but should be within a tiny relative error.
+    const TWO_P52: f64 = 4503599627370496.0; // 2^52
+                                             // Build 2^exp2 by setting the exponent (bias 1023), mantissa 0
+    let two_pow_exp2 = f64::from_bits(((exp2 + 1023) as u64) << 52);
+    Some((sig53 as f64 / TWO_P52) * two_pow_exp2)
+}
+
 // Nudge one floating point unit (ULP) down to counter rounding-up at integer boundaries.
 #[inline]
 fn next_down(x: f64) -> f64 {
@@ -473,14 +493,7 @@ mod tests {
         use primitive_types::U512;
 
         let original_u512 = U512::from_dec_str("3872628503165662556508806093911347954645375156922").unwrap();
-        let (exp2, sig53) = u512_exp2_sig53(&original_u512).unwrap();
-
-        // Grafana-style reconstruction: (sig53 / 2^52) * 2^exp2
-        // This is not exact (limited by f64), but should be within a tiny relative error.
-        const TWO_P52: f64 = 4503599627370496.0; // 2^52
-                                                 // Build 2^exp2 by setting the exponent (bias 1023), mantissa 0
-        let two_pow_exp2 = f64::from_bits(((exp2 + 1023) as u64) << 52);
-        let reconstructed_u512 = (sig53 as f64 / TWO_P52) * two_pow_exp2;
+        let reconstructed_u512 = approximate_u512_with_f64(&original_u512).unwrap();
 
         // Expected bits using our robust log2 (with next_down ULP guard)
         let expected_bits = log2_u512(&original_u512).unwrap();
@@ -495,27 +508,5 @@ mod tests {
         );
 
         // println!("approx f64 = {}\noriginal   = {}", reconstructed_u512, original_u512);
-
-        // Convert to string conserving all significant digits
-        let reconstructed_str = format!("{}", reconstructed_u512);
-        let original_str = original_u512.to_string();
-
-        // Extract the first 16 digits [Rust preserves 17] (excluding decimal point and exponent for f64)
-        let reconstructed_digits: String = reconstructed_str
-            .chars()
-            .filter(|c| c.is_ascii_digit())
-            .take(16)
-            .collect();
-        let original_digits: String = original_str.chars().take(16).collect();
-
-        assert_eq!(
-            reconstructed_digits, original_digits,
-            "The 16 most significant digits do not match"
-        );
-        assert_eq!(
-            reconstructed_str.chars().filter(|c| c.is_ascii_digit()).count(),
-            original_str.len(),
-            "The digit lengths do not match"
-        );
     }
 }

--- a/base_layer/core/src/base_node/metrics.rs
+++ b/base_layer/core/src/base_node/metrics.rs
@@ -23,7 +23,7 @@
 use once_cell::sync::Lazy;
 use primitive_types::U512;
 use tari_common_types::types::FixedHash;
-use tari_metrics::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+use tari_metrics::{Gauge, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 use tari_utilities::hex::Hex;
 
 pub fn tip_height() -> &'static IntGauge {
@@ -128,24 +128,41 @@ pub fn difficulty_indicator_height() -> &'static IntGauge {
     &METER
 }
 
-/// floor(log2(total_accumulated_difficulty)) at height [reconstruction: (sig53 / 2^52) * 2^exp2]
+/// floor(log2(total_accumulated_difficulty)) at height [reconstruction: (acc_diff_sig53 / 2^52) * 2^acc_diff_exp2]
 pub fn accumulated_difficulty_exp2() -> &'static IntGauge {
     static METER: Lazy<IntGauge> = Lazy::new(|| {
         tari_metrics::register_int_gauge(
             "base_node::blockchain::acc_diff_exp2",
-            "floor(log2(total_accumulated_difficulty)) at height [reconstruction: (sig53 / 2^52) * 2^exp2]",
+            "floor(log2(total_accumulated_difficulty)) at height [reconstruction: (acc_diff_sig53 / 2^52) * \
+             2^acc_diff_exp2]",
         )
         .unwrap()
     });
     &METER
 }
 
-/// Top 53 bits of total_accumulated_difficulty at height [reconstruction: (sig53 / 2^52) * 2^exp2]
+/// Top 53 bits of total_accumulated_difficulty at height [reconstruction: (acc_diff_sig53 / 2^52) * 2^acc_diff_exp2]
 pub fn accumulated_difficulty_sig53() -> &'static IntGauge {
     static METER: Lazy<IntGauge> = Lazy::new(|| {
         tari_metrics::register_int_gauge(
             "base_node::blockchain::acc_diff_sig53",
-            "Top 53 bits of total_accumulated_difficulty at height [reconstruction: (sig53 / 2^52) * 2^exp2]",
+            "Top 53 bits of total_accumulated_difficulty at height [reconstruction: (acc_diff_sig53 / 2^52) * \
+             2^acc_diff_exp2]",
+        )
+        .unwrap()
+    });
+    &METER
+}
+
+/// Approximate total_accumulated_difficulty at height as an f64 [reconstruction: (acc_diff_sig53 / 2^52) *
+/// 2^acc_diff_exp2] Note: This is less accurate than doing the computation directly in the client, but is provided for
+/// convenience.
+pub fn accumulated_difficulty_as_f64() -> &'static Gauge {
+    static METER: Lazy<Gauge> = Lazy::new(|| {
+        tari_metrics::register_gauge(
+            "base_node::blockchain::acc_diff_as_f64",
+            "Approximate total_accumulated_difficulty at height as an f64 [approximation: (acc_diff_sig53 / 2^52) * \
+             2^acc_diff_exp2]",
         )
         .unwrap()
     });
@@ -288,9 +305,9 @@ pub fn log2_u512(value_u512: &U512) -> Option<f64> {
     Some(res)
 }
 
-/// Returns (exp2, sig53) where:
-///   - exp2 = floor(log2(value)) (u32)
-///   - sig53 = top 53 bits (u64)
+// Returns (exp2, sig53) where:
+//   - exp2 = floor(log2(value)) (u32)
+//   - sig53 = top 53 bits (u64)
 #[allow(clippy::cast_possible_truncation)]
 fn u512_into_parts(value_u512: &U512) -> (u32, u64) {
     let total_bits: u32 = value_u512.bits() as u32; // total bits
@@ -320,13 +337,12 @@ pub fn u512_exp2_sig53(value: &U512) -> Option<(i64, i64)> {
     Some((i64::from(total_bits) - 1, i64::try_from(sig53).unwrap_or(i64::MAX)))
 }
 
-// Approximate a U512 as f64 using a 53-bit significand and exponent as `(sig53 / 2^52) * 2^exp2`.
-//   - exp2 = floor(log2(value)) (i64)
-//   - sig53 = top 53 bits (i64, always positive, safe up to 2^53-1)
-//   - Returns None if value == 0.
+/// Approximate a U512 as f64 using a 53-bit significand and exponent as `(sig53 / 2^52) * 2^exp2`.
+///   - exp2 = floor(log2(value)) (i64)
+///   - sig53 = top 53 bits (i64, always positive, safe up to 2^53-1)
+///   - Returns None if value == 0.
 #[allow(clippy::cast_possible_truncation)]
-#[cfg(test)]
-fn approximate_u512_with_f64(value: &U512) -> Option<f64> {
+pub fn approximate_u512_with_f64(value: &U512) -> Option<f64> {
     if value.is_zero() {
         return None;
     }
@@ -344,7 +360,7 @@ fn approximate_u512_with_f64(value: &U512) -> Option<f64> {
 #[inline]
 fn next_down(x: f64) -> f64 {
     // Move to the next representable float toward -∞
-    f64::from_bits(x.to_bits() - 1)
+    f64::from_bits(x.to_bits().saturating_sub(1))
 }
 
 /// Computes log₂(value) as f64 for a u128 using a 53-bit normalized significand.
@@ -499,19 +515,23 @@ mod tests {
         use primitive_types::U512;
 
         let original_u512 = U512::from_dec_str("3872628503165662556508806093911347954645375156922").unwrap();
-        let reconstructed_u512 = approximate_u512_with_f64(&original_u512).unwrap();
+        let approximate_u512 = approximate_u512_with_f64(&original_u512).unwrap();
 
         // Expected bits using our robust log2 (with next_down ULP guard)
         let expected_bits = log2_u512(&original_u512).unwrap();
 
         // The two log2 values should match within a tiny epsilon (a few ULPs)
-        let approx_bits = reconstructed_u512.log2();
+        let approx_bits = approximate_u512.log2();
         assert!(
             (approx_bits - expected_bits).abs() < 1e-9,
             "reconstructed log2 mismatch: approx={}, expected={}",
             approx_bits,
             expected_bits
         );
+
+        // Relative error via logs (safer for huge values):
+        let relative_err = (approximate_u512.log2() - log2_u512(&original_u512).unwrap()).abs() / log2_u512(&original_u512).unwrap().abs();
+        assert!(relative_err < 1e-12);
 
         // println!("approx f64 = {}\noriginal   = {}", reconstructed_u512, original_u512);
     }

--- a/base_layer/core/src/base_node/metrics.rs
+++ b/base_layer/core/src/base_node/metrics.rs
@@ -530,7 +530,8 @@ mod tests {
         );
 
         // Relative error via logs (safer for huge values):
-        let relative_err = (approximate_u512.log2() - log2_u512(&original_u512).unwrap()).abs() / log2_u512(&original_u512).unwrap().abs();
+        let relative_err = (approximate_u512.log2() - log2_u512(&original_u512).unwrap()).abs() /
+            log2_u512(&original_u512).unwrap().abs();
         assert!(relative_err < 1e-12);
 
         // println!("approx f64 = {}\noriginal   = {}", reconstructed_u512, original_u512);

--- a/base_layer/core/src/base_node/metrics.rs
+++ b/base_layer/core/src/base_node/metrics.rs
@@ -416,6 +416,12 @@ mod tests {
         // u128::MAX = 2^128 - 1  => strictly less than 128
         assert!(log2_u512(&U512::from(u128::MAX)).unwrap() < 128.0);
 
+        // Test U512 max value = 2^512 - 1  => strictly less than 512
+        let u512_max = U512::MAX;
+        let log2_u512_max = log2_u512(&u512_max).unwrap();
+        assert!(log2_u512_max < 512.0);
+        assert!(log2_u512_max > 511.0);
+
         // log2(0) == None
         assert!(log2_u512(&U512::from(0u64)).is_none());
     }

--- a/base_layer/core/src/base_node/metrics.rs
+++ b/base_layer/core/src/base_node/metrics.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use once_cell::sync::Lazy;
+use primitive_types::U512;
 use tari_common_types::types::FixedHash;
 use tari_metrics::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 use tari_utilities::hex::Hex;
@@ -77,6 +78,77 @@ pub fn target_difficulty_cuckaroo() -> &'static IntGauge {
         .unwrap()
     });
 
+    &METER
+}
+
+/// The target difficulty at the given height
+pub fn target_difficulty() -> &'static IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge("base_node::blockchain::target_diff", "target_difficulty at height").unwrap()
+    });
+
+    &METER
+}
+
+/// The accumulated difficulty indicator (log_2 scale) at the given height
+pub fn accumulated_difficulty_indicator() -> &'static IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge(
+            "base_node::blockchain::acc_diff_indicator",
+            "log2(accumulated_difficulty at height) * 1000",
+        )
+        .unwrap()
+    });
+
+    &METER
+}
+
+/// The target difficulty indicator (log_2 scale) at the given height
+pub fn target_difficulty_indicator() -> &'static IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge(
+            "base_node::blockchain::target_diff_indicator",
+            "log2(target_difficulty at height) * 1000",
+        )
+        .unwrap()
+    });
+
+    &METER
+}
+
+/// The block height associated with the current difficulty indicators
+pub fn difficulty_indicator_height() -> &'static IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge(
+            "base_node::blockchain::diff_indicator_height",
+            "block height associated with difficulty indicators",
+        )
+        .unwrap()
+    });
+    &METER
+}
+
+/// floor(log2(total_accumulated_difficulty)) at height [reconstruction: (sig53 / 2^52) * 2^exp2]
+pub fn accumulated_difficulty_exp2() -> &'static IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge(
+            "base_node::blockchain::acc_diff_exp2",
+            "floor(log2(total_accumulated_difficulty)) at height [reconstruction: (sig53 / 2^52) * 2^exp2]",
+        )
+        .unwrap()
+    });
+    &METER
+}
+
+/// Top 53 bits of total_accumulated_difficulty at height [reconstruction: (sig53 / 2^52) * 2^exp2]
+pub fn accumulated_difficulty_sig53() -> &'static IntGauge {
+    static METER: Lazy<IntGauge> = Lazy::new(|| {
+        tari_metrics::register_int_gauge(
+            "base_node::blockchain::acc_diff_sig53",
+            "Top 53 bits of total_accumulated_difficulty at height [reconstruction: (sig53 / 2^52) * 2^exp2]",
+        )
+        .unwrap()
+    });
     &METER
 }
 
@@ -183,4 +255,267 @@ pub fn utxo_set_size() -> &'static IntGauge {
     });
 
     &METER
+}
+
+// Ref: IEEE 754-2008, binary64 format.
+// f64 has a 53-bit significand (52 explicit + 1 implicit bit).
+// Scaling by 1/2^52 ensures we map the 53-bit integer into [1, 2),
+// which is exactly representable in f64 without rounding.
+const INV_2P52: f64 = 1.0 / ((1u64 << 52) as f64);
+
+/// Computes log₂(value) as f64 for a U512 using a 53-bit normalized significand.
+/// Uses IEEE 754 binary64 rules to avoid precision loss:
+/// - Exact powers of two return an integer result.
+/// - Non-powers-of-two are guaranteed to be strictly less than the next integer, preventing rounding-up artifacts.
+#[allow(clippy::cast_possible_truncation)]
+pub fn log2_u512(value_u512: &U512) -> Option<f64> {
+    if value_u512.is_zero() {
+        return None;
+    }
+
+    let (total_bits, sig53) = u512_into_parts(value_u512);
+
+    // Converts the 53-bit integer significand into a floating-point number in the range [1, 2)
+    let x = (sig53 as f64) * INV_2P52;
+
+    let frac = x.log2();
+    let mut res = (f64::from(total_bits) - 1.0) + frac;
+
+    // If not an exact power of two (sig53 > 2^52), ensure we never round up to the next integer.
+    if sig53 > (1u64 << 52) {
+        res = next_down(res);
+    }
+    Some(res)
+}
+
+/// Returns (exp2, sig53) where:
+///   - exp2 = floor(log2(value)) (u32)
+///   - sig53 = top 53 bits (u64)
+#[allow(clippy::cast_possible_truncation)]
+fn u512_into_parts(value_u512: &U512) -> (u32, u64) {
+    let total_bits: u32 = value_u512.bits() as u32; // total bits
+
+    // Build exact 53-bit significand with MSB at bit 52 into u64
+    let sig53: u64 = if total_bits > 53 {
+        // Keep only the top 53 bits
+        (value_u512 >> (total_bits - 53)).as_u64()
+    } else {
+        // Move the most significant bit to position 52
+        (value_u512 << (53 - total_bits)).as_u64()
+    };
+    debug_assert!(((1u64 << 52)..(1u64 << 53)).contains(&sig53));
+    (total_bits, sig53)
+}
+
+/// Returns (exp2, sig53) where:
+///   - exp2 = floor(log2(value)) (i64)
+///   - sig53 = top 53 bits (i64, always positive, safe up to 2^53-1)
+///   - Returns None if value == 0.
+#[allow(clippy::cast_possible_truncation)]
+pub fn u512_exp2_sig53(value: &U512) -> Option<(i64, i64)> {
+    if value.is_zero() {
+        return None;
+    }
+    let (total_bits, sig53) = u512_into_parts(value);
+    Some((i64::from(total_bits) - 1, i64::try_from(sig53).unwrap_or(i64::MAX)))
+}
+
+// Nudge one floating point unit (ULP) down to counter rounding-up at integer boundaries.
+#[inline]
+fn next_down(x: f64) -> f64 {
+    // Move to the next representable float toward -∞
+    f64::from_bits(x.to_bits() - 1)
+}
+
+/// Computes log₂(value) as f64 for a u128 using a 53-bit normalized significand.
+/// Uses IEEE 754 binary64 rules to avoid precision loss:
+/// - Exact powers of two return an integer result.
+/// - Non-powers-of-two are guaranteed to be strictly less than the next integer, preventing rounding-up artifacts.
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+pub fn log2_u128(value_u128: u128) -> Option<f64> {
+    if value_u128 == 0 {
+        return None;
+    }
+    let total_bits: u32 = 128 - value_u128.leading_zeros(); // In the range 1..=128
+
+    // Build exact 53-bit significand with MSB at bit 52 into u64
+    let sig53: u64 = if total_bits > 53 {
+        // Keep only the top 53 bits
+        (value_u128 >> (total_bits - 53)) as u64
+    } else {
+        // Move the most significant bit to position 52
+        (value_u128 << (53 - total_bits)) as u64
+    };
+    debug_assert!(((1u64 << 52)..(1u64 << 53)).contains(&sig53));
+
+    // Converts the 53-bit integer significand into a floating-point number in the range [1, 2)
+    let x = (sig53 as f64) * INV_2P52;
+
+    let frac = x.log2();
+    let mut res = (f64::from(total_bits) - 1.0) + frac;
+
+    // If not an exact power of two (sig53 > 2^52), ensure we never round up to the next integer.
+    if sig53 > (1u64 << 52) {
+        res = next_down(res);
+    }
+    Some(res)
+}
+
+/// Converts a floating point number of bits into an integer number of milli-bits (1/1000 bits).
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+pub fn milli_bits(x: f64) -> i64 {
+    (x * 1000.0).round() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use primitive_types::U512;
+
+    use super::*;
+
+    #[test]
+    fn test_log2_u512() {
+        // log2(1) == 0
+        assert_eq!(log2_u512(&U512::from(1u64)), Some(0.0));
+
+        // Exact powers of two
+        assert_eq!(log2_u512(&(U512::from(2u64))), Some(1.0));
+        assert_eq!(log2_u512(&(U512::from(8u64))), Some(3.0));
+        assert_eq!(log2_u512(&(U512::from(1024u64))), Some(10.0));
+
+        // 2^200 exactly
+        let value = U512::from(1u64) << 200;
+        assert_eq!(log2_u512(&value), Some(200.0));
+
+        // 2^200 - 1  => strictly less than 200
+        let value = (U512::from(1u64) << 200) - U512::from(1u64);
+        assert!(log2_u512(&value).unwrap() < 200.0);
+
+        // u128::MAX = 2^128 - 1  => strictly less than 128
+        assert!(log2_u512(&U512::from(u128::MAX)).unwrap() < 128.0);
+
+        // log2(0) == None
+        assert!(log2_u512(&U512::from(0u64)).is_none());
+    }
+
+    #[test]
+    fn test_log2_u128() {
+        // log2(1) == 0
+        assert_eq!(log2_u128(1), Some(0.0));
+
+        // exact powers of two
+        assert_eq!(log2_u128(2), Some(1.0));
+        assert_eq!(log2_u128(8), Some(3.0));
+        assert_eq!(log2_u128(1024), Some(10.0));
+
+        // 2^100 exactly
+        let value = 1u128 << 100;
+        assert_eq!(log2_u128(value), Some(100.0));
+
+        // 2^100 - 1  => strictly less than 100
+        let value = (1u128 << 100) - 1;
+        assert!(log2_u128(value).unwrap() < 100.0);
+
+        // u128::MAX = 2^128 - 1  => strictly less than 128
+        assert!(log2_u128(u128::MAX).unwrap() < 128.0);
+
+        // log2(0) == None
+        assert!(log2_u128(0).is_none());
+    }
+
+    #[test]
+    fn millibit_correctly_handles_small_difficulty_growth() {
+        // Accumulated difficulty (U512)
+        let acc_diff_v1 = U512::from_dec_str("3872628503165662556508806093911347954645375156922").unwrap();
+        // Target difficulty (fits in u128)
+        let target_diff_v1: u128 = 33_208_643_413_617_919;
+
+        // --- Baseline milli-bits ---
+        let acc_diff_v1_mbits = milli_bits(log2_u512(&acc_diff_v1).unwrap());
+        let target_diff_v1_mbits = milli_bits(log2_u128(target_diff_v1).unwrap());
+
+        // --- Apply +0.15% change (δ = 0.0015) --- (1/0.0015 = 666.666666667 ~= 667)
+        let acc_diff_v2 = acc_diff_v1 + acc_diff_v1 / U512::from(667u64);
+        let target_diff_v2 = target_diff_v1 + (target_diff_v1 / 667);
+
+        let acc_diff_v2_mbits = milli_bits(log2_u512(&acc_diff_v2).unwrap());
+        let target_diff_v2_mbits = milli_bits(log2_u128(target_diff_v2).unwrap());
+
+        assert!(acc_diff_v2_mbits > acc_diff_v1_mbits);
+        assert!(target_diff_v2_mbits > target_diff_v1_mbits);
+    }
+
+    #[test]
+    fn exp2_sig53_power_of_two_and_neighbors() {
+        // 2^200
+        let v = U512::from(1u64) << 200;
+        let (e, s) = u512_exp2_sig53(&v).unwrap();
+        assert_eq!(e, 200);
+        assert_eq!(s, 1i64 << 52, "exact power of two => normalized sig53 == 2^52");
+
+        // 2^200 - 1  (just below)
+        let v = (U512::from(1u64) << 200) - U512::from(1u64);
+        let (e, s) = u512_exp2_sig53(&v).unwrap();
+        assert_eq!(e, 199, "floor(log2(2^200-1)) = 199");
+        assert!(((1i64 << 52)..(1i64 << 53)).contains(&s));
+
+        // 2^200 + 1  (just above)
+        let v = (U512::from(1u64) << 200) + U512::from(1u64);
+        let (e, s) = u512_exp2_sig53(&v).unwrap();
+        assert_eq!(e, 200);
+        assert!(((1i64 << 52)..(1i64 << 53)).contains(&s));
+    }
+
+    #[test]
+    fn it_can_reconstruct_u512_from_exp2_sig53_parts_as_f64() {
+        use primitive_types::U512;
+
+        let original_u512 = U512::from_dec_str("3872628503165662556508806093911347954645375156922").unwrap();
+        let (exp2, sig53) = u512_exp2_sig53(&original_u512).unwrap();
+
+        // Grafana-style reconstruction: (sig53 / 2^52) * 2^exp2
+        // This is not exact (limited by f64), but should be within a tiny relative error.
+        const TWO_P52: f64 = 4503599627370496.0; // 2^52
+                                                 // Build 2^exp2 by setting the exponent (bias 1023), mantissa 0
+        let two_pow_exp2 = f64::from_bits(((exp2 + 1023) as u64) << 52);
+        let reconstructed_u512 = (sig53 as f64 / TWO_P52) * two_pow_exp2;
+
+        // Expected bits using our robust log2 (with next_down ULP guard)
+        let expected_bits = log2_u512(&original_u512).unwrap();
+
+        // The two log2 values should match within a tiny epsilon (a few ULPs)
+        let approx_bits = reconstructed_u512.log2();
+        assert!(
+            (approx_bits - expected_bits).abs() < 1e-9,
+            "reconstructed log2 mismatch: approx={}, expected={}",
+            approx_bits,
+            expected_bits
+        );
+
+        // println!("approx f64 = {}\noriginal   = {}", reconstructed_u512, original_u512);
+
+        // Convert to string conserving all significant digits
+        let reconstructed_str = format!("{}", reconstructed_u512);
+        let original_str = original_u512.to_string();
+
+        // Extract the first 16 digits [Rust preserves 17] (excluding decimal point and exponent for f64)
+        let reconstructed_digits: String = reconstructed_str
+            .chars()
+            .filter(|c| c.is_ascii_digit())
+            .take(16)
+            .collect();
+        let original_digits: String = original_str.chars().take(16).collect();
+
+        assert_eq!(
+            reconstructed_digits, original_digits,
+            "The 16 most significant digits do not match"
+        );
+        assert_eq!(
+            reconstructed_str.chars().filter(|c| c.is_ascii_digit()).count(),
+            original_str.len(),
+            "The digit lengths do not match"
+        );
+    }
 }


### PR DESCRIPTION
Description
---
This PR adds new Prometheus gauges to expose difficulty metrics for display in Grafana.

Because Prometheus gauges are limited to f64 and i64, we cannot transmit the full 512-bit accumulated difficulty (U512) directly. Instead, we expose it in two forms:

1. Log_2 representation (f64) of the log_2(U512) value.

2. Binary scientific notation parts (2 × i64):
   - `exp2`: `floor(log₂(U512 value))`
   - `sig53`: top 53 bits of the U512 value, normalised to [1, 2)
   - Together, these allow reconstructing an approximate U512 value with the first ~16 significant decimal digits exact: [reconstruction: `(sig53 / 2^52) * 2^exp2`].

For target difficulty (u64), we expose:

1. Log_2 representation (f64) of the log_2(u64) value.

2. The raw 64-bit target difficulty value (i64).

Additionally, we publish the block height at which these values are sampled, lagging ~25 blocks behind the tip, to ensure stability across potential short reorgs.

**Notes:** 
- When using these metrics to identify chain divergences or forks, the published height must always be used as the X-axis reference to ensure correctness.
- Prometheus stores all metric values as f64 (64-bit floating point). Splitting a 512-bit number into multiple gauges and expecting Grafana or Prometheus to recombine them with full precision will not work, because each gauge is still limited to f64 precision. This is why the code extracts the top 53 bits (the significand that fits in an f64) and the exponent, allowing approximate reconstruction within the limits of f64 accuracy.

Motivation and Context
---
Not all pertinent accumulated difficulty values are currently available in metrics.

How Has This Been Tested?
---
Added unit tests.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added difficulty indicator metrics (target, accumulated, indicator height, derived indicators including exp2/sig53 and f64 approximation). Metrics publish automatically on new blocks and reorganizations; active only when metrics are enabled.
  - Added high-precision large-integer utilities and conversions to support those metrics.

- **Tests**
  - Added tests for metric calculations, edge cases, and precision/reconstruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->