### PR TITLE
fix: update ledger wallet sdk to newer ledger firmware

### DIFF
--- a/.github/workflows/build_ledger_wallet.yml
+++ b/.github/workflows/build_ledger_wallet.yml
@@ -15,7 +15,7 @@ name: Build minotari_ledger_wallet
 env:
   TS_FILENAME: "minotari_ledger_wallet"
   SHARUN: "shasum --algorithm 256"
-  DOCKER_IMAGE: "ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:4.2.0"
+  DOCKER_IMAGE: "ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:4.15.0"
 
 concurrency:
   # https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     name: ledger build tests
     runs-on: [ubuntu-latest]
     env:
-      DOCKER_IMAGE: "ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:4.2.0"
+      DOCKER_IMAGE: "ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:4.15.0"
     steps:
       - name: checkout tari
         uses: actions/checkout@v5

--- a/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
+++ b/applications/minotari_ledger_wallet/comms/examples/ledger_demo/main.rs
@@ -136,7 +136,9 @@ fn main() {
             return;
         },
         Err(e) => {
-            if e != LedgerDeviceError::Processing("GetPublicKey: expected 33 bytes, got 0 (BadBranchKey)".to_string()) {
+            if e != LedgerDeviceError::Processing(
+                "GetPublicKey: expected 1 + 32 bytes, got 0 (BadBranchKey)".to_string(),
+            ) {
                 println!("\nError: Unexpected response ({e})\n");
                 return;
             }

--- a/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
+++ b/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
@@ -218,7 +218,7 @@ pub fn ledger_get_public_spend_key(account: u64) -> Result<CompressedPublicKey, 
         Ok(result) => {
             if result.data().len() < 33 {
                 return Err(LedgerDeviceError::Processing(format!(
-                    "GetPublicSpendKey: expected 33 bytes, got {} ({:?})",
+                    "GetPublicSpendKey: expected 1 + 32 bytes, got {} ({:?})",
                     result.data().len(),
                     AppSW::try_from(result.retcode())?
                 )));
@@ -252,7 +252,7 @@ pub fn ledger_get_public_key(
         Ok(result) => {
             if result.data().len() < 33 {
                 return Err(LedgerDeviceError::Processing(format!(
-                    "GetPublicKey: expected 33 bytes, got {} ({:?})",
+                    "GetPublicKey: expected 1 + 32 bytes, got {} ({:?})",
                     result.data().len(),
                     AppSW::try_from(result.retcode())?
                 )));
@@ -401,7 +401,7 @@ pub fn ledger_get_script_offset(
         Some(result) => {
             if result.data().len() < 33 {
                 return Err(LedgerDeviceError::Processing(format!(
-                    "GetScriptOffset: expected 33 bytes, got {} ({:?})",
+                    "GetScriptOffset: expected 1 + 32 bytes, got {} ({:?})",
                     result.data().len(),
                     AppSW::try_from(result.retcode())?
                 )));
@@ -423,7 +423,7 @@ pub fn ledger_get_view_key(account: u64) -> Result<PrivateKey, LedgerDeviceError
         Ok(result) => {
             if result.data().len() < 33 {
                 return Err(LedgerDeviceError::Processing(format!(
-                    "GetViewKey: expected 33 bytes, got {} ({:?})",
+                    "GetViewKey: expected 1 + 32 bytes, got {} ({:?})",
                     result.data().len(),
                     AppSW::try_from(result.retcode())?
                 )));
@@ -457,7 +457,7 @@ pub fn ledger_get_dh_shared_secret(
         Ok(result) => {
             if result.data().len() < 33 {
                 return Err(LedgerDeviceError::Processing(format!(
-                    "GetDHSharedSecret: expected 33 bytes, got {} ({:?})",
+                    "GetDHSharedSecret: expected 1 + 32 bytes, got {} ({:?})",
                     result.data().len(),
                     AppSW::try_from(result.retcode())?
                 )));

--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -14,7 +14,7 @@ blake2 = { version = "0.10", default-features = false }
 borsh = { version = "1.5.7", default-features = false }
 digest = { version = "0.10", default-features = false }
 include_gif = "1.2"
-ledger_device_sdk = "=1.22.1"
+ledger_device_sdk = "=1.25.0"
 rand_core = { version = "0.6", default_features = false }
 zeroize = { version = "1", default-features = false }
 curve25519-dalek = { version = "4", default-features = false, features = [ "alloc", "rand_core", "precomputed-tables", "zeroize"] }

--- a/applications/minotari_ledger_wallet/wallet/rust-toolchain.toml
+++ b/applications/minotari_ledger_wallet/wallet/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-11-10"
+channel = "nightly-2024-12-01"

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_dh_shared_secret.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_dh_shared_secret.rs
@@ -57,7 +57,6 @@ pub fn handler_get_dh_shared_secret(comm: &mut Comm) -> Result<(), AppSW> {
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(shared_secret_key.deref().as_bytes());
-    comm.reply_ok();
 
     Ok(())
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_one_sided_metadata_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_one_sided_metadata_signature.rs
@@ -272,7 +272,6 @@ pub fn handler_get_one_sided_metadata_signature(comm: &mut Comm) -> Result<(), A
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(&metadata_signature.to_vec());
-    comm.reply_ok();
 
     Ok(())
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_public_key.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_public_key.rs
@@ -45,7 +45,6 @@ pub fn handler_get_public_key(comm: &mut Comm) -> Result<(), AppSW> {
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(pk.as_bytes());
-    comm.reply_ok();
 
     Ok(())
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_public_spend_key.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_public_spend_key.rs
@@ -43,7 +43,6 @@ pub fn handler_get_public_spend_key(comm: &mut Comm) -> Result<(), AppSW> {
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(pk.as_bytes());
-    comm.reply_ok();
 
     Ok(())
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_schnorr_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_schnorr_signature.rs
@@ -91,7 +91,6 @@ pub fn handler_get_raw_schnorr_signature(comm: &mut Comm) -> Result<(), AppSW> {
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(&signature.get_public_nonce().to_vec());
     comm.append(&signature.get_signature().to_vec());
-    comm.reply_ok();
 
     Ok(())
 }
@@ -150,7 +149,6 @@ pub fn handler_get_script_schnorr_signature(comm: &mut Comm) -> Result<(), AppSW
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(&signature.get_public_nonce().to_vec());
     comm.append(&signature.get_signature().to_vec());
-    comm.reply_ok();
 
     Ok(())
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_offset.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_offset.rs
@@ -200,7 +200,6 @@ pub fn handler_get_script_offset(
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(&script_offset.to_vec());
     offset_ctx.reset();
-    comm.reply_ok();
 
     Ok(())
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_signature.rs
@@ -73,7 +73,6 @@ pub fn handler_get_script_signature_managed(comm: &mut Comm) -> Result<(), AppSW
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(&script_signature.to_vec());
-    comm.reply_ok();
 
     Ok(())
 }
@@ -115,7 +114,6 @@ pub fn handler_get_script_signature_derived(comm: &mut Comm) -> Result<(), AppSW
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(&script_signature.to_vec());
-    comm.reply_ok();
 
     Ok(())
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_view_key.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_view_key.rs
@@ -36,7 +36,6 @@ pub fn handler_get_view_key(comm: &mut Comm) -> Result<(), AppSW> {
 
     comm.append(&[RESPONSE_VERSION]); // version
     comm.append(p.as_bytes());
-    comm.reply_ok();
 
     Ok(())
 }


### PR DESCRIPTION
Description
---
- Updated ledger wallet to use the latest ledger_device_sdk.
- Also updated the ledger wallet rust toolchain.
- Fixed double `comm.reply_ok();` sent from the ledger device - this caused the the accessor methods to receive an empty data array, the first containing the data and the second containing the empty array.

Fixes #7518.

Motivation and Context
---
See above.

How Has This Been Tested?
---
- System-level testing passed (send & recieve).
- Demo passed:
```
cargo run --release --example ledger_demo
    Finished `release` profile [optimized] target(s) in 1.11s
     Running `target\release\examples\ledger_demo.exe`

Transport created in 26.7992ms
Transport created in 11.8355ms
Transport created in 14.8429ms
Transport created in 11.8416ms
Transport created in 12.8842ms
Transport created in 11.903ms
Transport created in 13.8822ms
Transport created in 11.9641ms
Transport created in 14.883ms
Transport created in 11.8267ms

Result data: [1, 98, 229, 50, 140, 22, 238, 33, 222, 42, 25, 252, 173, 215, 208, 105, 100, 217, 79, 187, 33, 141, 151, 212, 144, 248, 237, 197, 107, 68, 34, 39, 121]
Application verified in 1.6788405s
Application verified in 200ns
Application verified in 100ns
Application verified in 100ns
Application verified in 100ns
Application verified in 100ns
Application verified in 100ns
Application verified in 100ns
Application verified in 100ns
Application verified in 100ns


test: GetAppName
app name:       minotari_ledger_wallet

test: GetVersion
version:        5.1.0-pre.2

test: GetPublicAlpha
public_alpha:   d4edcf00d1ed7c5facbdac780e31e86187faefe086e4d62823e900a906bab46a

test: GetPublicKey
Result data: [1, 90, 154, 86, 152, 203, 121, 156, 164, 81, 186, 107, 138, 195, 132, 157, 244, 235, 38, 183, 72, 223, 220, 1, 29, 94, 184, 211, 220, 75, 84, 53, 59]
public_key:     5a9a5698cb799ca451ba6b8ac3849df4eb26b748dfdc011d5eb8d3dc4b54353b
Result data: [1, 88, 73, 90, 146, 76, 107, 125, 48, 228, 215, 112, 245, 29, 147, 141, 53, 231, 209, 202, 150, 240, 142, 250, 216, 55, 202, 196, 249, 65, 88, 96, 25]
public_key:     58495a924c6b7d30e4d770f51d938d35e7d1ca96f08efad837cac4f941586019
Result data: [1, 124, 216, 106, 50, 92, 186, 37, 190, 222, 110, 36, 119, 18, 244, 133, 136, 97, 87, 226, 88, 236, 97, 106, 218, 129, 28, 108, 146, 235, 229, 3, 53]
public_key:     7cd86a325cba25bede6e247712f485886157e258ec616ada811c6c92ebe50335
Result data: [1, 168, 85, 53, 245, 6, 31, 154, 116, 250, 88, 51, 62, 60, 108, 105, 129, 108, 236, 57, 202, 193, 97, 185, 127, 240, 124, 114, 177, 139, 130, 89, 71]
public_key:     a85535f5061f9a74fa58333e3c6c69816cec39cac161b97ff07c72b18b825947
Result data: []

test: GetScriptSignature
script_sig:     (7c72c68b3d03fa125556161962839054f89f2664059636a8c57a0ea4b1190a74,cc89c338b04af0b04bc9dcd0f7c8469ccecbb9b4eb80d160d1a0d709c512c071,c8d428c267c70530005015f1c74762fbc1b61b0dae425c0e984eec0fe7a0310b,9c84b20efb6664a5b1511872f2717653801d74f8dc6069ce1d023ca276772d0e,37c9907c2bde5863f2abee29807051c58c16b82868ba4b0befc5e1f355ccfb04)
script_sig:     (80150a290ba0aa8b8b81853a6e6a64d24d17d8804949664dc85aa9c3bfcf1b1e,0ac380fd0ed7814534127cc5ead78f898ff459e2390a7bfe43db908c3d95b150,e3ee24ae2d515e8c1c44a9faff423d191efc8eb451d0b0d16fd1c1916904290e,b008911bc514af864a1e955bceda9d1e27f45e3f18a111001c891166dd159c02,114d1b0252fa6140f8c1b665033112089fec8821d5407d47a09cc8a94843f00c)

test: GetScriptOffset
script_offset:  d1d192616549b806b204b39ee57cb707d517f8837c6ebc34cfc651fc7d3fc509

test: GetViewKey
view_key:       55512cba3d3aaeb57a01fb7bbd03770899c9904bfee8b9d962cc660f4dbf2004

test: GetDHSharedSecret
shared_secret:  b29f20d54beb8f93687aaac238586cc379f4689228b7a3c141005b5c4c1c390d

test: GetRawSchnorrSignature
signature:      (1c97bd9f5a1ac7a14e08a7d4eb8343e8983a103652f2fbc8e4630e75d1af1104,8e0b5856943723bd4500199662c9c63b3ab65919055f66ddca811c82b3baf224)

test: GetScriptSchnorrSignature
signature:      (616d5dad3bc8883d5639f29ee95481222d060c4ed6f1cceed7ce738770eeea06,66e3655cd43f488be8748e2d1a24acec50419c6e9b9a8d02ec40982fc654c565)

test: GetOneSidedMetadataSignature
signature:      (f238391e79ab1fdd83e3e94a608d08a8e09e482ede7b6faa5ec3e97770064370,780d26fe2e748e2f014c1e6142498375a98b8a0d73c450d6c852b064519ab52a,26ca59bd1edeb316c0caff063d2a23523b85386f10b7a2e08a10cc8ab90ba701,3e173bc7ea3bd7a4ba17639917ee910e0c8ede95de651a64379d85fdba60ca03,3ffaf3ce19795b56dd652f3dff686a73342de3dde61b6d6648ad48ae34502a04)

test: Ledger app not running
✔ Exit the 'MinoTari Wallet' Ledger app and press Enter to continue.. · Ok

Ledger comms responded with: 'Invalid value for AppSW (28161)'


test: Ledger disconnected
✔ Disconnect the Ledger device and press Enter to continue.. · Ok

Ledger comms responded with: 'Invalid value for AppSW (28161)'


test: Ledger reconnected
✔ Reconnect the Ledger device (with password) and press Enter to continue.. · Ok

Ledger comms responded with: 'Invalid value for AppSW (28161)'


test: Ledger app restart
✔ Start the 'MinoTari Wallet' Ledger app and press Enter to continue.. · Ok
view_key:       55512cba3d3aaeb57a01fb7bbd03770899c9904bfee8b9d962cc660f4dbf2004
```

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Streamlined wallet response handling to finalize replies implicitly, removing redundant acknowledgement calls.
- Bug Fixes
  - Clarified error messages to specify expected data length as "1 + 32 bytes" for key, signature, and secret retrieval.
- Chores
  - Updated Ledger SDK dependency to 1.25.0.
  - Upgraded Rust toolchain to nightly-2024-12-01 and updated CI build image to ledger-app-builder:4.15.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->