### PR TITLE
chore: update soft fork height

### DIFF
--- a/base_layer/transaction_components/src/consensus/consensus_constants.rs
+++ b/base_layer/transaction_components/src/consensus/consensus_constants.rs
@@ -979,7 +979,7 @@ impl ConsensusConstants {
 
         let mut con_6 = con_5.clone();
         con_6.include_c29_accumulated_difficulty_into_total = true;
-        con_6.effective_from_height = 140_000;
+        con_6.effective_from_height = 121_000;
 
         let consensus_constants = vec![con_1, con_2, con_3, con_4, con_5, con_6];
         consensus_constants


### PR DESCRIPTION
Description
---
updates fork height to be Wednesday afternoon 22 Oct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Nextnet consensus activation height for con_6 from 140,000 to 121,000. The associated network changes will now take effect at block height 121,000. No other runtime behavior or user-facing functionality is altered, and no public APIs are affected. Users should be aware of the updated activation timing if monitoring block-height–based events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->