### PR TITLE
fix: ledger birthday

### DIFF
--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -220,6 +220,7 @@ where
             self.resources.db.clear_scanned_blocks()?;
             let wallet_birthday = match self.resources.db.get_wallet_type()? {
                 Some(WalletType::ProvidedKeys(wallet)) => Some(wallet.birthday.unwrap_or_default()),
+                Some(WalletType::Ledger(_)) => Some(0), // Ledger wallets have no birthday, so start from genesis
                 _ => None,
             };
             let scanning_start_height_hash = self


### PR DESCRIPTION
Description
---
Fixes the birthday for ledger wallets. 
Ledger wallets dont have birthdays so we need to force it to 0, so that it will corectly pick up all transactions and not today

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ledger wallets now scan from the genesis block, ensuring complete transaction history and accurate UTXO detection.
  * Resolves issues where missing or undefined wallet birthdays could lead to missed outputs.
  * Initial sync for Ledger wallets may take longer but is more reliable and predictable.
  * Users may see more complete balances after syncing; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->