### PR TITLE
feat: throttle background rebuild tasks

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -33,7 +33,7 @@ use std::{
         RwLockReadGuard,
         RwLockWriteGuard,
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use blake2::Blake2b;
@@ -417,6 +417,9 @@ where B: BlockchainBackend
 
             let mut height = start_height;
             loop {
+                // Add a small tokio sleep to allow other tasks to run more freely - this will push out the rebuild a
+                // bit, for example, 80_000 blocks will take at least 8_000 seconds longer, just over two hours.
+                tokio::time::sleep(Duration::from_millis(100)).await;
                 let db = db_rw_lock.clone();
                 let difficulty_calculator = difficulty_calculator.clone();
                 // We use `spawn_blocking` with `.await` here to ensure that the async spawned task will be able to
@@ -494,6 +497,9 @@ where B: BlockchainBackend
 
             let mut initialize_stats = Some(metadata_at_start.best_block_height());
             for height in start_height..=metadata_at_start.best_block_height() {
+                // Add a small tokio sleep to allow other tasks to run more freely - this will push out the rebuild a
+                // bit, for example, 80_000 blocks will take at least 8_000 seconds longer, just over two hours.
+                tokio::time::sleep(Duration::from_millis(100)).await;
                 let finalize = height == metadata_at_start.best_block_height();
                 let metadata = metadata_at_start.clone();
                 let db = db_rw_lock.clone();


### PR DESCRIPTION
Description
---
Throttle background migration rebuild tasks, preventing them from consuming excessive CPU and I/O resources. This is especially important when processing large numbers of blocks, as it allows other async tasks to run and avoids starving the runtime. The trade-off is that the rebuild process will take longer (e.g., 80,000 blocks will take at least 8,000 seconds more), but system responsiveness and stability are improved during heavy background operations.

Fixes #7505.

Motivation and Context
---
Intensive blockchain lmdb read and write operations may starve high-priority processes when competing with background migration rebuilding tasks.

In the background tasks, we have this in a tight loop
```
get write lock -> tokio spawn_blocking -> update counters
```
On a slow computer, this was observed:

The db needed a migration from <=v4.7 to v50.1. The base node has been restarted a couple of times, but the migration was still not complete. This shows the last attempt.

The two background migration tasks kicked off at startup, and 7 min. after that the base node received its first sets of metadata from peers
```rust
  19345: 2025-09-17 18:07:13.752595464 [c::bn::state_machine_service::states::listening] [,] INFO  Listening for chain metadata updates // /home/runner/work/tari/tari/base_layer/core/src/base_node/state_machine_service/states/listening.rs:145
  19580: 2025-09-17 18:07:17.808933924 [c::bn::state_machine_service::states::listening] [,] INFO  Our local blockchain accumulated difficulty is a little behind that of the network. We're at block #95000 with an accumulated difficulty of 347058905640187252783161818556261814922495619743726592, and the network chain tip is at #96125 with an accumulated difficulty of 355086801657250902279859506567825898382300926848963600 // base_layer/core/src/base_node/state_machine_service/states/listening.rs:395
  19582: 2025-09-17 18:07:17.809096955 [c::bn::state_machine_service::states::listening] [,] DEBUG Lagging (local height = 95000, network height = 96125, peer = 729155ef9cdaf3fd38b432e709 (1.60s)) // base_layer/core/src/base_node/state_machine_service/states/listening.rs:459
  19584: 2025-09-17 18:07:17.809139347 [c::bn::state_machine_service::states::listening] [,] DEBUG Metadata event subscriber lagged by 134 item(s) // /home/runner/work/tari/tari/base_layer/core/src/base_node/state_machine_service/states/listening.rs:330
  21185: 2025-09-17 18:08:05.823100164 [c::bn::state_machine_service::states::listening] [,] INFO  Our local blockchain accumulated difficulty is a little behind that of the network. We're at block #95000 with an accumulated difficulty of 347058905640187252783161818556261814922495619743726592, and the network chain tip is at #96128 with an accumulated difficulty of 355114772503208037216871673464033517358463045994989750 // base_layer/core/src/base_node/state_machine_service/states/listening.rs:395
  21187: 2025-09-17 18:08:05.823197746 [c::bn::state_machine_service::states::listening] [,] DEBUG Lagging (local height = 95000, network height = 96128, peer = 5928b3d76ba8d4773085903395 (913.82ms)) // base_layer/core/src/base_node/state_machine_service/states/listening.rs:459
  21188: 2025-09-17 18:08:05.823219852 [c::bn::state_machine_service::states::listening] [,] DEBUG Metadata event subscriber lagged by 15 item(s) // /home/runner/work/tari/tari/base_layer/core/src/base_node/state_machine_service/states/listening.rs:330
  ```
Only  28 minutes later, when the background tasks completed, did the header sync commence:
```rust
  41792: 2025-09-17 18:36:06.234159168 [c::bn::state_machine_service::states::listening] [,] INFO  Our local blockchain accumulated difficulty is a little behind that of the network. We're at block #95000 with an accumulated difficulty of 347058905640187252783161818556261814922495619743726592, and the network chain tip is at #96128 with an accumulated difficulty of 355114772503208037216871673464033517358463045994989750 // base_layer/core/src/base_node/state_machine_service/states/listening.rs:395
  41794: 2025-09-17 18:36:06.234245130 [c::bn::state_machine_service::states::listening] [,] DEBUG Lagging (local height = 95000, network height = 96128, peer = 366f386f85f45b4f28bbe86fc4 (866.31ms)) // base_layer/core/src/base_node/state_machine_service/states/listening.rs:459
  41795: 2025-09-17 18:36:06.234265384 [c::bn::state_machine_service::states::listening] [,] DEBUG Metadata event subscriber lagged by 783 item(s) // /home/runner/work/tari/tari/base_layer/core/src/base_node/state_machine_service/states/listening.rs:330
  41809: 2025-09-17 18:36:06.237086972 [c::bn::state_machine_service::states::listening] [,] INFO  Our local blockchain accumulated difficulty is a little behind that of the network. We're at block #95000 with an accumulated difficulty of 347058905640187252783161818556261814922495619743726592, and the network chain tip is at #96138 with an accumulated difficulty of 355157217770171636289325965317001728753391046977220512 // base_layer/core/src/base_node/state_machine_service/states/listening.rs:395
  41811: 2025-09-17 18:36:06.237156858 [c::bn::state_machine_service::states::listening] [,] DEBUG Lagging (local height = 95000, network height = 96138, peer = 366f386f85f45b4f28bbe86fc4 (unknown)) // base_layer/core/src/base_node/state_machine_service/states/listening.rs:459
  41821: 2025-09-17 18:36:06.249515225 [c::bn::state_machine_service::states::listening] [,] INFO  Our local blockchain accumulated difficulty is a little behind that of the network. We're at block #95000 with an accumulated difficulty of 347058905640187252783161818556261814922495619743726592, and the network chain tip is at #96138 with an accumulated difficulty of 355157217770171636289325965317001728753391046977220512 // base_layer/core/src/base_node/state_machine_service/states/listening.rs:395
  41822: 2025-09-17 18:36:06.249626215 [c::bn::state_machine_service::states::listening] [,] DEBUG Lagging (local height = 95000, network height = 96138, peer = 68eec4d9429d781e0c97d59524 (unknown)) // base_layer/core/src/base_node/state_machine_service/states/listening.rs:459
  10776: 2025-09-17 18:36:38.087873037 [c::bn::state_machine_service::states::sync_decide] [,] DEBUG Selecting a suitable sync peer from 4 peer(s) // /home/runner/work/tari/tari/base_layer/core/src/base_node/state_machine_service/states/sync_decide.rs:58
  10777: 2025-09-17 18:36:38.087907944 [c::bn::state_machine_service::states::sync_decide] [,] DEBUG Proceeding to block sync with 4 sync peer(s) with a best latency of None // /home/runner/work/tari/tari/base_layer/core/src/base_node/state_machine_service/states/sync_decide.rs:115
  ```
This is a direct correlation between the many `get write lock -> tokio spawn_blocking -> update counters` cycles, stopping other tasks from operating properly.
  

How Has This Been Tested?
---
System-level testing [**TBD**]

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Throttled background database rebuild tasks with brief delays to yield resources to other operations, improving responsiveness and reducing contention during heavy rebuilds.

* **Behavior Changes**
  * Full rebuilds may take longer due to intentional pacing (e.g., hours over very large histories).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->