### PR TITLE
fix: accumulated data in c29

### DIFF
--- a/base_layer/core/src/blocks/accumulated_data.rs
+++ b/base_layer/core/src/blocks/accumulated_data.rs
@@ -167,7 +167,8 @@ impl BlockHeaderAccumulatedDataBuilder<'_> {
             })?;
         let total_accumulated: U512 = U512::from(monero_randomx_diff.as_u128()) *
             U512::from(tari_randomx_diff.as_u128()) *
-            U512::from(sha3x_diff.as_u128());
+            U512::from(sha3x_diff.as_u128()) *
+            U512::from(cuckaroo_diff.as_u128());
 
         let result = BlockHeaderAccumulatedData {
             hash,

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -4133,6 +4133,71 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             write_txn.commit()?;
         }
 
+        // Migration Total accumulated difficulty migration - re-calculate accumulated difficultie for c29
+        if migrate_from_version == 6 {
+            let txn = db.write_transaction()?;
+            let rebuild_status = {
+                let val: Option<MetadataValue> = lmdb_get(
+                    &txn,
+                    &db.metadata_db,
+                    &MetadataKey::AccumulatedDataRebuildStatus.as_u32(),
+                )
+                .unwrap_or_default();
+                match val {
+                    Some(MetadataValue::AccumulatedDataRebuildStatus(status)) => status,
+                    _ => AccumulatedDataRebuildStatus::default(),
+                }
+            };
+            match (rebuild_status.is_rebuilt, rebuild_status.last_rebuild_height) {
+                (_, Some(val)) => {
+                    if val < 95000 {
+                        info!(
+                            target: LOG_TARGET,
+                            "[MIGRATIONS] v{migrate_from_version}: No need to reset accumulated data rebuilding, below fork height for c29",
+                        );
+                        continue;
+                    } else {
+                        info!(
+                            target: LOG_TARGET,
+                            "[MIGRATIONS] v{migrate_from_version}: Already past accumulated rebuild already past fork height of c29, need to rebuild"
+                        );
+                        let status = AccumulatedDataRebuildStatus {
+                            is_rebuilt: false,
+                            last_rebuild_height: Some(94999),
+                        };
+                        lmdb_replace(
+                            &txn,
+                            &db.metadata_db,
+                            &MetadataKey::AccumulatedDataRebuildStatus.as_u32(),
+                            &MetadataValue::AccumulatedDataRebuildStatus(status),
+                            None,
+                        )?;
+                        txn.commit()?;
+                    }
+                },
+                (_, None) => {
+                    let height = fetch_chain_height(&txn, &db.metadata_db).unwrap_or(0);
+
+                    info!(
+                        target: LOG_TARGET,
+                        "[MIGRATIONS] v{migrate_from_version}: Already past accumulated rebuild already past fork height of c29, need to rebuild"
+                    );
+                    let status = AccumulatedDataRebuildStatus {
+                        is_rebuilt: false,
+                        last_rebuild_height: Some(std::cmp::min(94999, height)),
+                    };
+                    lmdb_replace(
+                        &txn,
+                        &db.metadata_db,
+                        &MetadataKey::AccumulatedDataRebuildStatus.as_u32(),
+                        &MetadataValue::AccumulatedDataRebuildStatus(status),
+                        None,
+                    )?;
+                    txn.commit()?;
+                },
+            }
+        }
+
         // Let's update the migration version
         {
             let migrated_to_version = migrate_from_version + 1;

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -3823,7 +3823,7 @@ impl fmt::Display for MetadataValue {
 
 #[allow(clippy::too_many_lines)]
 fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
-    const MIGRATION_VERSION: u64 = 6;
+    const MIGRATION_VERSION: u64 = 7;
     db.stats_collector().set_target_db_version(MIGRATION_VERSION);
     let txn = db.read_transaction()?;
     let k = MetadataKey::MigrationVersion;
@@ -4155,7 +4155,6 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
                             target: LOG_TARGET,
                             "[MIGRATIONS] v{migrate_from_version}: No need to reset accumulated data rebuilding, below fork height for c29",
                         );
-                        continue;
                     } else {
                         info!(
                             target: LOG_TARGET,


### PR DESCRIPTION
Description
---
Fixes the accumulated difficulty in base node and reset index rebuilder to recalculate it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improves upgrade reliability around the c29 fork by correctly detecting when accumulated data needs rebuilding.
  * Avoids unnecessary resets for chains below the fork height and triggers rebuilds only when required.
  * Ensures the last-rebuild height is set appropriately (based on current chain state) for smoother, more accurate migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->