### PR TITLE
fix: race condition in getting seed peers in connectivity manager at startup

### DIFF
--- a/base_layer/p2p/src/peer_seeds.rs
+++ b/base_layer/p2p/src/peer_seeds.rs
@@ -76,7 +76,8 @@ impl DnsSeedResolver {
     /// ```
     pub async fn resolve(&mut self, addr: &str) -> Result<Vec<SeedPeer>, DnsClientError> {
         let records = self.client.query_txt(addr).await?;
-        let peers = records
+        trace!(target: LOG_TARGET, "DNS records: {:?}", records);
+        let peers: Vec<_> = records
             .into_iter()
             .filter_map(|txt| {
                 txt.parse()
@@ -89,6 +90,7 @@ impl DnsSeedResolver {
                     .ok()
             })
             .collect();
+        trace!(target: LOG_TARGET, "Seed peers: {:?}", peers.iter().map(|p| format!("{}", p)).collect::<Vec<_>>());
         Ok(peers)
     }
 }

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -199,18 +199,6 @@ impl ConnectivityManagerActor {
 
         self.publish_event(ConnectivityEvent::ConnectivityStateInitialized);
 
-        self.seeds = self
-            .peer_manager
-            .get_seed_peers()
-            .await
-            .unwrap_or({
-                warn!(target: LOG_TARGET, "Failed to get seed peers from PeerManager, using empty list");
-                vec![]
-            })
-            .iter()
-            .map(|s| s.node_id.clone())
-            .collect();
-
         loop {
             tokio::select! {
                 Some(req) = self.request_rx.recv() => {
@@ -1217,6 +1205,23 @@ impl ConnectivityManagerActor {
         self.update_circuit_breaker_metrics();
 
         // Execute proactive dialing logic
+        if self.seeds.is_empty() {
+            self.seeds = self
+                .peer_manager
+                .get_seed_peers()
+                .await
+                .inspect_err(|err| {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Failed to get seed peers from PeerManager, using empty list for proactive dialing, seed peers \
+                        will not be excluded as a first pass. ({})", err
+                    );
+                })
+                .unwrap_or(vec![])
+                .iter()
+                .map(|s| s.node_id.clone())
+                .collect();
+        }
         match self
             .proactive_dialer
             .execute_proactive_dialing(&self.pool, &self.connection_stats, &self.seeds, task_id)

--- a/comms/core/src/peer_manager/peer_storage_sql.rs
+++ b/comms/core/src/peer_manager/peer_storage_sql.rs
@@ -265,8 +265,15 @@ impl PeerStorageSql {
         )?)
     }
 
+    /// Get all seed peers
     pub fn get_seed_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
-        Ok(self.peer_db.get_seed_peers()?)
+        let seed_peers = self.peer_db.get_seed_peers()?;
+        trace!(
+            target: LOG_TARGET,
+            "Get seed peers: {:?}",
+            seed_peers.iter().map(|p| p.node_id.short_str()).collect::<Vec<_>>(),
+        );
+        Ok(seed_peers)
     }
 
     /// Compile a random list of communication node peers of size _n_ that are not banned or offline and


### PR DESCRIPTION
Description
---
This PR fixes a race condition between adding seed peers at startup and retrieving them from the peer manager in the connectivity manager.

Motivation and Context
---
The warning message `WARN  Failed to get seed peers from PeerManager, using empty list // comms/core/src/connectivity/manager.rs:207` is a timing issue. In this context the seed peer list is passed to the proactive dialer to exclude them from being proactively dialed if other connections exist. On a node with proper connectivity, seed peer dial requests are coming through straight after.

- `2025-09-04 16:28:05.638210600 [p2p::initialization] DEBUG Adding seed peer [PeerFlags(SEED)[0984896e74022c44] `
- `2025-09-04 16:28:05.648016500 [comms::connectivity::manager] DEBUG ConnectivityManager started`
- `2025-09-04 16:28:05.648239900 [comms::connectivity::manager] WARN  Failed to get seed peers from PeerManager, using empty list`
- `2025-09-04 16:28:05.648850400 [comms::dht::connectivity] DEBUG Adding 5 neighbouring peer(s), removing 0 peers: 0984896e74022c442c1034852c, `
- `2025-09-04 16:28:05.648912900 [comms::connectivity::manager] TRACE Request (11267568784269984977): DialPeer { node_id: NodeId(0984896e74022c442c1034852c), reply_tx: None }` ...
- `2025-09-04 16:31:05.655859300 [comms::connectivity::manager] DEBUG (5619097807157888458) Starting proactive dialing execution - current connections: 10, target: 8`

How Has This Been Tested?
---
System-level testing

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Seed peers now load on-demand instead of at startup, reducing startup overhead and improving initial responsiveness.

* **Chores**
  * Improved diagnostic logging around seed peer retrieval and DNS seed parsing, including warnings for parse failures and failed seed lookups to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->