### PR TITLE
chore: change integration tests to use stable

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -30,7 +30,6 @@ permissions: {}
 
 env:
   toolchain: stable
-  nightly_toolchain: nightly-2025-06-01
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -67,7 +66,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt, clippy
-          toolchain: ${{ env.nightly_toolchain }}
+          toolchain: ${{ env.toolchain }}
 
       - name: Install ubuntu dependencies
         shell: bash
@@ -89,13 +88,13 @@ jobs:
             ~/.cargo/registry/CACHEDIR.TAG
             ~/.cargo/git
             target
-          key: tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
+          key: tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly
+            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
+            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly
 
       - name: cargo test compile
-        run: cargo +${{ env.nightly_toolchain }} test --no-run --locked --all-features --release ${{ env.TARGET_BINS }}
+        run: cargo +${{ env.toolchain }} test --no-run --locked --all-features --release ${{ env.TARGET_BINS }}
 
       - name: Run ${{ env.CI_PROFILE }} integration tests for binaries
         if: ${{ env.CI_BINS == 'true' }}
@@ -104,7 +103,7 @@ jobs:
           set -e
           set -o pipefail
           echo "Running integration tests with profile: ${{ env.CI_PROFILE }}"
-          cargo +${{ env.nightly_toolchain }} test \
+          cargo +${{ env.toolchain }} test \
             --test cucumber \
             -v \
             --all-features \
@@ -158,7 +157,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt, clippy
-          toolchain: ${{ env.nightly_toolchain }}
+          toolchain: ${{ env.toolchain }}
 
       - name: Install ubuntu dependencies
         if: ${{ env.CI_FFI == 'true' }}
@@ -179,14 +178,14 @@ jobs:
             ~/.cargo/registry/CACHEDIR.TAG
             ~/.cargo/git
             target
-          key: tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
+          key: tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
-            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly
+            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly-${{ hashFiles('**/Cargo.lock') }}
+            tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-nightly
 
       - name: cargo test compile
         if: ${{ env.CI_FFI == 'true' }}
-        run: cargo +${{ env.nightly_toolchain }} test --no-run --locked --all-features --release ${{ env.TARGET_BINS }}
+        run: cargo +${{ env.toolchain }} test --no-run --locked --all-features --release ${{ env.TARGET_BINS }}
 
       - name: Run ${{ env.CI_PROFILE }} integration tests for ffi
         if: ${{ env.CI_FFI == 'true' }}
@@ -195,7 +194,7 @@ jobs:
           set -e
           set -o pipefail
           echo "Running FFI integration tests with profile: ${{ env.CI_PROFILE }}"
-          cargo +${{ env.nightly_toolchain }} test \
+          cargo +${{ env.toolchain }} test \
             --test cucumber \
             -v \
             --all-features \


### PR DESCRIPTION
Description
---
make integration tests stable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CI integration tests to use a unified toolchain reference across setup, caching, and test execution.
  * Aligned all test commands (including FFI and cucumber) with the new toolchain configuration for consistency.
  * Improved maintainability of test workflows without altering product behavior.

* **Notes**
  * No user-facing changes.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->