### PR TITLE
chore: revert accumulated difficulty fix and let orphans clean at startup

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -109,7 +109,6 @@ impl BlockHeaderSyncError {
             BlockHeaderSyncError::ConnectivityError(_) |
             BlockHeaderSyncError::NotInSync |
             BlockHeaderSyncError::TargetDifficultiesError(_) |
-            BlockHeaderSyncError::PeerSentInaccurateChainMetadata { .. } |
             BlockHeaderSyncError::PeerNotFound => None,
             BlockHeaderSyncError::ChainStorageError(e) => e.get_ban_reason(),
 
@@ -130,6 +129,7 @@ impl BlockHeaderSyncError {
             err @ BlockHeaderSyncError::InvalidProtocolResponse(_) |
             err @ BlockHeaderSyncError::ChainLinkBroken { .. } |
             err @ BlockHeaderSyncError::BlockError(_) |
+            err @ BlockHeaderSyncError::PeerSentInaccurateChainMetadata { .. } |
             err @ BlockHeaderSyncError::PeerSentTooManyHeaders(_) => Some(BanReason {
                 reason: format!("{err}"),
                 ban_duration: BanPeriod::Long,

--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -115,7 +115,8 @@ impl BlockHeaderSyncError {
             // short ban
             err @ BlockHeaderSyncError::MaxLatencyExceeded { .. } |
             err @ BlockHeaderSyncError::RpcError { .. } |
-            err @ BlockHeaderSyncError::RpcRequestError { .. } => Some(BanReason {
+            err @ BlockHeaderSyncError::RpcRequestError { .. } |
+            err @ BlockHeaderSyncError::PeerSentInaccurateChainMetadata { .. } => Some(BanReason {
                 reason: format!("{err}"),
                 ban_duration: BanPeriod::Short,
             }),
@@ -129,7 +130,6 @@ impl BlockHeaderSyncError {
             err @ BlockHeaderSyncError::InvalidProtocolResponse(_) |
             err @ BlockHeaderSyncError::ChainLinkBroken { .. } |
             err @ BlockHeaderSyncError::BlockError(_) |
-            err @ BlockHeaderSyncError::PeerSentInaccurateChainMetadata { .. } |
             err @ BlockHeaderSyncError::PeerSentTooManyHeaders(_) => Some(BanReason {
                 reason: format!("{err}"),
                 ban_duration: BanPeriod::Long,

--- a/base_layer/core/src/blocks/accumulated_data.rs
+++ b/base_layer/core/src/blocks/accumulated_data.rs
@@ -167,8 +167,7 @@ impl BlockHeaderAccumulatedDataBuilder<'_> {
             })?;
         let total_accumulated: U512 = U512::from(monero_randomx_diff.as_u128()) *
             U512::from(tari_randomx_diff.as_u128()) *
-            U512::from(sha3x_diff.as_u128()) *
-            U512::from(cuckaroo_diff.as_u128());
+            U512::from(sha3x_diff.as_u128());
 
         let result = BlockHeaderAccumulatedData {
             hash,

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -160,7 +160,7 @@ impl Default for BlockchainDatabaseConfig {
             pruning_horizon: BLOCKCHAIN_DATABASE_PRUNING_HORIZON,
             pruning_interval: BLOCKCHAIN_DATABASE_PRUNED_MODE_PRUNING_INTERVAL,
             track_reorgs: false,
-            cleanup_orphans_at_startup: false,
+            cleanup_orphans_at_startup: true,
             clear_bad_blocks_at_startup: true,
         }
     }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -3823,7 +3823,7 @@ impl fmt::Display for MetadataValue {
 
 #[allow(clippy::too_many_lines)]
 fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
-    const MIGRATION_VERSION: u64 = 7;
+    const MIGRATION_VERSION: u64 = 6;
     db.stats_collector().set_target_db_version(MIGRATION_VERSION);
     let txn = db.read_transaction()?;
     let k = MetadataKey::MigrationVersion;
@@ -4131,70 +4131,6 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
                 None,
             )?;
             write_txn.commit()?;
-        }
-
-        // Migration Total accumulated difficulty migration - re-calculate accumulated difficultie for c29
-        if migrate_from_version == 6 {
-            let txn = db.write_transaction()?;
-            let rebuild_status = {
-                let val: Option<MetadataValue> = lmdb_get(
-                    &txn,
-                    &db.metadata_db,
-                    &MetadataKey::AccumulatedDataRebuildStatus.as_u32(),
-                )
-                .unwrap_or_default();
-                match val {
-                    Some(MetadataValue::AccumulatedDataRebuildStatus(status)) => status,
-                    _ => AccumulatedDataRebuildStatus::default(),
-                }
-            };
-            match (rebuild_status.is_rebuilt, rebuild_status.last_rebuild_height) {
-                (_, Some(val)) => {
-                    if val < 95000 {
-                        info!(
-                            target: LOG_TARGET,
-                            "[MIGRATIONS] v{migrate_from_version}: No need to reset accumulated data rebuilding, below fork height for c29",
-                        );
-                    } else {
-                        info!(
-                            target: LOG_TARGET,
-                            "[MIGRATIONS] v{migrate_from_version}: Already past accumulated rebuild already past fork height of c29, need to rebuild"
-                        );
-                        let status = AccumulatedDataRebuildStatus {
-                            is_rebuilt: false,
-                            last_rebuild_height: Some(94999),
-                        };
-                        lmdb_replace(
-                            &txn,
-                            &db.metadata_db,
-                            &MetadataKey::AccumulatedDataRebuildStatus.as_u32(),
-                            &MetadataValue::AccumulatedDataRebuildStatus(status),
-                            None,
-                        )?;
-                        txn.commit()?;
-                    }
-                },
-                (_, None) => {
-                    let height = fetch_chain_height(&txn, &db.metadata_db).unwrap_or(0);
-
-                    info!(
-                        target: LOG_TARGET,
-                        "[MIGRATIONS] v{migrate_from_version}: Already past accumulated rebuild already past fork height of c29, need to rebuild"
-                    );
-                    let status = AccumulatedDataRebuildStatus {
-                        is_rebuilt: false,
-                        last_rebuild_height: Some(std::cmp::min(94999, height)),
-                    };
-                    lmdb_replace(
-                        &txn,
-                        &db.metadata_db,
-                        &MetadataKey::AccumulatedDataRebuildStatus.as_u32(),
-                        &MetadataValue::AccumulatedDataRebuildStatus(status),
-                        None,
-                    )?;
-                    txn.commit()?;
-                },
-            }
         }
 
         // Let's update the migration version

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -66,7 +66,7 @@
 # Set to true to record all reorgs. Recorded reorgs can be viewed using the list-reorgs command. Default = false
 track_reorgs = true
 # Clean out
-#cleanup_orphans_at_startup = false
+#cleanup_orphans_at_startup = true
 #clear_bad_blocks_at_startup = true
 
 [base_node.mempool]


### PR DESCRIPTION
Description
---
- Revert "fix: accumulated data in c29 (#7507)" This reverts commit 840c6d24e02923453ec77dab70073c7d1d9569cc.
- Revert "fix: remove ban for wrong accumulated difficulty" This reverts commit ccb41e6c5933073041bc77dbf5f23900e12411a2.
- Set `cleanup_orphans_at_startup` config option to true to combat the base node being fixated on bad orphan blocks - this stops the node from syncing when it happens.

Motivation and Context
---
Network forks and base nodes cannot sync anymore

How Has This Been Tested?
---
System-level testing.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
 BREAKING CHANGE: This changes back the accumulated difficulty calculation to that which is currently the official release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated accumulated difficulty calculation; reported totals may change.
- Chores
  - Base node now cleans up orphan blocks on startup by default.
  - Tightened peer ban policy: inaccurate chain metadata now triggers a short ban.
- Documentation
  - Config preset comments updated to reflect the new orphan-cleanup default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->