### PR TITLE
feat: multi recipient support

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1519,6 +1519,7 @@ message BroadcastSignedOneSidedTransactionResponse {
 // A request to send funds to one or more recipients.
 message TransferRequest {
   repeated PaymentRecipient recipients = 1;
+  bool single_tx = 2;
 }
 
 message SendShaAtomicSwapRequest {

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -234,6 +234,7 @@ service Wallet {
   // This call supports standard interactive transactions (Mimblewimble),
   // one-sided transactions, and one-sided-to-stealth-address transactions.
   // Each recipient must include a valid Tari address, amount, fee, and payment type.
+  // SingleTx is used to indicate should this be sent as a single MW tx or multiple, one tx per recipient.
   //
   // ### Example JavaScript gRPC client usage:
   //
@@ -247,6 +248,7 @@ service Wallet {
   //
   // const request = new TransferRequest();
   // request.setRecipientsList([recipient]);
+  // request.setSingleTx(false);
   //
   // client.transfer(request, (err, response) => {
   //   if (err) console.error(err);

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -243,6 +243,94 @@ impl WalletGrpcServer {
     fn get_output_manager_service(&self) -> OutputManagerHandle<WalletKeyManager> {
         self.wallet.output_manager_service.clone()
     }
+
+    async fn transfer_single_tx(
+        &self,
+        recipients: Vec<minotari_app_grpc::tari_rpc::PaymentRecipient>,
+    ) -> Result<Response<minotari_app_grpc::tari_rpc::TransferResponse>, Status> {
+        let fee_per_gram = recipients.first().expect("already checked").fee_per_gram;
+        let recipients = recipients
+            .into_iter()
+            .enumerate()
+            .map(|(idx, dest)| -> Result<_, String> {
+                let address = TariAddress::from_str(&dest.address)
+                    .map_err(|_| format!("Destination address at index {idx} is malformed"))?;
+                let payment_id = if !dest.raw_payment_id.is_empty() {
+                    MemoField::open_unchecked(dest.raw_payment_id.to_vec(), TxType::PaymentToOther)
+                } else if let Some(user_pay_id) = dest.user_payment_id {
+                    let bytes = match (
+                        user_pay_id.u256.is_empty(),
+                        user_pay_id.utf8_string.is_empty(),
+                        user_pay_id.user_bytes.is_empty(),
+                    ) {
+                        (false, true, true) => user_pay_id.u256,
+                        (true, false, true) => user_pay_id.utf8_string.as_bytes().to_vec(),
+                        (true, true, false) => user_pay_id.user_bytes,
+                        _ => {
+                            return Err("user_payment_id must be one of u256, utf8_string or user_bytes".to_string());
+                        },
+                    };
+                    MemoField::open_unchecked(bytes, TxType::PaymentToOther)
+                } else {
+                    MemoField::new_empty()
+                };
+                Ok((address, MicroMinotari(dest.amount), payment_id))
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Status::invalid_argument)?;
+        let mut transaction_service = self.get_transaction_service();
+        let ids = transaction_service
+            .send_one_sided_multi_recipient_transaction(
+                recipients,
+                UtxoSelectionCriteria::default(),
+                OutputFeatures::default(),
+                fee_per_gram.into(),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Failed to send transaction: {e}")))?;
+        let mut results = Vec::new();
+        for id in ids {
+            let wallet_address = self
+                .wallet
+                .get_wallet_one_sided_address()
+                .await
+                .map_err(|e| Status::internal(format!("{e:?}")))?;
+            let wallet_tx = timeout(Duration::from_millis(100), async {
+                loop {
+                    let tx = self
+                        .get_transaction_service()
+                        .get_any_transaction(id)
+                        .await
+                        .map_err(|e| Status::internal(format!("{e:?}")));
+
+                    if let Ok(Some(tx)) = tx {
+                        break tx;
+                    }
+                    sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .map_err(|_| {
+                error!(target: LOG_TARGET, "Transaction {id} not found within timeout");
+                Status::not_found(format!("Transaction {id} not found within timeout"))
+            })?;
+            let address = wallet_tx.destination_address().expect("cannot fail").to_string();
+            let final_tx = convert_wallet_transaction_into_transaction_info(
+                wallet_tx,
+                &wallet_address,
+                &self.wallet.key_manager_service,
+            )
+            .await;
+            results.push(minotari_app_grpc::tari_rpc::TransferResult {
+                address,
+                transaction_id: id.into(),
+                is_success: true,
+                failure_message: Default::default(),
+                transaction_info: Some(final_tx),
+            });
+        }
+        Ok(Response::new(minotari_app_grpc::tari_rpc::TransferResponse { results }))
+    }
 }
 
 #[tonic::async_trait]
@@ -954,6 +1042,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
     #[allow(clippy::too_many_lines)]
     async fn transfer(&self, request: Request<TransferRequest>) -> Result<Response<TransferResponse>, Status> {
         let message = request.into_inner();
+
+        if message.single_tx {
+            return self.transfer_single_tx(message.recipients).await;
+        }
         let recipients = message
             .recipients
             .into_iter()
@@ -973,7 +1065,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
             })
             .collect::<Result<Vec<_>, _>>()
             .map_err(Status::invalid_argument)?;
-
         let mut transfers = Vec::new();
         for (hex_address, address, amount, fee_per_gram, payment_type, user_payment_id, raw_payment_id) in recipients {
             if payment_type == PaymentType::StandardMimblewimble as i32 {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -256,7 +256,7 @@ impl WalletGrpcServer {
                 let address = TariAddress::from_str(&dest.address)
                     .map_err(|_| format!("Destination address at index {idx} is malformed"))?;
                 let payment_id = if !dest.raw_payment_id.is_empty() {
-                    MemoField::open_unchecked(dest.raw_payment_id.to_vec(), TxType::PaymentToOther)
+                    MemoField::new_open(dest.raw_payment_id.to_vec(), TxType::PaymentToOther)?
                 } else if let Some(user_pay_id) = dest.user_payment_id {
                     let bytes = match (
                         user_pay_id.u256.is_empty(),
@@ -270,7 +270,7 @@ impl WalletGrpcServer {
                             return Err("user_payment_id must be one of u256, utf8_string or user_bytes".to_string());
                         },
                     };
-                    MemoField::open_unchecked(bytes, TxType::PaymentToOther)
+                    MemoField::new_open(bytes, TxType::PaymentToOther)?
                 } else {
                     MemoField::new_empty()
                 };
@@ -593,7 +593,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     ));
                 },
             };
-            MemoField::open_unchecked(bytes, TxType::ClaimAtomicSwap)
+            MemoField::new_open(bytes, TxType::ClaimAtomicSwap).map_err(|e| Status::internal(e.to_string()))?
         } else {
             MemoField::new_empty()
         };
@@ -827,7 +827,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     ));
                 },
             };
-            MemoField::open_unchecked(bytes, TxType::PaymentToOther)
+            MemoField::new_open(bytes, TxType::PaymentToOther).map_err(|e| Status::internal(e.to_string()))?
         } else {
             MemoField::new_empty()
         };
@@ -1044,7 +1044,9 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let message = request.into_inner();
 
         if message.recipients.is_empty() {
-            return Err(Status::invalid_argument("At least one recipient is required".to_string()));
+            return Err(Status::invalid_argument(
+                "At least one recipient is required".to_string(),
+            ));
         }
 
         if message.single_tx {
@@ -1077,7 +1079,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 ));
             }
             let payment_id = if !raw_payment_id.is_empty() {
-                MemoField::open_unchecked(raw_payment_id.to_vec(), TxType::PaymentToOther)
+                MemoField::new_open(raw_payment_id.to_vec(), TxType::PaymentToOther).map_err(|e| Status::internal(e.to_string()))?
             } else if let Some(user_pay_id) = user_payment_id {
                 let bytes = match (
                     user_pay_id.u256.is_empty(),
@@ -1093,7 +1095,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         ));
                     },
                 };
