### PR TITLE
fix: ambiguous seedstrap warning log

### DIFF
--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -71,13 +71,19 @@ impl SeedStrap {
         };
 
         match self.discover_peers_via_seeds(&mut round_info).await {
-            Ok(num_added) => {
+            Ok((num_added, seeds_communicated_with)) => {
                 round_info.num_new_peers = num_added;
 
-                if round_info.num_succeeded == 0 && num_added == 0 {
+                if seeds_communicated_with == 0 {
                     warn!(
                         target: LOG_TARGET,
-                        "SeedStrap: Failed to contact any seed nodes or retrieve new peers."
+                        "SeedStrap: Failed to communicate with any seed nodes."
+                    );
+                } else  if round_info.num_succeeded == 0 && num_added == 0 {
+                    warn!(
+                        target: LOG_TARGET,
+                        "SeedStrap: Communicated with {} seed nodes but did not retrieve any peers.",
+                        seeds_communicated_with
                     );
                 } else if num_added == 0 {
                     warn!(
@@ -129,7 +135,7 @@ impl SeedStrap {
     async fn discover_peers_via_seeds(
         &mut self,
         round_info: &mut DhtNetworkDiscoveryRoundInfo,
-    ) -> Result<usize, NetworkDiscoveryError> {
+    ) -> Result<(usize, usize), NetworkDiscoveryError> {
         let seed_peers_available = self.context.connectivity.get_seeds().await?;
         debug!(
             target: LOG_TARGET,
@@ -143,7 +149,7 @@ impl SeedStrap {
                 target: LOG_TARGET,
                 "SeedStrap: No seed peers configured. Unable to perform initial peer discovery via seeds."
             );
-            return Ok(0);
+            return Ok((0, 0));
         }
 
         let seed_node_ids_set: HashSet<NodeId> = seed_peers_available.iter().map(|p| p.node_id.clone()).collect();
@@ -209,9 +215,13 @@ impl SeedStrap {
             task_stream.push(handle);
         }
 
+        let mut seeds_communicated_with = 0;
         while let Some(result) = task_stream.next().await {
             let (peers_from_seed, new_peers_this_seed, duplicates_this_seed, spawn_another_task) = match result {
-                Ok((peers, n_new, n_dup)) => (peers, n_new, n_dup, false),
+                Ok((peers, n_new, n_dup, communicated)) => {
+                    if communicated { seeds_communicated_with += 1;}
+                    (peers, n_new, n_dup, false)
+                },
                 Err(e) => {
                     debug!(target: LOG_TARGET, "SeedStrap: get_peers task unsuccessful, starting a new one: {e}");
                     (Vec::new(), 0, 0, true)
@@ -301,7 +311,7 @@ impl SeedStrap {
 
         );
 
-        Ok(total_peers_added_this_round)
+        Ok((total_peers_added_this_round, seeds_communicated_with))
     }
 
     fn early_exit_conditions_met(&self, total_peers_added_this_round: usize, successful_seed_contacts: usize) -> bool {
@@ -381,9 +391,10 @@ async fn get_peers(
     rpc_connect_timeout: Duration,
     rpc_get_peers_stream_timeout: Duration,
     rpc_streaming_timeout: Duration,
-) -> (Vec<PeerInfo>, usize, usize) {
+) -> (Vec<PeerInfo>, usize, usize, bool) {
     let seed_peer_node_id_str = seed_peer_candidate.node_id.to_string();
 
+    let mut communicated_with_seed = false;
     if context.node_identity.node_id() == &seed_peer_candidate.node_id {
         info!(
             target: LOG_TARGET,
@@ -392,7 +403,7 @@ async fn get_peers(
             num_seeds_this_round,
             seed_peer_node_id_str
         );
-        return (vec![], 0, 0);
+        return (vec![], 0, 0, communicated_with_seed);
     }
 
     debug!(
@@ -422,14 +433,14 @@ async fn get_peers(
                     seed_peer_node_id_str,
                     e
                 );
-                return (vec![], 0, 0);
+                return (vec![], 0, 0, communicated_with_seed);
             },
             Err(_) => {
                 warn!(
                     target: LOG_TARGET,
                     "SeedStrap: Peer dial_peer to seed '{seed_peer_node_id_str}' timed out after {dial_peer_timeout:?}"
                 );
-                return (vec![], 0, 0);
+                return (vec![], 0, 0, communicated_with_seed);
             },
         };
 
@@ -450,6 +461,9 @@ async fn get_peers(
         .await
         {
             Ok(peers) => {
+                if !communicated_with_seed {
+                    communicated_with_seed = true;
+                }
                 if peers.is_empty() && !conn.is_connected() && attempt < NUM_RETRIES {
                     debug!(
                         target: LOG_TARGET,
@@ -484,7 +498,7 @@ async fn get_peers(
                         "SeedStrap: Also failed to disconnect from seed peer '{seed_peer_node_id_str}' after fetch failure: {disc_err}"
                     );
                 }
-                return (vec![], 0, 0);
+                return (vec![], 0, 0, communicated_with_seed);
             },
         };
     }
@@ -497,7 +511,7 @@ async fn get_peers(
             num_seeds_this_round,
             seed_peer_node_id_str
         );
-        return (vec![], 0, 0);
+        return (vec![], 0, 0, communicated_with_seed);
     }
 
     debug!(
@@ -642,7 +656,12 @@ async fn get_peers(
         duplicates_this_seed
     );
 
-    (peers_from_seed, new_peers_this_seed, duplicates_this_seed)
+    (
+        peers_from_seed,
+        new_peers_this_seed,
+        duplicates_this_seed,
+        communicated_with_seed,
+    )
 }
 
 async fn fetch_peers_from_connection(

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -79,7 +79,7 @@ impl SeedStrap {
                         target: LOG_TARGET,
                         "SeedStrap: Failed to communicate with any seed nodes."
                     );
-                } else  if round_info.num_succeeded == 0 && num_added == 0 {
+                } else if round_info.num_succeeded == 0 && num_added == 0 {
                     warn!(
                         target: LOG_TARGET,
                         "SeedStrap: Communicated with {} seed nodes but did not retrieve any peers.",
@@ -219,7 +219,9 @@ impl SeedStrap {
         while let Some(result) = task_stream.next().await {
             let (peers_from_seed, new_peers_this_seed, duplicates_this_seed, spawn_another_task) = match result {
                 Ok((peers, n_new, n_dup, communicated)) => {
-                    if communicated { seeds_communicated_with += 1;}
+                    if communicated {
+                        seeds_communicated_with += 1;
+                    }
                     (peers, n_new, n_dup, false)
                 },
                 Err(e) => {


### PR DESCRIPTION
Description
---
Fixed a seedstrap warning log whereby the log would state _SeedStrap: **Failed to contact any seed nodes** or retrieve new peers._ without giving proper feedback about the real issue. The log message tells two different stories, and we would not know which to believe.

This PR changes the single warning message into these two:
- `"SeedStrap: Failed to communicate with any seed nodes."`
- `"SeedStrap: Communicated with {} seed nodes but did not retrieve any peers."`

See related issue #7469, where this behaviour was picked up.

Motivation and Context
---
Analysing a similar log file to the problem described in issue #7469, it is apparent that the seed peers were contacted successfully, but that they did not return any peer information:
```
2025-09-08 14:30:39.753172000 [comms::dht::network_discovery::seed_strap] [Thread:2313251] INFO  SeedStrap: Attempt 2/2: Seed peer 'ab2fad12f448628436bcbe98d1' returned an empty peer list. Disconnecting.
2025-09-08 14:30:39.756704000 [comms::dht::network_discovery::seed_strap] [Thread:2313257] INFO  SeedStrap: Attempt 1/2: Seed peer 'ace05844c9c9723a8597682be3' returned an empty peer list. Disconnecting.
2025-09-08 14:30:39.757084000 [comms::dht::network_discovery::seed_strap] [Thread:2313257] WARN  SeedStrap: Failed to contact any seed nodes or retrieve new peers.
2025-09-08 14:30:39.757122000 [comms::dht::network_discovery] [Thread:2313257] WARN  SeedStrap round was not successful. Waiting before next attempt.
```

How Has This Been Tested?
---
Encountered this condition locally with esmeralda during system-level testing and could replicate it with the new PR.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer discovery now tracks per-seed communication and reports both new peers added and how many seed nodes were successfully contacted.
  * Discovery returns explicit counts when no seeds are configured or when communication occurred but yielded no peers.
  * Logging updated to distinguish failed seed contact, communication without new peers, and successful peer additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->