### PR TITLE
chore(ci): add check for minimum supported Rust version (MSRV)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ permissions: {}
 
 env:
   toolchain: stable
+  toolchain_msrv: 1.89.0
+  toolchain_msrv-reject-older: 1.80.0
   nightly_toolchain: nightly-2025-06-01
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
@@ -173,10 +175,21 @@ jobs:
   build-stable:
     # Runs cargo check with stable toolchain to determine whether the codebase is likely to build
     #  on stable Rust.
-    name: cargo check with stable
+    name: cargo check with ${{ matrix.rust }}
     runs-on: [self-hosted, ubuntu-high-cpu]
+    # fail jobs unless - msrv-reject-older
+    continue-on-error: ${{ startsWith(matrix.rust, 'msrv-reject-older') || false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+          - msrv
+          - msrv-reject-older
+
     env:
       RUSTUP_PERMIT_COPY_RENAME: true
+
     steps:
       - name: checkout
         uses: actions/checkout@v5
@@ -204,18 +217,44 @@ jobs:
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-stable-${{ hashFiles('**/Cargo.lock') }}
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}-stable
             tari-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.toolchain }}
-      - name: toolchain
+
+      - name: Extract MSRV from env/Cargo.toml
+        id: msrv
+        if: startsWith(matrix.rust,'msrv')
+        run: |
+          if [[ "${{ matrix.rust }}" == 'msrv' ]]; then
+            #version=$(grep -m1 '^rust-version' Cargo.toml | sed 's/[^0-9.]//g')
+            version=${{ env.toolchain_msrv }}
+          else
+            version=${{ env.toolchain_msrv-reject-older }}
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+          # Temporary disable toolchain pinning
+          rm -vf rust-toolchain.toml
+
+      # Stable toolchain
+      - name: Set up Rust (stable)
+        if: matrix.rust == 'stable'
         uses: dtolnay/rust-toolchain@stable
+
+      # MSRV toolchain
+      - name: Set up Rust (${{ matrix.rust }}-${{ steps.msrv.outputs.version }})
+        if: startsWith(matrix.rust,'msrv')
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ steps.msrv.outputs.version }}
+
       - name: ubuntu dependencies
         run: |
           sudo apt-get update
           sudo bash scripts/install_ubuntu_dependencies.sh
+
       - name: rustup show
         run: rustup show
+
       - name: cargo check
         run: cargo check --release --all-targets --workspace --exclude tari_integration_tests --locked
+
       - name: cargo check individual features
         shell: bash
         run: |
@@ -226,6 +265,7 @@ jobs:
               --features ${FEATURE_TEST} \
               --workspace --exclude tari_integration_tests --locked
           done
+
       - name: cargo check wallet ffi separately
         run: cargo check --release --package minotari_wallet_ffi --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
           if [[ "${{ matrix.rust }}" == 'msrv' ]]; then
             version=$(grep -m1 '^rust-version' Cargo.toml | sed 's/[^0-9.]//g')
           else
-            version=${{ env.toolchain_msrv-reject-older }}
+            version=${{ env.toolchain_msrv_reject_older }}
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
           # Temporary disable toolchain pinning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         rust:
           - stable
           - msrv
-          # - msrv-reject-older
+          # - msrv_reject_older
 
     env:
       RUSTUP_PERMIT_COPY_RENAME: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         rust:
           - stable
           - msrv
-          - msrv-reject-older
+          # - msrv-reject-older
 
     env:
       RUSTUP_PERMIT_COPY_RENAME: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 env:
   toolchain: stable
-  toolchain_msrv-reject-older: 1.80.0
+  toolchain_msrv_reject_older: 1.80.0
   nightly_toolchain: nightly-2025-06-24
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Description
Split out cargo check with stable, msrv and older toolchain

Motivation and Context
Make sure that the project compiles with a minimum supported Rust version (MSRV)

How Has This Been Tested?
Runs in local fork


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now tests multiple Rust toolchains, including the minimum supported Rust version (MSRV), improving compatibility coverage.
  * Builds run as a matrix with per-feature checks to catch configuration-specific issues earlier.
  * MSRV is detected and used to drive dynamic toolchain setup, with temporary pinning adjustments during those runs.
  * Failures from older MSRV variants are handled conditionally so they surface without blocking stable builds; caching and setup steps streamlined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->