-                MemoField::open_unchecked(bytes, TxType::PaymentToOther)
+                MemoField::new_open(bytes, TxType::PaymentToOther).map_err(|e| Status::internal(e.to_string()))?
             } else {
                 MemoField::new_empty()
             };
@@ -2216,7 +2218,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 request.max_epoch.into(),
                 UtxoSelectionCriteria::default(),
                 request.fee_per_gram.into(),
-                MemoField::open_unchecked(request.message, TxType::PaymentToSelf),
+                MemoField::new_open(request.message, TxType::PaymentToSelf).map_err(|e| Status::internal(e.to_string()))?,
             )
             .await
         {
@@ -2270,7 +2272,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 proof,
                 request.fee_per_gram.into(),
                 sidechain_key,
-                MemoField::open_unchecked(request.message.into_bytes(), TxType::PaymentToSelf),
+                MemoField::new_open(request.message.into_bytes(), TxType::PaymentToSelf).map_err(|e| Status::internal(e.to_string()))?,
             )
             .await
         {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1043,6 +1043,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
     async fn transfer(&self, request: Request<TransferRequest>) -> Result<Response<TransferResponse>, Status> {
         let message = request.into_inner();
 
+        if message.recipients.is_empty() {
+            return Err(Status::invalid_argument("At least one recipient is required".to_string()));
+        }
+
         if message.single_tx {
             return self.transfer_single_tx(message.recipients).await;
         }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1079,7 +1079,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 ));
             }
             let payment_id = if !raw_payment_id.is_empty() {
-                MemoField::new_open(raw_payment_id.to_vec(), TxType::PaymentToOther).map_err(|e| Status::internal(e.to_string()))?
+                MemoField::new_open(raw_payment_id.to_vec(), TxType::PaymentToOther)
+                    .map_err(|e| Status::internal(e.to_string()))?
             } else if let Some(user_pay_id) = user_payment_id {
                 let bytes = match (
                     user_pay_id.u256.is_empty(),
@@ -2218,7 +2219,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 request.max_epoch.into(),
                 UtxoSelectionCriteria::default(),
                 request.fee_per_gram.into(),
-                MemoField::new_open(request.message, TxType::PaymentToSelf).map_err(|e| Status::internal(e.to_string()))?,
+                MemoField::new_open(request.message, TxType::PaymentToSelf)
+                    .map_err(|e| Status::internal(e.to_string()))?,
             )
             .await
         {
@@ -2272,7 +2274,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 proof,
                 request.fee_per_gram.into(),
                 sidechain_key,
-                MemoField::new_open(request.message.into_bytes(), TxType::PaymentToSelf).map_err(|e| Status::internal(e.to_string()))?,
+                MemoField::new_open(request.message.into_bytes(), TxType::PaymentToSelf)
+                    .map_err(|e| Status::internal(e.to_string()))?,
             )
             .await
         {

--- a/base_layer/transaction_components/src/key_manager/inner.rs
+++ b/base_layer/transaction_components/src/key_manager/inner.rs
@@ -1651,14 +1651,18 @@ where TBackend: TransactionKeyManagerBackend + 'static
         &self,
         commitment: &CompressedCommitment,
         encrypted_data: &EncryptedData,
-        custom_recovery_key_id: Option<&TariKeyId>,
+        custom_recovery_key_id: Option<PrivateKey>,
     ) -> Result<bool, TransactionError> {
-        let recovery_key = if let Some(key_id) = custom_recovery_key_id {
-            self.get_private_key(key_id).await?
+        let recovery_key = if let Some(key) = custom_recovery_key_id {
+            key
         } else {
             self.get_private_view_key().await?
         };
-        let (value, private_key, _payment_id) = EncryptedData::decrypt_data(&recovery_key, commitment, encrypted_data)?;
+        let (value, private_key, _payment_id) =
+            match EncryptedData::decrypt_data(&recovery_key, commitment, encrypted_data) {
+                Ok(res) => res,
+                Err(_) => return Ok(false),
+            };
         self.crypto_factories
             .range_proof
             .verify_mask(&commitment.to_commitment()?, &private_key, value.into())?;

--- a/base_layer/transaction_components/src/key_manager/interface.rs
+++ b/base_layer/transaction_components/src/key_manager/interface.rs
@@ -405,7 +405,7 @@ pub trait TransactionKeyManagerInterface: Clone + Send + Sync + 'static {
         &self,
         commitment: &CompressedCommitment,
         encrypted_data: &EncryptedData,
-        custom_recovery_key_id: Option<&TariKeyId>,
+        custom_recovery_key_id: Option<PrivateKey>,
     ) -> Result<bool, TransactionError>;
 
     async fn get_script_offset(

--- a/base_layer/transaction_components/src/key_manager/wrapper.rs
+++ b/base_layer/transaction_components/src/key_manager/wrapper.rs
@@ -415,7 +415,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
         &self,
         commitment: &CompressedCommitment,
         encrypted_data: &EncryptedData,
-        custom_recovery_key_id: Option<&TariKeyId>,
+        custom_recovery_key_id: Option<PrivateKey>,
     ) -> Result<bool, TransactionError> {
         self.transaction_key_manager_inner
             .read()

--- a/base_layer/transaction_components/src/transaction_builder/builder.rs
+++ b/base_layer/transaction_components/src/transaction_builder/builder.rs
@@ -530,8 +530,11 @@ where KM: TransactionKeyManagerInterface
         for recipient in &self.recipient_outputs {
             sent_hashes.push(recipient.output.tx_output(&self.key_manager).await?.hash());
         }
-        memo.transaction_info_set_sent_output_hashes(sent_hashes)
-            .map_err(TransactionBuilderError::InvalidMemo)?;
+        // if its too much outputs, we dont track this
+        if sent_hashes.len() <= 2 {
+            memo.transaction_info_set_sent_output_hashes(sent_hashes)
+                .map_err(TransactionBuilderError::InvalidMemo)?;
+        }
         Ok(memo)
     }
 
@@ -978,15 +981,43 @@ impl<KM> Debug for TransactionBuilder<KM> {
 
 #[cfg(test)]
 mod test {
-    use chacha20poly1305::aead::OsRng;
-    use tari_common_types::key_branches::TransactionKeyManagerBranch;
+
+    async fn create_view_key_manager(keys: ProvidedKeysWallet) -> Result<MemoryKeyManager, KeyManagerServiceError> {
+        let cipher = CipherSeed::new();
+        let mut key = Zeroizing::new([0u8; size_of::<Key>()]);
+        OsRng.fill_bytes(key.as_mut());
+        let factory = CryptoFactories::new(64);
+
+        let backend = MemoryKeyManagerBackend::new();
+        TransactionKeyManagerWrapper::new(cipher, backend, factory, Arc::new(WalletType::ProvidedKeys(keys))).await
+    }
+
+    use std::sync::Arc;
+
+    use chacha20poly1305::{
+        aead::{rand_core::RngCore, OsRng},
+        Key,
+    };
+    use tari_common_types::{
+        key_branches::TransactionKeyManagerBranch,
+        seeds::cipher_seed::CipherSeed,
+        wallet_types::{ProvidedKeysWallet, WalletType},
+    };
     use tari_crypto::keys::SecretKey;
     use tari_script::{script, TariScript};
+    use zeroize::Zeroizing;
 
     use super::*;
     use crate::{
         crypto_factories::CryptoFactories,
-        key_manager::{create_memory_key_manager, SecretTransactionKeyManagerInterface},
+        key_manager::{
+            create_memory_key_manager,
+            error::KeyManagerServiceError,
+            memory_key_manager::MemoryKeyManagerBackend,
+            MemoryKeyManager,
+            SecretTransactionKeyManagerInterface,
+            TransactionKeyManagerWrapper,
+        },
         tari_amount::{uT, MicroMinotari},
         test_helpers::{
             create_consensus_constants,
@@ -1448,16 +1479,12 @@ mod test {
         assert_eq!(bob_output.script, script);
 
         let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret).unwrap();
-        let encryption_public_key = CompressedPublicKey::from_secret_key(&encryption_private_key);
-        let encryption_key_id = TariKeyId::Imported {
-            key: encryption_public_key,
-        };
         let bob_tx_output = bob_output.to_transaction_output(&key_manager).await.unwrap();
         assert!(key_manager
             .is_this_output_ours(
                 &bob_tx_output.commitment,
                 &bob_output.encrypted_data,
-                Some(&encryption_key_id)
+                Some(encryption_private_key)
             )
             .await
             .unwrap());
@@ -1535,16 +1562,12 @@ mod test {
         assert_eq!(bob_output.script, script);
 
         let encryption_private_key = shared_secret_to_output_encryption_key(&shared_secret).unwrap();
-        let encryption_public_key = CompressedPublicKey::from_secret_key(&encryption_private_key);
-        let encryption_key_id = TariKeyId::Imported {
-            key: encryption_public_key,
-        };
         let bob_tx_output = bob_output.to_transaction_output(&key_manager).await.unwrap();
         assert!(key_manager
             .is_this_output_ours(
                 &bob_tx_output.commitment,
                 &bob_output.encrypted_data,
-                Some(&encryption_key_id)
+                Some(encryption_private_key)
             )
             .await
             .unwrap());
@@ -1660,5 +1683,413 @@ mod test {
             Ok(_) => {},
             Err(e) => panic!("Unexpected error: {e:?}"),
         };
+    }
+
+    #[tokio::test]
+    async fn create_multi_recipients_transaction() {
+        let rules = create_consensus_manager();
+        let factories = CryptoFactories::default();
+        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let bob_key_manager = create_memory_key_manager().await.unwrap();
+        let carol_key_manager = create_memory_key_manager().await.unwrap();
+
+        let spend_key = bob_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = bob_key_manager.get_view_key().await.unwrap().pub_key;
+        let bob_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+        let spend_key = carol_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = carol_key_manager.get_view_key().await.unwrap().pub_key;
+        let carol_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+
+        let input = create_test_input(MicroMinotari(5000), 0, &alice_key_manager, vec![], None).await;
+        let consensus_constants = create_consensus_constants(0);
+        let mut builder = TransactionBuilder::new(
+            consensus_constants.clone(),
+            alice_key_manager.clone(),
+            Network::LocalNet,
+        )
+        .await
+        .unwrap();
+        let fee_per_gram = MicroMinotari(4);
+        builder
+            .with_lock_height(0)
+            .with_fee_per_gram(fee_per_gram)
+            .with_input(input)
+            .await
+            .unwrap();
+        builder
+            .add_stealth_recipient(
+                bob_address,
+                MicroMinotari(1000),
+                OutputFeatures::default(),
+                MemoField::new_empty(),
+            )
+            .await
+            .unwrap();
+        builder
+            .add_stealth_recipient(
+                carol_address,
+                MicroMinotari(1000),
+                OutputFeatures::default(),
+                MemoField::new_empty(),
+            )
+            .await
+            .unwrap();
+        let finalized = builder.build().await.unwrap();
+        let tx = finalized.transaction;
+        assert_eq!(tx.body.inputs().len(), 1);
+        assert_eq!(tx.body.outputs().len(), 3);
+        let validator = TransactionInternalConsistencyValidator::new(false, rules, factories);
+        assert!(validator.validate(&tx, None, None, u64::MAX).is_ok());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn recover_multi_recipients_transaction() {
+        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let alice_keys = ProvidedKeysWallet {
+            public_spend_key: alice_key_manager.get_spend_key().await.unwrap().pub_key,
+            private_spend_key: None,
+            private_comms_key: None,
+            view_key: alice_key_manager.get_private_view_key().await.unwrap(),
+            birthday: None,
+        };
+        let alice_view_key_manager = create_view_key_manager(alice_keys).await.unwrap();
+        let bob_key_manager = create_memory_key_manager().await.unwrap();
+        let bob_keys = ProvidedKeysWallet {
+            public_spend_key: bob_key_manager.get_spend_key().await.unwrap().pub_key,
+            private_spend_key: None,
+            private_comms_key: None,
+            view_key: bob_key_manager.get_private_view_key().await.unwrap(),
+            birthday: None,
+        };
+        let bob_view_key_manager = create_view_key_manager(bob_keys).await.unwrap();
+        let carol_key_manager = create_memory_key_manager().await.unwrap();
+        let carol_keys = ProvidedKeysWallet {
+            public_spend_key: carol_key_manager.get_spend_key().await.unwrap().pub_key,
+            private_spend_key: None,
+            private_comms_key: None,
+            view_key: carol_key_manager.get_private_view_key().await.unwrap(),
+            birthday: None,
+        };
+        let carol_view_key_manager = create_view_key_manager(carol_keys).await.unwrap();
+
+        let spend_key = bob_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = bob_key_manager.get_view_key().await.unwrap().pub_key;
+        let bob_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+        let spend_key = carol_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = carol_key_manager.get_view_key().await.unwrap().pub_key;
+        let carol_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+
+        let input = create_test_input(MicroMinotari(5000), 0, &alice_key_manager, vec![], None).await;
+        let consensus_constants = create_consensus_constants(0);
+        let mut builder = TransactionBuilder::new(
+            consensus_constants.clone(),
+            alice_key_manager.clone(),
+            Network::LocalNet,
+        )
+        .await
+        .unwrap();
+        let fee_per_gram = MicroMinotari(4);
+        builder
+            .with_lock_height(0)
+            .with_fee_per_gram(fee_per_gram)
+            .with_input(input)
+            .await
+            .unwrap();
+        builder
+            .add_stealth_recipient(
+                bob_address,
+                MicroMinotari(1000),
+                OutputFeatures::default(),
+                MemoField::new_empty(),
+            )
+            .await
+            .unwrap();
+        builder
+            .add_stealth_recipient(
+                carol_address,
+                MicroMinotari(1000),
+                OutputFeatures::default(),
+                MemoField::new_empty(),
+            )
+            .await
+            .unwrap();
+        let finalized = builder.build().await.unwrap();
+        let tx = finalized.transaction;
+        let mut alice_count = 0;
+        let mut bob_count = 0;
+        let mut carol_count = 0;
+        let mut wrong = 0;
+        for output in tx.body.outputs() {
+            // alice change output
+            if alice_key_manager
+                .is_this_output_ours(&output.commitment, &output.encrypted_data, None)
+                .await
+                .unwrap()
+            {
+                alice_count += 1;
+            }
+            // let assume a stealth key for alice
+            let alice_shared_secret = alice_key_manager
+                .get_diffie_hellman_shared_secret(
+                    &alice_key_manager.get_view_key().await.unwrap().key_id,
+                    &output.sender_offset_public_key,
+                )
+                .await
+                .unwrap();
+            let alice_encryption_private_key = shared_secret_to_output_encryption_key(&alice_shared_secret).unwrap();
+            if alice_key_manager
+                .is_this_output_ours(
+                    &output.commitment,
+                    &output.encrypted_data,
+                    Some(alice_encryption_private_key),
+                )
+                .await
+                .unwrap()
+            {
+                wrong += 1;
+            }
+
+            // bob change output
+            if bob_key_manager
+                .is_this_output_ours(&output.commitment, &output.encrypted_data, None)
+                .await
+                .unwrap()
+            {
+                wrong += 1;
+            }
+            // let assume a stealth key for bob
+            let bob_shared_secret = bob_key_manager
+                .get_diffie_hellman_shared_secret(
+                    &bob_key_manager.get_view_key().await.unwrap().key_id,
+                    &output.sender_offset_public_key,
+                )
+                .await
+                .unwrap();
+            let bob_encryption_private_key = shared_secret_to_output_encryption_key(&bob_shared_secret).unwrap();
+            if bob_key_manager
+                .is_this_output_ours(
+                    &output.commitment,
+                    &output.encrypted_data,
+                    Some(bob_encryption_private_key),
+                )
+                .await
+                .unwrap()
+            {
+                bob_count += 1;
+            }
+
+            // carol change output
+            if carol_key_manager
+                .is_this_output_ours(&output.commitment, &output.encrypted_data, None)
+                .await
+                .unwrap()
+            {
+                wrong += 1;
+            }
+            // let assume a stealth key for bob
+            let carol_shared_secret = carol_key_manager
+                .get_diffie_hellman_shared_secret(
+                    &carol_key_manager.get_view_key().await.unwrap().key_id,
+                    &output.sender_offset_public_key,
+                )
+                .await
+                .unwrap();
+            let carol_encryption_private_key = shared_secret_to_output_encryption_key(&carol_shared_secret).unwrap();
+            if carol_key_manager
+                .is_this_output_ours(
+                    &output.commitment,
+                    &output.encrypted_data,
+                    Some(carol_encryption_private_key),
+                )
+                .await
+                .unwrap()
+            {
+                carol_count += 1;
+            }
+        }
+        assert_eq!(alice_count, 1); // alice change output
+        assert_eq!(bob_count, 1); // bob recipient output
+        assert_eq!(carol_count, 1); // carol recipient output
+        assert_eq!(wrong, 0);
+
+        // lets do view only
+        let mut alice_count = 0;
+        let mut bob_count = 0;
+        let mut carol_count = 0;
+        let mut wrong = 0;
+        for output in tx.body.outputs() {
+            // alice change output
+            if alice_view_key_manager
+                .is_this_output_ours(&output.commitment, &output.encrypted_data, None)
+                .await
+                .unwrap()
+            {
+                alice_count += 1;
+            }
+            // let assume a stealth key for alice
+            let alice_shared_secret = alice_view_key_manager
+                .get_diffie_hellman_shared_secret(
+                    &alice_view_key_manager.get_view_key().await.unwrap().key_id,
+                    &output.sender_offset_public_key,
+                )
+                .await
+                .unwrap();
+            let alice_encryption_private_key = shared_secret_to_output_encryption_key(&alice_shared_secret).unwrap();
+            if alice_view_key_manager
+                .is_this_output_ours(
+                    &output.commitment,
+                    &output.encrypted_data,
+                    Some(alice_encryption_private_key),
+                )
+                .await
+                .unwrap()
+            {
+                wrong += 1;
+            }
+
+            // bob change output
+            if bob_view_key_manager
+                .is_this_output_ours(&output.commitment, &output.encrypted_data, None)
+                .await
+                .unwrap()
+            {
+                wrong += 1;
+            }
+            // let assume a stealth key for bob
+            let bob_shared_secret = bob_view_key_manager
+                .get_diffie_hellman_shared_secret(
+                    &bob_view_key_manager.get_view_key().await.unwrap().key_id,
+                    &output.sender_offset_public_key,
+                )
+                .await
+                .unwrap();
+            let bob_encryption_private_key = shared_secret_to_output_encryption_key(&bob_shared_secret).unwrap();
+            if bob_view_key_manager
+                .is_this_output_ours(
+                    &output.commitment,
+                    &output.encrypted_data,
+                    Some(bob_encryption_private_key),
+                )
+                .await
+                .unwrap()
+            {
+                bob_count += 1;
+            }
+
+            // carol change output
+            if carol_view_key_manager
+                .is_this_output_ours(&output.commitment, &output.encrypted_data, None)
+                .await
+                .unwrap()
+            {
+                wrong += 1;
+            }
+            // let assume a stealth key for bob
+            let carol_shared_secret = carol_view_key_manager
+                .get_diffie_hellman_shared_secret(
+                    &carol_view_key_manager.get_view_key().await.unwrap().key_id,
+                    &output.sender_offset_public_key,
+                )
+                .await
+                .unwrap();
+            let carol_encryption_private_key = shared_secret_to_output_encryption_key(&carol_shared_secret).unwrap();
+            if carol_view_key_manager
+                .is_this_output_ours(
+                    &output.commitment,
+                    &output.encrypted_data,
+                    Some(carol_encryption_private_key),
+                )
+                .await
+                .unwrap()
+            {
+                carol_count += 1;
+            }
+        }
+        assert_eq!(alice_count, 1); // alice change output
+        assert_eq!(bob_count, 1); // bob recipient output
+        assert_eq!(carol_count, 1); // carol recipient output
+        assert_eq!(wrong, 0);
+    }
+
+    #[tokio::test]
+    async fn create_very_large_multi_recipients_transaction() {
+        let rules = create_consensus_manager();
+        let factories = CryptoFactories::default();
+        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let bob_key_manager = create_memory_key_manager().await.unwrap();
+
+        let spend_key = bob_key_manager.get_spend_key().await.unwrap().pub_key;
+        let view_key = bob_key_manager.get_view_key().await.unwrap().pub_key;
+        let bob_address = TariAddress::new_dual_address(
+            view_key,
+            spend_key,
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap();
+        let input = create_test_input(MicroMinotari(500000), 0, &alice_key_manager, vec![], None).await;
+        let consensus_constants = create_consensus_constants(0);
+        let mut builder = TransactionBuilder::new(
+            consensus_constants.clone(),
+            alice_key_manager.clone(),
+            Network::LocalNet,
+        )
+        .await
+        .unwrap();
+        let fee_per_gram = MicroMinotari(4);
+        builder
+            .with_lock_height(0)
+            .with_fee_per_gram(fee_per_gram)
+            .with_input(input)
+            .await
+            .unwrap();
+        for _ in 0..100 {
+            builder
+                .add_stealth_recipient(
+                    bob_address.clone(),
+                    MicroMinotari(1000),
+                    OutputFeatures::default(),
+                    MemoField::new_empty(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let finalized = builder.build().await.unwrap();
+        let tx = finalized.transaction;
+        assert_eq!(tx.body.inputs().len(), 1);
+        assert_eq!(tx.body.outputs().len(), 101);
+        let validator = TransactionInternalConsistencyValidator::new(false, rules, factories);
+        assert!(validator.validate(&tx, None, None, u64::MAX).is_ok());
     }
 }

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -212,6 +212,12 @@ pub enum TransactionServiceRequest {
         fee_per_gram: MicroMinotari,
         payment_id: MemoField,
     },
+    SendManyOneSidedTransactions {
+        destinations: Vec<(TariAddress, MicroMinotari, MemoField)>,
+        selection_criteria: UtxoSelectionCriteria,
+        output_features: Box<OutputFeatures>,
+        fee_per_gram: MicroMinotari,
+    },
     SendOneSidedToStealthAddressTransaction {
         destination: TariAddress,
         amount: MicroMinotari,
@@ -301,6 +307,7 @@ impl fmt::Display for TransactionServiceRequest {
             Self::GetCancelledPendingInboundTransactions => write!(f, "GetCancelledPendingInboundTransactions"),
             Self::GetCancelledPendingOutboundTransactions => write!(f, "GetCancelledPendingOutboundTransactions"),
             Self::GetCancelledCompletedTransactions(_) => write!(f, "GetCancelledCompletedTransactions"),
+            Self::SendManyOneSidedTransactions { .. } => write!(f, "SendManyOneSidedTransactions"),
             Self::GetCompletedTransaction(t) => write!(f, "GetCompletedTransaction({t})"),
             Self::SignOneSidedDepositMultisigTransaction { request } => {
                 write!(f, "SignOneSidedDepositMultisigTransaction (request {request:?})")
@@ -555,6 +562,7 @@ impl fmt::Display for TransactionServiceRequest {
 #[derive(Debug)]
 pub enum TransactionServiceResponse {
     TransactionSent(TxId),
+    TransactionsSent(Vec<TxId>),
     TransactionSentWithOutputHash(TxId, FixedHash),
     EncumberAggregateUtxo(
         TxId,
@@ -1005,6 +1013,28 @@ impl TransactionServiceHandle {
             .await??
         {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn send_one_sided_multi_recipient_transaction(
+        &mut self,
+        destinations: Vec<(TariAddress, MicroMinotari, MemoField)>,
+        selection_criteria: UtxoSelectionCriteria,
+        output_features: OutputFeatures,
+        fee_per_gram: MicroMinotari,
+    ) -> Result<Vec<TxId>, TransactionServiceError> {
+        match self
+            .handle
+            .call(TransactionServiceRequest::SendManyOneSidedTransactions {
+                destinations,
+                selection_criteria,
+                output_features: Box::new(output_features),
+                fee_per_gram,
+            })
+            .await??
+        {
+            TransactionServiceResponse::TransactionsSent(tx_id) => Ok(tx_id),
             _ => Err(TransactionServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -96,6 +96,7 @@ use tari_transaction_components::{
     },
     MicroMinotari,
     TransactionBuilder,
+    TransactionBuilderError,
 };
 use tari_utilities::hex::Hex;
 use tokio::{
@@ -758,6 +759,21 @@ where
                 )
                 .await
                 .map(TransactionServiceResponse::TransactionSent),
+            TransactionServiceRequest::SendManyOneSidedTransactions {
+                destinations,
+                selection_criteria,
+                output_features,
+                fee_per_gram,
+            } => self
+                .send_many_one_sided_transactions(
+                    destinations,
+                    selection_criteria,
+                    *output_features,
+                    fee_per_gram,
+                    transaction_broadcast_join_handles,
+                )
+                .await
+                .map(TransactionServiceResponse::TransactionsSent),
 
             TransactionServiceRequest::ScrapeWallet {
                 destination,
@@ -2203,6 +2219,161 @@ where
             payment_id,
         )
         .await
+    }
+
+    /// Sends a one side payment transaction to a recipient
+    /// # Arguments
+    /// 'dest_pubkey': The Comms pubkey of the recipient node
+    /// 'amount': The amount of Tari to send to the recipient
+    /// 'fee_per_gram': The amount of fee per transaction gram to be included in transaction
+    #[allow(clippy::too_many_lines)]
+    pub async fn send_many_one_sided_transactions(
+        &mut self,
+        mut destinations: Vec<(TariAddress, MicroMinotari, MemoField)>,
+        selection_criteria: UtxoSelectionCriteria,
+        output_features: OutputFeatures,
+        fee_per_gram: MicroMinotari,
+        transaction_broadcast_join_handles: &mut FuturesUnordered<
+            JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
+        >,
+    ) -> Result<Vec<TxId>, TransactionServiceError> {
+        debug!(target: LOG_TARGET, "Sending many one sided transactions");
+        if destinations.is_empty() {
+            return Err(TransactionServiceError::TransactionBuilderError(
+                TransactionBuilderError::NoRecipients,
+            ));
+        }
+        let tx_id = TxId::new_random();
+        // let override the payment_id if the address says we should
+        let mut total_send = MicroMinotari::zero();
+        for destination in &mut destinations {
+            total_send += destination.1;
+            if destination.0.features().contains(TariAddressFeatures::PAYMENT_ID) {
+                debug!(target: LOG_TARGET, "Address contains memo, overriding memo {} with {:?}", destination.2, destination.0.get_memo_field_payment_id_bytes());
+                destination.2 =
+                    MemoField::open(destination.0.get_memo_field_payment_id_bytes(), TxType::PaymentToOther);
+            }
+            destination.2 = destination
+                .2
+                .clone()
+                .add_sender_address(
+                    self.resources.one_sided_tari_address.clone(),
+                    true,
+                    fee_per_gram,
+                    if destination.0 == self.resources.one_sided_tari_address ||
+                        destination.0 == self.resources.interactive_tari_address
+                    {
+                        Some(TxType::PaymentToSelf)
+                    } else {
+                        Some(TxType::PaymentToOther)
+                    },
+                )
+                .map_err(TransactionServiceError::InvalidPaymentId)?;
+            self.verify_send(&destination.0, TariAddressFeatures::create_one_sided_only())?;
+        }
+
+        // Prepare sender part of the transaction
+        let mut tx_builder = self
+            .resources
+            .output_manager_service
+            .prepare_transaction_to_send(
+                tx_id,
+                total_send,
+                selection_criteria,
+                output_features.clone(),
+                fee_per_gram,
+                push_pubkey_script(&Default::default()),
+                Covenant::default(),
+            )
+            .await?;
+        for destination in &destinations {
+            tx_builder
+                .add_stealth_recipient(
+                    destination.0.clone(),
+                    destination.1,
+                    output_features.clone(),
+                    destination.2.clone(),
+                )
+                .await?;
+        }
+
+        let finalized = tx_builder.build().await?;
+
+        // Finalize
+
+        info!(target: LOG_TARGET, "Finalized one-side transaction TxId: {tx_id}");
+
+        // This event being sent is important, but not critical to the protocol being successful. Send only fails if
+        // there are no subscribers.
+        let _result = self
+            .event_publisher
+            .send(Arc::new(TransactionEvent::TransactionCompletedImmediately(tx_id)));
+
+        // Broadcast one-sided transaction
+
+        let tx = finalized.transaction.clone();
+        let fee = finalized.fee;
+        let change = finalized.change.clone().map(|change| vec![change]);
+        self.resources
+            .output_manager_service
+            .confirm_pending_transaction(tx_id, change)
+            .await
+            .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
+        let sent_hashes = finalized.sent_output_hashes.clone();
+        let change_hashes = finalized.change_output_hashes.clone();
+
+        check_transaction_size(&tx, tx_id)?;
+        let (first_address, first_amount, first_memo) = destinations.remove(0);
+        self.submit_transaction(
+            transaction_broadcast_join_handles,
+            CompletedTransaction::new_with_output_hashes(
+                tx_id,
+                self.resources.one_sided_tari_address.clone(),
+                first_address,
+                first_amount,
+                fee,
+                tx.clone(),
+                LegacyTransactionStatus::Completed,
+                Utc::now(),
+                TransactionDirection::Outbound,
+                None,
+                None,
+                first_memo,
+                sent_hashes.clone(),
+                vec![],
+                change_hashes.clone(),
+            )?,
+        )
+        .await?;
+        let mut tx_ids = vec![tx_id];
+        for destination in destinations {
+            let new_tx_id = TxId::new_random();
+            tx_ids.push(new_tx_id);
+            let completed_tx = CompletedTransaction::new_with_output_hashes(
+                new_tx_id,
+                self.resources.one_sided_tari_address.clone(),
+                destination.0.clone(),
+                destination.1,
+                fee,
+                tx.clone(),
+                LegacyTransactionStatus::Completed,
+                Utc::now(),
+                TransactionDirection::Outbound,
+                None,
+                None,
+                destination.2,
+                sent_hashes.clone(),
+                vec![],
+                change_hashes.clone(),
+            )?;
+            self.db.insert_completed_transaction(new_tx_id, completed_tx.clone())?;
+            trace!(
+                target: LOG_TARGET,
+                "Launch the transaction broadcast protocol for submitted transaction ({tx_id})."
+            );
+        }
+
+        Ok(tx_ids)
     }
 
     /// Creates a transaction to burn some Minotari. The optional _claim public key_ parameter is used in the challenge

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2252,10 +2252,10 @@ where
             total_send += *amount;
             if address.features().contains(TariAddressFeatures::PAYMENT_ID) {
                 debug!(target: LOG_TARGET, "Address contains memo, overriding memo {} with {:?}", memo, address.get_memo_field_payment_id_bytes());
-                *memo =
-                    MemoField::open(address.get_memo_field_payment_id_bytes(), TxType::PaymentToOther);
+                *memo = MemoField::open(address.get_memo_field_payment_id_bytes(), TxType::PaymentToOther);
             }
-            *memo = memo.clone()
+            *memo = memo
+                .clone()
                 .add_sender_address(
                     self.resources.one_sided_tari_address.clone(),
                     true,
@@ -2288,12 +2288,7 @@ where
             .await?;
         for (address, amount, memo) in &destinations {
             tx_builder
-                .add_stealth_recipient(
-                    address.clone(),
-                    *amount,
-                    output_features.clone(),
-                    memo.clone(),
-                )
+                .add_stealth_recipient(address.clone(), *amount, output_features.clone(), memo.clone())
                 .await?;
         }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2269,7 +2269,7 @@ where
                     },
                 )
                 .map_err(TransactionServiceError::InvalidPaymentId)?;
-            self.verify_send(&address, TariAddressFeatures::create_one_sided_only())?;
+            self.verify_send(address, TariAddressFeatures::create_one_sided_only())?;
         }
 
         // Prepare sender part of the transaction

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2369,7 +2369,7 @@ where
             self.db.insert_completed_transaction(new_tx_id, completed_tx.clone())?;
             trace!(
                 target: LOG_TARGET,
-                "Launch the transaction broadcast protocol for submitted transaction ({tx_id})."
+                "Created transaction for ({tx_id})."
             );
         }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2221,10 +2221,12 @@ where
         .await
     }
 
-    /// Sends a one side payment transaction to a recipient
+    /// Sends a one side payment transaction to each of the recipients
     /// # Arguments
-    /// 'dest_pubkey': The Comms pubkey of the recipient node
+    /// 'destinations': array of destinations of (TariAddress, amount, MemoField)
     /// 'amount': The amount of Tari to send to the recipient
+    /// 'selection_criteria': The UTXO selection criteria to use for coin selection
+    /// 'output_features': The output features to use for the transaction outputs
     /// 'fee_per_gram': The amount of fee per transaction gram to be included in transaction
     #[allow(clippy::too_many_lines)]
     pub async fn send_many_one_sided_transactions(
@@ -2246,22 +2248,20 @@ where
         let tx_id = TxId::new_random();
         // let override the payment_id if the address says we should
         let mut total_send = MicroMinotari::zero();
-        for destination in &mut destinations {
-            total_send += destination.1;
-            if destination.0.features().contains(TariAddressFeatures::PAYMENT_ID) {
-                debug!(target: LOG_TARGET, "Address contains memo, overriding memo {} with {:?}", destination.2, destination.0.get_memo_field_payment_id_bytes());
-                destination.2 =
-                    MemoField::open(destination.0.get_memo_field_payment_id_bytes(), TxType::PaymentToOther);
+        for (address, amount, memo) in &mut destinations {
+            total_send += *amount;
+            if address.features().contains(TariAddressFeatures::PAYMENT_ID) {
+                debug!(target: LOG_TARGET, "Address contains memo, overriding memo {} with {:?}", memo, address.get_memo_field_payment_id_bytes());
+                *memo =
+                    MemoField::open(address.get_memo_field_payment_id_bytes(), TxType::PaymentToOther);
             }
-            destination.2 = destination
-                .2
-                .clone()
+            *memo = memo.clone()
                 .add_sender_address(
                     self.resources.one_sided_tari_address.clone(),
                     true,
                     fee_per_gram,
-                    if destination.0 == self.resources.one_sided_tari_address ||
-                        destination.0 == self.resources.interactive_tari_address
+                    if *address == self.resources.one_sided_tari_address ||
+                        *address == self.resources.interactive_tari_address
                     {
                         Some(TxType::PaymentToSelf)
                     } else {
@@ -2269,7 +2269,7 @@ where
                     },
                 )
                 .map_err(TransactionServiceError::InvalidPaymentId)?;
-            self.verify_send(&destination.0, TariAddressFeatures::create_one_sided_only())?;
+            self.verify_send(&address, TariAddressFeatures::create_one_sided_only())?;
         }
 
         // Prepare sender part of the transaction
@@ -2286,13 +2286,13 @@ where
                 Covenant::default(),
             )
             .await?;
-        for destination in &destinations {
+        for (address, amount, memo) in &destinations {
             tx_builder
                 .add_stealth_recipient(
-                    destination.0.clone(),
-                    destination.1,
+                    address.clone(),
+                    *amount,
                     output_features.clone(),
-                    destination.2.clone(),
+                    memo.clone(),
                 )
                 .await?;
         }

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -586,6 +586,14 @@ impl WalletTransaction {
         }
     }
 
+    pub fn destination_address(&self) -> Option<TariAddress> {
+        match self {
+            WalletTransaction::PendingInbound(_) => None,
+            WalletTransaction::PendingOutbound(tx) => Some(tx.destination_address.clone()),
+            WalletTransaction::Completed(tx) => Some(tx.destination_address.clone()),
+        }
+    }
+
     pub fn is_pending(&self) -> bool {
         match self {
             WalletTransaction::PendingInbound(_) => true,

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -804,6 +804,7 @@ async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
+        single_tx: false,
     };
     let tx_res = source_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -869,6 +870,7 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
+        single_tx: false,
     };
     let tx_res = sender_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -982,6 +984,7 @@ async fn send_interactive_amount_from_wallet_to_wallet_at_fee(
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
+        single_tx: false,
     };
     let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -1098,6 +1101,7 @@ async fn send_many_interactive_amount_from_wallet_to_wallet_at_fee(
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
+        single_tx: false,
     };
     let mut tx_ids = Vec::with_capacity(usize::try_from(number_of_transactions).unwrap());
     for i in 0..number_of_transactions {
@@ -1640,6 +1644,7 @@ async fn send_num_one_sided_transactions_to_wallets_at_fee(
         };
         let transfer_req = TransferRequest {
             recipients: vec![payment_recipient],
+            single_tx: false,
         };
         let transfer_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
         let transfer_res = transfer_res.results.first().unwrap();
@@ -1819,6 +1824,7 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
+        single_tx: false,
     };
     let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -2050,6 +2056,7 @@ async fn transfer_one_sided_from_wallet_to_two_recipients_at_fee(
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient1, payment_recipient2],
+        single_tx: true,
     };
     let tx_res = sender_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -2176,6 +2183,7 @@ async fn transfer_tari_to_self(world: &mut TariWorld, amount: u64, sender: Strin
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
+        single_tx: false,
     };
     let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -2546,6 +2554,7 @@ async fn send_one_sided_stealth_transaction(
     };
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
+        single_tx: false,
     };
     let tx_res = sender_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -3081,6 +3090,7 @@ async fn multi_send_txs_from_wallet(
 
         let transfer_req = TransferRequest {
             recipients: vec![payment_recipient],
+            single_tx: false,
         };
         let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
         let tx_res = tx_res.results;


### PR DESCRIPTION
Description
---
Allows support of multiple recipients per single chain transaction. 
This will create a single on chain transaction with multiple recipients, but in the wallet it will still only show a single transaction per recipient. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Multi-recipient one-sided payments: send to many recipients in a single request, returning multiple transaction IDs.
  - Single-transaction toggle: choose to bundle multiple recipients into one transaction or send separate transactions per recipient.

- Bug Fixes
  - Added input validation with clear errors when no recipients are provided.

- Refactor
  - Safer memo construction and reduced memo data for large-recipient transactions.

- Tests
  - Expanded multi-recipient and key-manager test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->