### PR TITLE
fix: correctly scale c29

### DIFF
--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -435,113 +435,133 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             .consensus_rules
             .get_block_reward_at(metadata.best_block_height())
             .as_u64();
+        let enabled_algos = self
+            .consensus_rules
+            .consensus_constants(metadata.best_block_height())
+            .current_permitted_pow_algos();
         let constants = self.consensus_rules.consensus_constants(metadata.best_block_height());
-        let sha3x_estimated_hash_rate = match self
-            .data_cache
-            .get_sha3x_estimated_hash_rate(metadata.best_block_hash())
-            .await
-        {
-            Some(hash_rate) => hash_rate,
-            None => {
-                let target_difficulty = handler
-                    .get_target_difficulty_for_next_block(PowAlgorithm::Sha3x)
-                    .await
-                    .inspect_err(|e| {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Could not get target difficulty for Sha3x: {e}"
-                        );
-                    })
-                    .unwrap_or(Difficulty::min());
-                let target_time = constants.pow_target_block_interval(PowAlgorithm::Sha3x);
-                let estimated_hash_rate = target_difficulty.as_u64().checked_div(target_time).unwrap_or(0);
-                self.data_cache
-                    .set_sha3x_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
-                    .await;
-                estimated_hash_rate
-            },
+        let sha3x_estimated_hash_rate = if enabled_algos.contains(&PowAlgorithm::Sha3x) {
+            match self
+                .data_cache
+                .get_sha3x_estimated_hash_rate(metadata.best_block_hash())
+                .await
+            {
+                Some(hash_rate) => hash_rate,
+                None => {
+                    let target_difficulty = handler
+                        .get_target_difficulty_for_next_block(PowAlgorithm::Sha3x)
+                        .await
+                        .inspect_err(|e| {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Could not get target difficulty for Sha3x: {e}"
+                            );
+                        })
+                        .unwrap_or(Difficulty::min());
+                    let target_time = constants.pow_target_block_interval(PowAlgorithm::Sha3x);
+                    let estimated_hash_rate = target_difficulty.as_u64().checked_div(target_time).unwrap_or(0);
+                    self.data_cache
+                        .set_sha3x_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
+                        .await;
+                    estimated_hash_rate
+                },
+            }
+        } else {
+            0
         };
-        let monero_randomx_estimated_hash_rate = match self
-            .data_cache
-            .get_monero_randomx_estimated_hash_rate(metadata.best_block_hash())
-            .await
-        {
-            Some(hash_rate) => hash_rate,
-            None => {
-                let target_difficulty = handler
-                    .get_target_difficulty_for_next_block(PowAlgorithm::RandomXM)
-                    .await
-                    .inspect_err(|e| {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Could not get target difficulty for Monero RandomX: {e}"
-                        );
-                    })
-                    .unwrap_or(Difficulty::min());
-                let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomXM);
-                let estimated_hash_rate = target_difficulty.as_u64().checked_div(target_time).unwrap_or(0);
-                self.data_cache
-                    .set_monero_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
-                    .await;
-                estimated_hash_rate
-            },
-        };
-
-        let tari_randomx_estimated_hash_rate = match self
-            .data_cache
-            .get_tari_randomx_estimated_hash_rate(metadata.best_block_hash())
-            .await
-        {
-            Some(hash_rate) => hash_rate,
-            None => {
-                let target_difficulty = handler
-                    .get_target_difficulty_for_next_block(PowAlgorithm::RandomXT)
-                    .await
-                    .inspect_err(|e| {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Could not get target difficulty for Tari RandomX: {e}"
-                        );
-                    })
-                    .unwrap_or(Difficulty::min());
-                let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomXT);
-                let estimated_hash_rate = target_difficulty.as_u64().checked_div(target_time).unwrap_or(0);
-                self.data_cache
-                    .set_tari_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
-                    .await;
-                estimated_hash_rate
-            },
+        let monero_randomx_estimated_hash_rate = if enabled_algos.contains(&PowAlgorithm::RandomXM) {
+            match self
+                .data_cache
+                .get_monero_randomx_estimated_hash_rate(metadata.best_block_hash())
+                .await
+            {
+                Some(hash_rate) => hash_rate,
+                None => {
+                    let target_difficulty = handler
+                        .get_target_difficulty_for_next_block(PowAlgorithm::RandomXM)
+                        .await
+                        .inspect_err(|e| {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Could not get target difficulty for Monero RandomX: {e}"
+                            );
+                        })
+                        .unwrap_or(Difficulty::min());
+                    let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomXM);
+                    let estimated_hash_rate = target_difficulty.as_u64().checked_div(target_time).unwrap_or(0);
+                    self.data_cache
+                        .set_monero_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
+                        .await;
+                    estimated_hash_rate
+                },
+            }
+        } else {
+            0
         };
 
