### PR TITLE
chore(ci): switch to stable toolchain except for rustfmt in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v5
       - name: toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.nightly_toolchain }}
-          components: clippy, rustfmt
+          toolchain: ${{ env.toolchain }}
+          components: clippy
       - name: ubuntu dependencies
         run: |
           sudo apt-get update
@@ -72,12 +72,6 @@ jobs:
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}-small
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly
-      - name: rust-toolchain.toml override by renaming
-        run: mv rust-toolchain.toml rust-toolchain.toml.bak
-      - name: cargo format
-        run: cargo +${{ env.nightly_toolchain }} fmt --all -- --check
-      - name: rust-toolchain.toml.bak renaming back
-        run: mv rust-toolchain.toml.bak rust-toolchain.toml
       - name: Install cargo-lints
         run: cargo install cargo-lints
       - name: Clippy check (with lints)
@@ -94,6 +88,10 @@ jobs:
         run: |
           cargo install cargo-vet@0.10.0 --locked
           cargo vet
+      - name: Install nightly with rustfmt
+        run: rustup toolchain install ${{ env.nightly_toolchain }} --component rustfmt
+      - name: cargo format
+        run: cargo +${{ env.nightly_toolchain }} fmt --all -- --check
 
   ledger-build-tests:
     name: ledger build tests


### PR DESCRIPTION
Description
Change default CI workflow to use stable toolchian and move format to night at the end

Motivation and Context
By default use the stable toolchain

How Has This Been Tested?
Builds selective tests in local fork, as there are a few clippy break awaiting fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI to use the stable Rust toolchain by default, improving consistency.
  - Added explicit nightly installation with rustfmt and a formatting check to validate code style.
  - Simplified formatting steps by removing temporary file renaming and redundant commands.
  - Reorganized workflow steps, keeping wasm tests intact while clarifying toolchain usage.
  - No user-facing changes; functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->