### PR TITLE
chore(ci): switch rust toolchain to stable

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -211,9 +211,8 @@ jobs:
           echo "S3_DEST_OVERRIDE=daily/" >> $GITHUB_ENV
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
           toolchain: ${{ matrix.builds.rust }}
           targets: ${{ matrix.builds.target }}
 

--- a/.github/workflows/build_libffis.yml
+++ b/.github/workflows/build_libffis.yml
@@ -15,8 +15,8 @@ name: Build ffi libraries
 env:
   CARGO_UNSTABLE_SPARSE_REGISTRY: true
   CARGO: cargo
-  # CARGO_OPTIONS: "--verbose"
-  CARGO_OPTIONS: "--release"
+  # CARGO_OPTIONS: '--verbose'
+  CARGO_OPTIONS: '--release'
   TARI_NETWORK_CHANGELOG: 'development'
   TOOLCHAIN: 'stable'
   ## Must be a JSon string
@@ -186,7 +186,7 @@ jobs:
 
       - name: Setup Rust toolchain
         if: ${{ ! matrix.builds.cross }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
           toolchain: ${{ env.TOOLCHAIN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v5
       - name: toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.toolchain }}
       - name: ubuntu dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ name: Source Coverage
 
 env:
   toolchain: stable
+  RUSTUP_PERMIT_COPY_RENAME: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,9 +31,9 @@ jobs:
           sudo apt-get update
           sudo bash scripts/install_ubuntu_dependencies.sh
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
+          toolchain: ${{ env.toolchain }}
 
       - name: run tests with coverage
         # Prepare the coverage data, even if some tests fail

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,6 +2,9 @@
 name: "Integration Tests"
 
 "on":
+  push:
+    branches:
+      - "ci-*"
   pull_request:
     types:
       - opened
@@ -31,6 +34,7 @@ permissions: {}
 env:
   toolchain: stable
   nightly_toolchain: nightly-2025-06-01
+  RUSTUP_PERMIT_COPY_RENAME: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -64,10 +68,10 @@ jobs:
           fi
 
       - name: Setup rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-          toolchain: ${{ env.nightly_toolchain }}
+          toolchain: ${{ env.toolchain }}
 
       - name: Install ubuntu dependencies
         shell: bash
@@ -95,7 +99,7 @@ jobs:
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.nightly_toolchain }}-nightly
 
       - name: cargo test compile
-        run: cargo +${{ env.nightly_toolchain }} test --no-run --locked --all-features --release ${{ env.TARGET_BINS }}
+        run: cargo test --no-run --locked --all-features --release
 
       - name: Run ${{ env.CI_PROFILE }} integration tests for binaries
         if: ${{ env.CI_BINS == 'true' }}
@@ -104,7 +108,7 @@ jobs:
           set -e
           set -o pipefail
           echo "Running integration tests with profile: ${{ env.CI_PROFILE }}"
-          cargo +${{ env.nightly_toolchain }} test \
+          cargo test \
             --test cucumber \
             -v \
             --all-features \
@@ -155,10 +159,10 @@ jobs:
 
       - name: Setup rust toolchain
         if: ${{ env.CI_FFI == 'true' }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-          toolchain: ${{ env.nightly_toolchain }}
+          toolchain: ${{ env.toolchain }}
 
       - name: Install ubuntu dependencies
         if: ${{ env.CI_FFI == 'true' }}
@@ -186,7 +190,7 @@ jobs:
 
       - name: cargo test compile
         if: ${{ env.CI_FFI == 'true' }}
-        run: cargo +${{ env.nightly_toolchain }} test --no-run --locked --all-features --release ${{ env.TARGET_BINS }}
+        run: cargo test --no-run --locked --all-features --release
 
       - name: Run ${{ env.CI_PROFILE }} integration tests for ffi
         if: ${{ env.CI_FFI == 'true' }}
@@ -195,7 +199,7 @@ jobs:
           set -e
           set -o pipefail
           echo "Running FFI integration tests with profile: ${{ env.CI_PROFILE }}"
-          cargo +${{ env.nightly_toolchain }} test \
+          cargo test \
             --test cucumber \
             -v \
             --all-features \


### PR DESCRIPTION
Description
switch rust toolchain to stable

Motivation and Context
use stable rust toolchain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Rust toolchain on stable across CI workflows for more predictable builds.
  * Streamlined setup by removing unnecessary components and aligning toolchain configuration with environment variables.
  * Enabled an environment flag to improve rustup behavior during CI.
  * Improved coverage workflow consistency with dynamic toolchain selection.

* **Tests**
  * Removed nightly-only requirements, simplifying test commands and improving compatibility.
  * Expanded CI triggers to include ci-* branches for better pre-merge validation.
  * Maintained existing job logic while improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->