-        let cuckaroo_estimated_hash_rate = match self
-            .data_cache
-            .get_cuckaroo_estimated_hash_rate(metadata.best_block_hash())
-            .await
-        {
-            Some(hash_rate) => hash_rate,
-            None => {
-                let target_difficulty = handler
-                    .get_target_difficulty_for_next_block(PowAlgorithm::Cuckaroo)
-                    .await
-                    .inspect_err(|e| {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Could not get target difficulty for Cuckaroo: {e}"
-                        );
-                    })
-                    .unwrap_or(Difficulty::min());
-                let target_time = constants.pow_target_block_interval(PowAlgorithm::Cuckaroo);
-                let estimated_hash_rate_scaled = target_difficulty
-                    .as_u64()
-                    .saturating_mul(NANOS_PER_UNIT) // We have to add scaling as this value can be < 1
-                    .checked_div(target_time)
-                    .unwrap_or(0);
-                let estimated_hash_rate = HashRateMovingAverage::average_as_u_decimal(estimated_hash_rate_scaled);
-                self.data_cache
-                    .set_cuckaroo_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
-                    .await;
-                estimated_hash_rate
-            },
+        let tari_randomx_estimated_hash_rate = if enabled_algos.contains(&PowAlgorithm::RandomXT) {
+            match self
+                .data_cache
+                .get_tari_randomx_estimated_hash_rate(metadata.best_block_hash())
+                .await
+            {
+                Some(hash_rate) => hash_rate,
+                None => {
+                    let target_difficulty = handler
+                        .get_target_difficulty_for_next_block(PowAlgorithm::RandomXT)
+                        .await
+                        .inspect_err(|e| {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Could not get target difficulty for Tari RandomX: {e}"
+                            );
+                        })
+                        .unwrap_or(Difficulty::min());
+                    let target_time = constants.pow_target_block_interval(PowAlgorithm::RandomXT);
+                    let estimated_hash_rate = target_difficulty.as_u64().checked_div(target_time).unwrap_or(0);
+                    self.data_cache
+                        .set_tari_randomx_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
+                        .await;
+                    estimated_hash_rate
+                },
+            }
+        } else {
+            0
+        };
+
+        let cuckaroo_estimated_hash_rate = if enabled_algos.contains(&PowAlgorithm::Cuckaroo) {
+            match self
+                .data_cache
+                .get_cuckaroo_estimated_hash_rate(metadata.best_block_hash())
+                .await
+            {
+                Some(hash_rate) => hash_rate,
+                None => {
+                    let target_difficulty = handler
+                        .get_target_difficulty_for_next_block(PowAlgorithm::Cuckaroo)
+                        .await
+                        .inspect_err(|e| {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Could not get target difficulty for Cuckaroo: {e}"
+                            );
+                        })
+                        .unwrap_or(Difficulty::min());
+                    let target_time = constants.pow_target_block_interval(PowAlgorithm::Cuckaroo);
+                    let estimated_hash_rate_scaled = target_difficulty
+                        .as_u64()
+                        .saturating_mul(NANOS_PER_UNIT) // We have to add scaling as this value can be < 1
+                        .checked_div(target_time)
+                        .unwrap_or(0);
+                    let estimated_hash_rate = HashRateMovingAverage::average_as_u_decimal(estimated_hash_rate_scaled);
+                    self.data_cache
+                        .set_cuckaroo_estimated_hash_rate(estimated_hash_rate, *metadata.best_block_hash())
+                        .await;
+                    estimated_hash_rate
+                },
+            }
+        } else {
+            tari_rpc::UDecimalValue { units: 0, nanos: 0 }
         };
 
         let failed_checkpoints = *self.tari_pulse.get_failed_checkpoints_notifier();

