### PR TITLE
fix: always cancel transactions

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -3169,12 +3169,12 @@ where
             };
         };
 
-        self.db.cancel_pending_transaction(tx_id).inspect_err(|e| {
+        let _unused = self.db.cancel_pending_transaction(tx_id).inspect_err(|e| {
             warn!(
                 target: LOG_TARGET,
                 "Pending Transaction does not exist and could not be cancelled: {e:?}"
             );
-        })?;
+        });
 
         self.resources.output_manager_service.cancel_transaction(tx_id).await?;
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -3176,7 +3176,17 @@ where
             );
         });
 
-        self.resources.output_manager_service.cancel_transaction(tx_id).await?;
+        let _unused = self
+            .resources
+            .output_manager_service
+            .cancel_transaction(tx_id)
+            .await
+            .inspect_err(|e| {
+                warn!(
+                    target: LOG_TARGET,
+                    "Locked UTXO's could not be unlocked: {e:?}"
+                );
+            });
 
         if let Some(cancellation_sender) = self.send_transaction_cancellation_senders.remove(&tx_id) {
             let _result = cancellation_sender.send(());


### PR DESCRIPTION
Description
---
Cancel tx and outputs. Don't assume they exist or not. Sending 1-sided offline transactions doesn't have an existing transaction to cancel 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of canceling pending transactions: missing or already-processed pending records and unlock failures are now logged as warnings and do not abort cancellation.
  * Reduces spurious errors during cancellation while preserving normal cleanup, signals, and event emission for more stable wallet behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->