### PR TITLE
fix: discovery syncing regression bug

### DIFF
--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -177,12 +177,8 @@ impl PeerManager {
         features: Option<PeerFeatures>,
         external_addresses_only: bool,
     ) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.discovery_syncing(
-            n,
-            excluded_peers,
-            features,
-            external_addresses_only,
-        )
+        self.peer_storage_sql
+            .discovery_syncing(n, excluded_peers, features, external_addresses_only)
     }
 
     /// Adds or updates a peer and sets the last connection as successful.

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -182,7 +182,6 @@ impl PeerManager {
             excluded_peers,
             features,
             external_addresses_only,
-            &self.transport_protocols,
         )
     }
 

--- a/comms/core/src/peer_manager/peer_storage_sql.rs
+++ b/comms/core/src/peer_manager/peer_storage_sql.rs
@@ -198,7 +198,6 @@ impl PeerStorageSql {
         excluded_peers: &[NodeId],
         features: Option<PeerFeatures>,
         external_addresses_only: bool,
-        transport_protocols: &[TransportProtocol],
     ) -> Result<Vec<Peer>, PeerManagerError> {
         if n == 0 {
             n = PEER_MANAGER_SYNC_PEERS;
@@ -213,7 +212,7 @@ impl PeerStorageSql {
             None,
             Some(STALE_PEER_THRESHOLD_DURATION),
             external_addresses_only,
-            transport_protocols,
+            &[],
         )?)
     }
 

--- a/comms/core/src/peer_manager/peer_storage_sql.rs
+++ b/comms/core/src/peer_manager/peer_storage_sql.rs
@@ -831,20 +831,14 @@ mod test {
         assert_eq!(peer_storage.all(None).unwrap().len(), 5);
         assert_eq!(
             peer_storage
-                .discovery_syncing(
-                    100,
-                    &[good_seed.node_id],
-                    Some(PeerFeatures::COMMUNICATION_NODE),
-                    false,
-                    &[]
-                )
+                .discovery_syncing(100, &[good_seed.node_id], Some(PeerFeatures::COMMUNICATION_NODE), false,)
                 .unwrap()
                 .len(),
             1
         );
         assert_eq!(
             peer_storage
-                .discovery_syncing(100, &[], Some(PeerFeatures::COMMUNICATION_NODE), false, &[])
+                .discovery_syncing(100, &[], Some(PeerFeatures::COMMUNICATION_NODE), false)
                 .unwrap()
                 .len(),
             2
@@ -867,7 +861,7 @@ mod test {
 
         // Assert that peers have internal and external addresses
         let nodes_all_addresses = peer_storage
-            .discovery_syncing(100, &[], Some(PeerFeatures::COMMUNICATION_NODE), false, &[])
+            .discovery_syncing(100, &[], Some(PeerFeatures::COMMUNICATION_NODE), false)
             .unwrap();
         assert!(nodes_all_addresses
             .iter()
@@ -878,7 +872,7 @@ mod test {
 
         // Assert that peers have external addresses only
         let nodes_external_addresses_only = peer_storage
-            .discovery_syncing(100, &[], Some(PeerFeatures::COMMUNICATION_NODE), true, &[])
+            .discovery_syncing(100, &[], Some(PeerFeatures::COMMUNICATION_NODE), true)
             .unwrap();
         assert!(nodes_external_addresses_only
             .iter()

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -196,7 +196,7 @@ impl Discovering {
             rpc_get_peers_stream_timeout,
             client.get_peers(GetPeersRequest {
                 n: self.params.num_peers_to_request,
-                include_clients: true,
+                include_clients: false,
                 max_claims: self.config().max_permitted_peer_claims.try_into().unwrap_or_else(|_| {
                     error!(
                         target: LOG_TARGET,


### PR DESCRIPTION
Description
---
- Fixed regression bug due to a recent PR. When responding to a discovery syncing request, a node's own transport capabilities should not dictate which peers are returned. The call originates in `async fn get_peers(&self, request: Request<GetPeersRequest>) -> Result<Streaming<GetPeersResponse>, RpcStatus> {`.
- Also fixed discovery syncing requests to not request clients anymore, as old wallet addresses should not be going around.

Motivation and Context
---
See above.

How Has This Been Tested?
---
Not tested - just reasoned about.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified peer discovery: syncing no longer uses transport-protocol filtering, streamlining peer selection.
- Bug Fixes
  - Discovery requests adjusted to exclude client-only peers, reducing irrelevant results and improving relevance of discovered nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->