--- a/applications/minotari_node/src/grpc/hash_rate.rs
+++ b/applications/minotari_node/src/grpc/hash_rate.rs
@@ -71,11 +71,19 @@ impl HashRateMovingAverage {
         }
 
         // add the new hash rate to the list
-        let current_hash_rate = if self.use_scaling {
+        let mut current_hash_rate = if self.use_scaling {
             difficulty.as_u64().saturating_mul(NANOS_PER_UNIT) / target_time
         } else {
             difficulty.as_u64() / target_time
         };
+        // cuckoo is special as we need to multiply by the cycle length to get the hash rate
+        if self.pow_algo == PowAlgorithm::Cuckaroo {
+            current_hash_rate = current_hash_rate.saturating_mul(u64::from(
+                self.consensus_manager
+                    .consensus_constants(height)
+                    .cuckaroo_cycle_length(),
+            ));
+        }
         self.hash_rates.push_front(current_hash_rate);
 
         // after adding the hash rate we need to recalculate the average
@@ -118,10 +126,9 @@ impl HashRateMovingAverage {
     }
 
     pub fn average_as_u_decimal(average: u64) -> tari_rpc::UDecimalValue {
-        let scaled_average = average * 42;
         tari_rpc::UDecimalValue {
-            units: scaled_average / NANOS_PER_UNIT,
-            nanos: u32::try_from(scaled_average % NANOS_PER_UNIT).unwrap_or(MAX_NANOS_PER_DECIMAL),
+            units: average / NANOS_PER_UNIT,
+            nanos: u32::try_from(average % NANOS_PER_UNIT).unwrap_or(MAX_NANOS_PER_DECIMAL),
         }
     }
 }
@@ -283,8 +290,8 @@ mod test {
         assert_eq!(decimal.nanos, 176666666);
         let decimal = c29_hash_rate_ma.u_decimal_average();
         assert_eq!(decimal.units, c29_hash_rate_ma.average());
-        assert_eq!(decimal.units, 0);
-        assert_eq!(decimal.nanos, 61666666);
+        assert_eq!(decimal.units, 2);
+        assert_eq!(decimal.nanos, 590000000);
     }
 
     #[test]

--- a/applications/minotari_node/src/grpc/hash_rate.rs
+++ b/applications/minotari_node/src/grpc/hash_rate.rs
@@ -118,9 +118,10 @@ impl HashRateMovingAverage {
     }
 
     pub fn average_as_u_decimal(average: u64) -> tari_rpc::UDecimalValue {
+        let scaled_average = average * 42;
         tari_rpc::UDecimalValue {
-            units: average / NANOS_PER_UNIT,
-            nanos: u32::try_from(average % NANOS_PER_UNIT).unwrap_or(MAX_NANOS_PER_DECIMAL),
+            units: scaled_average / NANOS_PER_UNIT,
+            nanos: u32::try_from(scaled_average % NANOS_PER_UNIT).unwrap_or(MAX_NANOS_PER_DECIMAL),
         }
     }
 }


### PR DESCRIPTION
Description
---
Fix calculated c29 hashrate in base node. 
also not ask for hashrate if its not enabledf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Hash-rate metrics now respect the network’s active PoW algorithms; disabled algorithms report zero and are excluded from calculations.
- Bug Fixes
  - Prevents unnecessary computation and history updates for disabled algorithms, improving stability and performance.
- Refactor
  - Streamlined per-algorithm hash-rate flow to ensure consistent gating.
- Tests
  - Updated moving-average expectations to reflect adjusted scaling for one PoW algorithm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->