### PR TITLE
chore(ci): fix no stable installed clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,9 @@ jobs:
       - name: Install cargo-lints
         run: cargo install cargo-lints
       - name: Clippy check (with lints)
-        run: cargo lints clippy --all-targets --all-features
+        run: |
+          rustup component add --toolchain stable-x86_64-unknown-linux-gnu clippy
+          cargo lints clippy --all-targets --all-features
       - name: cargo machete
         run: |
           cargo install cargo-machete@0.7.0


### PR DESCRIPTION
Description
Install clippy for stable toolchain

Motivation and Context
Fix missing clippy for stable toolchain

How Has This Been Tested?
Running clippy in CI, but clippy is not happy at the moment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by updating the linting workflow to perform environment setup before running code quality checks. This ensures consistent tooling availability and more predictable results across environments, reducing intermittent failures and speeding up feedback in pull requests. No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->