### PR TITLE
chore: remove RwLock from TransactionKeyManagerWrapper

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/block_template_manager.rs
+++ b/applications/minotari_merge_mining_proxy/src/block_template_manager.rs
@@ -242,7 +242,7 @@ impl BlockTemplateManager<'_> {
             block_reward.into(),
             tari_height,
             &CoinBaseExtra::try_from(self.config.coinbase_extra.as_bytes().to_vec())?,
-            &self.key_manager,
+            &mut self.key_manager,
             &self.wallet_payment_address,
             true,
             self.consensus_manager.consensus_constants(tari_height),

--- a/applications/minotari_miner/src/run_miner.rs
+++ b/applications/minotari_miner/src/run_miner.rs
@@ -96,7 +96,7 @@ pub async fn start_miner(cli: Cli) -> Result<(), ExitError> {
     config.set_base_path(cli.common.get_base_path());
 
     debug!(target: LOG_TARGET_FILE, "{config:?}");
-    let key_manager = create_memory_db_key_manager().await.map_err(|err| {
+    let mut key_manager = create_memory_db_key_manager().await.map_err(|err| {
         ExitError::new(
             ExitCode::KeyManagerServiceError,
             "'wallet_payment_address' ".to_owned() + &err.to_string(),
@@ -180,7 +180,7 @@ pub async fn start_miner(cli: Cli) -> Result<(), ExitError> {
                 p2pool_node_client.clone(),
                 &config,
                 &cli,
-                &key_manager,
+                &mut key_manager,
                 &wallet_payment_address,
                 &consensus_manager,
             )
@@ -373,7 +373,7 @@ async fn get_new_block(
     sha_p2pool_client: Arc<Mutex<Option<ShaP2PoolGrpcClient>>>,
     config: &MinerConfig,
     cli: &Cli,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     wallet_payment_address: &TariAddress,
     consensus_manager: &BaseNodeConsensusManager,
 ) -> Result<GetNewBlockResponse, MinerError> {
@@ -398,7 +398,7 @@ async fn get_new_block_base_node(
     base_node_client: &mut BaseNodeGrpcClient,
     config: &MinerConfig,
     cli: &Cli,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     wallet_payment_address: &TariAddress,
     consensus_manager: &BaseNodeConsensusManager,
 ) -> Result<GetNewBlockResponse, MinerError> {
@@ -530,7 +530,7 @@ async fn mining_cycle(
     sha_p2pool_client: Option<ShaP2PoolGrpcClient>,
     config: &MinerConfig,
     cli: &Cli,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     wallet_payment_address: &TariAddress,
     consensus_manager: &BaseNodeConsensusManager,
 ) -> Result<bool, MinerError> {

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -1265,7 +1265,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             prev_coinbase_value += u128::from(coinbase.value);
         }
 
-        let key_manager = create_memory_key_manager().await.map_err(|e| {
+        let mut key_manager = create_memory_key_manager().await.map_err(|e| {
             obscure_error_if_true(report_error_flag, Status::internal(format!("Key manager error: '{e}'")))
         })?;
         let height = new_template.header.height;
@@ -1291,7 +1291,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 height,
                 &CoinBaseExtra::try_from(coinbase.coinbase_extra)
                     .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?,
-                &key_manager,
+                &mut key_manager,
                 &script_key_id,
                 &address,
                 coinbase.stealth_payment,
@@ -1508,7 +1508,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 Status::invalid_argument("Malformed coinbase amounts".to_string()),
             ));
         }
-        let key_manager = create_memory_key_manager().await.map_err(|s| {
+        let mut key_manager = create_memory_key_manager().await.map_err(|s| {
             obscure_error_if_true(report_error_flag, Status::internal(format!("Key manager error: {s}")))
         })?;
         let height = block_template.header.height;
@@ -1534,7 +1534,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 height,
                 &CoinBaseExtra::try_from(coinbase.coinbase_extra)
                     .map_err(|e| obscure_error_if_true(report_error_flag, Status::internal(e.to_string())))?,
-                &key_manager,
+                &mut key_manager,
                 &script_key_id,
                 &address,
                 coinbase.stealth_payment,

--- a/base_layer/core/benches/mempool.rs
+++ b/base_layer/core/benches/mempool.rs
@@ -55,11 +55,10 @@ mod benches {
         num_outputs: usize,
         features: OutputFeatures,
     ) -> std::io::Result<Vec<Arc<Transaction>>> {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let mut txs = Vec::new();
         for _ in 0..num_txs {
-            let (tx, _, _) =
-                tx!(T, fee: uT, inputs: num_inputs, outputs: num_outputs, features: features.clone(), &key_manager)?;
+            let (tx, _, _) = tx!(T, fee: uT, inputs: num_inputs, outputs: num_outputs, features: features.clone(), &mut key_manager)?;
             txs.push(Arc::new(tx));
         }
         Ok(txs)

--- a/base_layer/core/src/blocks/pre_mine/mod.rs
+++ b/base_layer/core/src/blocks/pre_mine/mod.rs
@@ -813,7 +813,7 @@ pub async fn create_pre_mine_genesis_block_info(
         for key in public_keys {
             total_script_key = total_script_key + key.to_public_key().map_err(|e| e.to_string())?;
         }
-        let key_manager = create_memory_db_key_manager().await.map_err(|e| e.to_string())?;
+        let mut key_manager = create_memory_db_key_manager().await.map_err(|e| e.to_string())?;
         let view_key = public_key_to_output_encryption_key(&CompressedPublicKey::new_from_pk(total_script_key))
             .map_err(|e| e.to_string())?;
         let view_key_id = key_manager
@@ -870,7 +870,7 @@ pub async fn create_pre_mine_genesis_block_info(
             .with_sender_offset_public_key(sender_offset.pub_key)
             .with_script_key(script_key.key_id)
             .with_minimum_value_promise(item.value)
-            .sign_as_sender_and_receiver(&key_manager, &sender_offset.key_id)
+            .sign_as_sender_and_receiver(&mut key_manager, &sender_offset.key_id)
             .await
             .map_err(|e| e.to_string())?
             .try_build(&key_manager)

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -502,7 +502,7 @@ mod fetch_header_containing_kernel_mmr {
         )
         .await;
 
-        let (script_key_id, wallet_payment_address) = default_coinbase_entities(&mut key_manager).await;
+        let (script_key_id, wallet_payment_address) = default_coinbase_entities(&key_manager).await;
         let (block, _) = create_next_block(
             &db,
             &blocks[0],
@@ -636,7 +636,7 @@ mod validator_node_merkle_root {
             &mut key_manager,
         )
         .await;
-        let (script_key_id, wallet_payment_address) = default_coinbase_entities(&mut key_manager).await;
+        let (script_key_id, wallet_payment_address) = default_coinbase_entities(&key_manager).await;
         let (block, _) = create_next_block(
             &db,
             &blocks[0],

--- a/base_layer/core/src/chain_storage/tests/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/tests/blockchain_database.rs
@@ -55,7 +55,7 @@ async fn create_next_block(
     db: &BlockchainDatabase<TempDatabase>,
     prev_block: &Block,
     transactions: Vec<Arc<Transaction>>,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     script_key_id: &TariKeyId,
     wallet_payment_address: &TariAddress,
 ) -> (Arc<Block>, WalletOutput) {
@@ -92,7 +92,7 @@ pub fn apply_mmr_to_block(db: &BlockchainDatabase<TempDatabase>, block: Block) -
 async fn add_many_chained_blocks(
     size: usize,
     db: &BlockchainDatabase<TempDatabase>,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (Vec<Arc<Block>>, Vec<WalletOutput>) {
     let last_header = db.fetch_last_header().unwrap();
     let mut prev_block = Arc::new(db.fetch_block(last_header.height, true).unwrap().into_block());
@@ -133,8 +133,8 @@ mod fetch_blocks {
     #[tokio::test]
     async fn it_returns_all() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(4, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(4, &db, &mut key_manager).await;
         let blocks = db.fetch_blocks(.., true).unwrap();
         assert_eq!(blocks.len(), 5);
         for (i, item) in blocks.iter().enumerate().take(4 + 1) {
@@ -145,8 +145,8 @@ mod fetch_blocks {
     #[tokio::test]
     async fn it_returns_one() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (new_blocks, _) = add_many_chained_blocks(1, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (new_blocks, _) = add_many_chained_blocks(1, &db, &mut key_manager).await;
         let blocks = db.fetch_blocks(1..=1, true).unwrap();
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].block().hash(), new_blocks[0].hash());
@@ -155,8 +155,8 @@ mod fetch_blocks {
     #[tokio::test]
     async fn it_returns_nothing_if_asking_for_blocks_out_of_range() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(1, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(1, &db, &mut key_manager).await;
         let blocks = db.fetch_blocks(2.., true).unwrap();
         assert!(blocks.is_empty());
     }
@@ -164,8 +164,8 @@ mod fetch_blocks {
     #[tokio::test]
     async fn it_returns_blocks_between_bounds_exclusive() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let blocks = db.fetch_blocks(3..5, true).unwrap();
         assert_eq!(blocks.len(), 2);
         assert_eq!(blocks[0].header().height, 3);
@@ -175,8 +175,8 @@ mod fetch_blocks {
     #[tokio::test]
     async fn it_returns_blocks_between_bounds_inclusive() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let blocks = db.fetch_blocks(3..=5, true).unwrap();
         assert_eq!(blocks.len(), 3);
         assert_eq!(blocks[0].header().height, 3);
@@ -187,8 +187,8 @@ mod fetch_blocks {
     #[tokio::test]
     async fn it_returns_blocks_to_the_tip() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let blocks = db.fetch_blocks(3.., true).unwrap();
         assert_eq!(blocks.len(), 3);
         assert_eq!(blocks[0].header().height, 3);
@@ -199,8 +199,8 @@ mod fetch_blocks {
     #[tokio::test]
     async fn it_returns_blocks_from_genesis() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let blocks = db.fetch_blocks(..=3, true).unwrap();
         assert_eq!(blocks.len(), 4);
         assert_eq!(blocks[0].header().height, 0);
@@ -231,8 +231,8 @@ mod fetch_headers {
     #[tokio::test]
     async fn it_returns_all() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(4, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(4, &db, &mut key_manager).await;
         let headers = db.fetch_headers(..).unwrap();
         assert_eq!(headers.len(), 5);
         for (i, item) in headers.iter().enumerate().take(4 + 1) {
@@ -243,8 +243,8 @@ mod fetch_headers {
     #[tokio::test]
     async fn it_returns_nothing_if_asking_for_blocks_out_of_range() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(1, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(1, &db, &mut key_manager).await;
         let headers = db.fetch_headers(2..).unwrap();
         assert!(headers.is_empty());
     }
@@ -252,8 +252,8 @@ mod fetch_headers {
     #[tokio::test]
     async fn it_returns_blocks_between_bounds_exclusive() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let headers = db.fetch_headers(3..5).unwrap();
         assert_eq!(headers.len(), 2);
         assert_eq!(headers[0].height, 3);
@@ -263,8 +263,8 @@ mod fetch_headers {
     #[tokio::test]
     async fn it_returns_blocks_between_bounds_inclusive() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let headers = db.fetch_headers(3..=5).unwrap();
         assert_eq!(headers.len(), 3);
         assert_eq!(headers[0].height, 3);
@@ -274,8 +274,8 @@ mod fetch_headers {
     #[tokio::test]
     async fn it_returns_blocks_to_the_tip() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let headers = db.fetch_headers(3..).unwrap();
         assert_eq!(headers.len(), 3);
         assert_eq!(headers[0].height, 3);
@@ -286,8 +286,8 @@ mod fetch_headers {
     #[tokio::test]
     async fn it_returns_blocks_from_genesis() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let headers = db.fetch_headers(..=3).unwrap();
         assert_eq!(headers.len(), 4);
         assert_eq!(headers[0].height, 0);
@@ -314,8 +314,8 @@ mod find_headers_after_hash {
     async fn it_returns_from_genesis() {
         let db = setup();
         let genesis_hash = db.fetch_block(0, true).unwrap().block().hash();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(1, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(1, &db, &mut key_manager).await;
         let hashes = vec![genesis_hash];
         let (index, headers) = db.find_headers_after_hash(hashes, 1).unwrap().unwrap();
         assert_eq!(index, 0);
@@ -325,8 +325,8 @@ mod find_headers_after_hash {
     #[tokio::test]
     async fn it_returns_the_first_headers_found() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let hashes = (1..=3)
             .rev()
             .map(|i| db.fetch_block(i, true).unwrap().block().hash())
@@ -341,8 +341,8 @@ mod find_headers_after_hash {
     async fn fnit_ignores_unknown_hashes() {
         let db = setup();
 
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let hashes = (2..=4)
             .map(|i| db.fetch_block(i, true).unwrap().block().hash())
             .chain(vec![FixedHash::zero(), FixedHash::zero()])
@@ -370,8 +370,8 @@ mod fetch_block_hashes_from_header_tip {
     #[tokio::test]
     async fn it_returns_empty_set_for_big_offset() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        add_many_chained_blocks(5, &db, &mut key_manager).await;
         let hashes = db.fetch_block_hashes_from_header_tip(3, 6).unwrap();
         assert!(hashes.is_empty());
     }
@@ -379,8 +379,8 @@ mod fetch_block_hashes_from_header_tip {
     #[tokio::test]
     async fn it_returns_n_hashes_from_tip() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (blocks, _) = add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (blocks, _) = add_many_chained_blocks(5, &db, &mut key_manager).await;
         let hashes = db.fetch_block_hashes_from_header_tip(3, 1).unwrap();
         assert_eq!(hashes.len(), 3);
         assert_eq!(hashes[0], blocks[3].hash());
@@ -391,8 +391,8 @@ mod fetch_block_hashes_from_header_tip {
     #[tokio::test]
     async fn it_returns_hashes_without_overlapping() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (blocks, _) = add_many_chained_blocks(3, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (blocks, _) = add_many_chained_blocks(3, &db, &mut key_manager).await;
         let hashes = db.fetch_block_hashes_from_header_tip(2, 0).unwrap();
         assert_eq!(hashes[0], blocks[2].hash());
         assert_eq!(hashes[1], blocks[1].hash());
@@ -404,8 +404,8 @@ mod fetch_block_hashes_from_header_tip {
     async fn it_returns_all_hashes_from_tip() {
         let db = setup();
         let genesis = db.fetch_tip_header().unwrap();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (blocks, _) = add_many_chained_blocks(5, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (blocks, _) = add_many_chained_blocks(5, &db, &mut key_manager).await;
         let hashes = db.fetch_block_hashes_from_header_tip(10, 0).unwrap();
         assert_eq!(hashes.len(), 6);
         assert_eq!(hashes[0], blocks[4].hash());
@@ -433,8 +433,8 @@ mod fetch_total_size_stats {
     async fn it_measures_the_number_of_entries() {
         let db = setup();
         let genesis_output_count = db.fetch_header(0).unwrap().unwrap().output_smt_size;
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let _block_and_outputs = add_many_chained_blocks(2, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let _block_and_outputs = add_many_chained_blocks(2, &db, &mut key_manager).await;
         let stats = db.fetch_total_size_stats().unwrap();
         assert_eq!(
             stats.sizes().iter().find(|s| s.name == "utxos").unwrap().num_entries,
@@ -492,28 +492,28 @@ mod fetch_header_containing_kernel_mmr {
     async fn it_returns_corresponding_header() {
         let db = setup();
         let genesis = db.fetch_block(0, true).unwrap();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (blocks, outputs) = add_many_chained_blocks(1, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (blocks, outputs) = add_many_chained_blocks(1, &db, &mut key_manager).await;
         let num_genesis_kernels = genesis.block().body.kernels().len() as u64;
 
         let (txns, _) = schema_to_transaction(
             &[txn_schema!(from: vec![outputs[0].clone()], to: vec![50 * T])],
-            &key_manager,
+            &mut key_manager,
         )
         .await;
 
-        let (script_key_id, wallet_payment_address) = default_coinbase_entities(&key_manager).await;
+        let (script_key_id, wallet_payment_address) = default_coinbase_entities(&mut key_manager).await;
         let (block, _) = create_next_block(
             &db,
             &blocks[0],
             txns,
-            &key_manager,
+            &mut key_manager,
             &script_key_id,
             &wallet_payment_address,
         )
         .await;
         db.add_block(block).unwrap();
-        let _block_and_outputs = add_many_chained_blocks(3, &db, &key_manager).await;
+        let _block_and_outputs = add_many_chained_blocks(3, &db, &mut key_manager).await;
 
         let header = db.fetch_header_containing_kernel_mmr(num_genesis_kernels).unwrap();
         assert_eq!(header.height(), 1);
@@ -545,8 +545,8 @@ mod clear_all_pending_headers {
     async fn it_clears_no_headers() {
         let db = setup();
         assert_eq!(db.clear_all_pending_headers().unwrap(), 0);
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let _block_and_outputs = add_many_chained_blocks(2, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let _block_and_outputs = add_many_chained_blocks(2, &db, &mut key_manager).await;
         db.clear_all_pending_headers().unwrap();
         let last_header = db.fetch_last_header().unwrap();
         assert_eq!(last_header.height, 2);
@@ -555,8 +555,8 @@ mod clear_all_pending_headers {
     #[tokio::test]
     async fn it_clears_headers_after_tip() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let _blocks_and_outputs = add_many_chained_blocks(2, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let _blocks_and_outputs = add_many_chained_blocks(2, &db, &mut key_manager).await;
         let prev_block = db.fetch_block(2, true).unwrap();
         let mut prev_accum = prev_block.accumulated_data().clone();
         let mut prev_header = prev_block.try_into_chain_block().unwrap().to_chain_header();
@@ -611,17 +611,17 @@ mod validator_node_merkle_root {
     };
     #[tokio::test]
     async fn it_has_the_correct_genesis_merkle_root() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let db = setup();
-        let (blocks, _outputs) = add_many_chained_blocks(1, &db, &key_manager).await;
+        let (blocks, _outputs) = add_many_chained_blocks(1, &db, &mut key_manager).await;
         assert_eq!(blocks[0].header.validator_node_mr, VALIDATOR_MR_EMPTY_PLACEHOLDER_HASH);
     }
 
     #[tokio::test]
     async fn it_has_the_correct_merkle_root_for_current_vn_set() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (blocks, outputs) = add_many_chained_blocks(1, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (blocks, outputs) = add_many_chained_blocks(1, &db, &mut key_manager).await;
 
         let (sk, public_key) = CompressedPublicKey::random_keypair(&mut OsRng);
         let signature = ValidatorNodeSignature::sign_for_registration(&sk, None, &public_key, VnEpoch::zero());
@@ -633,15 +633,15 @@ mod validator_node_merkle_root {
                 to: vec![50 * T],
                 features: features
             )],
-            &key_manager,
+            &mut key_manager,
         )
         .await;
-        let (script_key_id, wallet_payment_address) = default_coinbase_entities(&key_manager).await;
+        let (script_key_id, wallet_payment_address) = default_coinbase_entities(&mut key_manager).await;
         let (block, _) = create_next_block(
             &db,
             &blocks[0],
             tx,
-            &key_manager,
+            &mut key_manager,
             &script_key_id,
             &wallet_payment_address,
         )
@@ -649,7 +649,8 @@ mod validator_node_merkle_root {
         db.add_block(block).unwrap().assert_added();
 
         let consts = db.consensus_constants().unwrap();
-        let (_, _) = add_many_chained_blocks(usize::try_from(consts.epoch_length()).unwrap(), &db, &key_manager).await;
+        let (_, _) =
+            add_many_chained_blocks(usize::try_from(consts.epoch_length()).unwrap(), &db, &mut key_manager).await;
 
         let vn = db.get_validator_node(None, public_key.clone()).unwrap().unwrap();
         let merkle_root = calculate_validator_node_mr(&[vn]).unwrap();
@@ -661,8 +662,8 @@ mod validator_node_merkle_root {
     #[tokio::test]
     async fn it_has_the_correct_merkle_root_for_current_vn_set_with_sidechain() {
         let db = setup();
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (blocks, outputs) = add_many_chained_blocks(1, &db, &key_manager).await;
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (blocks, outputs) = add_many_chained_blocks(1, &db, &mut key_manager).await;
 
         let (sk, public_key) = CompressedPublicKey::random_keypair(&mut OsRng);
         let (sidechain_private, sidechain_public) = CompressedPublicKey::random_keypair(&mut OsRng);
@@ -680,7 +681,7 @@ mod validator_node_merkle_root {
                 to: vec![50 * T],
                 features: features
             )],
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let (script_key_id, wallet_payment_address) = default_coinbase_entities(&key_manager).await;
@@ -688,7 +689,7 @@ mod validator_node_merkle_root {
             &db,
             &blocks[0],
             tx,
-            &key_manager,
+            &mut key_manager,
             &script_key_id,
             &wallet_payment_address,
         )
@@ -696,7 +697,8 @@ mod validator_node_merkle_root {
         db.add_block(block).unwrap().assert_added();
 
         let consts = db.consensus_constants().unwrap();
-        let (_, _) = add_many_chained_blocks(usize::try_from(consts.epoch_length()).unwrap(), &db, &key_manager).await;
+        let (_, _) =
+            add_many_chained_blocks(usize::try_from(consts.epoch_length()).unwrap(), &db, &mut key_manager).await;
 
         let vn = db
             .get_validator_node(Some(sidechain_public.clone()), public_key.clone())

--- a/base_layer/core/src/mempool/priority/prioritized_transaction.rs
+++ b/base_layer/core/src/mempool/priority/prioritized_transaction.rs
@@ -143,7 +143,7 @@ mod tests {
     use tari_transaction_key_manager::{create_memory_db_key_manager, MemoryDbKeyManager};
 
     use super::*;
-    async fn create_tx_with_fee(fee_per_gram: MicroMinotari, key_manager: &MemoryDbKeyManager) -> Transaction {
+    async fn create_tx_with_fee(fee_per_gram: MicroMinotari, key_manager: &mut MemoryDbKeyManager) -> Transaction {
         let (tx, _, _) = create_tx(10 * T, fee_per_gram, 0, 1, 0, 1, Default::default(), key_manager)
             .await
             .expect("Failed to get tx");
@@ -152,13 +152,13 @@ mod tests {
 
     #[tokio::test]
     async fn fee_increases_priority() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let weighting = TransactionWeight::latest();
         let epoch = u64::MAX / 2;
-        let tx = create_tx_with_fee(2 * uT, &key_manager).await;
+        let tx = create_tx_with_fee(2 * uT, &mut key_manager).await;
         let p1 = FeePriority::new(&tx, epoch, tx.calculate_weight(&weighting).expect("Failed to get tx")).unwrap();
 
-        let tx = create_tx_with_fee(3 * uT, &key_manager).await;
+        let tx = create_tx_with_fee(3 * uT, &mut key_manager).await;
         let p2 = FeePriority::new(&tx, epoch, tx.calculate_weight(&weighting).expect("Failed to get tx")).unwrap();
 
         assert!(p2 > p1);
@@ -166,13 +166,13 @@ mod tests {
 
     #[tokio::test]
     async fn age_increases_priority() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let weighting = TransactionWeight::latest();
         let epoch = u64::MAX / 2;
-        let tx = create_tx_with_fee(2 * uT, &key_manager).await;
+        let tx = create_tx_with_fee(2 * uT, &mut key_manager).await;
         let p1 = FeePriority::new(&tx, epoch, tx.calculate_weight(&weighting).expect("Failed to get tx")).unwrap();
 
-        let tx = create_tx_with_fee(2 * uT, &key_manager).await;
+        let tx = create_tx_with_fee(2 * uT, &mut key_manager).await;
         let p2 = FeePriority::new(
             &tx,
             epoch - 1,

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -342,34 +342,34 @@ mod test {
     use crate::{consensus::BaseNodeConsensusManagerBuilder, test_helpers::create_orphan_block};
     #[tokio::test]
     async fn test_insert_expire_by_height() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let tx1 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(100), lock: 4000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(100), lock: 4000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx2 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(60), lock: 3000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(60), lock: 3000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx3 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(20), lock: 2500, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(20), lock: 2500, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx4 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(40), lock: 1000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(40), lock: 1000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx5 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(100), lock: 2000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(100), lock: 2000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx6 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(120), lock: 5500, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(120), lock: 5500, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
@@ -402,19 +402,19 @@ mod test {
 
     #[tokio::test]
     async fn test_remove_all() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let tx1 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(100), lock: 4000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(100), lock: 4000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx2 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(60), lock: 3000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(60), lock: 3000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx3 = Arc::new(
-            tx!(MicroMinotari(100_000), fee: MicroMinotari(20), lock: 2500, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(100_000), fee: MicroMinotari(20), lock: 2500, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
@@ -439,36 +439,36 @@ mod test {
 
     #[tokio::test]
     async fn remove_scan_for_and_remove_reorged_txs() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let network = Network::LocalNet;
         let consensus = BaseNodeConsensusManagerBuilder::new(network).build().unwrap();
         let tx1 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(10), lock: 4000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(10), lock: 4000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx2 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(6), lock: 3000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(6), lock: 3000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx3 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(4), lock: 2500, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(4), lock: 2500, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx4 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(4), lock: 1000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(4), lock: 1000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx5 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(10), lock: 2000, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(10), lock: 2000, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx6 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(12), lock: 5500, inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(12), lock: 5500, inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );

--- a/base_layer/core/src/mempool/sync_protocol/test.rs
+++ b/base_layer/core/src/mempool/sync_protocol/test.rs
@@ -58,10 +58,10 @@ use crate::{
 };
 
 pub async fn create_transactions(n: usize) -> Vec<Transaction> {
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let mut transactions = Vec::new();
     for _i in 0..n {
-        let (transaction, _, _) = create_tx(5000 * uT, 3 * uT, 1, 2, 1, 3, Default::default(), &key_manager)
+        let (transaction, _, _) = create_tx(5000 * uT, 3 * uT, 1, 2, 1, 3, Default::default(), &mut key_manager)
             .await
             .expect("Failed to get transaction");
         transactions.push(transaction);

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -877,14 +877,14 @@ mod test {
     };
     #[tokio::test]
     async fn test_find_duplicate_input() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let tx1 = Arc::new(
-            tx!(MicroMinotari(5000), fee: MicroMinotari(5), inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(5000), fee: MicroMinotari(5), inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx2 = Arc::new(
-            tx!(MicroMinotari(5000), fee: MicroMinotari(5), inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(5000), fee: MicroMinotari(5), inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
@@ -906,29 +906,29 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_and_retrieve_highest_priority_txs() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let tx1 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(5), inputs: 2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(5), inputs: 2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx2 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(4), inputs: 4, outputs: 1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(4), inputs: 4, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx3 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(20), inputs: 5, outputs: 1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(20), inputs: 5, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx4 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(6), inputs: 3, outputs: 1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(6), inputs: 3, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx5 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(11), inputs: 5, outputs: 1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(11), inputs: 5, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
@@ -969,12 +969,12 @@ mod test {
 
     #[tokio::test]
     async fn test_double_spend_inputs() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (tx1, _, _) = tx!(MicroMinotari(5_000), fee: MicroMinotari(10), inputs: 1, outputs: 1, &key_manager)
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (tx1, _, _) = tx!(MicroMinotari(5_000), fee: MicroMinotari(10), inputs: 1, outputs: 1, &mut key_manager)
             .expect("Failed to get tx");
         const INPUT_AMOUNT: MicroMinotari = MicroMinotari(5_000);
-        let (tx2, inputs, _) =
-            tx!(INPUT_AMOUNT, fee: MicroMinotari(5), inputs: 1, outputs: 1, &key_manager).expect("Failed to get tx");
+        let (tx2, inputs, _) = tx!(INPUT_AMOUNT, fee: MicroMinotari(5), inputs: 1, outputs: 1, &mut key_manager)
+            .expect("Failed to get tx");
 
         let mut tx_builder =
             TransactionBuilder::new(create_consensus_constants(0), key_manager.clone(), Network::LocalNet)
@@ -983,7 +983,7 @@ mod test {
 
         tx_builder.with_lock_height(0).with_fee_per_gram(5.into());
 
-        let test_params = TestParams::new(&key_manager).await;
+        let test_params = TestParams::new(&mut key_manager).await;
         // Double spend the input from tx2 in tx3
         let double_spend_input = inputs.first().unwrap().clone();
 
@@ -1003,7 +1003,7 @@ mod test {
                     value: INPUT_AMOUNT - estimated_fee,
                     ..Default::default()
                 },
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap();
@@ -1048,36 +1048,36 @@ mod test {
 
     #[tokio::test]
     async fn test_remove_reorg_txs() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let network = Network::LocalNet;
         let consensus = BaseNodeConsensusManagerBuilder::new(network).build().unwrap();
         let tx1 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(5), inputs:2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(5), inputs:2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx2 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(2), inputs:3, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(2), inputs:3, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx3 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(1), inputs:2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(1), inputs:2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx4 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(3), inputs:4, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(3), inputs:4, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx5 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(5), inputs:3, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(5), inputs:3, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx6 = Arc::new(
-            tx!(MicroMinotari(10_000), fee: MicroMinotari(7), inputs:2, outputs: 1, &key_manager)
+            tx!(MicroMinotari(10_000), fee: MicroMinotari(7), inputs:2, outputs: 1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
@@ -1120,32 +1120,32 @@ mod test {
 
     #[tokio::test]
     async fn test_discard_double_spend_txs() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let consensus = create_consensus_rules();
         let tx1 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(5), inputs:2, outputs:1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(5), inputs:2, outputs:1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx2 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(4), inputs:3, outputs:1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(4), inputs:3, outputs:1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx3 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(5), inputs:2, outputs:1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(5), inputs:2, outputs:1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
         let tx4 = Arc::new(
-            tx!(MicroMinotari(5_000), fee: MicroMinotari(6), inputs:2, outputs:1, &key_manager)
+            tx!(MicroMinotari(5_000), fee: MicroMinotari(6), inputs:2, outputs:1, &mut key_manager)
                 .expect("Failed to get tx")
                 .0,
         );
-        let mut tx5 = tx!(MicroMinotari(5_000), fee:MicroMinotari(5), inputs:3, outputs:1, &key_manager)
+        let mut tx5 = tx!(MicroMinotari(5_000), fee:MicroMinotari(5), inputs:3, outputs:1, &mut key_manager)
             .expect("Failed to get tx")
             .0;
-        let mut tx6 = tx!(MicroMinotari(5_000), fee:MicroMinotari(13), inputs: 2, outputs: 1, &key_manager)
+        let mut tx6 = tx!(MicroMinotari(5_000), fee:MicroMinotari(13), inputs: 2, outputs: 1, &mut key_manager)
             .expect("Failed to get tx")
             .0;
         // tx1 and tx5 have a shared input. Also, tx3 and tx6 have a shared input
@@ -1195,18 +1195,18 @@ mod test {
 
     #[tokio::test]
     async fn test_multiple_transactions_with_same_outputs_in_mempool() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
-        let (tx1, _, _) = tx!(MicroMinotari(150_000), fee: MicroMinotari(50), inputs:5, outputs:5, &key_manager)
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
+        let (tx1, _, _) = tx!(MicroMinotari(150_000), fee: MicroMinotari(50), inputs:5, outputs:5, &mut key_manager)
             .expect("Failed to get tx");
-        let (tx2, _, _) = tx!(MicroMinotari(250_000), fee: MicroMinotari(50), inputs:5, outputs:5, &key_manager)
+        let (tx2, _, _) = tx!(MicroMinotari(250_000), fee: MicroMinotari(50), inputs:5, outputs:5, &mut key_manager)
             .expect("Failed to get tx");
 
         // Create transactions with duplicate kernels (will not pass internal validation, but that is ok)
         let mut tx3 = tx1.clone();
         let mut tx4 = tx2.clone();
-        let (tx5, _, _) = tx!(MicroMinotari(350_000), fee: MicroMinotari(50), inputs:5, outputs:5, &key_manager)
+        let (tx5, _, _) = tx!(MicroMinotari(350_000), fee: MicroMinotari(50), inputs:5, outputs:5, &mut key_manager)
             .expect("Failed to get tx");
-        let (tx6, _, _) = tx!(MicroMinotari(450_000), fee: MicroMinotari(50), inputs:5, outputs:5, &key_manager)
+        let (tx6, _, _) = tx!(MicroMinotari(450_000), fee: MicroMinotari(50), inputs:5, outputs:5, &mut key_manager)
             .expect("Failed to get tx");
         tx3.body.set_kernel(tx5.body.kernels()[0].clone());
         tx4.body.set_kernel(tx6.body.kernels()[0].clone());
@@ -1298,14 +1298,14 @@ mod test {
 
         #[tokio::test]
         async fn it_compiles_correct_stats_for_single_block() {
-            let key_manager = create_memory_db_key_manager().await.unwrap();
-            let (tx1, _, _) = tx!(MicroMinotari(150_000), fee: MicroMinotari(5), inputs:5, outputs:1, &key_manager)
+            let mut key_manager = create_memory_db_key_manager().await.unwrap();
+            let (tx1, _, _) = tx!(MicroMinotari(150_000), fee: MicroMinotari(5), inputs:5, outputs:1, &mut key_manager)
                 .expect("Failed to get tx");
-            let (tx2, _, _) = tx!(MicroMinotari(250_000), fee: MicroMinotari(5), inputs:5, outputs:5, &key_manager)
+            let (tx2, _, _) = tx!(MicroMinotari(250_000), fee: MicroMinotari(5), inputs:5, outputs:5, &mut key_manager)
                 .expect("Failed to get tx");
-            let (tx3, _, _) = tx!(MicroMinotari(350_000), fee: MicroMinotari(4), inputs:2, outputs:1, &key_manager)
+            let (tx3, _, _) = tx!(MicroMinotari(350_000), fee: MicroMinotari(4), inputs:2, outputs:1, &mut key_manager)
                 .expect("Failed to get tx");
-            let (tx4, _, _) = tx!(MicroMinotari(450_000), fee: MicroMinotari(4), inputs:4, outputs:5, &key_manager)
+            let (tx4, _, _) = tx!(MicroMinotari(450_000), fee: MicroMinotari(4), inputs:4, outputs:5, &mut key_manager)
                 .expect("Failed to get tx");
 
             let tx_weight = TransactionWeight::latest();
@@ -1328,7 +1328,7 @@ mod test {
 
         #[tokio::test]
         async fn it_compiles_correct_stats_for_multiple_blocks() {
-            let key_manager = create_memory_db_key_manager().await.unwrap();
+            let mut key_manager = create_memory_db_key_manager().await.unwrap();
             let expected_stats = [
                 FeePerGramStat {
                     order: 0,
@@ -1346,13 +1346,14 @@ mod test {
             let mut transactions = Vec::new();
             for i in 0..50 {
                 let (tx, _, _) =
-                    tx!(MicroMinotari(150_000 + i), fee: MicroMinotari(10), inputs: 1, outputs: 1, &key_manager)
+                    tx!(MicroMinotari(150_000 + i), fee: MicroMinotari(10), inputs: 1, outputs: 1, &mut key_manager)
                         .expect("Failed to get tx");
                 transactions.push(Arc::new(tx));
             }
 
-            let (tx1, _, _) = tx!(MicroMinotari(150_000), fee: MicroMinotari(5), inputs:1, outputs: 5, &key_manager)
-                .expect("Failed to get tx");
+            let (tx1, _, _) =
+                tx!(MicroMinotari(150_000), fee: MicroMinotari(5), inputs:1, outputs: 5, &mut key_manager)
+                    .expect("Failed to get tx");
             transactions.push(Arc::new(tx1));
 
             let tx_weight = TransactionWeight::latest();

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -586,7 +586,7 @@ pub async fn create_chained_blocks<T: Into<BlockSpecs>, TDB: BlockchainBackend>(
     let gb_height = genesis_block.header().height;
     block_hashes.insert("GB".to_string(), genesis_block);
     let rules = BaseNodeConsensusManager::builder(Network::LocalNet).build().unwrap();
-    let km = create_memory_db_key_manager().await.unwrap();
+    let mut km = create_memory_db_key_manager().await.unwrap();
     let blocks: BlockSpecs = blocks.into();
     let mut block_names = Vec::with_capacity(blocks.len());
     let (script_key_id, wallet_payment_address) = default_coinbase_entities(&km).await;
@@ -631,7 +631,7 @@ pub async fn create_chained_blocks<T: Into<BlockSpecs>, TDB: BlockchainBackend>(
             &rules,
             prev_block.block(),
             block_spec,
-            &km,
+            &mut km,
             &script_key_id,
             &wallet_payment_address,
             None,
@@ -776,7 +776,7 @@ impl TestBlockchain {
         Ok(blocks)
     }
 
-    pub async fn create_chain(&self, block_specs: BlockSpecs) -> Vec<(Arc<ChainBlock>, WalletOutput)> {
+    pub async fn create_chain(&mut self, block_specs: BlockSpecs) -> Vec<(Arc<ChainBlock>, WalletOutput)> {
         let mut result = Vec::new();
         for spec in block_specs {
             result.push(self.create_chained_block(spec).await);
@@ -834,7 +834,6 @@ impl TestBlockchain {
         block: Arc<ChainBlock>,
     ) -> Result<BlockAddResult, ChainStorageError> {
         let result = self.db.add_block(block.to_arc_block())?;
-        // let smt = self.db.smt().read().unwrap().clone();
         self.chain.push((name, block));
         Ok(result)
     }
@@ -847,41 +846,61 @@ impl TestBlockchain {
         self.chain.last().cloned().unwrap()
     }
 
-    pub async fn create_chained_block(&self, block_spec: BlockSpec) -> (Arc<ChainBlock>, WalletOutput) {
-        let parent = self
-            .get_block_and_smt_by_name(block_spec.parent)
-            .ok_or_else(|| format!("Parent block not found with name '{}'", block_spec.parent))
-            .unwrap();
+    pub async fn create_chained_block(&mut self, block_spec: BlockSpec) -> (Arc<ChainBlock>, WalletOutput) {
+        let parent = self.get_block_and_smt_by_name(block_spec.parent).unwrap();
+
         let difficulty = block_spec.difficulty;
+
+        // Destructure self to prove to the borrow checker that we are borrowing disjoint fields.
+        let Self {
+            db,
+            rules,
+            km,
+            script_key_id,
+            wallet_payment_address,
+            range_proof_type,
+            ..
+        } = self;
+
         let (block, coinbase) = create_block(
-            self.db(),
-            &self.rules,
+            db,
+            rules,
             parent.block(),
             block_spec,
-            &self.km,
-            &self.script_key_id,
-            &self.wallet_payment_address,
-            Some(self.range_proof_type),
+            km,
+            script_key_id,
+            wallet_payment_address,
+            Some(*range_proof_type),
         )
         .await;
+
         let block = mine_block(block, parent.accumulated_data(), difficulty);
         (block, coinbase)
     }
 
-    pub async fn create_unmined_block(&self, block_spec: BlockSpec) -> (Block, WalletOutput) {
-        let parent = self
-            .get_block_and_smt_by_name(block_spec.parent)
-            .ok_or_else(|| format!("Parent block not found with name '{}'", block_spec.parent))
-            .unwrap();
+    pub async fn create_unmined_block(&mut self, block_spec: BlockSpec) -> (Block, WalletOutput) {
+        let parent = self.get_block_and_smt_by_name(block_spec.parent).unwrap();
+
+        // Destructure self to prove to the borrow checker that we are borrowing disjoint fields.
+        let Self {
+            db,
+            rules,
+            km,
+            script_key_id,
+            wallet_payment_address,
+            range_proof_type,
+            ..
+        } = self;
+
         let (mut block, outputs) = create_block(
-            self.db(),
-            &self.rules,
+            db,
+            rules,
             parent.block(),
             block_spec,
-            &self.km,
-            &self.script_key_id,
-            &self.wallet_payment_address,
-            Some(self.range_proof_type),
+            km,
+            script_key_id,
+            wallet_payment_address,
+            Some(*range_proof_type),
         )
         .await;
         block.body.sort();
@@ -893,7 +912,7 @@ impl TestBlockchain {
         mine_block(block, parent.accumulated_data(), difficulty)
     }
 
-    pub async fn create_next_tip(&self, spec: BlockSpec) -> (Arc<ChainBlock>, WalletOutput) {
+    pub async fn create_next_tip(&mut self, spec: BlockSpec) -> (Arc<ChainBlock>, WalletOutput) {
         let (name, _) = self.get_tip_block();
         self.create_chained_block(spec.with_parent_block(name)).await
     }

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -122,7 +122,7 @@ pub async fn create_block<TDB: BlockchainBackend>(
     rules: &BaseNodeConsensusManager,
     prev_block: &Block,
     spec: BlockSpec,
-    km: &MemoryDbKeyManager,
+    km: &mut MemoryDbKeyManager,
     script_key_id: &TariKeyId,
     wallet_payment_address: &TariAddress,
     range_proof_type: Option<RangeProofType>,

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -90,7 +90,7 @@ async fn it_passes_if_large_output_block_is_valid() {
     }
 
     let schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: outs);
-    let (txs, _outputs) = schema_to_transaction(&[schema1], &blockchain.km).await;
+    let (txs, _outputs) = schema_to_transaction(&[schema1], &mut blockchain.km).await;
 
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
     let (chain_block, _coinbase_b) = blockchain
@@ -126,7 +126,7 @@ async fn it_validates_when_a_coinbase_is_spent() {
     let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).await.unwrap();
 
     let schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![9000 * uT]);
-    let (txs, _outputs) = schema_to_transaction(&[schema1], &blockchain.km).await;
+    let (txs, _outputs) = schema_to_transaction(&[schema1], &mut blockchain.km).await;
 
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
     let (chain_block, _coinbase_b) = blockchain
@@ -155,7 +155,7 @@ async fn it_passes_if_large_block_is_valid() {
     let (mut blockchain, validator) = setup(false).await;
     let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).await.unwrap();
     let schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![5 * T, 5 * T, 5 * T, 5 * T, 5 * T, 5 * T, 5 * T, 5 * T, 5 * T, 5 * T, 5 * T, 5 * T]);
-    let (txs, outputs) = schema_to_transaction(&[schema1], &blockchain.km).await;
+    let (txs, outputs) = schema_to_transaction(&[schema1], &mut blockchain.km).await;
 
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
     let (_block, _coinbase_b) = blockchain
@@ -168,7 +168,7 @@ async fn it_passes_if_large_block_is_valid() {
         let new_schema = txn_schema!(from: vec![output.clone()], to: vec![1 * T, 1 * T, 1 * T, 1 * T]);
         schemas.push(new_schema);
     }
-    let (txs, _) = schema_to_transaction(&schemas, &blockchain.km).await;
+    let (txs, _) = schema_to_transaction(&schemas, &mut blockchain.km).await;
 
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
     let (chain_block, _coinbase_c) = blockchain
@@ -200,7 +200,7 @@ async fn it_passes_if_large_block_is_valid() {
 
 #[tokio::test]
 async fn it_passes_if_block_is_valid() {
-    let (blockchain, validator) = setup(true).await;
+    let (mut blockchain, validator) = setup(true).await;
 
     let (chain_block, _) = blockchain.create_next_tip(BlockSpec::default()).await;
 
@@ -223,7 +223,7 @@ async fn it_passes_if_block_is_valid() {
 
 #[tokio::test]
 async fn it_checks_the_coinbase_reward() {
-    let (blockchain, validator) = setup(true).await;
+    let (mut blockchain, validator) = setup(true).await;
 
     let (block, _) = blockchain
         .create_chained_block(block_spec!("A", parent: "GB", reward: 10 * T, ))
@@ -241,7 +241,7 @@ async fn it_checks_the_coinbase_reward() {
 
 #[tokio::test]
 async fn it_allows_multiple_coinbases() {
-    let (blockchain, validator) = setup(true).await;
+    let (mut blockchain, validator) = setup(true).await;
 
     let (mut block, coinbase) = blockchain.create_unmined_block(block_spec!("A1", parent: "GB")).await;
     let commitment_mask_key = TariKeyId::Managed {
@@ -288,7 +288,7 @@ async fn it_checks_duplicate_kernel() {
     let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).await.unwrap();
     let (txs, _) = schema_to_transaction(
         &[txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T])],
-        &blockchain.km,
+        &mut blockchain.km,
     )
     .await;
 
@@ -315,7 +315,7 @@ async fn it_checks_double_spends() {
     let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).await.unwrap();
     let (txs, _) = schema_to_transaction(
         &[txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T])],
-        &blockchain.km,
+        &mut blockchain.km,
     )
     .await;
 
@@ -326,7 +326,7 @@ async fn it_checks_double_spends() {
     // lets create a new transction from the same input
     let (txs2, _) = schema_to_transaction(
         &[txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T])],
-        &blockchain.km,
+        &mut blockchain.km,
     )
     .await;
     let (block, _) = blockchain
@@ -350,7 +350,7 @@ async fn it_checks_input_maturity() {
     let mut features = schema.from[0].features().clone();
     features.maturity = 100;
     schema.from[0].set_features(features);
-    let (txs, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+    let (txs, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
     let (block, _) = blockchain
         .create_next_tip(
@@ -375,7 +375,7 @@ async fn it_checks_txo_sort_order() {
     let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).await.unwrap();
 
     let schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T, 12 * T]);
-    let (txs, _) = schema_to_transaction(&[schema1], &blockchain.km).await;
+    let (txs, _) = schema_to_transaction(&[schema1], &mut blockchain.km).await;
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
 
     let (mut block, _) = blockchain
@@ -412,7 +412,7 @@ async fn it_limits_the_script_byte_size() {
 
     let mut schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T, 12 * T]);
     schema1.script = script!(Nop Nop Nop).unwrap();
-    let (txs, _) = schema_to_transaction(&[schema1], &blockchain.km).await;
+    let (txs, _) = schema_to_transaction(&[schema1], &mut blockchain.km).await;
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
     let (block, _) = blockchain.create_next_tip(block_spec!("B", transactions: txs)).await;
 
@@ -440,7 +440,7 @@ async fn it_limits_the_encrypted_data_byte_size() {
 
     let mut schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T, 12 * T]);
     schema1.script = script!(Nop Nop Nop).unwrap();
-    let (txs, _) = schema_to_transaction(&[schema1], &blockchain.km).await;
+    let (txs, _) = schema_to_transaction(&[schema1], &mut blockchain.km).await;
     let mut txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
     let mut outputs = txs[0].body.outputs().clone();
     outputs[0].encrypted_data = EncryptedData::from_bytes(&vec![0; STATIC_ENCRYPTED_DATA_SIZE_TOTAL + 250]).unwrap();
@@ -473,7 +473,7 @@ async fn it_rejects_invalid_input_metadata() {
 
     let mut schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T, 12 * T]);
     schema1.from[0].set_sender_offset_public_key(Default::default());
-    let (txs, _) = schema_to_transaction(&[schema1], &blockchain.km).await;
+    let (txs, _) = schema_to_transaction(&[schema1], &mut blockchain.km).await;
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
     let (block, _) = blockchain.create_next_tip(block_spec!("B", transactions: txs)).await;
 
@@ -488,13 +488,13 @@ async fn it_rejects_zero_conf_double_spends() {
     let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).await.unwrap();
 
     let schema = txn_schema!(from: vec![coinbase.clone()], to: vec![201 * T]);
-    let (initial_tx, outputs) = schema_to_transaction(&[schema], &blockchain.km).await;
+    let (initial_tx, outputs) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
     let schema = txn_schema!(from: vec![outputs[0].clone()], to: vec![200 * T]);
-    let (first_spend, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+    let (first_spend, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
     let schema = txn_schema!(from: vec![outputs[0].clone()], to: vec![150 * T]);
-    let (double_spend, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+    let (double_spend, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
     let transactions = initial_tx
         .into_iter()
@@ -534,7 +534,7 @@ mod body_only {
 
         let mut schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T, 12 * T]);
         schema1.from[0].set_sender_offset_public_key(Default::default());
-        let (txs, _) = schema_to_transaction(&[schema1], &blockchain.km).await;
+        let (txs, _) = schema_to_transaction(&[schema1], &mut blockchain.km).await;
         let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
         let (block, _) = blockchain
             .create_next_tip(BlockSpec::new().with_transactions(txs).finish())
@@ -569,13 +569,13 @@ mod orphan_validator {
         let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).await.unwrap();
 
         let schema = txn_schema!(from: vec![coinbase.clone()], to: vec![201 * T]);
-        let (initial_tx, outputs) = schema_to_transaction(&[schema], &blockchain.km).await;
+        let (initial_tx, outputs) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
         let schema = txn_schema!(from: vec![outputs[0].clone()], to: vec![200 * T]);
-        let (first_spend, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+        let (first_spend, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
         let schema = txn_schema!(from: vec![outputs[0].clone()], to: vec![150 * T]);
-        let (double_spend, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+        let (double_spend, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
         let transactions = initial_tx
             .into_iter()
@@ -610,7 +610,7 @@ mod orphan_validator {
         let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).await.unwrap();
 
         let schema = txn_schema!(from: vec![coinbase.clone()], to: vec![201 * T]);
-        let (tx, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+        let (tx, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
         let transactions = tx.into_iter().map(|b| Arc::try_unwrap(b).unwrap()).collect::<Vec<_>>();
 
@@ -645,7 +645,7 @@ mod orphan_validator {
         let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).await.unwrap();
 
         let schema = txn_schema!(from: vec![coinbase.clone()], to: vec![201 * T]);
-        let (tx, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+        let (tx, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
         let transactions = tx.into_iter().map(|b| Arc::try_unwrap(b).unwrap()).collect::<Vec<_>>();
 
@@ -682,7 +682,7 @@ mod orphan_validator {
         let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).await.unwrap();
 
         let schema = txn_schema!(from: vec![coinbase.clone()], to: vec![201 * T]);
-        let (tx, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+        let (tx, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
         let transactions = tx.into_iter().map(|b| Arc::try_unwrap(b).unwrap()).collect::<Vec<_>>();
 
@@ -710,7 +710,7 @@ mod orphan_validator {
         let (_, coinbase) = blockchain.append(block_spec!("1", parent: "GB")).await.unwrap();
 
         let schema = txn_schema!(from: vec![coinbase.clone()], to: vec![201 * T]);
-        let (tx, _) = schema_to_transaction(&[schema], &blockchain.km).await;
+        let (tx, _) = schema_to_transaction(&[schema], &mut blockchain.km).await;
 
         let transactions = tx.into_iter().map(|b| Arc::try_unwrap(b).unwrap()).collect::<Vec<_>>();
 

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -551,20 +551,20 @@ mod test {
         #[tokio::test]
         async fn it_succeeds_for_valid_coinbase() {
             let height = 1;
-            let key_manager = create_memory_db_key_manager().await.unwrap();
-            let test_params = TestParams::new(&key_manager).await;
+            let mut key_manager = create_memory_db_key_manager().await.unwrap();
+            let test_params = TestParams::new(&mut key_manager).await;
             let rules = test_helpers::create_consensus_manager();
-            let key_manager = create_memory_db_key_manager().await.unwrap();
+            let mut key_manager = create_memory_db_key_manager().await.unwrap();
             let coinbase = block_on(test_helpers::create_coinbase_wallet_output(
                 &test_params,
                 height,
                 None,
                 RangeProofType::RevealedValue,
-                &key_manager,
+                &mut key_manager,
             ));
             let coinbase_output = coinbase.to_transaction_output().unwrap();
             let coinbase_kernel =
-                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &key_manager).await;
+                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &mut key_manager).await;
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
 
@@ -577,15 +577,15 @@ mod test {
         #[tokio::test]
         async fn it_returns_error_for_invalid_coinbase_maturity() {
             let height = 1;
-            let key_manager = create_memory_db_key_manager().await.unwrap();
-            let test_params = TestParams::new(&key_manager).await;
+            let mut key_manager = create_memory_db_key_manager().await.unwrap();
+            let test_params = TestParams::new(&mut key_manager).await;
             let rules = test_helpers::create_consensus_manager();
             let mut coinbase = test_helpers::create_coinbase_wallet_output(
                 &test_params,
                 height,
                 None,
                 RangeProofType::RevealedValue,
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             let mut features = coinbase.features().clone();
@@ -593,7 +593,7 @@ mod test {
             coinbase.set_features(features);
             let coinbase_output = coinbase.to_transaction_output().unwrap();
             let coinbase_kernel =
-                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &key_manager).await;
+                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &mut key_manager).await;
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
 
@@ -609,21 +609,21 @@ mod test {
         #[tokio::test]
         async fn it_returns_error_for_invalid_coinbase_reward() {
             let height = 1;
-            let key_manager = create_memory_db_key_manager().await.unwrap();
-            let test_params = TestParams::new(&key_manager).await;
+            let mut key_manager = create_memory_db_key_manager().await.unwrap();
+            let test_params = TestParams::new(&mut key_manager).await;
             let rules = test_helpers::create_consensus_manager();
             let mut coinbase = test_helpers::create_coinbase_wallet_output(
                 &test_params,
                 height,
                 None,
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             coinbase.set_value(123.into(), &key_manager).await.unwrap();
             let coinbase_output = coinbase.to_transaction_output().unwrap();
             let coinbase_kernel =
-                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &key_manager).await;
+                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &mut key_manager).await;
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
             let reward = rules.calculate_coinbase_and_fees(height, body.kernels()).unwrap();

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -196,10 +196,10 @@ async fn chain_balance_validation() {
         .unwrap();
     let genesis = consensus_manager.get_genesis_block();
     let pre_mine_value = 5000 * uT;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let (pre_mine_utxo, pre_mine_key_id, _) = create_utxo(
         pre_mine_value,
-        &key_manager,
+        &mut key_manager,
         &OutputFeatures::default(),
         &TariScript::default(),
         &Covenant::default(),
@@ -207,7 +207,7 @@ async fn chain_balance_validation() {
     )
     .await;
     let (pk, sig) = create_random_signature_from_secret_key(
-        &key_manager,
+        &mut key_manager,
         pre_mine_key_id,
         0.into(),
         0,
@@ -288,7 +288,7 @@ async fn chain_balance_validation() {
     let coinbase_value = consensus_manager.get_block_reward_at(1);
     let (coinbase, coinbase_key_id, _) = create_utxo(
         coinbase_value,
-        &key_manager,
+        &mut key_manager,
         &OutputFeatures::create_coinbase(1, None, RangeProofType::BulletProofPlus),
         &TariScript::default(),
         &Covenant::default(),
@@ -297,7 +297,7 @@ async fn chain_balance_validation() {
     .await;
 
     let (pk, sig) = create_random_signature_from_secret_key(
-        &key_manager,
+        &mut key_manager,
         coinbase_key_id,
         0.into(),
         0,
@@ -355,7 +355,7 @@ async fn chain_balance_validation() {
     let v = consensus_manager.get_block_reward_at(2) + uT;
     let (coinbase, spending_key_id, _) = create_utxo(
         v,
-        &key_manager,
+        &mut key_manager,
         &OutputFeatures::create_coinbase(1, None, RangeProofType::BulletProofPlus),
         &TariScript::default(),
         &Covenant::default(),
@@ -363,7 +363,7 @@ async fn chain_balance_validation() {
     )
     .await;
     let (pk, sig) = create_random_signature_from_secret_key(
-        &key_manager,
+        &mut key_manager,
         spending_key_id,
         0.into(),
         0,
@@ -424,10 +424,10 @@ async fn chain_balance_validation_burned() {
         .unwrap();
     let genesis = consensus_manager.get_genesis_block();
     let pre_mine_value = 5000 * uT;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let (pre_mine_utxo, pre_mine_key_id, _) = create_utxo(
         pre_mine_value,
-        &key_manager,
+        &mut key_manager,
         &OutputFeatures::default(),
         &TariScript::default(),
         &Covenant::default(),
@@ -435,7 +435,7 @@ async fn chain_balance_validation_burned() {
     )
     .await;
     let (pk, sig) = create_random_signature_from_secret_key(
-        &key_manager,
+        &mut key_manager,
         pre_mine_key_id,
         0.into(),
         0,
@@ -517,7 +517,7 @@ async fn chain_balance_validation_burned() {
     let coinbase_value = consensus_manager.get_block_reward_at(1) - MicroMinotari::from(100);
     let (coinbase, coinbase_key_id, _) = create_utxo(
         coinbase_value,
-        &key_manager,
+        &mut key_manager,
         &OutputFeatures::create_coinbase(1, None, RangeProofType::RevealedValue),
         &TariScript::default(),
         &Covenant::default(),
@@ -525,7 +525,7 @@ async fn chain_balance_validation_burned() {
     )
     .await;
     let (pk, sig) = create_random_signature_from_secret_key(
-        &key_manager,
+        &mut key_manager,
         coinbase_key_id,
         0.into(),
         0,
@@ -543,7 +543,7 @@ async fn chain_balance_validation_burned() {
 
     let (burned, burned_key_id, _) = create_utxo(
         100.into(),
-        &key_manager,
+        &mut key_manager,
         &OutputFeatures::create_burn_output(),
         &TariScript::default(),
         &Covenant::default(),
@@ -552,7 +552,7 @@ async fn chain_balance_validation_burned() {
     .await;
 
     let (pk2, sig2) = create_random_signature_from_secret_key(
-        &key_manager,
+        &mut key_manager,
         burned_key_id,
         0.into(),
         0,
@@ -624,14 +624,14 @@ mod transaction_validator {
 
     #[tokio::test]
     async fn it_rejects_coinbase_outputs() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let consensus_manager = BaseNodeConsensusManagerBuilder::new(Network::LocalNet).build().unwrap();
         let db = create_store_with_consensus(consensus_manager.clone());
         let factories = CryptoFactories::default();
         let validator =
             TransactionInternalConsistencyValidator::new(true, consensus_manager.consensus_manager(), factories);
         let features = OutputFeatures::create_coinbase(0, None, RangeProofType::BulletProofPlus);
-        let tx = match tx!(MicroMinotari(100_000), fee: MicroMinotari(5), inputs: 1, outputs: 1, features: features, &key_manager)
+        let tx = match tx!(MicroMinotari(100_000), fee: MicroMinotari(5), inputs: 1, outputs: 1, features: features, &mut key_manager)
         {
             Ok((tx, _, _)) => tx,
             Err(e) => panic!("Error found: {e}"),
@@ -647,7 +647,7 @@ mod transaction_validator {
 
     #[tokio::test]
     async fn coinbase_extra_must_be_empty() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let consensus_manager = BaseNodeConsensusManagerBuilder::new(Network::LocalNet).build().unwrap();
         let db = create_store_with_consensus(consensus_manager.clone());
         let factories = CryptoFactories::default();
@@ -655,7 +655,7 @@ mod transaction_validator {
             TransactionInternalConsistencyValidator::new(true, consensus_manager.consensus_manager(), factories);
         let mut features = OutputFeatures { ..Default::default() };
         features.coinbase_extra = CoinBaseExtra::try_from(b"deadbeef".to_vec()).unwrap();
-        let tx = match tx!(MicroMinotari(100_000), fee: MicroMinotari(5), inputs: 1, outputs: 1, features: features, &key_manager)
+        let tx = match tx!(MicroMinotari(100_000), fee: MicroMinotari(5), inputs: 1, outputs: 1, features: features, &mut key_manager)
         {
             Ok((tx, _, _)) => tx,
             Err(e) => panic!("Error found: {e}"),

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -72,7 +72,7 @@ pub async fn create_coinbase(
     value: MicroMinotari,
     maturity_height: u64,
     extra: Option<CoinBaseExtra>,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (TransactionOutput, TransactionKernel, WalletOutput) {
     let p = TestParams::new(key_manager).await;
     let public_exess = key_manager
@@ -131,7 +131,7 @@ pub async fn create_coinbase(
 async fn genesis_template(
     coinbase_value: MicroMinotari,
     consensus_constants: &ConsensusConstants,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (NewBlockTemplate, WalletOutput) {
     let header = BlockHeader::new(consensus_constants.blockchain_version().into());
     let (utxo, kernel, output) = create_coinbase(
@@ -157,7 +157,7 @@ async fn genesis_template(
 /// value, and the maturity is zero.
 pub async fn create_genesis_block(
     consensus_constants: &ConsensusConstants,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (ChainBlock, WalletOutput) {
     create_genesis_block_with_coinbase_value(
         consensus_constants.emission_amounts().0,
@@ -202,7 +202,7 @@ fn update_genesis_block_mmr_roots(template: NewBlockTemplate) -> Result<Block, C
 pub async fn create_genesis_block_with_coinbase_value(
     coinbase_value: MicroMinotari,
     consensus_constants: &ConsensusConstants,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (ChainBlock, WalletOutput) {
     let (template, output) = genesis_template(coinbase_value, consensus_constants, key_manager).await;
     let mut block = update_genesis_block_mmr_roots(template).unwrap();
@@ -231,7 +231,7 @@ pub async fn create_genesis_block_with_coinbase_value(
 pub async fn create_genesis_block_with_utxos(
     values: &[MicroMinotari],
     consensus_constants: &ConsensusConstants,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (ChainBlock, Vec<WalletOutput>) {
     let (mut template, coinbase) = genesis_template(100_000_000.into(), consensus_constants, key_manager).await;
     let script = script!(Nop).unwrap();
@@ -275,7 +275,7 @@ pub async fn chain_block(
     prev_block: &Block,
     transactions: Vec<Transaction>,
     consensus: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> NewBlockTemplate {
     let mut header = BlockHeader::from_previous(&prev_block.header);
     header.version = consensus.consensus_constants(header.height).blockchain_version().into();
@@ -332,7 +332,7 @@ pub async fn chain_block_with_new_coinbase(
     transactions: Vec<Transaction>,
     consensus_manager: &BaseNodeConsensusManager,
     extra: Option<CoinBaseExtra>,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (NewBlockTemplate, WalletOutput) {
     let height = prev_block.height() + 1;
     let mut coinbase_value = consensus_manager.emission_schedule().block_reward(height);
@@ -375,7 +375,7 @@ pub async fn append_block<B: BlockchainBackend>(
     txns: Vec<Transaction>,
     consensus: &BaseNodeConsensusManager,
     achieved_difficulty: Difficulty,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Result<(ChainBlock, WalletOutput), ChainStorageError> {
     append_block_with_coinbase(db, prev_block, txns, consensus, achieved_difficulty, key_manager).await
 }
@@ -388,7 +388,7 @@ pub async fn append_block_with_coinbase<B: BlockchainBackend>(
     txns: Vec<Transaction>,
     consensus_manager: &BaseNodeConsensusManager,
     achieved_difficulty: Difficulty,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Result<(ChainBlock, WalletOutput), ChainStorageError> {
     let height = prev_block.height() + 1;
     let mut coinbase_value = consensus_manager.emission_schedule().block_reward(height);
@@ -432,7 +432,7 @@ pub async fn generate_new_block<B: BlockchainBackend>(
     outputs: &mut Vec<Vec<WalletOutput>>,
     schemas: Vec<TransactionSchema>,
     consensus: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let coinbase_value = consensus.emission_schedule().block_reward(db.get_height().unwrap() + 1);
     generate_new_block_with_coinbase(db, blocks, outputs, schemas, coinbase_value, consensus, key_manager).await
@@ -446,7 +446,7 @@ pub async fn generate_new_block_with_achieved_difficulty<B: BlockchainBackend>(
     schemas: Vec<TransactionSchema>,
     achieved_difficulty: Difficulty,
     consensus: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let mut txns = Vec::new();
     let mut block_utxos = Vec::new();
@@ -468,7 +468,7 @@ pub async fn generate_new_block_with_coinbase<B: BlockchainBackend>(
     schemas: Vec<TransactionSchema>,
     coinbase_value: MicroMinotari,
     consensus: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let mut txns = Vec::new();
     let mut block_utxos = Vec::new();
@@ -511,7 +511,7 @@ pub async fn generate_block<B: BlockchainBackend>(
     blocks: &mut Vec<ChainBlock>,
     transactions: Vec<Transaction>,
     consensus: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let prev_block = blocks.last().unwrap();
     let template = chain_block_with_new_coinbase(prev_block, transactions, consensus, None, key_manager)
@@ -532,7 +532,7 @@ pub async fn generate_block_with_achieved_difficulty<B: BlockchainBackend>(
     transactions: Vec<Transaction>,
     achieved_difficulty: Difficulty,
     consensus: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Result<BlockAddResult, ChainStorageError> {
     let template = chain_block_with_new_coinbase(blocks.last().unwrap(), transactions, consensus, None, key_manager)
         .await
@@ -580,7 +580,7 @@ pub async fn construct_chained_blocks<B: BlockchainBackend>(
     block0: ChainBlock,
     consensus: &BaseNodeConsensusManager,
     n: usize,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Vec<ChainBlock> {
     let mut prev_block = block0;
     let mut blocks = Vec::new();

--- a/base_layer/core/tests/helpers/block_malleability.rs
+++ b/base_layer/core/tests/helpers/block_malleability.rs
@@ -69,7 +69,7 @@ async fn check_block_changes_are_detected(field: MerkleMountainRangeField, block
             input_version: TransactionInputVersion::V0,
             output_version: TransactionOutputVersion::V0
         )],
-        &blockchain.key_manager,
+        &mut blockchain.key_manager,
     )
     .await;
     blockchain

--- a/base_layer/core/tests/helpers/database.rs
+++ b/base_layer/core/tests/helpers/database.rs
@@ -41,7 +41,7 @@ pub async fn create_orphan_block(
     block_height: u64,
     transactions: Vec<Transaction>,
     consensus: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> Block {
     let mut coinbase_value = consensus.emission_schedule().block_reward(block_height);
     let lock_height = consensus.consensus_constants(block_height).coinbase_min_maturity();

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -89,7 +89,7 @@ pub async fn create_blockchain_db_no_cut_through() -> (
     MemoryDbKeyManager,
 ) {
     let network = Network::LocalNet;
-    let (mut db, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut db, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     // Block 1
     let txs = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![60*T], fee: 100*uT)];
     generate_new_block(
@@ -98,7 +98,7 @@ pub async fn create_blockchain_db_no_cut_through() -> (
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -113,7 +113,7 @@ pub async fn create_blockchain_db_no_cut_through() -> (
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -128,7 +128,7 @@ pub async fn create_blockchain_db_no_cut_through() -> (
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -143,7 +143,7 @@ pub async fn create_blockchain_db_no_cut_through() -> (
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -165,7 +165,7 @@ pub async fn create_blockchain_db_no_cut_through() -> (
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -189,9 +189,9 @@ pub async fn create_new_blockchain(
     BaseNodeConsensusManager,
     MemoryDbKeyManager,
 ) {
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = consensus_constants(network).build();
-    let (block0, output) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let (block0, output) = create_genesis_block(&consensus_constants, &mut key_manager).await;
     let consensus_manager = BaseNodeConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)
         .with_block(block0.clone())
@@ -218,8 +218,8 @@ pub async fn create_new_blockchain_with_constants(
     BaseNodeConsensusManager,
     MemoryDbKeyManager,
 ) {
-    let key_manager = create_memory_db_key_manager().await.unwrap();
-    let (block0, output) = create_genesis_block(&constants, &key_manager).await;
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
+    let (block0, output) = create_genesis_block(&constants, &mut key_manager).await;
     let consensus_manager = BaseNodeConsensusManagerBuilder::new(network)
         .add_consensus_constants(constants)
         .with_block(block0.clone())
@@ -247,9 +247,9 @@ pub async fn create_new_blockchain_lmdb(
     BaseNodeConsensusManager,
     MemoryDbKeyManager,
 ) {
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = consensus_constants(network).build();
-    let (block0, output) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let (block0, output) = create_genesis_block(&consensus_constants, &mut key_manager).await;
     let consensus_manager = BaseNodeConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)
         .with_block(block0.clone())

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -152,9 +152,9 @@ pub async fn create_network_with_multiple_nodes(
     }
     let network = Network::LocalNet;
     let temp_dir = tempdir().unwrap();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = sample_blockchains::consensus_constants(network).build();
-    let (initial_block, coinbase_wallet_output) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let (initial_block, coinbase_wallet_output) = create_genesis_block(&consensus_constants, &mut key_manager).await;
     let consensus_manager = BaseNodeConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)
         .with_block(initial_block.clone())
@@ -315,7 +315,7 @@ pub async fn create_and_add_some_blocks(
     start_coinbase: &WalletOutput,
     number_of_blocks: usize,
     consensus_manager: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     difficulties: &[u64],
     transactions: &Option<Vec<Vec<Transaction>>>,
 ) -> (Vec<ChainBlock>, Vec<WalletOutput>) {
@@ -398,7 +398,7 @@ pub async fn create_block_chain_with_transactions(
     initial_block: &ChainBlock,
     initial_coinbase: &WalletOutput,
     consensus_manager: &BaseNodeConsensusManager,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     intermediate_height: u64,
     number_of_blocks: usize,
     spend_genesis_coinbase_in_block: usize,

--- a/base_layer/core/tests/helpers/test_blockchain.rs
+++ b/base_layer/core/tests/helpers/test_blockchain.rs
@@ -85,7 +85,7 @@ impl TestBlockchain {
         &self.consensus_manager
     }
 
-    pub async fn build_block(&self, block: TestBlockBuilderInner) -> (Block, WalletOutput) {
+    pub async fn build_block(&mut self, block: TestBlockBuilderInner) -> (Block, WalletOutput) {
         debug!(target: LOG_TARGET, "Adding block '{}' to test block chain", block.name);
         let prev_block = self.blocks.get(&block.child_of.unwrap());
         let prev_block = prev_block.map(|b| &b.block).unwrap();
@@ -94,7 +94,7 @@ impl TestBlockchain {
             block.transactions,
             &self.consensus_manager,
             None,
-            &self.key_manager,
+            &mut self.key_manager,
         )
         .await;
 

--- a/base_layer/core/tests/tests/async_db.rs
+++ b/base_layer/core/tests/tests/async_db.rs
@@ -75,18 +75,19 @@ async fn fetch_async_block() {
 #[tokio::test]
 async fn async_add_new_block() {
     let network = Network::LocalNet;
-    let (db, blocks, outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (db, blocks, outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     let schema = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![20 * T, 20 * T])];
 
-    let txns = schema_to_transaction(&schema, &key_manager)
+    let txns = schema_to_transaction(&schema, &mut key_manager)
         .await
         .0
         .iter()
         .map(|t| t.deref().clone())
         .collect();
-    let new_block = chain_block_with_new_coinbase(blocks.last().unwrap(), txns, &consensus_manager, None, &key_manager)
-        .await
-        .0;
+    let new_block =
+        chain_block_with_new_coinbase(blocks.last().unwrap(), txns, &consensus_manager, None, &mut key_manager)
+            .await
+            .0;
 
     let new_block = db.prepare_new_block(new_block).unwrap();
     let db = AsyncBlockchainDb::new(db);
@@ -100,9 +101,9 @@ async fn async_add_new_block() {
 
 #[tokio::test]
 async fn async_add_block_fetch_orphan() {
-    let (db, _, _, consensus, key_manager) = create_blockchain_db_no_cut_through().await;
+    let (db, _, _, consensus, mut key_manager) = create_blockchain_db_no_cut_through().await;
 
-    let orphan = create_orphan_block(7, vec![], &consensus, &key_manager).await;
+    let orphan = create_orphan_block(7, vec![], &consensus, &mut key_manager).await;
     let block_hash = orphan.hash();
     let db = AsyncBlockchainDb::new(db);
     db.add_block(orphan.clone().into()).await.unwrap();

--- a/base_layer/core/tests/tests/block_sync.rs
+++ b/base_layer/core/tests/tests/block_sync.rs
@@ -33,7 +33,7 @@ async fn test_block_sync_happy_path() {
     // env_logger::builder().filter_level(log::LevelFilter::Trace).init();  //  > ./target/output.log 2>&1
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -50,7 +50,7 @@ async fn test_block_sync_happy_path() {
         &initial_coinbase,
         5,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 5],
         &None,
     )
@@ -98,7 +98,7 @@ async fn test_block_sync_peer_supplies_no_blocks_with_ban() {
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -115,7 +115,7 @@ async fn test_block_sync_peer_supplies_no_blocks_with_ban() {
         &initial_coinbase,
         10,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 10],
         &None,
     )
@@ -158,7 +158,7 @@ async fn test_block_sync_peer_supplies_not_all_blocks_with_ban() {
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -175,7 +175,7 @@ async fn test_block_sync_peer_supplies_not_all_blocks_with_ban() {
         &initial_coinbase,
         10,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 10],
         &None,
     )
@@ -221,7 +221,7 @@ async fn test_block_sync_with_conbase_spend_happy_path_1() {
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Bob (archival node) and Carol (archival node)
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             // Carol is an archival node
             BlockchainDatabaseConfig::default(),
@@ -240,7 +240,7 @@ async fn test_block_sync_with_conbase_spend_happy_path_1() {
         &initial_block,
         &initial_coinbase,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         3,
         10,                           // > follow_up_transaction_in_block + intermediate_height + 1
         2,                            // < intermediate_height,
@@ -330,7 +330,7 @@ async fn test_block_sync_with_conbase_spend_happy_path_2() {
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Bob (archival node) and Carol (archival node)
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             // Carol is an archival node
             BlockchainDatabaseConfig::default(),
@@ -349,7 +349,7 @@ async fn test_block_sync_with_conbase_spend_happy_path_2() {
         &initial_block,
         &initial_coinbase,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         3,
         10,                           // > follow_up_transaction_in_block + intermediate_height + 1
         2,                            // < intermediate_height,

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -1034,8 +1034,8 @@ async fn test_block_sync_body_validator() {
     .await
     .unwrap();
     let inputs = vec![
-        unblinded_utxo.to_transaction_input(&mut key_manager).await.unwrap(),
-        unblinded_utxo2.to_transaction_input(&mut key_manager).await.unwrap(),
+        unblinded_utxo.to_transaction_input(&key_manager).await.unwrap(),
+        unblinded_utxo2.to_transaction_input(&key_manager).await.unwrap(),
     ];
     new_block.body = AggregateBody::new(inputs, template.body.outputs().clone(), template.body.kernels().clone());
     {

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -106,7 +106,7 @@ async fn test_monero_blocks() {
     let seed1 = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad97";
     let seed2 = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad98";
 
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let cc = ConsensusConstantsBuilder::new(network)
         .with_max_randomx_seed_height(1)
         .clear_proof_of_work()
@@ -136,20 +136,20 @@ async fn test_monero_blocks() {
         Validators::new(block_validator, header_validator, MockValidator::new(true)),
     );
     let block_0 = db.fetch_block(0, true).unwrap().try_into_chain_block().unwrap();
-    let (block_1_t, _) = chain_block_with_new_coinbase(&block_0, vec![], &cm, None, &key_manager).await;
+    let (block_1_t, _) = chain_block_with_new_coinbase(&block_0, vec![], &cm, None, &mut key_manager).await;
     let mut block_1 = db.prepare_new_block(block_1_t).unwrap();
 
     // Now we have block 1, lets add monero data to it
     add_monero_test_data(&mut block_1, seed1);
     let cb_1 = assert_block_add_result_added(&db.add_block(Arc::new(block_1)).unwrap());
     // Now lets add a second faulty block using the same seed hash
-    let (block_2_t, _) = chain_block_with_new_coinbase(&cb_1, vec![], &cm, None, &key_manager).await;
+    let (block_2_t, _) = chain_block_with_new_coinbase(&cb_1, vec![], &cm, None, &mut key_manager).await;
     let mut block_2 = db.prepare_new_block(block_2_t).unwrap();
 
     add_monero_test_data(&mut block_2, seed1);
     let cb_2 = assert_block_add_result_added(&db.add_block(Arc::new(block_2)).unwrap());
     // Now lets add a third faulty block using the same seed hash. This should fail.
-    let (block_3_t, _) = chain_block_with_new_coinbase(&cb_2, vec![], &cm, None, &key_manager).await;
+    let (block_3_t, _) = chain_block_with_new_coinbase(&cb_2, vec![], &cm, None, &mut key_manager).await;
     let mut block_3 = db.prepare_new_block(block_3_t).unwrap();
     let mut block_3_broken = block_3.clone();
     add_monero_test_data(&mut block_3_broken, seed1);
@@ -268,7 +268,7 @@ async fn inputs_are_not_malleable() {
 
     let (txs, _) = schema_to_transaction(
         &[txn_schema!(from: vec![output.clone()], to: vec![50 * T])],
-        &blockchain.key_manager,
+        &mut blockchain.key_manager,
     )
     .await;
     let txs = txs.into_iter().map(|tx| Clone::clone(&*tx)).collect();
@@ -285,7 +285,7 @@ async fn inputs_are_not_malleable() {
     let mut block = blockchain.get_block("A2").cloned().unwrap().block.block().clone();
     blockchain.store().rewind_to_height(block.header.height - 1).unwrap();
 
-    let mut malicious_test_params = TestParams::new(&blockchain.key_manager).await;
+    let mut malicious_test_params = TestParams::new(&mut blockchain.key_manager).await;
 
     // Oh noes - they've managed to get hold of the private script and spend keys
     malicious_test_params.commitment_mask_key_id = spent_output.commitment_mask_key_id().clone();
@@ -313,7 +313,7 @@ async fn inputs_are_not_malleable() {
                 features: spent_output.features().clone(),
                 ..Default::default()
             },
-            &blockchain.key_manager,
+            &mut blockchain.key_manager,
         )
         .await;
 
@@ -343,12 +343,12 @@ async fn inputs_are_not_malleable() {
 #[allow(clippy::too_many_lines)]
 async fn test_orphan_validator() {
     let factories = CryptoFactories::default();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let network = Network::Igor;
     let consensus_constants = ConsensusConstantsBuilder::new(network)
         .with_max_block_transaction_weight(335)
         .build();
-    let (genesis, outputs) = create_genesis_block_with_utxos(&[T, T, T], &consensus_constants, &key_manager).await;
+    let (genesis, outputs) = create_genesis_block_with_utxos(&[T, T, T], &consensus_constants, &mut key_manager).await;
     let network = Network::LocalNet;
     let rules = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants)
@@ -377,29 +377,35 @@ async fn test_orphan_validator() {
     let (tx01, _) = spend_utxos(
         txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features:
         OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx02, _) = spend_utxos(
         txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features:
         OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx03, _) = spend_utxos(
         txn_schema!(from: vec![outputs[3].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features:
         OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx04, _) = spend_utxos(
         txn_schema!(from: vec![outputs[3].clone()], to: vec![50_000 * uT], fee: 20*uT, lock: 2, features:
         OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
-    let (template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx02.clone()], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx02.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let new_block = db.prepare_new_block(template).unwrap();
     // this block should be okay
     assert!(orphan_validator.validate_internal_consistency(&new_block).is_ok());
@@ -410,23 +416,35 @@ async fn test_orphan_validator() {
         vec![tx01.clone(), tx02.clone(), tx03],
         &rules,
         None,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let new_block = db.prepare_new_block(template).unwrap();
     assert!(orphan_validator.validate_internal_consistency(&new_block).is_err());
 
     // lets break the sorting
-    let (mut template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx02.clone()], &rules, None, &key_manager).await;
+    let (mut template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx02.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let outputs = vec![template.body.outputs()[1].clone(), template.body.outputs()[2].clone()];
     template.body = AggregateBody::new(template.body.inputs().clone(), outputs, template.body.kernels().clone());
     let new_block = db.prepare_new_block(template).unwrap();
     assert!(orphan_validator.validate_internal_consistency(&new_block).is_err());
 
     // lets break spend rules
-    let (template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx04.clone()], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx04.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let new_block = db.prepare_new_block(template).unwrap();
     assert!(orphan_validator.validate_internal_consistency(&new_block).is_err());
 
@@ -435,7 +453,7 @@ async fn test_orphan_validator() {
         10000000.into(),
         1 + rules.consensus_constants(0).coinbase_min_maturity(),
         None,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let template = chain_block_with_coinbase(
@@ -454,7 +472,7 @@ async fn test_orphan_validator() {
         rules.get_block_reward_at(1) + tx01.body.get_total_fee().unwrap() + tx02.body.get_total_fee().unwrap(),
         1,
         None,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let template = chain_block_with_coinbase(
@@ -469,7 +487,8 @@ async fn test_orphan_validator() {
     assert!(orphan_validator.validate_internal_consistency(&new_block).is_err());
 
     // lets break accounting
-    let (mut template, _) = chain_block_with_new_coinbase(&genesis, vec![tx01, tx02], &rules, None, &key_manager).await;
+    let (mut template, _) =
+        chain_block_with_new_coinbase(&genesis, vec![tx01, tx02], &rules, None, &mut key_manager).await;
     let outputs = vec![template.body.outputs()[1].clone(), tx04.body.outputs()[1].clone()];
     template.body = AggregateBody::new(template.body.inputs().clone(), outputs, template.body.kernels().clone());
     let new_block = db.prepare_new_block(template).unwrap();
@@ -491,8 +510,8 @@ async fn test_orphan_body_validation() {
         .clear_proof_of_work()
         .add_proof_of_work(PowAlgorithm::Sha3x, sha3x_constants)
         .build();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
-    let (genesis, outputs) = create_genesis_block_with_utxos(&[T, T, T], &consensus_constants, &key_manager).await;
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
+    let (genesis, outputs) = create_genesis_block_with_utxos(&[T, T, T], &consensus_constants, &mut key_manager).await;
     let network = Network::LocalNet;
     let rules = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants)
@@ -521,16 +540,16 @@ async fn test_orphan_body_validation() {
     let (tx01, _) = spend_utxos(
         txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features:
 OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx02, _) = spend_utxos(
         txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features:
 OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
-    let (template, _) = chain_block_with_new_coinbase(&genesis, vec![tx01, tx02], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(&genesis, vec![tx01, tx02], &rules, None, &mut key_manager).await;
     let mut new_block = db.prepare_new_block(template.clone()).unwrap();
     new_block.header.nonce = OsRng.next_u64();
 
@@ -579,8 +598,8 @@ OutputFeatures::default()),
     // lets have unknown inputs;
     let mut new_block = db.prepare_new_block(template.clone()).unwrap();
     let prev_header = db.fetch_header(new_block.header.height - 1).unwrap().unwrap();
-    let test_params1 = TestParams::new(&key_manager).await;
-    let test_params2 = TestParams::new(&key_manager).await;
+    let test_params1 = TestParams::new(&mut key_manager).await;
+    let test_params2 = TestParams::new(&mut key_manager).await;
     // We dont need proper utxo's with signatures as the post_orphan validator does not check accounting balance +
     // signatures.
     let key_manager_utxo = create_wallet_output_with_data(
@@ -588,7 +607,7 @@ OutputFeatures::default()),
         OutputFeatures::default(),
         &test_params1,
         outputs[1].value(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -597,7 +616,7 @@ OutputFeatures::default()),
         OutputFeatures::default(),
         &test_params2,
         outputs[2].value(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -701,7 +720,7 @@ OutputFeatures::default()),
 #[allow(clippy::too_many_lines)]
 async fn test_header_validation() {
     let factories = CryptoFactories::default();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let network = Network::Igor;
     // we dont want localnet's 1 difficulty or the full mined difficulty of weather wax but we want some.
     let sha3x_constants = PowAlgorithmConstants {
@@ -713,7 +732,7 @@ async fn test_header_validation() {
         .clear_proof_of_work()
         .add_proof_of_work(PowAlgorithm::Sha3x, sha3x_constants)
         .build();
-    let (genesis, outputs) = create_genesis_block_with_utxos(&[T, T, T], &consensus_constants, &key_manager).await;
+    let (genesis, outputs) = create_genesis_block_with_utxos(&[T, T, T], &consensus_constants, &mut key_manager).await;
     let network = Network::LocalNet;
     let rules = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants)
@@ -741,16 +760,16 @@ async fn test_header_validation() {
     let (tx01, _) = spend_utxos(
         txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features:
 OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx02, _) = spend_utxos(
         txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features:
 OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
-    let (template, _) = chain_block_with_new_coinbase(&genesis, vec![tx01, tx02], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(&genesis, vec![tx01, tx02], &rules, None, &mut key_manager).await;
     let mut new_block = db.prepare_new_block(template.clone()).unwrap();
     new_block.header.nonce = OsRng.next_u64();
     let timestamps = db.fetch_block_timestamps(new_block.header.prev_hash).unwrap();
@@ -830,8 +849,8 @@ async fn test_block_sync_body_validator() {
     let consensus_constants = ConsensusConstantsBuilder::new(network)
         .with_max_block_transaction_weight(400)
         .build();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
-    let (genesis, outputs) = create_genesis_block_with_utxos(&[T, T, T], &consensus_constants, &key_manager).await;
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
+    let (genesis, outputs) = create_genesis_block_with_utxos(&[T, T, T], &consensus_constants, &mut key_manager).await;
     let network = Network::LocalNet;
     let rules = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants.clone())
@@ -859,16 +878,16 @@ async fn test_block_sync_body_validator() {
     // we have created the blockchain, lets create a second valid block
 
     let (tx01, _) = spend_utxos(
-        txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features: OutputFeatures::default()),&mut key_manager
     ).await;
     let (tx02, _) = spend_utxos(
-        txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features: OutputFeatures::default()),&mut key_manager
     ).await;
     let (tx03, _) = spend_utxos(
-        txn_schema!(from: vec![outputs[3].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[3].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features: OutputFeatures::default()),&mut key_manager
     ).await;
     let (tx04, _) = spend_utxos(
-        txn_schema!(from: vec![outputs[3].clone()], to: vec![50_000 * uT], fee: 20*uT, lock: 2, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[3].clone()], to: vec![50_000 * uT], fee: 20*uT, lock: 2, features: OutputFeatures::default()),&mut key_manager
     ).await;
 
     // Coinbase extra field is too large
@@ -878,7 +897,7 @@ async fn test_block_sync_body_validator() {
         vec![tx01.clone(), tx02.clone()],
         &rules,
         Some(extra),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let new_block = db.prepare_new_block(template).unwrap();
@@ -898,8 +917,14 @@ async fn test_block_sync_body_validator() {
         err
     );
 
-    let (template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx02.clone()], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx02.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let new_block = db.prepare_new_block(template).unwrap();
     // this block should be okay
     {
@@ -914,7 +939,7 @@ async fn test_block_sync_body_validator() {
         vec![tx01.clone(), tx02.clone(), tx03],
         &rules,
         None,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let new_block = db.prepare_new_block(template).unwrap();
@@ -943,8 +968,14 @@ async fn test_block_sync_body_validator() {
     );
 
     // lets break spend rules
-    let (template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx04.clone()], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx04.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let new_block = db.prepare_new_block(template).unwrap();
     {
         // `MutexGuard` cannot be held across an `await` point
@@ -953,8 +984,14 @@ async fn test_block_sync_body_validator() {
     }
 
     // lets break the sorting
-    let (mut template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx02.clone()], &rules, None, &key_manager).await;
+    let (mut template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx02.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let output = vec![template.body.outputs()[1].clone(), template.body.outputs()[2].clone()];
     template.body = AggregateBody::new(template.body.inputs().clone(), output, template.body.kernels().clone());
     let new_block = db.prepare_new_block(template).unwrap();
@@ -965,11 +1002,17 @@ async fn test_block_sync_body_validator() {
     }
 
     // lets have unknown inputs;
-    let (template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx02.clone()], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx02.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let mut new_block = db.prepare_new_block(template.clone()).unwrap();
-    let test_params1 = TestParams::new(&key_manager).await;
-    let test_params2 = TestParams::new(&key_manager).await;
+    let test_params1 = TestParams::new(&mut key_manager).await;
+    let test_params2 = TestParams::new(&mut key_manager).await;
     // We dont need proper utxo's with signatures as the post_orphan validator does not check accounting balance +
     // signatures.
     let unblinded_utxo = create_wallet_output_with_data(
@@ -977,7 +1020,7 @@ async fn test_block_sync_body_validator() {
         OutputFeatures::default(),
         &test_params1,
         outputs[1].value(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -986,13 +1029,13 @@ async fn test_block_sync_body_validator() {
         OutputFeatures::default(),
         &test_params2,
         outputs[2].value(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
     let inputs = vec![
-        unblinded_utxo.to_transaction_input(&key_manager).await.unwrap(),
-        unblinded_utxo2.to_transaction_input(&key_manager).await.unwrap(),
+        unblinded_utxo.to_transaction_input(&mut key_manager).await.unwrap(),
+        unblinded_utxo2.to_transaction_input(&mut key_manager).await.unwrap(),
     ];
     new_block.body = AggregateBody::new(inputs, template.body.outputs().clone(), template.body.kernels().clone());
     {
@@ -1002,8 +1045,14 @@ async fn test_block_sync_body_validator() {
     }
 
     // lets check duplicate txos
-    let (template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx02.clone()], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx02.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let mut new_block = db.prepare_new_block(template.clone()).unwrap();
     // We dont need proper utxo's with signatures as the post_orphan validator does not check accounting balance +
     // signatures.
@@ -1020,7 +1069,7 @@ async fn test_block_sync_body_validator() {
         10000000.into(),
         1 + rules.consensus_constants(0).coinbase_min_maturity(),
         None,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let template = chain_block_with_coinbase(
@@ -1043,7 +1092,7 @@ async fn test_block_sync_body_validator() {
         rules.get_block_reward_at(1) + tx01.body.get_total_fee().unwrap() + tx02.body.get_total_fee().unwrap(),
         1 + rules.consensus_constants(1).coinbase_min_maturity(),
         None,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let template = chain_block_with_coinbase(
@@ -1062,8 +1111,14 @@ async fn test_block_sync_body_validator() {
     }
 
     // lets break accounting
-    let (mut template, _) =
-        chain_block_with_new_coinbase(&genesis, vec![tx01.clone(), tx02.clone()], &rules, None, &key_manager).await;
+    let (mut template, _) = chain_block_with_new_coinbase(
+        &genesis,
+        vec![tx01.clone(), tx02.clone()],
+        &rules,
+        None,
+        &mut key_manager,
+    )
+    .await;
     let outputs = vec![template.body.outputs()[1].clone(), tx04.body.outputs()[1].clone()];
     template.body = AggregateBody::new(template.body.inputs().clone(), outputs, template.body.kernels().clone());
     let new_block = db.prepare_new_block(template).unwrap();
@@ -1074,7 +1129,7 @@ async fn test_block_sync_body_validator() {
     }
 
     // lets the mmr root
-    let (template, _) = chain_block_with_new_coinbase(&genesis, vec![tx01, tx02], &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(&genesis, vec![tx01, tx02], &rules, None, &mut key_manager).await;
     let mut new_block = db.prepare_new_block(template).unwrap();
     new_block.header.output_mr = FixedHash::zero();
     {
@@ -1090,7 +1145,7 @@ async fn add_block_with_large_block() {
     let factories = CryptoFactories::default();
     let network = Network::LocalNet;
     let consensus_constants = ConsensusConstantsBuilder::new(network).build();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let (genesis, outputs) = create_genesis_block_with_utxos(
         &[
             5 * T,
@@ -1107,7 +1162,7 @@ async fn add_block_with_large_block() {
             5 * T,
         ],
         &consensus_constants,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let network = Network::LocalNet;
@@ -1139,9 +1194,9 @@ async fn add_block_with_large_block() {
         schemas.push(new_schema);
     }
 
-    let (txs, _outputs) = schema_to_transaction(&schemas, &key_manager).await;
+    let (txs, _outputs) = schema_to_transaction(&schemas, &mut key_manager).await;
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
-    let (template, _) = chain_block_with_new_coinbase(&genesis, txs, &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(&genesis, txs, &rules, None, &mut key_manager).await;
     let new_block = db.prepare_new_block(template).unwrap();
     println!(
         "Total block weight is : {}",
@@ -1167,8 +1222,8 @@ async fn add_block_with_large_many_output_block() {
     let consensus_constants = ConsensusConstantsBuilder::new(network)
         .with_max_block_transaction_weight(127_795)
         .build();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
-    let (genesis, outputs) = create_genesis_block_with_utxos(&[501 * T], &consensus_constants, &key_manager).await;
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
+    let (genesis, outputs) = create_genesis_block_with_utxos(&[501 * T], &consensus_constants, &mut key_manager).await;
     let network = Network::LocalNet;
     let rules = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants.clone())
@@ -1199,10 +1254,10 @@ async fn add_block_with_large_many_output_block() {
     }
 
     let schema = txn_schema!(from: vec![outputs[1].clone()], to: outs);
-    let (txs, _outputs) = schema_to_transaction(&[schema], &key_manager).await;
+    let (txs, _outputs) = schema_to_transaction(&[schema], &mut key_manager).await;
 
     let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
-    let (template, _) = chain_block_with_new_coinbase(&genesis, txs, &rules, None, &key_manager).await;
+    let (template, _) = chain_block_with_new_coinbase(&genesis, txs, &rules, None, &mut key_manager).await;
     let new_block = db.prepare_new_block(template).unwrap();
     println!(
         "Total block weight is : {}",

--- a/base_layer/core/tests/tests/header_sync.rs
+++ b/base_layer/core/tests/tests/header_sync.rs
@@ -34,7 +34,7 @@ async fn test_header_sync_happy_path() {
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -51,7 +51,7 @@ async fn test_header_sync_happy_path() {
         &initial_coinbase,
         1,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3],
         &None,
     )
@@ -100,7 +100,7 @@ async fn test_header_sync_happy_path() {
         &bob_coinbases[1],
         1,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3],
         &None,
     )
@@ -132,7 +132,7 @@ async fn test_header_sync_with_fork_happy_path() {
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -149,7 +149,7 @@ async fn test_header_sync_with_fork_happy_path() {
         &initial_coinbase,
         1,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3],
         &None,
     )
@@ -163,7 +163,7 @@ async fn test_header_sync_with_fork_happy_path() {
         &bob_coinbases[1],
         1,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3],
         &None,
     )
@@ -177,7 +177,7 @@ async fn test_header_sync_with_fork_happy_path() {
         &initial_coinbase,
         3,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3, 2, 1],
         &None,
     )
@@ -215,7 +215,7 @@ async fn test_header_sync_with_fork_happy_path() {
         &bob_coinbases[1],
         2,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 2],
         &None,
     )
@@ -246,7 +246,7 @@ async fn test_header_sync_uneven_headers_and_blocks_happy_path() {
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -263,7 +263,7 @@ async fn test_header_sync_uneven_headers_and_blocks_happy_path() {
         &initial_coinbase,
         10,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 10],
         &None,
     )
@@ -303,7 +303,7 @@ async fn test_header_sync_uneven_headers_and_blocks_peer_lies_about_pow_no_ban()
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -320,7 +320,7 @@ async fn test_header_sync_uneven_headers_and_blocks_peer_lies_about_pow_no_ban()
         &initial_coinbase,
         10,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 10],
         &None,
     )
@@ -375,7 +375,7 @@ async fn test_header_sync_even_headers_and_blocks_peer_lies_about_pow_with_ban()
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -392,7 +392,7 @@ async fn test_header_sync_even_headers_and_blocks_peer_lies_about_pow_with_ban()
         &initial_coinbase,
         6,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 6],
         &None,
     )
@@ -437,7 +437,7 @@ async fn test_header_sync_even_headers_and_blocks_peer_metadata_improve_with_reo
     // env_logger::init(); // Set `$env:RUST_LOG = "trace"`
 
     // Create the network with Alice node and Bob node
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig::default(),
             BlockchainDatabaseConfig::default(),
@@ -454,7 +454,7 @@ async fn test_header_sync_even_headers_and_blocks_peer_metadata_improve_with_reo
         &initial_coinbase,
         6,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 6],
         &None,
     )
@@ -477,7 +477,7 @@ async fn test_header_sync_even_headers_and_blocks_peer_metadata_improve_with_reo
         &coinbases[4],
         3,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         &[3; 3],
         &None,
     )

--- a/base_layer/core/tests/tests/horizon_sync.rs
+++ b/base_layer/core/tests/tests/horizon_sync.rs
@@ -43,7 +43,7 @@ async fn test_initial_horizon_sync_from_archival_node_happy_path() {
 
     // Create the network with Alice (pruning node) and Bob (archival node)
     let pruning_horizon = 5;
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             BlockchainDatabaseConfig {
                 orphan_storage_capacity: 5,
@@ -67,7 +67,7 @@ async fn test_initial_horizon_sync_from_archival_node_happy_path() {
         &initial_block,
         &initial_coinbase,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         pruning_horizon,
         30,                           // > follow_up_transaction_in_block + pruning_horizon + 1
         3,                            // < pruning_horizon
@@ -297,7 +297,7 @@ async fn test_consecutive_horizon_sync_from_prune_node_happy_path() {
     // Create the network with Alice (pruning node) and Bob (archival node) and Carol (pruning node)
     let pruning_horizon_alice = 4;
     let pruning_horizon_carol = 12;
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             // Alice is a pruned node
             BlockchainDatabaseConfig {
@@ -334,7 +334,7 @@ async fn test_consecutive_horizon_sync_from_prune_node_happy_path() {
         &initial_block,
         &initial_coinbase,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         min(pruning_horizon_alice, pruning_horizon_carol),
         28,                           // > follow_up_transaction_in_block + pruning_horizon_carol + 1
         2,                            // < pruning_horizon_alice, < pruning_horizon_carol
@@ -678,7 +678,7 @@ async fn test_initial_horizon_sync_from_prune_node_happy_path() {
     // Create the network with Alice (pruning node) and Bob (archival node) and Carol (pruning node)
     let pruning_horizon_alice = 4;
     let pruning_horizon_carol = 12;
-    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, mut key_manager, initial_coinbase) =
         sync::create_network_with_multiple_nodes(vec![
             // Alice is a pruned node
             BlockchainDatabaseConfig {
@@ -715,7 +715,7 @@ async fn test_initial_horizon_sync_from_prune_node_happy_path() {
         &initial_block,
         &initial_coinbase,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
         min(pruning_horizon_alice, pruning_horizon_carol),
         28,                           // > follow_up_transaction_in_block + pruning_horizon_carol + 1
         2,                            // < pruning_horizon_alice, < pruning_horizon_carol

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -1210,7 +1210,7 @@ async fn consensus_validation_large_tx() {
     let amount = MicroMinotari::from(5_000_000);
 
     let input = outputs[1][0].clone();
-    let inputs = vec![input.to_transaction_input(&mut key_manager).await.unwrap()];
+    let inputs = vec![input.to_transaction_input(&key_manager).await.unwrap()];
     let input_script_keys = vec![input.script_key_id().clone()];
 
     let fee = Fee::new(*consensus_manager.consensus_constants(0).transaction_weight_params()).calculate(

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -97,7 +97,7 @@ use crate::helpers::{
 #[allow(clippy::too_many_lines)]
 async fn test_insert_and_process_published_block() {
     let network = Network::LocalNet;
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     let mempool_validator = TransactionChainLinkedValidator::new(store.clone(), consensus_manager.clone());
     let mempool = Mempool::new(
         MempoolConfig::default(),
@@ -115,16 +115,16 @@ async fn test_insert_and_process_published_block() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
     // Create 6 new transactions to add to the mempool
-    let (orphan, _, _) = tx!(1*T, fee: 100*uT, &key_manager).expect("Failed to get tx");
+    let (orphan, _, _) = tx!(1*T, fee: 100*uT, &mut key_manager).expect("Failed to get tx");
     let orphan = Arc::new(orphan);
 
     let tx2 = txn_schema!(from: vec![outputs[1][0].clone()], to: vec![1*T], fee: 20*uT, lock: 0, features: OutputFeatures::default());
-    let tx2 = Arc::new(spend_utxos(tx2, &key_manager).await.0);
+    let tx2 = Arc::new(spend_utxos(tx2, &mut key_manager).await.0);
 
     let tx3 = txn_schema!(
         from: vec![outputs[1][1].clone()],
@@ -136,7 +136,7 @@ async fn test_insert_and_process_published_block() {
             ..Default::default()
         }
     );
-    let tx3 = Arc::new(spend_utxos(tx3, &key_manager).await.0);
+    let tx3 = Arc::new(spend_utxos(tx3, &mut key_manager).await.0);
 
     let tx5 = txn_schema!(
         from: vec![outputs[1][2].clone()],
@@ -148,9 +148,9 @@ async fn test_insert_and_process_published_block() {
             ..Default::default()
         }
     );
-    let tx5 = Arc::new(spend_utxos(tx5, &key_manager).await.0);
+    let tx5 = Arc::new(spend_utxos(tx5, &mut key_manager).await.0);
     let tx6 = txn_schema!(from: vec![outputs[1][3].clone()], to: vec![1 * T], fee: 25*uT, lock: 0, features: OutputFeatures::default());
-    let tx6 = spend_utxos(tx6, &key_manager).await.0;
+    let tx6 = spend_utxos(tx6, &mut key_manager).await.0;
 
     mempool.insert(orphan.clone()).await.unwrap();
     mempool.insert(tx2.clone()).await.unwrap();
@@ -213,7 +213,7 @@ async fn test_insert_and_process_published_block() {
         &mut blocks,
         vec![tx2.deref().clone()],
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -268,7 +268,7 @@ async fn test_insert_and_process_published_block() {
 #[allow(clippy::identity_op)]
 async fn test_time_locked() {
     let network = Network::LocalNet;
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     let mempool_validator = TransactionChainLinkedValidator::new(store.clone(), consensus_manager.clone());
     let mempool = Mempool::new(
         MempoolConfig::default(),
@@ -286,7 +286,7 @@ async fn test_time_locked() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -294,7 +294,7 @@ async fn test_time_locked() {
     // Block height should be 1
     let mut tx2 = txn_schema!(from: vec![outputs[1][0].clone()], to: vec![1*T], fee: 20*uT, lock: 0, features: OutputFeatures::default());
     tx2.lock_height = 3;
-    let tx2 = Arc::new(spend_utxos(tx2, &key_manager).await.0);
+    let tx2 = Arc::new(spend_utxos(tx2, &mut key_manager).await.0);
 
     let mut tx3 = txn_schema!(
         from: vec![outputs[1][1].clone()],
@@ -307,7 +307,7 @@ async fn test_time_locked() {
         }
     );
     tx3.lock_height = 2;
-    let tx3 = Arc::new(spend_utxos(tx3, &key_manager).await.0);
+    let tx3 = Arc::new(spend_utxos(tx3, &mut key_manager).await.0);
 
     // Tx2 should not go in, but Tx3 should
     assert_eq!(
@@ -325,7 +325,7 @@ async fn test_time_locked() {
         &mut blocks,
         vec![tx3.deref().clone()],
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -340,7 +340,7 @@ async fn test_time_locked() {
 #[allow(clippy::identity_op)]
 async fn test_retrieve() {
     let network = Network::LocalNet;
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     let mempool_validator = TransactionChainLinkedValidator::new(store.clone(), consensus_manager.clone());
     let mempool = Mempool::new(
         MempoolConfig::default(),
@@ -358,7 +358,7 @@ async fn test_retrieve() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -390,7 +390,7 @@ async fn test_retrieve() {
             ..Default::default()
         }),
     ];
-    let (tx, utxos) = schema_to_transaction(&txs, &key_manager).await;
+    let (tx, utxos) = schema_to_transaction(&txs, &mut key_manager).await;
 
     for t in &tx {
         mempool.insert(t.clone()).await.unwrap();
@@ -417,7 +417,7 @@ async fn test_retrieve() {
         tx[7].deref().clone(),
     ];
     // "Mine" block 2
-    generate_block(&store, &mut blocks, block2_txns, &consensus_manager, &key_manager)
+    generate_block(&store, &mut blocks, block2_txns, &consensus_manager, &mut key_manager)
         .await
         .unwrap();
     outputs.push(utxos);
@@ -438,7 +438,7 @@ async fn test_retrieve() {
         // account for change output
         txn_schema!(from: vec![outputs[2][15].clone()], to: vec![outputs[2][15].value() /2], fee: 40*uT, lock: 0, features: OutputFeatures::default()),
     ];
-    let (tx2, _) = schema_to_transaction(&txs, &key_manager).await;
+    let (tx2, _) = schema_to_transaction(&txs, &mut key_manager).await;
     for t in &tx2 {
         mempool.insert(t.clone()).await.unwrap();
     }
@@ -461,7 +461,7 @@ async fn test_retrieve() {
 async fn test_zero_conf_no_piggyback() {
     // This is the scenario described in fetch_highest_priority_txs function.
     let network = Network::LocalNet;
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     let mempool_validator = TransactionChainLinkedValidator::new(store.clone(), consensus_manager.clone());
     let mempool = Mempool::new(
         MempoolConfig::default(),
@@ -479,7 +479,7 @@ async fn test_zero_conf_no_piggyback() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -493,7 +493,7 @@ async fn test_zero_conf_no_piggyback() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     assert_eq!(
@@ -508,7 +508,7 @@ async fn test_zero_conf_no_piggyback() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     assert_eq!(
@@ -523,7 +523,7 @@ async fn test_zero_conf_no_piggyback() {
             fee: 2*uT, lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     assert_eq!(
@@ -538,7 +538,7 @@ async fn test_zero_conf_no_piggyback() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
 
@@ -561,7 +561,7 @@ async fn test_zero_conf_no_piggyback() {
 #[allow(clippy::too_many_lines)]
 async fn test_zero_conf() {
     let network = Network::LocalNet;
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     let mempool_validator = TransactionChainLinkedValidator::new(store.clone(), consensus_manager.clone());
     let mempool = Mempool::new(
         MempoolConfig::default(),
@@ -579,7 +579,7 @@ async fn test_zero_conf() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -611,7 +611,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx02, tx02_out) = spend_utxos(
@@ -622,7 +622,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx03, tx03_out) = spend_utxos(
@@ -633,7 +633,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx04, tx04_out) = spend_utxos(
@@ -644,7 +644,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     assert_eq!(
@@ -668,7 +668,7 @@ async fn test_zero_conf() {
             fee: 50*uT, lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx12, tx12_out) = spend_utxos(
@@ -679,7 +679,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx13, tx13_out) = spend_utxos(
@@ -690,7 +690,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx14, tx14_out) = spend_utxos(
@@ -700,7 +700,7 @@ async fn test_zero_conf() {
             fee: 80*uT, lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     assert_eq!(
@@ -729,7 +729,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx22, tx22_out) = spend_utxos(
@@ -740,7 +740,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx23, tx23_out) = spend_utxos(
@@ -751,7 +751,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx24, tx24_out) = spend_utxos(
@@ -761,7 +761,7 @@ async fn test_zero_conf() {
             fee: 120*uT, lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     assert_eq!(
@@ -790,7 +790,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx32, _) = spend_utxos(
@@ -801,7 +801,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx33, _) = spend_utxos(
@@ -812,7 +812,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx34, _) = spend_utxos(
@@ -823,7 +823,7 @@ async fn test_zero_conf() {
             lock: 0,
             features: OutputFeatures::default()
         ),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     assert_eq!(
@@ -945,7 +945,7 @@ async fn test_zero_conf() {
 #[allow(clippy::identity_op)]
 async fn test_reorg() {
     let network = Network::LocalNet;
-    let (mut db, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut db, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     let mempool_validator =
         TransactionFullValidator::new(CryptoFactories::default(), true, db.clone(), consensus_manager.clone());
     let mempool = Mempool::new(
@@ -964,7 +964,7 @@ async fn test_reorg() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -975,7 +975,7 @@ async fn test_reorg() {
         txn_schema!(from: vec![outputs[1][1].clone()], to: vec![outputs[1][1].value()/2], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
         txn_schema!(from: vec![outputs[1][2].clone()], to: vec![outputs[1][2].value()/2], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
     ];
-    let (txns2, utxos) = schema_to_transaction(&schemas, &key_manager).await;
+    let (txns2, utxos) = schema_to_transaction(&schemas, &mut key_manager).await;
     outputs.push(utxos);
     for tx in &txns2 {
         mempool.insert(tx.clone()).await.unwrap();
@@ -983,7 +983,7 @@ async fn test_reorg() {
     let stats = mempool.stats().await.unwrap();
     assert_eq!(stats.unconfirmed_txs, 3);
     let txns2 = txns2.iter().map(|t| t.deref().clone()).collect();
-    generate_block(&db, &mut blocks, txns2, &consensus_manager, &key_manager)
+    generate_block(&db, &mut blocks, txns2, &consensus_manager, &mut key_manager)
         .await
         .unwrap();
     mempool.process_published_block(blocks[2].to_arc_block()).await.unwrap();
@@ -994,7 +994,7 @@ async fn test_reorg() {
         txn_schema!(from: vec![outputs[2][1].clone()], to: vec![outputs[2][1].value()/2], fee: 25*uT, lock: 5, features: OutputFeatures::default()),
         txn_schema!(from: vec![outputs[2][2].clone()], to: vec![outputs[2][1].value()/2], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
     ];
-    let (txns3, utxos) = schema_to_transaction(&schemas, &key_manager).await;
+    let (txns3, utxos) = schema_to_transaction(&schemas, &mut key_manager).await;
     outputs.push(utxos);
     for tx in &txns3 {
         mempool.insert(tx.clone()).await.unwrap();
@@ -1006,7 +1006,7 @@ async fn test_reorg() {
         &mut blocks,
         vec![txns3[0].clone(), txns3[2].clone()],
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -1019,7 +1019,7 @@ async fn test_reorg() {
 
     db.rewind_to_height(2).unwrap();
 
-    let template = chain_block(blocks[2].block(), vec![], &consensus_manager, &key_manager).await;
+    let template = chain_block(blocks[2].block(), vec![], &consensus_manager, &mut key_manager).await;
     let reorg_block3 = db.prepare_new_block(template).unwrap();
 
     mempool
@@ -1032,7 +1032,7 @@ async fn test_reorg() {
     assert_eq!(stats.reorg_txs, 3);
 
     // "Mine" block 4
-    let template = chain_block(blocks[2].block(), vec![], &consensus_manager, &key_manager).await;
+    let template = chain_block(blocks[2].block(), vec![], &consensus_manager, &mut key_manager).await;
     let reorg_block4 = db.prepare_new_block(template).unwrap();
 
     // test that process_reorg can handle the case when removed_blocks is empty
@@ -1049,8 +1049,8 @@ async fn receive_and_propagate_transaction() {
     let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network)
         .with_coinbase_lockheight(100)
         .build();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
-    let (block0, utxo) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
+    let (block0, utxo) = create_genesis_block(&consensus_constants, &mut key_manager).await;
     let consensus_manager = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants)
         .with_block(block0)
@@ -1092,10 +1092,10 @@ async fn receive_and_propagate_transaction() {
 
     let (tx, _) = spend_utxos(
         txn_schema!(from: vec![utxo.clone()], to: vec![2 * T, 2 * T, 2 * T]),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
-    let (orphan, _, _) = tx!(1*T, fee: 100*uT, &key_manager).expect("Failed to get tx");
+    let (orphan, _, _) = tx!(1*T, fee: 100*uT, &mut key_manager).expect("Failed to get tx");
     let tx_excess_sig = tx.body.kernels()[0].excess_sig.clone();
     let orphan_excess_sig = orphan.body.kernels()[0].excess_sig.clone();
     assert!(alice_node.mempool.insert(Arc::new(tx.clone())).await.is_ok());
@@ -1177,7 +1177,7 @@ async fn consensus_validation_large_tx() {
     let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network)
         .with_max_block_transaction_weight(500)
         .build();
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) =
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) =
         create_new_blockchain_with_constants(network, consensus_constants).await;
     let mempool_validator = TransactionFullValidator::new(
         CryptoFactories::default(),
@@ -1198,7 +1198,7 @@ async fn consensus_validation_large_tx() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -1210,7 +1210,7 @@ async fn consensus_validation_large_tx() {
     let amount = MicroMinotari::from(5_000_000);
 
     let input = outputs[1][0].clone();
-    let inputs = vec![input.to_transaction_input(&key_manager).await.unwrap()];
+    let inputs = vec![input.to_transaction_input(&mut key_manager).await.unwrap()];
     let input_script_keys = vec![input.script_key_id().clone()];
 
     let fee = Fee::new(*consensus_manager.consensus_constants(0).transaction_weight_params()).calculate(
@@ -1237,7 +1237,7 @@ async fn consensus_validation_large_tx() {
     let mut sender_offsets = Vec::new();
     let mut pub_nonce = input_kernel_nonce.pub_key.clone().to_public_key().unwrap();
     for i in 0..output_count {
-        let test_params = TestParams::new(&key_manager).await;
+        let test_params = TestParams::new(&mut key_manager).await;
         let output_amount = if i < output_count - 1 {
             amount_per_output
         } else {
@@ -1248,7 +1248,7 @@ async fn consensus_validation_large_tx() {
             OutputFeatures::default(),
             &test_params,
             output_amount,
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -1362,7 +1362,7 @@ async fn validation_reject_min_fee() {
     let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network)
         .with_max_block_transaction_weight(500)
         .build();
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) =
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) =
         create_new_blockchain_with_constants(network, consensus_constants).await;
     let mempool_validator = TransactionFullValidator::new(
         CryptoFactories::default(),
@@ -1381,7 +1381,7 @@ async fn validation_reject_min_fee() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -1406,13 +1406,13 @@ async fn validation_reject_min_fee() {
             .unwrap();
     let mut sender_offsets = Vec::new();
 
-    let test_params = TestParams::new(&key_manager).await;
+    let test_params = TestParams::new(&mut key_manager).await;
     let wallet_output = create_wallet_output_with_data(
         script!(Nop).unwrap(),
         OutputFeatures::default(),
         &test_params,
         input.value(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -1516,7 +1516,7 @@ async fn consensus_validation_versions() {
     };
 
     let network = Network::LocalNet;
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
     let cc = consensus_manager.consensus_constants(0);
 
     // check the current localnet defaults
@@ -1550,16 +1550,16 @@ async fn consensus_validation_versions() {
         Box::new(mempool_validator),
     );
 
-    let test_params = TestParams::new(&key_manager).await;
+    let test_params = TestParams::new(&mut key_manager).await;
     let params = UtxoTestParams::with_value(1 * T);
-    let output_v0_features_v0 = test_params.create_output(params, &key_manager).await.unwrap();
+    let output_v0_features_v0 = test_params.create_output(params, &mut key_manager).await.unwrap();
     assert_eq!(output_v0_features_v0.version(), TransactionOutputVersion::V0);
     assert_eq!(output_v0_features_v0.features().version, OutputFeaturesVersion::V0);
 
-    let test_params = TestParams::new(&key_manager).await;
+    let test_params = TestParams::new(&mut key_manager).await;
     let mut params = UtxoTestParams::with_value(1 * T);
     params.output_version = Some(TransactionOutputVersion::V1);
-    let output_v1_features_v0 = test_params.create_output(params, &key_manager).await.unwrap();
+    let output_v1_features_v0 = test_params.create_output(params, &mut key_manager).await.unwrap();
     assert_eq!(output_v1_features_v0.version(), TransactionOutputVersion::V1);
     assert_eq!(output_v1_features_v0.features().version, OutputFeaturesVersion::V0);
 
@@ -1572,18 +1572,18 @@ async fn consensus_validation_versions() {
         RangeProofType::BulletProofPlus,
     );
 
-    let test_params = TestParams::new(&key_manager).await;
+    let test_params = TestParams::new(&mut key_manager).await;
     let mut params = UtxoTestParams::with_value(1 * T);
     params.features = features_v1.clone();
-    let output_v0_features_v1 = test_params.create_output(params, &key_manager).await.unwrap();
+    let output_v0_features_v1 = test_params.create_output(params, &mut key_manager).await.unwrap();
     assert_eq!(output_v0_features_v1.version(), TransactionOutputVersion::V0);
     assert_eq!(output_v0_features_v1.features().version, OutputFeaturesVersion::V1);
 
-    let test_params = TestParams::new(&key_manager).await;
+    let test_params = TestParams::new(&mut key_manager).await;
     let mut params = UtxoTestParams::with_value(1 * T);
     params.features = features_v1;
     params.output_version = Some(TransactionOutputVersion::V1);
-    let output_v1_features_v1 = test_params.create_output(params, &key_manager).await.unwrap();
+    let output_v1_features_v1 = test_params.create_output(params, &mut key_manager).await.unwrap();
     assert_eq!(output_v1_features_v1.version(), TransactionOutputVersion::V1);
     assert_eq!(output_v1_features_v1.features().version, OutputFeaturesVersion::V1);
 
@@ -1598,7 +1598,7 @@ async fn consensus_validation_versions() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -1622,7 +1622,7 @@ async fn consensus_validation_versions() {
         input_version: Some(TransactionInputVersion::V1),
         output_version: None,
     };
-    let (tx, _) = spend_utxos(tx_schema, &key_manager).await;
+    let (tx, _) = spend_utxos(tx_schema, &mut key_manager).await;
     validator.validate(&tx, Some(25.into()), None, u64::MAX).unwrap_err();
 
     // invalid output version
@@ -1640,7 +1640,7 @@ async fn consensus_validation_versions() {
         output_version: Some(TransactionOutputVersion::V1),
     };
 
-    let (tx, _) = spend_utxos(tx_schema, &key_manager).await;
+    let (tx, _) = spend_utxos(tx_schema, &mut key_manager).await;
     validator.validate(&tx, Some(25.into()), None, u64::MAX).unwrap_err();
 
     // invalid output features version
@@ -1658,14 +1658,14 @@ async fn consensus_validation_versions() {
         output_version: None,
     };
 
-    let (tx, _) = spend_utxos(tx_schema, &key_manager).await;
+    let (tx, _) = spend_utxos(tx_schema, &mut key_manager).await;
     validator.validate(&tx, Some(25.into()), None, u64::MAX).unwrap_err();
 }
 
 #[tokio::test]
 async fn consensus_validation_unique_excess_sig() {
     let network = Network::LocalNet;
-    let (mut store, mut blocks, mut outputs, consensus_manager, key_manager) = create_new_blockchain(network).await;
+    let (mut store, mut blocks, mut outputs, consensus_manager, mut key_manager) = create_new_blockchain(network).await;
 
     let mempool_validator = TransactionFullValidator::new(
         CryptoFactories::default(),
@@ -1691,16 +1691,22 @@ async fn consensus_validation_unique_excess_sig() {
         &mut outputs,
         txs,
         &consensus_manager,
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
 
     let schema = txn_schema!(from: vec![outputs[1][0].clone()], to: vec![1_500_000 * uT]);
-    let (tx1, _) = spend_utxos(schema.clone(), &key_manager).await;
-    generate_block(&store, &mut blocks, vec![tx1.clone()], &consensus_manager, &key_manager)
-        .await
-        .unwrap();
+    let (tx1, _) = spend_utxos(schema.clone(), &mut key_manager).await;
+    generate_block(
+        &store,
+        &mut blocks,
+        vec![tx1.clone()],
+        &consensus_manager,
+        &mut key_manager,
+    )
+    .await
+    .unwrap();
 
     // trying to submit a transaction with an existing excess signature already in the chain is an error
     let tx = Arc::new(tx1);
@@ -1721,14 +1727,14 @@ async fn block_event_and_reorg_event_handling() {
     // When block B2A is submitted, then both nodes have TX2A and TX3A in their reorg pools
     // When block B2B is submitted with TX2B, TX3B, then TX2A, TX3A are discarded (Not Stored)
     let network = Network::LocalNet;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = ConsensusConstantsBuilder::new(Network::LocalNet)
         .with_coinbase_lockheight(1)
         .build();
 
     let temp_dir = tempdir().unwrap();
     let (block0, utxos0) =
-        create_genesis_block_with_coinbase_value(100_000_000.into(), &consensus_constants, &key_manager).await;
+        create_genesis_block_with_coinbase_value(100_000_000.into(), &consensus_constants, &mut key_manager).await;
     let consensus_manager = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants.clone())
         .with_block(block0.clone())
@@ -1759,7 +1765,7 @@ async fn block_event_and_reorg_event_handling() {
     // service will receive.
     let (tx1, utxos1) = schema_to_transaction(
         &[txn_schema!(from: vec![utxos0.clone()], to: vec![1 * T, 1 * T])],
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (txs_a, _utxos2) = schema_to_transaction(
@@ -1767,7 +1773,7 @@ async fn block_event_and_reorg_event_handling() {
             txn_schema!(from: vec![utxos1[0].clone()], to: vec![400_000 * uT, 590_000 * uT]),
             txn_schema!(from: vec![utxos1[1].clone()], to: vec![750_000 * uT, 240_000 * uT]),
         ],
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (txs_b, _utxos3) = schema_to_transaction(
@@ -1775,7 +1781,7 @@ async fn block_event_and_reorg_event_handling() {
             txn_schema!(from: vec![utxos1[0].clone()], to: vec![100_000 * uT, 890_000 * uT]),
             txn_schema!(from: vec![utxos1[1].clone()], to: vec![850_000 * uT, 140_000 * uT]),
         ],
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let tx1 = (*tx1[0]).clone();
@@ -1792,7 +1798,7 @@ async fn block_event_and_reorg_event_handling() {
     // These blocks are manually constructed to allow the block event system to be used.
     let empty_block = bob
         .blockchain_db
-        .prepare_new_block(chain_block(block0.block(), vec![], &consensus_manager, &key_manager).await)
+        .prepare_new_block(chain_block(block0.block(), vec![], &consensus_manager, &mut key_manager).await)
         .unwrap();
 
     // Add one empty block, so the coinbase UTXO is no longer time-locked.
@@ -1802,7 +1808,7 @@ async fn block_event_and_reorg_event_handling() {
     bob.mempool.insert(Arc::new(tx1.clone())).await.unwrap();
     let mut block1 = bob
         .blockchain_db
-        .prepare_new_block(chain_block(&empty_block, vec![tx1], &consensus_manager, &key_manager).await)
+        .prepare_new_block(chain_block(&empty_block, vec![tx1], &consensus_manager, &mut key_manager).await)
         .unwrap();
     find_header_with_achieved_difficulty(&mut block1.header, Difficulty::from_u64(1).unwrap());
     // Add Block1 - tx1 will be moved to the ReorgPool.
@@ -1828,13 +1834,13 @@ async fn block_event_and_reorg_event_handling() {
 
     let mut block2a = bob
         .blockchain_db
-        .prepare_new_block(chain_block(&block1, vec![tx2a, tx3a], &consensus_manager, &key_manager).await)
+        .prepare_new_block(chain_block(&block1, vec![tx2a, tx3a], &consensus_manager, &mut key_manager).await)
         .unwrap();
     find_header_with_achieved_difficulty(&mut block2a.header, Difficulty::from_u64(1).unwrap());
     // Block2b also builds on Block1 but has a stronger PoW
     let mut block2b = bob
         .blockchain_db
-        .prepare_new_block(chain_block(&block1, vec![tx2b, tx3b], &consensus_manager, &key_manager).await)
+        .prepare_new_block(chain_block(&block1, vec![tx2b, tx3b], &consensus_manager, &mut key_manager).await)
         .unwrap();
     find_header_with_achieved_difficulty(&mut block2b.header, Difficulty::from_u64(10).unwrap());
 

--- a/base_layer/core/tests/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/tests/node_comms_interface.rs
@@ -187,10 +187,10 @@ async fn inbound_fetch_utxos() {
     let utxo_1 = block0.body.outputs()[0].clone();
     let hash_1 = utxo_1.hash();
 
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let (utxo_2, _, _) = create_utxo(
         MicroMinotari(10_000),
-        &key_manager,
+        &mut key_manager,
         &Default::default(),
         &script!(Nop).unwrap(),
         &Covenant::default(),
@@ -253,7 +253,7 @@ async fn inbound_fetch_blocks() {
 async fn inbound_fetch_blocks_before_horizon_height() {
     let consensus_manager = BaseNodeConsensusManager::builder(Network::LocalNet).build().unwrap();
     let block0 = consensus_manager.get_genesis_block();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let validators = Validators::new(
         MockValidator::new(true),
         MockValidator::new(true),
@@ -293,7 +293,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         vec![],
         &consensus_manager,
         Difficulty::min(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -303,7 +303,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         vec![],
         &consensus_manager,
         Difficulty::min(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -313,7 +313,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         vec![],
         &consensus_manager,
         Difficulty::min(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -323,7 +323,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         vec![],
         &consensus_manager,
         Difficulty::min(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -333,7 +333,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         vec![],
         &consensus_manager,
         Difficulty::min(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();

--- a/base_layer/core/tests/tests/node_service.rs
+++ b/base_layer/core/tests/tests/node_service.rs
@@ -76,7 +76,7 @@ use crate::{
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn propagate_and_forward_many_valid_blocks() {
     let temp_dir = tempdir().unwrap();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     // Alice will propagate a number of block hashes to bob, bob will receive it, request the full block, verify and
     // then propagate the hash to carol and dan. Dan and Carol will also try to propagate the block hashes to each
     // other, but the block should not be re-requested. These duplicate blocks will be discarded and wont be
@@ -92,10 +92,10 @@ async fn propagate_and_forward_many_valid_blocks() {
     let dan_node_identity = random_node_identity();
     let network = Network::LocalNet;
     let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
-    let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants, &key_manager).await;
+    let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants, &mut key_manager).await;
 
     let (tx01, _tx01_out) = spend_utxos(
-        txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features: OutputFeatures::default()),&mut key_manager
     ).await;
 
     let rules = BaseNodeConsensusManager::builder(network)
@@ -179,14 +179,22 @@ async fn propagate_and_forward_many_valid_blocks() {
             rules
                 .consensus_constants(block0.height())
                 .min_pow_difficulty(PowAlgorithm::Sha3x),
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap()
         .0,
     );
-    blocks
-        .extend(construct_chained_blocks(&alice_node.blockchain_db, blocks[0].clone(), &rules, 5, &key_manager).await);
+    blocks.extend(
+        construct_chained_blocks(
+            &alice_node.blockchain_db,
+            blocks[0].clone(),
+            &rules,
+            5,
+            &mut key_manager,
+        )
+        .await,
+    );
 
     for block in &blocks {
         alice_node
@@ -238,9 +246,9 @@ async fn propagate_and_forward_invalid_block_hash() {
     let bob_node_identity = random_node_identity();
     let carol_node_identity = random_node_identity();
     let network = Network::LocalNet;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
-    let (block0, genesis_coinbase) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let (block0, genesis_coinbase) = create_genesis_block(&consensus_constants, &mut key_manager).await;
     let rules = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants)
         .with_block(block0.clone())
@@ -296,7 +304,7 @@ async fn propagate_and_forward_invalid_block_hash() {
     // Add a transaction that Bob does not have to force a request
     let (txs, _) = schema_to_transaction(
         &[txn_schema!(from: vec![genesis_coinbase.clone()], to: vec![5 * T], fee: 5.into())],
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let txs = txs.into_iter().map(|tx| (*tx).clone()).collect();
@@ -306,7 +314,7 @@ async fn propagate_and_forward_invalid_block_hash() {
         txs,
         &rules,
         Difficulty::from_u64(4).unwrap(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -368,10 +376,10 @@ async fn propagate_and_forward_invalid_block() {
     let bob_node_identity = random_node_identity();
     let carol_node_identity = random_node_identity();
     let dan_node_identity = random_node_identity();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let network = Network::LocalNet;
     let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
-    let (block0, _) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let (block0, _) = create_genesis_block(&consensus_constants, &mut key_manager).await;
     let rules = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants)
         .with_block(block0.clone())
@@ -463,7 +471,7 @@ async fn propagate_and_forward_invalid_block() {
         vec![],
         &rules,
         Difficulty::from_u64(4).unwrap(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
@@ -517,18 +525,32 @@ async fn propagate_and_forward_invalid_block() {
 async fn local_get_metadata() {
     let temp_dir = tempdir().unwrap();
     let network = Network::LocalNet;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let (mut node, consensus_manager) = BaseNodeBuilder::new(network.into())
         .start(temp_dir.path().to_str().unwrap(), BlockchainDatabaseConfig::default())
         .await;
     let db = &node.blockchain_db;
     let block0 = db.fetch_block(0, true).unwrap().try_into_chain_block().unwrap();
-    let (block1, _) = append_block(db, &block0, vec![], &consensus_manager, Difficulty::min(), &key_manager)
-        .await
-        .unwrap();
-    let (block2, _) = append_block(db, &block1, vec![], &consensus_manager, Difficulty::min(), &key_manager)
-        .await
-        .unwrap();
+    let (block1, _) = append_block(
+        db,
+        &block0,
+        vec![],
+        &consensus_manager,
+        Difficulty::min(),
+        &mut key_manager,
+    )
+    .await
+    .unwrap();
+    let (block2, _) = append_block(
+        db,
+        &block1,
+        vec![],
+        &consensus_manager,
+        Difficulty::min(),
+        &mut key_manager,
+    )
+    .await
+    .unwrap();
 
     let metadata = node.local_nci.get_metadata().await.unwrap();
     assert_eq!(metadata.best_block_height(), 2);
@@ -541,9 +563,9 @@ async fn local_get_metadata() {
 async fn local_get_new_block_template_and_get_new_block() {
     let temp_dir = tempdir().unwrap();
     let network = Network::LocalNet;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = NetworkConsensus::from(network).create_consensus_constants();
-    let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants[0], &key_manager).await;
+    let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants[0], &mut key_manager).await;
     let rules = BaseNodeConsensusManager::builder(network)
         .add_consensus_constants(consensus_constants[0].clone())
         .with_block(block0)
@@ -558,7 +580,7 @@ async fn local_get_new_block_template_and_get_new_block() {
         txn_schema!(from: vec![outputs[1].clone()], to: vec![10_000 * uT, 20_000 * uT]),
         txn_schema!(from: vec![outputs[2].clone()], to: vec![30_000 * uT, 40_000 * uT]),
     ];
-    let (txs, _) = schema_to_transaction(&schema, &key_manager).await;
+    let (txs, _) = schema_to_transaction(&schema, &mut key_manager).await;
     node.mempool.insert(txs[0].clone()).await.unwrap();
     node.mempool.insert(txs[1].clone()).await.unwrap();
 
@@ -584,9 +606,9 @@ async fn local_get_new_block_with_zero_conf() {
     let factories = CryptoFactories::default();
     let temp_dir = tempdir().unwrap();
     let network = Network::LocalNet;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = NetworkConsensus::from(network).create_consensus_constants();
-    let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants[0], &key_manager).await;
+    let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants[0], &mut key_manager).await;
     let rules = BaseNodeConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants[0].clone())
         .with_block(block0)
@@ -604,10 +626,10 @@ async fn local_get_new_block_with_zero_conf() {
         .await;
 
     let (tx01, tx01_out) = spend_utxos(
-        txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features: OutputFeatures::default()),&mut key_manager
     ).await;
     let (tx02, tx02_out) = spend_utxos(
-        txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features: OutputFeatures::default()),&mut key_manager
     ).await;
     assert_eq!(
         node.mempool.insert(Arc::new(tx01)).await.unwrap(),
@@ -620,12 +642,12 @@ async fn local_get_new_block_with_zero_conf() {
 
     let (tx11, _) = spend_utxos(
         txn_schema!(from: tx01_out, to: vec![10_000 * uT], fee: 50*uT, lock: 0, features: OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx12, _) = spend_utxos(
         txn_schema!(from: tx02_out, to: vec![20_000 * uT], fee: 60*uT, lock: 0, features: OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     assert_eq!(
@@ -649,7 +671,7 @@ async fn local_get_new_block_with_zero_conf() {
         coinbase_value,
         rules.consensus_constants(1).coinbase_min_maturity() + 1,
         None,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     block_template.body.add_kernel(kernel);
@@ -670,9 +692,9 @@ async fn local_get_new_block_with_combined_transaction() {
     let factories = CryptoFactories::default();
     let temp_dir = tempdir().unwrap();
     let network = Network::LocalNet;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = NetworkConsensus::from(network).create_consensus_constants();
-    let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants[0], &key_manager).await;
+    let (block0, outputs) = create_genesis_block_with_utxos(&[T, T], &consensus_constants[0], &mut key_manager).await;
     let rules = BaseNodeConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants[0].clone())
         .with_block(block0)
@@ -690,19 +712,19 @@ async fn local_get_new_block_with_combined_transaction() {
         .await;
 
     let (tx01, tx01_out) = spend_utxos(
-        txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features: OutputFeatures::default()),&mut key_manager
     ).await;
     let (tx02, tx02_out) = spend_utxos(
-        txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features: OutputFeatures::default()),&key_manager
+        txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features: OutputFeatures::default()),&mut key_manager
     ).await;
     let (tx11, _) = spend_utxos(
         txn_schema!(from: tx01_out, to: vec![10_000 * uT], fee: 50*uT, lock: 0, features: OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let (tx12, _) = spend_utxos(
         txn_schema!(from: tx02_out, to: vec![20_000 * uT], fee: 60*uT, lock: 0, features: OutputFeatures::default()),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
 
@@ -730,7 +752,7 @@ async fn local_get_new_block_with_combined_transaction() {
         coinbase_value,
         rules.consensus_constants(1).coinbase_min_maturity() + 1,
         None,
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     block_template.body.add_kernel(kernel);
@@ -750,7 +772,7 @@ async fn local_get_new_block_with_combined_transaction() {
 async fn local_submit_block() {
     let temp_dir = tempdir().unwrap();
     let network = Network::LocalNet;
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let (mut node, consensus_manager) = BaseNodeBuilder::new(network.into())
         .start(temp_dir.path().to_str().unwrap(), BlockchainDatabaseConfig::default())
         .await;
@@ -759,7 +781,7 @@ async fn local_submit_block() {
     let mut event_stream = node.local_nci.get_block_event_stream();
     let block0 = db.fetch_block(0, true).unwrap().block().clone();
     let mut block1 = db
-        .prepare_new_block(chain_block(&block0, vec![], &consensus_manager, &key_manager).await)
+        .prepare_new_block(chain_block(&block0, vec![], &consensus_manager, &mut key_manager).await)
         .unwrap();
     block1.header.kernel_mmr_size += 1;
     block1.header.output_smt_size += 1;

--- a/base_layer/core/tests/tests/node_state_machine.rs
+++ b/base_layer/core/tests/tests/node_state_machine.rs
@@ -71,9 +71,9 @@ use crate::helpers::{
 async fn test_listening_lagging() {
     let network = Network::LocalNet;
     let temp_dir = tempdir().unwrap();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
-    let (prev_block, _) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let (prev_block, _) = create_genesis_block(&consensus_constants, &mut key_manager).await;
     let consensus_manager = BaseNodeConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)
         .with_block(prev_block.clone())
@@ -132,13 +132,13 @@ async fn test_listening_lagging() {
         vec![],
         &consensus_manager,
         Difficulty::from_u64(4).unwrap(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
     // Bob Block 2 - with block event and liveness service metadata update
     let mut prev_block = bob_db
-        .prepare_new_block(chain_block(prev_block.block(), vec![], &consensus_manager, &key_manager).await)
+        .prepare_new_block(chain_block(prev_block.block(), vec![], &consensus_manager, &mut key_manager).await)
         .unwrap();
     prev_block.header.output_smt_size += 1;
     prev_block.header.kernel_mmr_size += 1;
@@ -157,9 +157,9 @@ async fn test_listening_lagging() {
 async fn test_listening_initial_fallen_behind() {
     let network = Network::LocalNet;
     let temp_dir = tempdir().unwrap();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let consensus_constants = crate::helpers::sample_blockchains::consensus_constants(network).build();
-    let (gen_block, _) = create_genesis_block(&consensus_constants, &key_manager).await;
+    let (gen_block, _) = create_genesis_block(&consensus_constants, &mut key_manager).await;
     let consensus_manager = BaseNodeConsensusManagerBuilder::new(network)
         .add_consensus_constants(consensus_constants)
         .with_block(gen_block.clone())
@@ -198,13 +198,13 @@ async fn test_listening_initial_fallen_behind() {
         vec![],
         &consensus_manager,
         Difficulty::from_u64(4).unwrap(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
     // Bob Block 2 - with block event and liveness service metadata update
     let mut prev_block = bob_db
-        .prepare_new_block(chain_block(prev_block.block(), vec![], &consensus_manager, &key_manager).await)
+        .prepare_new_block(chain_block(prev_block.block(), vec![], &consensus_manager, &mut key_manager).await)
         .unwrap();
     prev_block.header.output_smt_size += 1;
     prev_block.header.kernel_mmr_size += 1;
@@ -225,13 +225,13 @@ async fn test_listening_initial_fallen_behind() {
         vec![],
         &consensus_manager,
         Difficulty::from_u64(4).unwrap(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
     // charlie Block 2 - with block event and liveness service metadata update
     let mut prev_block = charlie_db
-        .prepare_new_block(chain_block(prev_block.block(), vec![], &consensus_manager, &key_manager).await)
+        .prepare_new_block(chain_block(prev_block.block(), vec![], &consensus_manager, &mut key_manager).await)
         .unwrap();
     prev_block.header.output_smt_size += 1;
     prev_block.header.kernel_mmr_size += 1;

--- a/base_layer/transaction_components/src/coinbase_builder.rs
+++ b/base_layer/transaction_components/src/coinbase_builder.rs
@@ -244,7 +244,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::erasing_op)] // This is for 0 * uT
     pub async fn build_with_reward(
-        self,
+        mut self,
         constants: &ConsensusConstants,
         block_reward: MicroMinotari,
         payment_id: MemoField,
@@ -387,7 +387,7 @@ pub async fn generate_coinbase<KM: TransactionKeyManagerInterface>(
     reward: MicroMinotari,
     height: u64,
     extra: &CoinBaseExtra,
-    key_manager: &KM,
+    key_manager: &mut KM,
     wallet_payment_address: &TariAddress,
     stealth_payment: bool,
     consensus_constants: &ConsensusConstants,
@@ -420,7 +420,7 @@ pub async fn generate_coinbase_with_wallet_output<KM: TransactionKeyManagerInter
     reward: MicroMinotari,
     height: u64,
     extra: &CoinBaseExtra,
-    key_manager: &KM,
+    key_manager: &mut KM,
     script_key_id: &TariKeyId,
     wallet_payment_address: &TariAddress,
     stealth_payment: bool,
@@ -597,8 +597,8 @@ mod test {
 
     #[tokio::test]
     async fn valid_coinbase() {
-        let (builder, rules, factories, key_manager) = get_builder().await;
-        let p = TestParams::new(&key_manager).await;
+        let (builder, rules, factories, mut key_manager) = get_builder().await;
+        let p = TestParams::new(&mut key_manager).await;
         let wallet_payment_address = TariAddress::default();
         let builder = builder
             .with_block_height(42)
@@ -652,8 +652,8 @@ mod test {
 
     #[tokio::test]
     async fn invalid_coinbase_maturity() {
-        let (builder, rules, factories, key_manager) = get_builder().await;
-        let p = TestParams::new(&key_manager).await;
+        let (builder, rules, factories, mut key_manager) = get_builder().await;
+        let p = TestParams::new(&mut key_manager).await;
         let block_reward = rules.emission_schedule().block_reward(42) + 145 * uT;
         let wallet_payment_address = TariAddress::default();
         let builder = builder
@@ -691,8 +691,8 @@ mod test {
     #[tokio::test]
     #[allow(clippy::identity_op)]
     async fn invalid_coinbase_value() {
-        let (builder, rules, factories, key_manager) = get_builder().await;
-        let p = TestParams::new(&key_manager).await;
+        let (builder, rules, factories, mut key_manager) = get_builder().await;
+        let p = TestParams::new(&mut key_manager).await;
         // We just want some small amount here.
         let missing_fee = rules.emission_schedule().block_reward(4200000) + (2 * uT);
         let wallet_payment_address = TariAddress::default();
@@ -787,8 +787,8 @@ mod test {
     async fn invalid_coinbase_amount() {
         // We construct two txs both valid with a single coinbase. We then add a duplicate coinbase utxo to the one, and
         // a duplicate coinbase kernel to the other one.
-        let (builder, rules, factories, key_manager) = get_builder().await;
-        let p = TestParams::new(&key_manager).await;
+        let (builder, rules, factories, mut key_manager) = get_builder().await;
+        let p = TestParams::new(&mut key_manager).await;
         // We just want some small amount here.
         let missing_fee = rules.emission_schedule().block_reward(4200000) + (2 * uT);
         let wallet_payment_address = TariAddress::default();
@@ -931,8 +931,8 @@ mod test {
     async fn multi_coinbase_amount() {
         // We construct two txs both valid with a single coinbase. We then add a duplicate coinbase utxo to the one, and
         // a duplicate coinbase kernel to the other one.
-        let (builder, rules, factories, key_manager) = get_builder().await;
-        let p = TestParams::new(&key_manager).await;
+        let (builder, rules, factories, mut key_manager) = get_builder().await;
+        let p = TestParams::new(&mut key_manager).await;
         // We just want some small amount here.
         let missing_fee = rules.emission_schedule().block_reward(4200000) + (2 * uT);
         let wallet_payment_address = TariAddress::default();
@@ -1077,8 +1077,8 @@ mod test {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::identity_op)]
     async fn too_may_coinbases() {
-        let (builder, rules, factories, key_manager) = get_builder().await;
-        let p = TestParams::new(&key_manager).await;
+        let (builder, rules, factories, mut key_manager) = get_builder().await;
+        let p = TestParams::new(&mut key_manager).await;
         // We just want some small amount here.
         let missing_fee = rules.emission_schedule().block_reward(4200000) + (2 * uT);
         let wallet_payment_address = TariAddress::default();
@@ -1201,7 +1201,7 @@ mod test {
 
     #[tokio::test]
     async fn test_generate_coinbase_with_payment_id_from_address() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let wallet_private_spend_key = PrivateKey::random(&mut rand::rngs::OsRng);
         let wallet_private_view_key = PrivateKey::random(&mut rand::rngs::OsRng);
 
@@ -1233,7 +1233,7 @@ mod test {
             reward,
             header_height,
             &CoinBaseExtra::default(),
-            &key_manager,
+            &mut key_manager,
             &script_key_id,
             &wallet_payment_address,
             false,

--- a/base_layer/transaction_components/src/key_manager/inner.rs
+++ b/base_layer/transaction_components/src/key_manager/inner.rs
@@ -110,9 +110,10 @@ use crate::{
     MicroMinotari,
 };
 
+#[derive(Clone)]
 pub struct TransactionKeyManagerInner<TBackend> {
-    key_managers: HashMap<String, RwLock<TariKeyManager<KeyDigest>>>,
-    db: Option<TBackend>,
+    key_managers: HashMap<String, TariKeyManager<KeyDigest>>,
+    db: Option<Arc<RwLock<TBackend>>>,
     master_seed: CipherSeed,
     crypto_factories: CryptoFactories,
     wallet_type: Arc<WalletType>,
@@ -129,7 +130,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
     ) -> Result<Self, KeyManagerServiceError> {
         let mut km = TransactionKeyManagerInner {
             key_managers: HashMap::new(),
-            db,
+            db: db.map(|db| Arc::new(RwLock::new(db))),
             master_seed,
             crypto_factories,
             wallet_type,
@@ -165,26 +166,20 @@ where TBackend: TransactionKeyManagerBackend + 'static
         };
         self.key_managers.insert(
             branch.to_string(),
-            RwLock::new(TariKeyManager::<KeyDigest>::from(
-                self.master_seed.clone(),
-                state.branch_seed,
-                state.primary_key_index,
-            )),
+            TariKeyManager::<KeyDigest>::from(self.master_seed.clone(), state.branch_seed, state.primary_key_index),
         );
         Ok(result)
     }
 
-    pub async fn get_next_key(&self, branch: &str) -> Result<TariKeyAndId, KeyManagerServiceError> {
+    pub async fn get_next_key(&mut self, branch: &str) -> Result<TariKeyAndId, KeyManagerServiceError> {
         let index = {
             match branch {
                 PRE_MINE => {
-                    let mut km = self
-                        .key_managers
-                        .get(branch)
-                        .ok_or_else(|| self.unknown_key_branch_error("get_next_key", branch))?
-                        .write()
-                        .await;
-                    km.increment_key_index(1)
+                    if let Some(km) = self.key_managers.get_mut(branch) {
+                        km.increment_key_index(1)
+                    } else {
+                        return Err(self.unknown_key_branch_error("get_next_key", branch));
+                    }
                 },
                 _ => OsRng.next_u64(),
             }
@@ -364,9 +359,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
             let km = self
                 .key_managers
                 .get(branch)
-                .ok_or_else(|| self.unknown_key_branch_error("get_public_key_at_key_id", branch))?
-                .read()
-                .await;
+                .ok_or_else(|| self.unknown_key_branch_error("get_public_key_at_key_id", branch))?;
             Ok(km.derive_public_key(*index)?.key)
         } else {
             Err(KeyManagerServiceError::UnknownError(
@@ -426,7 +419,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
             TariKeyId::Zero => Ok(PrivateKey::default()),
             TariKeyId::Imported { key } => {
                 if let Some(db) = &self.db {
-                    let pvt_key = db.get_imported_key(key).await?;
+                    let pvt_key = db.write().await.get_imported_key(key).await?;
                     return Ok(pvt_key);
                 }
                 Err(KeyManagerServiceError::NoStorage)
@@ -468,9 +461,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
                 let km = self
                     .key_managers
                     .get(branch)
-                    .ok_or_else(|| self.unknown_key_branch_error("get_private_key", branch))?
-                    .read()
-                    .await;
+                    .ok_or_else(|| self.unknown_key_branch_error("get_private_key", branch))?;
                 let key = km.get_private_key(*index)?;
                 Ok(key)
             },
@@ -493,9 +484,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
                                     "get_private_key",
                                     &TransactionKeyManagerBranch::Spend.get_branch_key(),
                                 )
-                            })?
-                            .read()
-                            .await;
+                            })?;
                         let private_alpha = km.get_private_key(0)?;
                         let hasher =
                             DomainSeparatedHasher::<Blake2b<U64>, KeyManagerTransactionsHashDomain>::new_with_label(
@@ -630,7 +619,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
     }
 
     pub async fn get_next_commitment_mask_and_script_key(
-        &self,
+        &mut self,
     ) -> Result<(TariKeyAndId, TariKeyAndId), KeyManagerServiceError> {
         let commitment_mask = self
             .get_next_key(&TransactionKeyManagerBranch::CommitmentMask.get_branch_key())
@@ -708,9 +697,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
                     let km = self
                         .key_managers
                         .get(&branch)
-                        .ok_or_else(|| self.unknown_key_branch_error("get_private_comms_key", &branch))?
-                        .read()
-                        .await;
+                        .ok_or_else(|| self.unknown_key_branch_error("get_private_comms_key", &branch))?;
                     let key = km.get_private_key(index)?;
                     Ok(key)
                 }
@@ -719,9 +706,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
                 let km = self
                     .key_managers
                     .get(&branch)
-                    .ok_or_else(|| self.unknown_key_branch_error("get_private_comms_key", &branch))?
-                    .read()
-                    .await;
+                    .ok_or_else(|| self.unknown_key_branch_error("get_private_comms_key", &branch))?;
                 let key = km.get_private_key(index)?;
                 Ok(key)
             },
@@ -1406,7 +1391,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
     }
 
     pub async fn get_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value_as_private_key: &PrivateKey,
         sender_offset_key_id: &TariKeyId,
@@ -1453,7 +1438,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
 
     #[allow(unused_variables)]
     pub async fn get_one_sided_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value: MicroMinotari,
         sender_offset_key_id: &TariKeyId,
@@ -1516,7 +1501,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
     }
 
     pub async fn get_receiver_partial_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
         sender_offset_public_key: &CompressedPublicKey,

--- a/base_layer/transaction_components/src/key_manager/interface.rs
+++ b/base_layer/transaction_components/src/key_manager/interface.rs
@@ -346,10 +346,11 @@ pub trait TransactionKeyManagerInterface: Clone + Send + Sync + 'static {
     /// manager from the backend to track in memory, will return `Ok(AddResult::NewEntry)`. If the branch is already
     /// tracked in memory the result will be `Ok(AddResult::AlreadyExists)`. If the branch does not exist in memory
     /// or in the backend, a new branch will be created and tracked the backend, `Ok(AddResult::NewEntry)`.
-    async fn add_new_branch<T: Into<String> + Send>(&self, branch: T) -> Result<AddResult, KeyManagerServiceError>;
+    async fn add_new_branch<T: Into<String> + Send>(&mut self, branch: T) -> Result<AddResult, KeyManagerServiceError>;
 
     /// Gets the next key id from the branch. This will auto-increment the branch key index by 1
-    async fn get_next_key<T: Into<String> + Send>(&self, branch: T) -> Result<TariKeyAndId, KeyManagerServiceError>;
+    async fn get_next_key<T: Into<String> + Send>(&mut self, branch: T)
+        -> Result<TariKeyAndId, KeyManagerServiceError>;
 
     /// Gets a randomly generated key, which the key manager will manage
     async fn get_random_key(&self) -> Result<TariKeyAndId, KeyManagerServiceError>;
@@ -397,7 +398,7 @@ pub trait TransactionKeyManagerInterface: Clone + Send + Sync + 'static {
     async fn get_comms_key(&self) -> Result<TariKeyAndId, KeyManagerServiceError>;
 
     async fn get_next_commitment_mask_and_script_key(
-        &self,
+        &mut self,
     ) -> Result<(TariKeyAndId, TariKeyAndId), KeyManagerServiceError>;
 
     async fn find_script_key_id_from_commitment_mask_key_id(
@@ -512,7 +513,7 @@ pub trait TransactionKeyManagerInterface: Clone + Send + Sync + 'static {
     // Look into perhaps removing all nonce here, if the signer and receiver are the same it should not be required to
     // share or pre calc the nonces
     async fn get_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value_as_private_key: &PrivateKey,
         sender_offset_key_id: &TariKeyId,
@@ -522,7 +523,7 @@ pub trait TransactionKeyManagerInterface: Clone + Send + Sync + 'static {
     ) -> Result<ComAndPubSignature, TransactionError>;
 
     async fn get_one_sided_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value: MicroMinotari,
         sender_offset_key_id: &TariKeyId,
@@ -559,7 +560,7 @@ pub trait TransactionKeyManagerInterface: Clone + Send + Sync + 'static {
     ) -> Result<CompressedSignature, TransactionError>;
 
     async fn get_receiver_partial_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
         sender_offset_public_key: &CompressedPublicKey,

--- a/base_layer/transaction_components/src/key_manager/wrapper.rs
+++ b/base_layer/transaction_components/src/key_manager/wrapper.rs
@@ -44,7 +44,6 @@ use tari_common_types::{
 };
 use tari_crypto::hashing::DomainSeparatedHash;
 use tari_script::{CompressedCheckSigSchnorrSignature, TariScript};
-use tokio::sync::RwLock;
 
 use crate::{
     crypto_factories::CryptoFactories,
@@ -76,7 +75,7 @@ use crate::{
 /// This handle can be cloned cheaply and safely shared across multiple threads.
 #[derive(Clone)]
 pub struct TransactionKeyManagerWrapper<TBackend> {
-    transaction_key_manager_inner: Arc<RwLock<TransactionKeyManagerInner<TBackend>>>,
+    transaction_key_manager_inner: TransactionKeyManagerInner<TBackend>,
 }
 
 impl<TBackend> TransactionKeyManagerWrapper<TBackend>
@@ -92,9 +91,13 @@ where TBackend: TransactionKeyManagerBackend + 'static
         wallet_type: Arc<WalletType>,
     ) -> Result<Self, KeyManagerServiceError> {
         Ok(TransactionKeyManagerWrapper {
-            transaction_key_manager_inner: Arc::new(RwLock::new(
-                TransactionKeyManagerInner::new(master_seed, Some(db), crypto_factories, wallet_type).await?,
-            )),
+            transaction_key_manager_inner: TransactionKeyManagerInner::new(
+                master_seed,
+                Some(db),
+                crypto_factories,
+                wallet_type,
+            )
+            .await?,
         })
     }
 
@@ -104,20 +107,24 @@ where TBackend: TransactionKeyManagerBackend + 'static
         wallet_type: Arc<WalletType>,
     ) -> Result<Self, KeyManagerServiceError> {
         Ok(TransactionKeyManagerWrapper {
-            transaction_key_manager_inner: Arc::new(RwLock::new(
-                TransactionKeyManagerInner::new(master_seed, None, crypto_factories, wallet_type).await?,
-            )),
+            transaction_key_manager_inner: TransactionKeyManagerInner::new(
+                master_seed,
+                None,
+                crypto_factories,
+                wallet_type,
+            )
+            .await?,
         })
     }
 
     /// Get the wallet type
     pub async fn get_wallet_type(&self) -> Arc<WalletType> {
-        self.transaction_key_manager_inner.read().await.get_wallet_type()
+        self.transaction_key_manager_inner.get_wallet_type()
     }
 
     /// Get the birthday of the wallet seed
     pub async fn get_birthday(&self) -> u16 {
-        self.transaction_key_manager_inner.read().await.master_seed().birthday()
+        self.transaction_key_manager_inner.master_seed().birthday()
     }
 }
 
@@ -125,32 +132,25 @@ where TBackend: TransactionKeyManagerBackend + 'static
 impl<TBackend> TransactionKeyManagerInterface for TransactionKeyManagerWrapper<TBackend>
 where TBackend: TransactionKeyManagerBackend + 'static
 {
-    async fn add_new_branch<T: Into<String> + Send>(&self, branch: T) -> Result<AddResult, KeyManagerServiceError> {
+    async fn add_new_branch<T: Into<String> + Send>(&mut self, branch: T) -> Result<AddResult, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .write()
-            .await
             .add_key_manager_branch(&branch.into())
             .await
     }
 
-    async fn get_next_key<T: Into<String> + Send>(&self, branch: T) -> Result<TariKeyAndId, KeyManagerServiceError> {
-        self.transaction_key_manager_inner
-            .read()
-            .await
-            .get_next_key(&branch.into())
-            .await
+    async fn get_next_key<T: Into<String> + Send>(
+        &mut self,
+        branch: T,
+    ) -> Result<TariKeyAndId, KeyManagerServiceError> {
+        self.transaction_key_manager_inner.get_next_key(&branch.into()).await
     }
 
     async fn get_random_key(&self) -> Result<TariKeyAndId, KeyManagerServiceError> {
-        self.transaction_key_manager_inner.read().await.get_random_key().await
+        self.transaction_key_manager_inner.get_random_key().await
     }
 
     async fn get_static_key<T: Into<String> + Send>(&self, branch: T) -> Result<TariKeyId, KeyManagerServiceError> {
-        self.transaction_key_manager_inner
-            .read()
-            .await
-            .get_static_key(&branch.into())
-            .await
+        self.transaction_key_manager_inner.get_static_key(&branch.into()).await
     }
 
     async fn get_public_key_at_key_id(
@@ -158,8 +158,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         key_id: &TariKeyId,
     ) -> Result<CompressedPublicKey, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_public_key_at_key_id(key_id)
             .await
     }
@@ -170,8 +168,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         encryption_key: Option<TariKeyId>,
     ) -> Result<TariKeyId, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .import_key(private_key, encryption_key)
             .await
     }
@@ -182,8 +178,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         encryption_key: Option<TariKeyId>,
     ) -> Result<TariKeyId, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .create_encrypted_key_from_existing_key(key_id, encryption_key)
             .await
     }
@@ -194,8 +188,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         value: &PrivateKey,
     ) -> Result<CompressedCommitment, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_commitment(commitment_mask_key_id, value)
             .await
     }
@@ -207,26 +199,20 @@ where TBackend: TransactionKeyManagerBackend + 'static
         value: u64,
     ) -> Result<bool, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .verify_mask(commitment, commitment_mask_key_id, value)
             .await
     }
 
     async fn get_view_key(&self) -> Result<TariKeyAndId, KeyManagerServiceError> {
-        self.transaction_key_manager_inner.read().await.get_view_key().await
+        self.transaction_key_manager_inner.get_view_key().await
     }
 
     async fn get_private_view_key(&self) -> Result<PrivateKey, KeyManagerServiceError> {
-        self.transaction_key_manager_inner
-            .read()
-            .await
-            .get_private_view_key()
-            .await
+        self.transaction_key_manager_inner.get_private_view_key().await
     }
 
     async fn get_spend_key(&self) -> Result<TariKeyAndId, KeyManagerServiceError> {
-        self.transaction_key_manager_inner.read().await.get_spend_key().await
+        self.transaction_key_manager_inner.get_spend_key().await
     }
 
     async fn sign_message_with_spend_key(
@@ -235,22 +221,18 @@ where TBackend: TransactionKeyManagerBackend + 'static
         sender_offset_pub_key: Option<&CompressedPublicKey>,
     ) -> Result<WalletMessageSchnorrSignature, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .sign_message(message, sender_offset_pub_key)
             .await
     }
 
     async fn get_comms_key(&self) -> Result<TariKeyAndId, KeyManagerServiceError> {
-        self.transaction_key_manager_inner.read().await.get_comms_key().await
+        self.transaction_key_manager_inner.get_comms_key().await
     }
 
     async fn get_next_commitment_mask_and_script_key(
-        &self,
+        &mut self,
     ) -> Result<(TariKeyAndId, TariKeyAndId), KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_next_commitment_mask_and_script_key()
             .await
     }
@@ -261,8 +243,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         public_script_key: Option<&CompressedPublicKey>,
     ) -> Result<Option<TariKeyId>, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .find_script_key_id_from_commitment_mask_key_id(commitment_mask_key_id, public_script_key)
             .await
     }
@@ -273,8 +253,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         public_key: &CompressedPublicKey,
     ) -> Result<CommsDHKE, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_diffie_hellman_shared_secret(secret_key_id, public_key)
             .await
     }
@@ -285,8 +263,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         public_key: &CompressedPublicKey,
     ) -> Result<DomainSeparatedHash<Blake2b<U64>>, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_diffie_hellman_stealth_domain_hasher(secret_key_id, public_key)
             .await
     }
@@ -298,8 +274,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         min_value: u64,
     ) -> Result<RangeProof, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .construct_range_proof(commitment_mask_key_id, value, min_value)
             .await
     }
@@ -313,8 +287,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         script_message: &[u8; 32],
     ) -> Result<ComAndPubSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_script_signature(
                 script_key_id,
                 commitment_mask_key_id,
@@ -335,8 +307,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         script_message: &[u8; 32],
     ) -> Result<ComAndPubSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_partial_script_signature(
                 commitment_mask_id,
                 value,
@@ -360,8 +330,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         txo_type: TxoStage,
     ) -> Result<CompressedSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_partial_txo_kernel_signature(
                 commitment_mask_key_id,
                 nonce_id,
@@ -381,8 +349,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         nonce_id: &TariKeyId,
     ) -> Result<CompressedPublicKey, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_txo_kernel_signature_excess_with_offset(commitment_mask_key_id, nonce_id)
             .await
     }
@@ -393,8 +359,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         nonce_id: &TariKeyId,
     ) -> Result<PrivateKey, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_txo_private_kernel_offset(commitment_mask_key_id, nonce_id)
             .await
     }
@@ -407,8 +371,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         payment_id: MemoField,
     ) -> Result<EncryptedData, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .encrypt_data_for_recovery(commitment_mask_key_id, custom_recovery_key_id, value, payment_id)
             .await
     }
@@ -420,8 +382,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         custom_recovery_key_id: Option<&TariKeyId>,
     ) -> Result<MemoField, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .extract_payment_id_from_encrypted_data(encrypted_data, commitment, custom_recovery_key_id)
             .await
     }
@@ -433,8 +393,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         sender_offset_public_key: &CompressedPublicKey,
     ) -> Result<Option<(TariKeyId, MicroMinotari, MemoField)>, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .try_output_key_recovery(commitment, encrypted_data, sender_offset_public_key)
             .await
     }
@@ -446,8 +404,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         custom_recovery_key_id: Option<PrivateKey>,
     ) -> Result<bool, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .is_this_output_ours(commitment, encrypted_data, custom_recovery_key_id)
             .await
     }
@@ -458,8 +414,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         sender_offset_key_ids: &[TariKeyId],
     ) -> Result<PrivateKey, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_script_offset(script_key_ids, sender_offset_key_ids)
             .await
     }
@@ -470,14 +424,12 @@ where TBackend: TransactionKeyManagerBackend + 'static
         range_proof_type: RangeProofType,
     ) -> Result<CompressedCommitment, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_metadata_signature_ephemeral_commitment(nonce_id, range_proof_type)
             .await
     }
 
     async fn get_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value_as_private_key: &PrivateKey,
         sender_offset_key_id: &TariKeyId,
@@ -486,8 +438,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         range_proof_type: RangeProofType,
     ) -> Result<ComAndPubSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_metadata_signature(
                 commitment_mask_key_id,
                 value_as_private_key,
@@ -500,7 +450,7 @@ where TBackend: TransactionKeyManagerBackend + 'static
     }
 
     async fn get_one_sided_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value: MicroMinotari,
         sender_offset_key_id: &TariKeyId,
@@ -511,8 +461,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         receiver_address: &TariAddress,
     ) -> Result<ComAndPubSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_one_sided_metadata_signature(
                 commitment_mask_key_id,
                 value,
@@ -532,8 +480,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         challenge: &[u8],
     ) -> Result<CompressedCheckSigSchnorrSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .sign_script_message(private_key_id, challenge)
             .await
     }
@@ -544,8 +490,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         sender_offset_pub_key: Option<&CompressedPublicKey>,
     ) -> Result<CompressedCheckSigSchnorrSignature, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .sign_script_message_with_spend_key(message, sender_offset_pub_key)
             .await
     }
@@ -557,14 +501,12 @@ where TBackend: TransactionKeyManagerBackend + 'static
         challenge: &[u8; 64],
     ) -> Result<CompressedSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .sign_with_nonce_and_challenge(private_key_id, nonce, challenge)
             .await
     }
 
     async fn get_receiver_partial_metadata_signature(
-        &self,
+        &mut self,
         commitment_mask_key_id: &TariKeyId,
         value: &PrivateKey,
         sender_offset_public_key: &CompressedPublicKey,
@@ -574,8 +516,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         range_proof_type: RangeProofType,
     ) -> Result<ComAndPubSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_receiver_partial_metadata_signature(
                 commitment_mask_key_id,
                 value,
@@ -601,8 +541,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         metadata_signature_message: &[u8; 32],
     ) -> Result<ComAndPubSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .get_sender_partial_metadata_signature(
                 ephemeral_private_nonce_id,
                 sender_offset_key_id,
@@ -621,8 +559,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         claim_public_key: &CompressedPublicKey,
     ) -> Result<CompressedSignature, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .generate_burn_claim_proof_signature(commitment_mask_key_id, value, claim_public_key)
             .await
     }
@@ -633,8 +569,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         spend_key: &CompressedPublicKey,
     ) -> Result<CompressedPublicKey, TransactionError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .stealth_address_script_spending_key(commitment_mask_key_id, spend_key)
             .await
     }
@@ -645,8 +579,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         sender_offset_pub_key: &CompressedPublicKey,
     ) -> Result<TariKeyId, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .write()
-            .await
             .add_offset_to_spend_key(spend_key_id, sender_offset_pub_key)
             .await
     }
@@ -657,8 +589,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         encryption_key_id: Option<&TariKeyId>,
     ) -> Result<Vec<u8>, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .encrypted_key(key_id, encryption_key_id)
             .await
     }
@@ -669,8 +599,6 @@ where TBackend: TransactionKeyManagerBackend + 'static
         encryption_key_id: Option<&TariKeyId>,
     ) -> Result<TariKeyId, KeyManagerServiceError> {
         self.transaction_key_manager_inner
-            .read()
-            .await
             .import_encrypted_key(encrypted, encryption_key_id)
             .await
     }
@@ -681,11 +609,7 @@ impl<TBackend> SecretTransactionKeyManagerInterface for TransactionKeyManagerWra
 where TBackend: TransactionKeyManagerBackend + 'static
 {
     async fn get_private_key(&self, key_id: &TariKeyId) -> Result<PrivateKey, KeyManagerServiceError> {
-        self.transaction_key_manager_inner
-            .read()
-            .await
-            .get_private_key(key_id)
-            .await
+        self.transaction_key_manager_inner.get_private_key(key_id).await
     }
 }
 

--- a/base_layer/transaction_components/src/multisig/session.rs
+++ b/base_layer/transaction_components/src/multisig/session.rs
@@ -70,7 +70,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
 
     #[allow(clippy::too_many_lines)]
     pub async fn create_deposit_multisig_transaction(
-        &self,
+        &mut self,
         amount: MicroMinotari,
         party_number: u8,
         public_keys: Vec<CompressedPublicKey>,
@@ -157,7 +157,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
             .await?
             .with_script_key(TariKeyId::Zero)
             .with_sender_offset_public_key(sender_offset_public_key.clone())
-            .sign_as_sender_and_receiver_verified(&self.key_manager, &sender_offset_key.key_id, &recipient)
+            .sign_as_sender_and_receiver_verified(&mut self.key_manager, &sender_offset_key.key_id, &recipient)
             .await?
             .try_build(&self.key_manager)
             .await?;

--- a/base_layer/transaction_components/src/offline_signing/mod.rs
+++ b/base_layer/transaction_components/src/offline_signing/mod.rs
@@ -98,12 +98,12 @@ mod test {
             view_key: alice_key_manager.get_private_view_key().await.unwrap(),
             birthday: None,
         };
-        let alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
+        let mut alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
         let bob_key_manager = create_memory_key_manager().await.unwrap();
 
-        let input = create_test_input(MicroMinotari(10000), 0, &alice_view_key_manager, vec![], None).await;
-        let input2 = create_test_input(MicroMinotari(2000), 0, &alice_view_key_manager, vec![], None).await;
-        let input3 = create_test_input(MicroMinotari(15000), 0, &alice_view_key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(10000), 0, &mut alice_view_key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &mut alice_view_key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &mut alice_view_key_manager, vec![], None).await;
         // this replicates the behaviour od the oms that selects the inputs and starts the build tx process.
         let mut tx_builder = TransactionBuilder::new(
             rules.consensus_constants(0).clone(),
@@ -184,7 +184,7 @@ mod test {
         assert_eq!(init.info.inputs.len(), 3);
         assert_eq!(init.info.outputs.len(), 0);
 
-        let signer = OfflineSigner::new(alice_key_manager.clone());
+        let mut signer = OfflineSigner::new(alice_key_manager.clone());
         let signed = signer.sign_locked_transaction(init).await.unwrap();
         assert!(signed.signed_transaction.change_output.is_some());
         assert_eq!(
@@ -217,7 +217,7 @@ mod test {
             birthday: None,
         };
 
-        let alice_view_key_manager = create_view_key_manager(alice_keys.clone()).await.unwrap();
+        let mut alice_view_key_manager = create_view_key_manager(alice_keys.clone()).await.unwrap();
 
         let charlie_keys = ProvidedKeysWallet {
             public_spend_key: charlie_key_manager.get_spend_key().await.unwrap().pub_key,
@@ -257,9 +257,9 @@ mod test {
             bob_spend_key.clone(),
         ];
 
-        let input = create_test_input(MicroMinotari(10000), 0, &alice_view_key_manager, vec![], None).await;
-        let input2 = create_test_input(MicroMinotari(2000), 0, &alice_view_key_manager, vec![], None).await;
-        let input3 = create_test_input(MicroMinotari(15000), 0, &alice_view_key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(10000), 0, &mut alice_view_key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &mut alice_view_key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &mut alice_view_key_manager, vec![], None).await;
         // this replicates the behaviour od the oms that selects the inputs and starts the build tx process.
         let mut tx_builder = TransactionBuilder::new(
             rules.consensus_constants(0).clone(),
@@ -320,7 +320,7 @@ mod test {
         assert_eq!(init.info.inputs.len(), 3);
         assert_eq!(init.info.outputs.len(), 0);
 
-        let signer = OfflineSigner::new(alice_key_manager.clone());
+        let mut signer = OfflineSigner::new(alice_key_manager.clone());
 
         let signed = signer.sign_locked_deposit_multisig_transaction(init).await.unwrap();
 
@@ -354,7 +354,7 @@ mod test {
             birthday: None,
         };
 
-        let alice_view_key_manager = create_view_key_manager(alice_keys.clone()).await.unwrap();
+        let mut alice_view_key_manager = create_view_key_manager(alice_keys.clone()).await.unwrap();
 
         let charlie_keys = ProvidedKeysWallet {
             public_spend_key: charlie_key_manager.get_spend_key().await.unwrap().pub_key,
@@ -485,7 +485,7 @@ mod test {
             .unwrap()
             .with_sender_offset_public_key(sender_offset_key.pub_key.clone())
             .sign_as_sender_and_receiver_verified(
-                &alice_view_key_manager,
+                &mut alice_view_key_manager,
                 &sender_offset_key.key_id,
                 &Default::default(),
             )
@@ -548,7 +548,7 @@ mod test {
         assert_eq!(init.info.metadata.fee, fee);
         assert_eq!(init.info.inputs.len(), 1);
         assert_eq!(init.info.outputs.len(), 0);
-        let signer = OfflineSigner::new(alice_key_manager.clone());
+        let mut signer = OfflineSigner::new(alice_key_manager.clone());
         let signed = signer.sign_locked_withdraw_multisig_transaction(init).await.unwrap();
         assert_eq!(signed.signed_transaction.transaction.body.kernels()[0].fee, fee,);
         assert_eq!(signed.signed_transaction.transaction.body.inputs().len(), 1);
@@ -571,10 +571,10 @@ mod test {
             view_key: alice_key_manager.get_private_view_key().await.unwrap(),
             birthday: None,
         };
-        let alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
+        let mut alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
         let bob_key_manager = create_memory_key_manager().await.unwrap();
 
-        let input = create_test_input(MicroMinotari(100000), 0, &alice_view_key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(100000), 0, &mut alice_view_key_manager, vec![], None).await;
         // this replicates the behaviour od the oms that selects the inputs and starts the build tx process.
         let mut tx_builder = TransactionBuilder::new(
             rules.consensus_constants(0).clone(),
@@ -626,7 +626,7 @@ mod test {
             .await
             .unwrap();
 
-        let signer = OfflineSigner::new(alice_key_manager.clone());
+        let mut signer = OfflineSigner::new(alice_key_manager.clone());
         let signed = signer.sign_locked_transaction(init).await.unwrap();
         let tx = signed.signed_transaction.transaction.clone();
 
@@ -681,12 +681,12 @@ mod test {
             view_key: alice_key_manager.get_private_view_key().await.unwrap(),
             birthday: None,
         };
-        let alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
+        let mut alice_view_key_manager = create_view_key_manager(keys).await.unwrap();
         let bob_key_manager = create_memory_key_manager().await.unwrap();
 
-        let input = create_test_input(MicroMinotari(10000), 0, &alice_view_key_manager, vec![], None).await;
-        let input2 = create_test_input(MicroMinotari(2000), 0, &alice_view_key_manager, vec![], None).await;
-        let input3 = create_test_input(MicroMinotari(15000), 0, &alice_view_key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(10000), 0, &mut alice_view_key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &mut alice_view_key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &mut alice_view_key_manager, vec![], None).await;
         // this replicates the behaviour od the oms that selects the inputs and starts the build tx process.
         let mut tx_builder = TransactionBuilder::new(
             rules.consensus_constants(0).clone(),
@@ -767,7 +767,7 @@ mod test {
         assert_eq!(init.info.inputs.len(), 3);
         assert_eq!(init.info.outputs.len(), 0);
 
-        let signer = OfflineSigner::new(alice_view_key_manager.clone());
+        let mut signer = OfflineSigner::new(alice_view_key_manager.clone());
         assert!(signer.sign_locked_transaction(init).await.is_err());
     }
 }

--- a/base_layer/transaction_components/src/offline_signing/offline_signer.rs
+++ b/base_layer/transaction_components/src/offline_signing/offline_signer.rs
@@ -292,10 +292,10 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
     }
 
     pub async fn sign_locked_transaction(
-        &self,
+        &mut self,
         request: PrepareOneSidedTransactionForSigningResult,
     ) -> Result<SignedOneSidedTransactionResult, TransactionBuilderError> {
-        let signer = OneSidedSigner::new(&self.key_manager);
+        let mut signer = OneSidedSigner::new(&mut self.key_manager);
         let signed_transaction = signer.sign_transaction(request.tx_id, request.info.clone()).await?;
 
         Ok(SignedOneSidedTransactionResult {
@@ -306,10 +306,10 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
     }
 
     pub async fn sign_locked_deposit_multisig_transaction(
-        &self,
+        &mut self,
         request: PrepareDepositMultisigTransactionResult,
     ) -> Result<SignedOneSidedDepositMultisigTransactionResult, TransactionBuilderError> {
-        let signer = OneSidedSigner::new(&self.key_manager);
+        let mut signer = OneSidedSigner::new(&mut self.key_manager);
         let signed_transaction = signer
             .sign_multisig_transaction(request.tx_id, request.info.clone())
             .await?;
@@ -322,10 +322,10 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
     }
 
     pub async fn sign_locked_withdraw_multisig_transaction(
-        &self,
+        &mut self,
         request: PrepareWithdrawMultisigTransactionResult,
     ) -> Result<SignedOneSidedWithdrawMultisigTransactionResult, TransactionBuilderError> {
-        let signer = OneSidedSigner::new(&self.key_manager);
+        let mut signer = OneSidedSigner::new(&mut self.key_manager);
 
         let signed_transaction = signer
             .sign_multisig_withdraw_transaction(request.tx_id, request.info.clone())

--- a/base_layer/transaction_components/src/offline_signing/one_sided_signer.rs
+++ b/base_layer/transaction_components/src/offline_signing/one_sided_signer.rs
@@ -82,16 +82,16 @@ struct SignedMessage {
 }
 
 pub struct OneSidedSigner<'a, KM: TransactionKeyManagerInterface> {
-    key_manager: &'a KM,
+    key_manager: &'a mut KM,
 }
 
 impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
-    pub fn new(key_manager: &'a KM) -> Self {
+    pub fn new(key_manager: &'a mut KM) -> Self {
         Self { key_manager }
     }
 
     pub async fn sign_transaction(
-        &self,
+        &mut self,
         tx_id: TxId,
         mut info: OneSidedTransactionInfo,
     ) -> Result<SignedTransaction, TransactionBuilderError> {
@@ -115,7 +115,7 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
     }
 
     pub async fn sign_multisig_transaction(
-        &self,
+        &mut self,
         tx_id: TxId,
         mut info: OneSidedMultisigTransactionInfo,
     ) -> Result<SignedTransaction, TransactionBuilderError> {
@@ -139,7 +139,7 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
     }
 
     pub async fn sign_multisig_withdraw_transaction(
-        &self,
+        &mut self,
         tx_id: TxId,
         mut info: OneSidedTransactionInfo,
     ) -> Result<SignedTransaction, TransactionBuilderError> {
@@ -235,7 +235,7 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
 
     #[allow(clippy::too_many_lines)]
     async fn sign_message(
-        &self,
+        &mut self,
         tx_id: TxId,
         info: &OneSidedTransactionInfo,
     ) -> Result<SignedMessage, TransactionBuilderError> {
@@ -364,7 +364,7 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
 
     #[allow(clippy::too_many_lines)]
     async fn sign_multisig_message(
-        &self,
+        &mut self,
         tx_id: TxId,
         info: &OneSidedMultisigTransactionInfo,
     ) -> Result<SignedMessage, TransactionBuilderError> {
@@ -501,7 +501,7 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
 
     #[allow(clippy::too_many_lines)]
     async fn sign_multisig_withdraw_message(
-        &self,
+        &mut self,
         tx_id: TxId,
         info: &OneSidedTransactionInfo,
     ) -> Result<SignedMessage, TransactionBuilderError> {
@@ -633,7 +633,7 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
 
     #[allow(clippy::too_many_lines)]
     async fn build_transaction(
-        &self,
+        &mut self,
         info: OneSidedTransactionInfo,
         signed_message: RecipientSignedMessage,
         sender_offset_key_id: TariKeyId,
@@ -791,7 +791,7 @@ impl<'a, KM: TransactionKeyManagerInterface> OneSidedSigner<'a, KM> {
     }
 
     async fn lock_sent_output_in_payment_id(
-        &self,
+        &mut self,
         change: &OutputPair,
         output_hash: FixedHash,
     ) -> Result<OutputPair, TransactionBuilderError> {

--- a/base_layer/transaction_components/src/test_helpers/test_helpers_functions.rs
+++ b/base_layer/transaction_components/src/test_helpers/test_helpers_functions.rs
@@ -63,7 +63,7 @@ use crate::{
 pub async fn create_test_input<KM: TransactionKeyManagerInterface>(
     amount: MicroMinotari,
     maturity: u64,
-    key_manager: &KM,
+    key_manager: &mut KM,
     coinbase_extra: Vec<u8>,
     payment_id: Option<MemoField>,
 ) -> WalletOutput {
@@ -102,7 +102,7 @@ pub struct TestParams {
 }
 
 impl TestParams {
-    pub async fn new<KM: TransactionKeyManagerInterface>(key_manager: &KM) -> TestParams {
+    pub async fn new<KM: TransactionKeyManagerInterface>(key_manager: &mut KM) -> TestParams {
         let (commitment_mask_key, script_key) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
         let sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
@@ -144,7 +144,7 @@ impl TestParams {
     pub async fn create_output<KM: TransactionKeyManagerInterface>(
         &self,
         params: UtxoTestParams,
-        key_manager: &KM,
+        key_manager: &mut KM,
     ) -> Result<WalletOutput, String> {
         let version = params.output_version.unwrap_or_default();
         let input_data = params.input_data.unwrap_or_else(|| inputs!(self.script_key_pk.clone()));
@@ -176,7 +176,7 @@ impl TestParams {
     pub async fn create_input<KM: TransactionKeyManagerInterface>(
         &self,
         params: UtxoTestParams,
-        key_manager: &KM,
+        key_manager: &mut KM,
     ) -> WalletOutput {
         self.create_output(params, key_manager).await.unwrap()
     }
@@ -260,7 +260,7 @@ pub fn create_signature(
 
 /// Generate a random transaction signature given a key, returning the public key (excess) and the signature.
 pub async fn create_random_signature_from_secret_key<KM: TransactionKeyManagerInterface>(
-    key_manager: &KM,
+    key_manager: &mut KM,
     secret_key_id: TariKeyId,
     fee: MicroMinotari,
     lock_height: u64,
@@ -308,7 +308,7 @@ pub async fn create_coinbase_wallet_output<KM: TransactionKeyManagerInterface>(
     height: u64,
     extra: Option<CoinBaseExtra>,
     range_proof_type: RangeProofType,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> WalletOutput {
     let rules = create_consensus_manager();
     let constants = rules.consensus_constants(height);
@@ -339,7 +339,7 @@ pub async fn create_wallet_output_with_data<KM: TransactionKeyManagerInterface>(
     output_features: OutputFeatures,
     test_params: &TestParams,
     value: MicroMinotari,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> Result<WalletOutput, String> {
     test_params
         .create_output(
@@ -506,7 +506,7 @@ pub async fn create_tx<KM: TransactionKeyManagerInterface>(
     input_maturity: u64,
     output_count: usize,
     output_features: OutputFeatures,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> std::io::Result<(Transaction, Vec<WalletOutput>, Vec<WalletOutput>)> {
     let (inputs, outputs) = create_wallet_outputs(
         amount,
@@ -533,7 +533,7 @@ pub async fn create_wallet_outputs<KM: TransactionKeyManagerInterface>(
     output_features: &OutputFeatures,
     output_script: &TariScript,
     output_covenant: &Covenant,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> std::io::Result<(Vec<WalletOutput>, Vec<(WalletOutput, TariKeyId)>)> {
     let weighting = TransactionWeight::latest();
     // This is a best guess to not underestimate metadata size
@@ -636,7 +636,7 @@ pub async fn create_transaction_with<KM: TransactionKeyManagerInterface>(
 /// The output features will be applied to every output
 pub async fn spend_utxos<KM: TransactionKeyManagerInterface>(
     schema: TransactionSchema,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> (Transaction, Vec<WalletOutput>) {
     let (finalized_tx, mut outputs) = create_test_transaction(schema, key_manager).await;
     let txn = finalized_tx.transaction.clone();
@@ -649,7 +649,7 @@ pub async fn spend_utxos<KM: TransactionKeyManagerInterface>(
 #[allow(clippy::too_many_lines)]
 pub async fn create_test_transaction<KM: TransactionKeyManagerInterface>(
     schema: TransactionSchema,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> (FinalizedTransaction, Vec<WalletOutput>) {
     let mut outputs = Vec::with_capacity(schema.to.len());
     let builder = create_test_transaction_internal(schema, key_manager, &mut outputs).await;
@@ -661,7 +661,7 @@ pub async fn create_test_transaction<KM: TransactionKeyManagerInterface>(
 #[allow(clippy::too_many_lines)]
 async fn create_test_transaction_internal<KM: TransactionKeyManagerInterface>(
     schema: TransactionSchema,
-    key_manager: &KM,
+    key_manager: &mut KM,
     outputs: &mut Vec<WalletOutput>,
 ) -> TransactionBuilder<KM> {
     let constants = ConsensusManager::builder(Network::LocalNet)
@@ -745,7 +745,7 @@ async fn create_test_transaction_internal<KM: TransactionKeyManagerInterface>(
 
 pub async fn create_coinbase_kernel<KM: TransactionKeyManagerInterface>(
     commitment_mask_key_id: &TariKeyId,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> TransactionKernel {
     let kernel_version = TransactionKernelVersion::get_current_version();
     let kernel_features = KernelFeatures::COINBASE_KERNEL;
@@ -798,7 +798,7 @@ pub fn create_test_kernel(fee: MicroMinotari, lock_height: u64, features: Kernel
 /// Create a new UTXO for the specified value and return the output and spending key
 pub async fn create_utxo<KM: TransactionKeyManagerInterface>(
     value: MicroMinotari,
-    key_manager: &KM,
+    key_manager: &mut KM,
     features: &OutputFeatures,
     script: &TariScript,
     covenant: &Covenant,
@@ -868,7 +868,7 @@ pub async fn create_utxo<KM: TransactionKeyManagerInterface>(
 
 pub async fn schema_to_transaction<KM: TransactionKeyManagerInterface>(
     txns: &[TransactionSchema],
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> (Vec<Arc<Transaction>>, Vec<WalletOutput>) {
     let mut txs = Vec::new();
     let mut utxos = Vec::new();

--- a/base_layer/transaction_components/src/transaction_builder/builder.rs
+++ b/base_layer/transaction_components/src/transaction_builder/builder.rs
@@ -211,7 +211,11 @@ where KM: TransactionKeyManagerInterface
             .with_sender_offset_public_key(sender_offset_public_key)
             .with_script_key(TariKeyId::Zero)
             .with_minimum_value_promise(minimum_value_promise)
-            .sign_as_sender_and_receiver_verified(&self.key_manager, &sender_offset_private_key.key_id, &destination)
+            .sign_as_sender_and_receiver_verified(
+                &mut self.key_manager,
+                &sender_offset_private_key.key_id,
+                &destination,
+            )
             .await?
             .try_build(&self.key_manager)
             .await?;
@@ -269,7 +273,11 @@ where KM: TransactionKeyManagerInterface
             .with_sender_offset_public_key(sender_offset_public_key)
             .with_script_key(TariKeyId::Zero)
             .with_minimum_value_promise(minimum_value_promise)
-            .sign_as_sender_and_receiver_verified(&self.key_manager, &sender_offset_private_key.key_id, &destination)
+            .sign_as_sender_and_receiver_verified(
+                &mut self.key_manager,
+                &sender_offset_private_key.key_id,
+                &destination,
+            )
             .await?
             .try_build(&self.key_manager)
             .await?;
@@ -338,7 +346,7 @@ where KM: TransactionKeyManagerInterface
     }
 
     pub async fn get_pre_build_change_output(
-        &self,
+        &mut self,
     ) -> Result<(MicroMinotari, Option<OutputPair>), TransactionBuilderError> {
         self.add_change_if_required().await
     }
@@ -404,7 +412,7 @@ where KM: TransactionKeyManagerInterface
         Ok(())
     }
 
-    async fn add_change_if_required(&self) -> Result<(MicroMinotari, Option<OutputPair>), TransactionBuilderError> {
+    async fn add_change_if_required(&mut self) -> Result<(MicroMinotari, Option<OutputPair>), TransactionBuilderError> {
         let total_being_spent =
             self.inputs
                 .iter()
@@ -535,7 +543,7 @@ where KM: TransactionKeyManagerInterface
         Ok(memo)
     }
 
-    async fn build_change(&self, amount: MicroMinotari) -> Result<Option<OutputPair>, TransactionBuilderError> {
+    async fn build_change(&mut self, amount: MicroMinotari) -> Result<Option<OutputPair>, TransactionBuilderError> {
         let (change_commitment_mask_key, change_script_key) =
             self.key_manager.get_next_commitment_mask_and_script_key().await?;
         let memo = self.create_change_memo(amount).await?;
@@ -1037,8 +1045,8 @@ mod test {
     #[allow(clippy::identity_op)]
     async fn change_edge_case() {
         // Create some inputs
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let p = TestParams::new(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let p = TestParams::new(&mut key_manager).await;
         let constants = create_consensus_constants(0);
         let weighting = constants.transaction_weight_params();
         let tx_fee = Fee::new(*weighting).calculate(1.into(), 1, 1, 1, 0);
@@ -1051,7 +1059,7 @@ mod test {
             // one under the amount required to pay the fee for a change output
             2000 * uT + tx_fee + fee_for_change_output - 1 * uT,
             0,
-            &key_manager,
+            &mut key_manager,
             vec![],
             None,
         )
@@ -1062,7 +1070,7 @@ mod test {
                     value: 2000 * uT,
                     ..Default::default()
                 },
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap();
@@ -1099,15 +1107,15 @@ mod test {
     #[tokio::test]
     async fn too_many_inputs() {
         // Create some inputs
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let p = TestParams::new(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let p = TestParams::new(&mut key_manager).await;
 
         let output = create_wallet_output_with_data(
             script!(Nop).unwrap(),
             OutputFeatures::default(),
             &p,
             MicroMinotari(500),
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -1122,7 +1130,7 @@ mod test {
             .await
             .unwrap()
             .with_fee_per_gram(MicroMinotari(2));
-        let input_base = create_test_input(MicroMinotari(50), 0, &key_manager, vec![], None).await;
+        let input_base = create_test_input(MicroMinotari(50), 0, &mut key_manager, vec![], None).await;
         for _ in 0..=MAX_TRANSACTION_INPUTS {
             builder.with_input(input_base.clone()).await.unwrap();
         }
@@ -1134,16 +1142,16 @@ mod test {
     #[tokio::test]
     async fn not_enough_funds() {
         // Create some inputs
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let p = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(400), 0, &key_manager, vec![], None).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let p = TestParams::new(&mut key_manager).await;
+        let input = create_test_input(MicroMinotari(400), 0, &mut key_manager, vec![], None).await;
         let script = script!(Nop).unwrap();
         let output = create_wallet_output_with_data(
             script.clone(),
             OutputFeatures::default(),
             &p,
             MicroMinotari(400),
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -1172,10 +1180,10 @@ mod test {
 
     #[tokio::test]
     async fn zero_recipient_outputs() {
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let p1 = TestParams::new(&key_manager).await;
-        let p2 = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(1200), 0, &key_manager, vec![], None).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let p1 = TestParams::new(&mut key_manager).await;
+        let p2 = TestParams::new(&mut key_manager).await;
+        let input = create_test_input(MicroMinotari(1200), 0, &mut key_manager, vec![], None).await;
         let mut builder =
             TransactionBuilder::new(create_consensus_constants(0), key_manager.clone(), Network::LocalNet)
                 .await
@@ -1194,7 +1202,7 @@ mod test {
                     output_features.clone(),
                     &p1,
                     MicroMinotari(500),
-                    &key_manager,
+                    &mut key_manager,
                 )
                 .await
                 .unwrap(),
@@ -1203,7 +1211,7 @@ mod test {
             .await
             .unwrap()
             .with_output(
-                create_wallet_output_with_data(script, output_features, &p2, MicroMinotari(400), &key_manager)
+                create_wallet_output_with_data(script, output_features, &p2, MicroMinotari(400), &mut key_manager)
                     .await
                     .unwrap(),
                 p2.sender_offset_key_id.clone(),
@@ -1222,9 +1230,9 @@ mod test {
     async fn single_recipient_no_change() {
         let rules = create_consensus_manager();
         let factories = CryptoFactories::default();
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let bob_key = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(1200), 0, &key_manager, vec![], None).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let bob_key = TestParams::new(&mut key_manager).await;
+        let input = create_test_input(MicroMinotari(1200), 0, &mut key_manager, vec![], None).await;
         let utxo = input.to_transaction_input(&key_manager).await.unwrap();
         let script = script!(Nop).unwrap();
         let consensus_constants = create_consensus_constants(0);
@@ -1257,7 +1265,7 @@ mod test {
         .with_sender_offset_public_key(bob_public_key)
         .with_script_key(bob_key.script_key_id)
         .with_minimum_value_promise(0.into())
-        .sign_as_sender_and_receiver_verified(&key_manager, &bob_sender_offset.key_id, &Default::default())
+        .sign_as_sender_and_receiver_verified(&mut key_manager, &bob_sender_offset.key_id, &Default::default())
         .await
         .unwrap()
         .try_build(&key_manager)
@@ -1285,13 +1293,13 @@ mod test {
     #[allow(clippy::too_many_lines)]
     async fn single_recipient_with_change() {
         let rules = create_consensus_manager();
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let factories = CryptoFactories::default();
         // Alice's parameters
-        let alice_key = TestParams::new(&key_manager).await;
+        let alice_key = TestParams::new(&mut key_manager).await;
         // Bob's parameters
-        let bob_key = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(25000), 0, &key_manager, vec![], None).await;
+        let bob_key = TestParams::new(&mut key_manager).await;
+        let input = create_test_input(MicroMinotari(25000), 0, &mut key_manager, vec![], None).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = TransactionBuilder::new(consensus_constants.clone(), key_manager.clone(), Network::LocalNet)
             .await
@@ -1328,7 +1336,7 @@ mod test {
             .with_sender_offset_public_key(bob_public_key)
             .with_script_key(bob_key.script_key_id)
             .with_minimum_value_promise(0.into())
-            .sign_as_sender_and_receiver_verified(&key_manager, &bob_sender_offset.key_id, &Default::default())
+            .sign_as_sender_and_receiver_verified(&mut key_manager, &bob_sender_offset.key_id, &Default::default())
             .await
             .unwrap()
             .try_build(&key_manager)
@@ -1352,13 +1360,13 @@ mod test {
     #[tokio::test]
     async fn single_recipient_multiple_inputs_with_change() {
         let rules = create_consensus_manager();
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let factories = CryptoFactories::default();
         // Bob's parameters
-        let bob_key = TestParams::new(&key_manager).await;
-        let input = create_test_input(MicroMinotari(10000), 0, &key_manager, vec![], None).await;
-        let input2 = create_test_input(MicroMinotari(2000), 0, &key_manager, vec![], None).await;
-        let input3 = create_test_input(MicroMinotari(15000), 0, &key_manager, vec![], None).await;
+        let bob_key = TestParams::new(&mut key_manager).await;
+        let input = create_test_input(MicroMinotari(10000), 0, &mut key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &mut key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &mut key_manager, vec![], None).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = TransactionBuilder::new(consensus_constants.clone(), key_manager.clone(), Network::LocalNet)
             .await
@@ -1391,7 +1399,7 @@ mod test {
             .with_sender_offset_public_key(bob_public_key)
             .with_script_key(bob_key.script_key_id)
             .with_minimum_value_promise(0.into())
-            .sign_as_sender_and_receiver_verified(&key_manager, &bob_sender_offset.key_id, &Default::default())
+            .sign_as_sender_and_receiver_verified(&mut key_manager, &bob_sender_offset.key_id, &Default::default())
             .await
             .unwrap()
             .try_build(&key_manager)
@@ -1414,11 +1422,11 @@ mod test {
     #[tokio::test]
     async fn add_stealth_recipient() {
         let rules = create_consensus_manager();
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let factories = CryptoFactories::default();
-        let input = create_test_input(MicroMinotari(10000), 0, &key_manager, vec![], None).await;
-        let input2 = create_test_input(MicroMinotari(2000), 0, &key_manager, vec![], None).await;
-        let input3 = create_test_input(MicroMinotari(15000), 0, &key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(10000), 0, &mut key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &mut key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &mut key_manager, vec![], None).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = TransactionBuilder::new(consensus_constants.clone(), key_manager.clone(), Network::LocalNet)
             .await
@@ -1501,11 +1509,11 @@ mod test {
     #[tokio::test]
     async fn add_depricated_one_sided_recipient() {
         let rules = create_consensus_manager();
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let factories = CryptoFactories::default();
-        let input = create_test_input(MicroMinotari(10000), 0, &key_manager, vec![], None).await;
-        let input2 = create_test_input(MicroMinotari(2000), 0, &key_manager, vec![], None).await;
-        let input3 = create_test_input(MicroMinotari(15000), 0, &key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(10000), 0, &mut key_manager, vec![], None).await;
+        let input2 = create_test_input(MicroMinotari(2000), 0, &mut key_manager, vec![], None).await;
+        let input3 = create_test_input(MicroMinotari(15000), 0, &mut key_manager, vec![], None).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = TransactionBuilder::new(consensus_constants.clone(), key_manager.clone(), Network::LocalNet)
             .await
@@ -1584,9 +1592,9 @@ mod test {
     #[tokio::test]
     async fn disallow_fee_larger_than_amount() {
         // Alice's parameters
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let (utxo_amount, fee_per_gram, amount) = (MicroMinotari(2500), MicroMinotari(10), MicroMinotari(500));
-        let input = create_test_input(utxo_amount, 0, &key_manager, vec![], None).await;
+        let input = create_test_input(utxo_amount, 0, &mut key_manager, vec![], None).await;
         let script = script!(Nop).unwrap();
         let mut builder =
             TransactionBuilder::new(create_consensus_constants(0), key_manager.clone(), Network::LocalNet)
@@ -1599,7 +1607,7 @@ mod test {
             .await
             .unwrap();
 
-        let bob_key = TestParams::new(&key_manager).await;
+        let bob_key = TestParams::new(&mut key_manager).await;
         let bob_sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
@@ -1615,7 +1623,7 @@ mod test {
             .with_sender_offset_public_key(bob_public_key)
             .with_script_key(bob_key.script_key_id)
             .with_minimum_value_promise(0.into())
-            .sign_as_sender_and_receiver_verified(&key_manager, &bob_sender_offset.key_id, &Default::default())
+            .sign_as_sender_and_receiver_verified(&mut key_manager, &bob_sender_offset.key_id, &Default::default())
             .await
             .unwrap()
             .try_build(&key_manager)
@@ -1635,9 +1643,9 @@ mod test {
     #[tokio::test]
     async fn allow_fee_larger_than_amount() {
         // Alice's parameters
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let (utxo_amount, fee_per_gram, amount) = (MicroMinotari(2500), MicroMinotari(10), MicroMinotari(500));
-        let input = create_test_input(utxo_amount, 0, &key_manager, vec![], None).await;
+        let input = create_test_input(utxo_amount, 0, &mut key_manager, vec![], None).await;
         let script = script!(Nop).unwrap();
         let mut builder =
             TransactionBuilder::new(create_consensus_constants(0), key_manager.clone(), Network::LocalNet)
@@ -1651,7 +1659,7 @@ mod test {
             .unwrap()
             .with_prevent_fee_gt_amount(false);
 
-        let bob_key = TestParams::new(&key_manager).await;
+        let bob_key = TestParams::new(&mut key_manager).await;
         let bob_sender_offset = key_manager
             .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
             .await
@@ -1667,7 +1675,7 @@ mod test {
             .with_sender_offset_public_key(bob_public_key)
             .with_script_key(bob_key.script_key_id)
             .with_minimum_value_promise(0.into())
-            .sign_as_sender_and_receiver_verified(&key_manager, &bob_sender_offset.key_id, &Default::default())
+            .sign_as_sender_and_receiver_verified(&mut key_manager, &bob_sender_offset.key_id, &Default::default())
             .await
             .unwrap()
             .try_build(&key_manager)
@@ -1689,7 +1697,7 @@ mod test {
     async fn create_multi_recipients_transaction() {
         let rules = create_consensus_manager();
         let factories = CryptoFactories::default();
-        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let mut alice_key_manager = create_memory_key_manager().await.unwrap();
         let bob_key_manager = create_memory_key_manager().await.unwrap();
         let carol_key_manager = create_memory_key_manager().await.unwrap();
 
@@ -1714,7 +1722,7 @@ mod test {
         )
         .unwrap();
 
-        let input = create_test_input(MicroMinotari(5000), 0, &alice_key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(5000), 0, &mut alice_key_manager, vec![], None).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = TransactionBuilder::new(
             consensus_constants.clone(),
@@ -1759,7 +1767,7 @@ mod test {
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn recover_multi_recipients_transaction() {
-        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let mut alice_key_manager = create_memory_key_manager().await.unwrap();
         let alice_keys = ProvidedKeysWallet {
             public_spend_key: alice_key_manager.get_spend_key().await.unwrap().pub_key,
             private_spend_key: None,
@@ -1808,7 +1816,7 @@ mod test {
         )
         .unwrap();
 
-        let input = create_test_input(MicroMinotari(5000), 0, &alice_key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(5000), 0, &mut alice_key_manager, vec![], None).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = TransactionBuilder::new(
             consensus_constants.clone(),
@@ -2044,7 +2052,7 @@ mod test {
     async fn create_very_large_multi_recipients_transaction() {
         let rules = create_consensus_manager();
         let factories = CryptoFactories::default();
-        let alice_key_manager = create_memory_key_manager().await.unwrap();
+        let mut alice_key_manager = create_memory_key_manager().await.unwrap();
         let bob_key_manager = create_memory_key_manager().await.unwrap();
 
         let spend_key = bob_key_manager.get_spend_key().await.unwrap().pub_key;
@@ -2057,7 +2065,7 @@ mod test {
             None,
         )
         .unwrap();
-        let input = create_test_input(MicroMinotari(500000), 0, &alice_key_manager, vec![], None).await;
+        let input = create_test_input(MicroMinotari(500000), 0, &mut alice_key_manager, vec![], None).await;
         let consensus_constants = create_consensus_constants(0);
         let mut builder = TransactionBuilder::new(
             consensus_constants.clone(),

--- a/base_layer/transaction_components/src/transaction_components/covenants/covenant.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/covenant.rs
@@ -204,9 +204,9 @@ mod test {
 
     #[tokio::test]
     async fn it_succeeds_when_empty() {
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let outputs = create_outputs(10, UtxoTestParams::default(), &key_manager).await;
-        let input = create_input(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let outputs = create_outputs(10, UtxoTestParams::default(), &mut key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let covenant = covenant!().unwrap();
         let num_matching_outputs = covenant.execute(0, &input, &outputs).unwrap();
         assert_eq!(num_matching_outputs, 10);
@@ -214,12 +214,12 @@ mod test {
 
     #[tokio::test]
     async fn it_executes_the_covenant() {
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let mut outputs = create_outputs(10, UtxoTestParams::default(), &key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let mut outputs = create_outputs(10, UtxoTestParams::default(), &mut key_manager).await;
         outputs[4].features.maturity = 42;
         outputs[5].features.maturity = 42;
         outputs[7].features.maturity = 42;
-        let mut input = create_input(&key_manager).await;
+        let mut input = create_input(&mut key_manager).await;
         input.set_maturity(42).unwrap();
         let covenant = covenant!(fields_preserved(@fields(
             @field::features_output_type,
@@ -232,12 +232,12 @@ mod test {
 
     #[tokio::test]
     async fn test_borsh_de_serialization() {
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let mut outputs = create_outputs(10, UtxoTestParams::default(), &key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let mut outputs = create_outputs(10, UtxoTestParams::default(), &mut key_manager).await;
         outputs[4].features.maturity = 42;
         outputs[5].features.maturity = 42;
         outputs[7].features.maturity = 42;
-        let mut input = create_input(&key_manager).await;
+        let mut input = create_input(&mut key_manager).await;
         input.set_maturity(42).unwrap();
         let covenant = covenant!(fields_preserved(@fields(
             @field::features_output_type,

--- a/base_layer/transaction_components/src/transaction_components/covenants/fields.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/fields.rs
@@ -404,7 +404,7 @@ mod test {
 
             #[tokio::test]
             async fn it_returns_true_if_eq() {
-                let key_manager = create_memory_key_manager().await.unwrap();
+                let mut key_manager = create_memory_key_manager().await.unwrap();
                 let side_chain_features = make_sample_sidechain_feature();
                 let output = create_outputs(
                     1,
@@ -416,7 +416,7 @@ mod test {
                         script: script![Drop Nop].unwrap(),
                         ..Default::default()
                     },
-                    &key_manager,
+                    &mut key_manager,
                 )
                 .await
                 .remove(0);
@@ -447,7 +447,7 @@ mod test {
 
             #[tokio::test]
             async fn it_returns_false_if_not_eq() {
-                let key_manager = create_memory_key_manager().await.unwrap();
+                let mut key_manager = create_memory_key_manager().await.unwrap();
                 let side_chain_features = make_sample_sidechain_feature();
                 let output = create_outputs(
                     1,
@@ -463,7 +463,7 @@ mod test {
                         value: MicroMinotari(123456),
                         ..Default::default()
                     },
-                    &key_manager,
+                    &mut key_manager,
                 )
                 .await
                 .remove(0);
@@ -501,7 +501,7 @@ mod test {
 
             #[tokio::test]
             async fn it_returns_true_if_eq_input() {
-                let key_manager = create_memory_key_manager().await.unwrap();
+                let mut key_manager = create_memory_key_manager().await.unwrap();
                 let output = create_outputs(
                     1,
                     UtxoTestParams {
@@ -512,11 +512,11 @@ mod test {
                         script: script![Drop Nop].unwrap(),
                         ..Default::default()
                     },
-                    &key_manager,
+                    &mut key_manager,
                 )
                 .await
                 .remove(0);
-                let mut input = create_input(&key_manager).await;
+                let mut input = create_input(&mut key_manager).await;
                 if let SpentOutput::OutputData {
                     features,
                     commitment,
@@ -578,7 +578,7 @@ mod test {
 
             #[tokio::test]
             async fn it_constructs_challenge_using_consensus_encoding() {
-                let key_manager = create_memory_key_manager().await.unwrap();
+                let mut key_manager = create_memory_key_manager().await.unwrap();
                 let features = OutputFeatures {
                     maturity: 42,
                     output_type: OutputType::Coinbase,
@@ -594,7 +594,7 @@ mod test {
                         value: MicroMinotari(123456),
                         ..Default::default()
                     },
-                    &key_manager,
+                    &mut key_manager,
                 )
                 .await
                 .remove(0);
@@ -626,7 +626,7 @@ mod test {
 
             #[tokio::test]
             async fn it_retrieves_the_value_as_ref() {
-                let key_manager = create_memory_key_manager().await.unwrap();
+                let mut key_manager = create_memory_key_manager().await.unwrap();
                 let features = OutputFeatures {
                     maturity: 42,
                     range_proof_type: RangeProofType::RevealedValue,
@@ -640,7 +640,7 @@ mod test {
                         value: MicroMinotari(123456),
                         ..Default::default()
                     },
-                    &key_manager,
+                    &mut key_manager,
                 )
                 .await
                 .pop()

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/absolute_height.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/absolute_height.rs
@@ -77,10 +77,10 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_all_out_if_height_not_reached() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let covenant = covenant!(absolute_height(@uint(100))).unwrap();
-        let input = create_input(&key_manager).await;
-        let (mut context, outputs) = setup_filter_test(&covenant, &input, 42, |_| {}, &key_manager).await;
+        let input = create_input(&mut key_manager).await;
+        let (mut context, outputs) = setup_filter_test(&covenant, &input, 42, |_| {}, &mut key_manager).await;
 
         let mut output_set = OutputSet::new(&outputs);
         AbsoluteHeightFilter.filter(&mut context, &mut output_set).unwrap();
@@ -90,10 +90,10 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_all_in_if_height_reached() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let covenant = covenant!(absolute_height(@uint(100))).unwrap();
-        let input = create_input(&key_manager).await;
-        let (mut context, outputs) = setup_filter_test(&covenant, &input, 100, |_| {}, &key_manager).await;
+        let input = create_input(&mut key_manager).await;
+        let (mut context, outputs) = setup_filter_test(&covenant, &input, 100, |_| {}, &mut key_manager).await;
 
         let mut output_set = OutputSet::new(&outputs);
         AbsoluteHeightFilter.filter(&mut context, &mut output_set).unwrap();
@@ -103,10 +103,10 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_all_in_if_height_exceeded() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let covenant = covenant!(absolute_height(@uint(42))).unwrap();
-        let input = create_input(&key_manager).await;
-        let (mut context, outputs) = setup_filter_test(&covenant, &input, 100, |_| {}, &key_manager).await;
+        let input = create_input(&mut key_manager).await;
+        let (mut context, outputs) = setup_filter_test(&covenant, &input, 100, |_| {}, &mut key_manager).await;
 
         let mut output_set = OutputSet::new(&outputs);
         AbsoluteHeightFilter.filter(&mut context, &mut output_set).unwrap();

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/and.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/and.rs
@@ -58,10 +58,10 @@ mod test {
     };
     #[tokio::test]
     async fn it_filters_outputset_using_intersection() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let script = script!(CheckHeight(101)).unwrap();
         let covenant = covenant!(and(field_eq(@field::features_maturity, @uint(42),), field_eq(@field::script, @script(script.clone())))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let (mut context, outputs) = setup_filter_test(
             &covenant,
             &input,
@@ -80,7 +80,7 @@ mod test {
                 outputs[8].features.maturity = 123;
                 outputs[8].script = script.clone();
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
 

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/field_eq.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/field_eq.rs
@@ -94,13 +94,13 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_uint() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let covenant = covenant!(field_eq(@field::features_maturity, @uint(42))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let mut context = create_context(&covenant, &input, 0);
         // Remove `field_eq`
         context.next_filter().unwrap();
-        let mut outputs = create_outputs(10, Default::default(), &key_manager).await;
+        let mut outputs = create_outputs(10, Default::default(), &mut key_manager).await;
         outputs[5].features.maturity = 42;
         let mut output_set = OutputSet::new(&outputs);
         FieldEqFilter.filter(&mut context, &mut output_set).unwrap();
@@ -113,17 +113,17 @@ mod test {
     async fn it_filters_sender_offset_public_key() {
         let pk =
             CompressedPublicKey::from_hex("5615a327e1d19da34e5aa8bbd2ecc97addf29b158844b885bfc4efa0dab17052").unwrap();
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let covenant = covenant!(field_eq(
             @field::sender_offset_public_key,
             @public_key(pk.clone())
         ))
         .unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let mut context = create_context(&covenant, &input, 0);
         // Remove `field_eq`
         context.next_filter().unwrap();
-        let mut outputs = create_outputs(10, Default::default(), &key_manager).await;
+        let mut outputs = create_outputs(10, Default::default(), &mut key_manager).await;
         outputs[5].sender_offset_public_key = pk.clone();
         let mut output_set = OutputSet::new(&outputs);
         FieldEqFilter.filter(&mut context, &mut output_set).unwrap();
@@ -134,7 +134,7 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_commitment() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let commitment =
             CompressedCommitment::from_hex("7ca31ba517d8b563609ed6707fedde5a2be64ac1d67b254cb5348bc2f680557f").unwrap();
         let covenant = covenant!(field_eq(
@@ -142,11 +142,11 @@ mod test {
             @commitment(commitment.clone())
         ))
         .unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let mut context = create_context(&covenant, &input, 0);
         // Remove `field_eq`
         context.next_filter().unwrap();
-        let mut outputs = create_outputs(10, Default::default(), &key_manager).await;
+        let mut outputs = create_outputs(10, Default::default(), &mut key_manager).await;
         outputs[5].commitment = commitment.clone();
         outputs[7].commitment = commitment;
         let mut output_set = OutputSet::new(&outputs);
@@ -158,18 +158,18 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_tari_script() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let script = script!(CheckHeight(100)).unwrap();
         let covenant = covenant!(field_eq(
             @field::script,
             @script(script.clone())
         ))
         .unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let mut context = create_context(&covenant, &input, 0);
         // Remove `field_eq`
         context.next_filter().unwrap();
-        let mut outputs = create_outputs(10, Default::default(), &key_manager).await;
+        let mut outputs = create_outputs(10, Default::default(), &mut key_manager).await;
         outputs[5].script = script.clone();
         outputs[7].script = script;
         let mut output_set = OutputSet::new(&outputs);
@@ -181,14 +181,14 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_covenant() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let next_cov = covenant!(and(identity(), or(field_eq(@field::features_maturity, @uint(42))))).unwrap();
         let covenant = covenant!(field_eq(@field::covenant, @covenant(next_cov.clone()))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let mut context = create_context(&covenant, &input, 0);
         // Remove `field_eq`
         context.next_filter().unwrap();
-        let mut outputs = create_outputs(10, Default::default(), &key_manager).await;
+        let mut outputs = create_outputs(10, Default::default(), &mut key_manager).await;
         outputs[5].covenant = next_cov.clone();
         outputs[7].covenant = next_cov;
         let mut output_set = OutputSet::new(&outputs);
@@ -200,13 +200,13 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_output_type() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let covenant = covenant!(field_eq(@field::features_output_type, @output_type(Coinbase))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let mut context = create_context(&covenant, &input, 0);
         // Remove `field_eq`
         context.next_filter().unwrap();
-        let mut outputs = create_outputs(10, Default::default(), &key_manager).await;
+        let mut outputs = create_outputs(10, Default::default(), &mut key_manager).await;
         outputs[5].features.output_type = OutputType::Coinbase;
         outputs[7].features.output_type = OutputType::Coinbase;
         let mut output_set = OutputSet::new(&outputs);
@@ -218,13 +218,13 @@ mod test {
 
     #[tokio::test]
     async fn it_errors_if_field_has_an_incorrect_type() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let covenant = covenant!(field_eq(@field::features, @uint(42))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let mut context = create_context(&covenant, &input, 0);
         // Remove `field_eq`
         context.next_filter().unwrap();
-        let outputs = create_outputs(10, Default::default(), &key_manager).await;
+        let outputs = create_outputs(10, Default::default(), &mut key_manager).await;
         let mut output_set = OutputSet::new(&outputs);
         let err = FieldEqFilter.filter(&mut context, &mut output_set).unwrap_err();
         unpack_enum!(CovenantError::InvalidArgument { .. } = err);

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/fields_hashed_eq.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/fields_hashed_eq.rs
@@ -71,7 +71,7 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_outputs_with_fields_that_hash_to_given_hash() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let features = OutputFeatures {
             maturity: 42,
             sidechain_feature: Some(make_sample_sidechain_feature()),
@@ -81,7 +81,7 @@ mod test {
         BaseLayerCovenantsDomain::add_domain_separation_tag(&mut hasher, COVENANTS_FIELD_HASHER_LABEL);
         let hash = hasher.chain(borsh::to_vec(&features).unwrap()).finalize();
         let covenant = covenant!(fields_hashed_eq(@fields(@field::features), @hash(hash.into()))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let (mut context, outputs) = setup_filter_test(
             &covenant,
             &input,
@@ -95,7 +95,7 @@ mod test {
                 };
                 outputs[7].features = features;
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut output_set = OutputSet::new(&outputs);

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/fields_preserved.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/fields_preserved.rs
@@ -60,8 +60,8 @@ mod test {
     async fn it_filters_outputs_that_match_input_fields() {
         let covenant =
             covenant!(fields_preserved(@fields(@field::features_maturity, @field::features_output_type))).unwrap();
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let mut input = create_input(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let mut input = create_input(&mut key_manager).await;
         input.set_maturity(42).unwrap();
         input.features_mut().unwrap().output_type = OutputType::ValidatorNodeRegistration;
         let (mut context, outputs) = setup_filter_test(
@@ -76,7 +76,7 @@ mod test {
                 outputs[8].features.maturity = 42;
                 outputs[8].features.output_type = OutputType::Coinbase;
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut output_set = OutputSet::new(&outputs);

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/identity.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/identity.rs
@@ -48,10 +48,10 @@ mod tests {
     };
     #[tokio::test]
     async fn it_returns_the_outputset_unchanged() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let covenant = covenant!(identity()).unwrap();
-        let input = create_input(&key_manager).await;
-        let (mut context, outputs) = setup_filter_test(&covenant, &input, 0, |_| {}, &key_manager).await;
+        let input = create_input(&mut key_manager).await;
+        let (mut context, outputs) = setup_filter_test(&covenant, &input, 0, |_| {}, &mut key_manager).await;
         let mut output_set = OutputSet::new(&outputs);
         let previous_len = output_set.len();
         IdentityFilter.filter(&mut context, &mut output_set).unwrap();

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/not.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/not.rs
@@ -56,10 +56,10 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_compliment_of_filter() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let script = script!(CheckHeight(100)).unwrap();
         let covenant = covenant!(not(or(field_eq(@field::features_maturity, @uint(42),), field_eq(@field::script, @script(script.clone()))))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let (mut context, outputs) = setup_filter_test(
             &covenant,
             &input,
@@ -70,7 +70,7 @@ mod test {
                 outputs[7].features.maturity = 42;
                 outputs[8].script = script;
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut output_set = OutputSet::new(&outputs);

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/or.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/or.rs
@@ -62,10 +62,10 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_outputset_using_union() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let script = script!(CheckHeight(100)).unwrap();
         let covenant = covenant!(or(field_eq(@field::features_maturity, @uint(42),), field_eq(@field::script, @script(script.clone())))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let (mut context, outputs) = setup_filter_test(
             &covenant,
             &input,
@@ -76,7 +76,7 @@ mod test {
                 outputs[7].features.maturity = 42;
                 outputs[8].script = script;
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut output_set = OutputSet::new(&outputs);

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/output_hash_eq.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/output_hash_eq.rs
@@ -56,11 +56,11 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_output_with_specific_hash() {
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let output = create_outputs(1, Default::default(), &key_manager).await.remove(0);
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let output = create_outputs(1, Default::default(), &mut key_manager).await.remove(0);
         let output_hash = output.hash();
         let covenant = covenant!(output_hash_eq(@hash(output_hash))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let (mut context, outputs) = setup_filter_test(
             &covenant,
             &input,
@@ -68,7 +68,7 @@ mod test {
             move |outputs| {
                 outputs.insert(5, output);
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut output_set = OutputSet::new(&outputs);

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/test.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/test.rs
@@ -40,7 +40,7 @@ pub async fn setup_filter_test<'a, F, KM: TransactionKeyManagerInterface>(
     input: &'a TransactionInput,
     block_height: u64,
     output_mod: F,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> (CovenantContext<'a>, Vec<TransactionOutput>)
 where
     F: FnOnce(&mut Vec<TransactionOutput>),

--- a/base_layer/transaction_components/src/transaction_components/covenants/filters/xor.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/filters/xor.rs
@@ -64,10 +64,10 @@ mod test {
 
     #[tokio::test]
     async fn it_filters_outputset_using_symmetric_difference() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let script = script!(CheckHeight(100)).unwrap();
         let covenant = covenant!(and(field_eq(@field::features_maturity, @uint(42),), field_eq(@field::script, @script(script.clone())))).unwrap();
-        let input = create_input(&key_manager).await;
+        let input = create_input(&mut key_manager).await;
         let (mut context, outputs) = setup_filter_test(
             &covenant,
             &input,
@@ -78,7 +78,7 @@ mod test {
                 outputs[7].features.maturity = 42;
                 outputs[8].script = script;
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut output_set = OutputSet::new(&outputs);

--- a/base_layer/transaction_components/src/transaction_components/covenants/test.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/test.rs
@@ -40,7 +40,7 @@ use crate::{
 pub async fn create_outputs<KM: TransactionKeyManagerInterface>(
     n: usize,
     utxo_params: UtxoTestParams,
-    key_manager: &KM,
+    key_manager: &mut KM,
 ) -> Vec<TransactionOutput> {
     let mut outputs = Vec::new();
     for _i in 0..n {
@@ -51,7 +51,7 @@ pub async fn create_outputs<KM: TransactionKeyManagerInterface>(
     outputs
 }
 
-pub async fn create_input<KM: TransactionKeyManagerInterface>(key_manager: &KM) -> TransactionInput {
+pub async fn create_input<KM: TransactionKeyManagerInterface>(key_manager: &mut KM) -> TransactionInput {
     let params = TestParams::new(key_manager).await;
     let output = params.create_output(Default::default(), key_manager).await.unwrap();
     output.to_transaction_input(key_manager).await.unwrap()

--- a/base_layer/transaction_components/src/transaction_components/test.rs
+++ b/base_layer/transaction_components/src/transaction_components/test.rs
@@ -558,7 +558,7 @@ async fn inputs_not_malleable() {
     .await
     .expect("Failed to create wallet outputs");
     let mut stack = inputs[0].input_data().clone();
-    let mut tx = test_helpers::create_transaction_with(1, 15.into(), inputs, outputs, &mut key_manager).await;
+    let mut tx = test_helpers::create_transaction_with(1, 15.into(), inputs, outputs, &key_manager).await;
 
     stack
         .push(StackItem::Hash(*b"Pls put this on tha tari network"))

--- a/base_layer/transaction_components/src/transaction_components/test.rs
+++ b/base_layer/transaction_components/src/transaction_components/test.rs
@@ -58,11 +58,11 @@ use crate::{
 
 #[tokio::test]
 async fn input_and_output_and_wallet_output_hash_match() {
-    let key_manager = create_memory_key_manager().await.unwrap();
-    let test_params = TestParams::new(&key_manager).await;
+    let mut key_manager = create_memory_key_manager().await.unwrap();
+    let test_params = TestParams::new(&mut key_manager).await;
 
     let i = test_params
-        .create_output(Default::default(), &key_manager)
+        .create_output(Default::default(), &mut key_manager)
         .await
         .unwrap();
     let output = i.to_transaction_output().unwrap();
@@ -82,11 +82,11 @@ fn test_smt_hashes() {
 
 #[tokio::test]
 async fn key_manager_input() {
-    let key_manager = create_memory_key_manager().await.unwrap();
-    let test_params = TestParams::new(&key_manager).await;
+    let mut key_manager = create_memory_key_manager().await.unwrap();
+    let test_params = TestParams::new(&mut key_manager).await;
 
     let i = test_params
-        .create_output(Default::default(), &key_manager)
+        .create_output(Default::default(), &mut key_manager)
         .await
         .unwrap();
     let input = i
@@ -114,10 +114,10 @@ async fn key_manager_input() {
 #[tokio::test]
 async fn range_proof_verification() {
     let factories = CryptoFactories::new(32);
-    let key_manager = create_memory_key_manager_with_range_proof_size(32).await.unwrap();
+    let mut key_manager = create_memory_key_manager_with_range_proof_size(32).await.unwrap();
     // Directly test the tx_output verification
-    let test_params_1 = TestParams::new(&key_manager).await;
-    let test_params_2 = TestParams::new(&key_manager).await;
+    let test_params_1 = TestParams::new(&mut key_manager).await;
+    let test_params_2 = TestParams::new(&mut key_manager).await;
 
     // For testing the max range has been limited to 2^32 so this value is too large.
     let wallet_output1 = test_params_1
@@ -126,7 +126,7 @@ async fn range_proof_verification() {
                 value: (2u64.pow(32) - 1u64).into(),
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -147,7 +147,7 @@ async fn range_proof_verification() {
     .with_version(TransactionOutputVersion::get_current_version())
     .with_sender_offset_public_key(test_params_2.sender_offset_key_pk.clone())
     .with_script_key(test_params_2.script_key_id.clone())
-    .sign_as_sender_and_receiver(&key_manager, &test_params_2.sender_offset_key_id)
+    .sign_as_sender_and_receiver(&mut key_manager, &test_params_2.sender_offset_key_id)
     .await
     .unwrap()
     .try_build(&key_manager)
@@ -177,71 +177,71 @@ async fn range_proof_verification() {
 #[tokio::test]
 async fn range_proof_verification_batch() {
     let factories = CryptoFactories::new(64);
-    let key_manager = create_memory_key_manager().await.unwrap();
-    let wallet_output1 = TestParams::new(&key_manager)
+    let mut key_manager = create_memory_key_manager().await.unwrap();
+    let wallet_output1 = TestParams::new(&mut key_manager)
         .await
         .create_output(
             UtxoTestParams {
                 value: (1u64).into(),
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
     let tx_output1 = wallet_output1.to_transaction_output().unwrap();
     assert!(tx_output1.verify_range_proof(&factories.range_proof).is_ok());
 
-    let wallet_output2 = TestParams::new(&key_manager)
+    let wallet_output2 = TestParams::new(&mut key_manager)
         .await
         .create_output(
             UtxoTestParams {
                 value: (2u64).into(),
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
     let tx_output2 = wallet_output2.to_transaction_output().unwrap();
     assert!(tx_output2.verify_range_proof(&factories.range_proof).is_ok());
 
-    let wallet_output3 = TestParams::new(&key_manager)
+    let wallet_output3 = TestParams::new(&mut key_manager)
         .await
         .create_output(
             UtxoTestParams {
                 value: (3u64).into(),
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
     let tx_output3 = wallet_output3.to_transaction_output().unwrap();
     assert!(tx_output3.verify_range_proof(&factories.range_proof).is_ok());
 
-    let wallet_output4 = TestParams::new(&key_manager)
+    let wallet_output4 = TestParams::new(&mut key_manager)
         .await
         .create_output(
             UtxoTestParams {
                 value: (4u64).into(),
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
     let tx_output4 = wallet_output4.to_transaction_output().unwrap();
     assert!(tx_output4.verify_range_proof(&factories.range_proof).is_ok());
 
-    let wallet_output5 = TestParams::new(&key_manager)
+    let wallet_output5 = TestParams::new(&mut key_manager)
         .await
         .create_output(
             UtxoTestParams {
                 value: (5u64).into(),
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -268,10 +268,10 @@ async fn range_proof_verification_batch() {
 
 #[tokio::test]
 async fn sender_signature_verification() {
-    let key_manager = create_memory_key_manager().await.unwrap();
-    let test_params = TestParams::new(&key_manager).await;
+    let mut key_manager = create_memory_key_manager().await.unwrap();
+    let test_params = TestParams::new(&mut key_manager).await;
     let wallet_output = test_params
-        .create_output(Default::default(), &key_manager)
+        .create_output(Default::default(), &mut key_manager)
         .await
         .unwrap();
 
@@ -434,8 +434,8 @@ fn check_timelocks() {
 #[tokio::test]
 async fn test_validate_internal_consistency() {
     let features = OutputFeatures { ..Default::default() };
-    let key_manager = create_memory_key_manager().await.unwrap();
-    let (tx, _, _) = test_helpers::create_tx(5000.into(), 3.into(), 1, 2, 1, 4, features, &key_manager)
+    let mut key_manager = create_memory_key_manager().await.unwrap();
+    let (tx, _, _) = test_helpers::create_tx(5000.into(), 3.into(), 1, 2, 1, 4, features, &mut key_manager)
         .await
         .expect("Failed to create tx");
     let rules = ConsensusManager::builder(Network::LocalNet).build();
@@ -447,11 +447,19 @@ async fn test_validate_internal_consistency() {
 #[tokio::test]
 #[allow(clippy::identity_op)]
 async fn check_cut_through() {
-    let key_manager = create_memory_key_manager().await.unwrap();
-    let (tx, _, outputs) =
-        test_helpers::create_tx(50000000.into(), 3.into(), 1, 2, 1, 2, Default::default(), &key_manager)
-            .await
-            .expect("Failed to create tx");
+    let mut key_manager = create_memory_key_manager().await.unwrap();
+    let (tx, _, outputs) = test_helpers::create_tx(
+        50000000.into(),
+        3.into(),
+        1,
+        2,
+        1,
+        2,
+        Default::default(),
+        &mut key_manager,
+    )
+    .await
+    .expect("Failed to create tx");
 
     assert_eq!(tx.body.inputs().len(), 2);
     assert_eq!(tx.body.outputs().len(), 2);
@@ -463,7 +471,7 @@ async fn check_cut_through() {
     validator.validate(&tx, None, None, u64::MAX).unwrap();
 
     let schema = txn_schema!(from: vec![outputs[1].clone()], to: vec![1 * T, 2 * T]);
-    let (tx2, _outputs) = test_helpers::spend_utxos(schema, &key_manager).await;
+    let (tx2, _outputs) = test_helpers::spend_utxos(schema, &mut key_manager).await;
 
     assert_eq!(tx2.body.inputs().len(), 1);
     assert_eq!(tx2.body.outputs().len(), 3);
@@ -504,11 +512,19 @@ async fn check_cut_through() {
 
 #[tokio::test]
 async fn check_duplicate_inputs_outputs() {
-    let key_manager = create_memory_key_manager().await.unwrap();
-    let (tx, _, _outputs) =
-        test_helpers::create_tx(50000000.into(), 3.into(), 1, 2, 1, 2, Default::default(), &key_manager)
-            .await
-            .expect("Failed to create tx");
+    let mut key_manager = create_memory_key_manager().await.unwrap();
+    let (tx, _, _outputs) = test_helpers::create_tx(
+        50000000.into(),
+        3.into(),
+        1,
+        2,
+        1,
+        2,
+        Default::default(),
+        &mut key_manager,
+    )
+    .await
+    .expect("Failed to create tx");
     assert!(!tx.body.contains_duplicated_outputs());
     assert!(!tx.body.contains_duplicated_inputs());
 
@@ -527,7 +543,7 @@ async fn check_duplicate_inputs_outputs() {
 
 #[tokio::test]
 async fn inputs_not_malleable() {
-    let key_manager = create_memory_key_manager().await.unwrap();
+    let mut key_manager = create_memory_key_manager().await.unwrap();
     let (inputs, outputs) = test_helpers::create_wallet_outputs(
         5000.into(),
         1,
@@ -537,12 +553,12 @@ async fn inputs_not_malleable() {
         &Default::default(),
         &script![Nop].unwrap(),
         &Default::default(),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .expect("Failed to create wallet outputs");
     let mut stack = inputs[0].input_data().clone();
-    let mut tx = test_helpers::create_transaction_with(1, 15.into(), inputs, outputs, &key_manager).await;
+    let mut tx = test_helpers::create_transaction_with(1, 15.into(), inputs, outputs, &mut key_manager).await;
 
     stack
         .push(StackItem::Hash(*b"Pls put this on tha tari network"))
@@ -562,8 +578,8 @@ async fn inputs_not_malleable() {
 
 #[tokio::test]
 async fn test_output_recover_openings() {
-    let key_manager = create_memory_key_manager().await.unwrap();
-    let test_params = TestParams::new(&key_manager).await;
+    let mut key_manager = create_memory_key_manager().await.unwrap();
+    let test_params = TestParams::new(&mut key_manager).await;
     let v = MicroMinotari::from(42);
 
     let wallet_output = test_params
@@ -572,7 +588,7 @@ async fn test_output_recover_openings() {
                 value: v,
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -606,7 +622,7 @@ mod validate_internal_consistency {
         input_params: &UtxoTestParams,
         utxo_params: &UtxoTestParams,
         height: u64,
-        key_manager: &KM,
+        key_manager: &mut KM,
     ) -> Result<(), TransactionError> {
         let (mut inputs, outputs) = create_wallet_outputs(
             100 * T,
@@ -639,7 +655,7 @@ mod validate_internal_consistency {
         //---------------------------------- Case1 - PASS --------------------------------------------//
         let covenant = covenant!(fields_preserved(@fields( @field::covenant))).unwrap();
         let features = OutputFeatures { ..Default::default() };
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         test_case(
             &UtxoTestParams {
                 features: features.clone(),
@@ -652,7 +668,7 @@ mod validate_internal_consistency {
                 ..Default::default()
             },
             0,
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -682,7 +698,7 @@ mod validate_internal_consistency {
                 ..Default::default()
             },
             0,
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -698,7 +714,7 @@ mod validate_internal_consistency {
             },
             &UtxoTestParams::default(),
             0,
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap_err();
@@ -722,7 +738,7 @@ mod validate_internal_consistency {
                 ..Default::default()
             },
             0,
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -736,7 +752,7 @@ mod validate_internal_consistency {
             },
             &UtxoTestParams::default(),
             100,
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();

--- a/base_layer/transaction_components/src/transaction_components/transaction_output.rs
+++ b/base_layer/transaction_components/src/transaction_components/transaction_output.rs
@@ -596,8 +596,8 @@ mod test {
     #[tokio::test]
     async fn it_builds_correctly() {
         let factories = CryptoFactories::default();
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let test_params = TestParams::new(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let test_params = TestParams::new(&mut key_manager).await;
 
         let value = MicroMinotari(10);
         let minimum_value_promise = MicroMinotari(10);
@@ -606,7 +606,7 @@ mod test {
             value,
             minimum_value_promise,
             RangeProofType::BulletProofPlus,
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -628,8 +628,8 @@ mod test {
     #[tokio::test]
     async fn it_does_not_verify_incorrect_minimum_value() {
         let factories = CryptoFactories::default();
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let test_params = TestParams::new(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let test_params = TestParams::new(&mut key_manager).await;
 
         let value = MicroMinotari(10);
         let minimum_value_promise = MicroMinotari(11);
@@ -638,7 +638,7 @@ mod test {
             value,
             minimum_value_promise,
             RangeProofType::BulletProofPlus,
-            &key_manager,
+            &mut key_manager,
         )
         .await;
 
@@ -648,8 +648,8 @@ mod test {
     #[tokio::test]
     async fn it_does_batch_verify_correct_minimum_values() {
         let factories = CryptoFactories::default();
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let test_params = TestParams::new(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let test_params = TestParams::new(&mut key_manager).await;
 
         let outputs = [
             &create_output(
@@ -657,7 +657,7 @@ mod test {
                 MicroMinotari(10),
                 MicroMinotari::zero(),
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap(),
@@ -666,7 +666,7 @@ mod test {
                 MicroMinotari(10),
                 MicroMinotari(5),
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap(),
@@ -675,7 +675,7 @@ mod test {
                 MicroMinotari(10),
                 MicroMinotari(10),
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap(),
@@ -686,9 +686,9 @@ mod test {
 
     #[tokio::test]
     async fn it_does_batch_verify_with_mixed_range_proof_types() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let factories = CryptoFactories::default();
-        let test_params = TestParams::new(&key_manager).await;
+        let test_params = TestParams::new(&mut key_manager).await;
 
         let outputs = [
             &create_output(
@@ -696,7 +696,7 @@ mod test {
                 MicroMinotari(10),
                 MicroMinotari::zero(),
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap(),
@@ -705,7 +705,7 @@ mod test {
                 MicroMinotari(10),
                 MicroMinotari(10),
                 RangeProofType::RevealedValue,
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap(),
@@ -714,7 +714,7 @@ mod test {
                 MicroMinotari(10),
                 MicroMinotari::zero(),
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap(),
@@ -723,7 +723,7 @@ mod test {
                 MicroMinotari(20),
                 MicroMinotari(20),
                 RangeProofType::RevealedValue,
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap(),
@@ -734,14 +734,14 @@ mod test {
 
     #[tokio::test]
     async fn invalid_revealed_value_proofs_are_blocked() {
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let test_params = TestParams::new(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let test_params = TestParams::new(&mut key_manager).await;
         assert!(create_output(
             &test_params,
             MicroMinotari(20),
             MicroMinotari::zero(),
             RangeProofType::BulletProofPlus,
-            &key_manager
+            &mut key_manager
         )
         .await
         .is_ok());
@@ -750,7 +750,7 @@ mod test {
             MicroMinotari(20),
             MicroMinotari::zero(),
             RangeProofType::RevealedValue,
-            &key_manager,
+            &mut key_manager,
         )
         .await
         {
@@ -766,8 +766,8 @@ mod test {
     #[tokio::test]
     async fn it_does_not_batch_verify_incorrect_minimum_values() {
         let factories = CryptoFactories::default();
-        let key_manager = create_memory_key_manager().await.unwrap();
-        let test_params = TestParams::new(&key_manager).await;
+        let mut key_manager = create_memory_key_manager().await.unwrap();
+        let test_params = TestParams::new(&mut key_manager).await;
 
         let outputs = [
             &create_output(
@@ -775,7 +775,7 @@ mod test {
                 MicroMinotari(10),
                 MicroMinotari(10),
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap(),
@@ -784,7 +784,7 @@ mod test {
                 MicroMinotari(10),
                 MicroMinotari(11),
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await,
         ];
@@ -797,7 +797,7 @@ mod test {
         value: MicroMinotari,
         minimum_value_promise: MicroMinotari,
         range_proof_type: RangeProofType,
-        key_manager: &KM,
+        key_manager: &mut KM,
     ) -> Result<TransactionOutput, String> {
         let utxo = test_params
             .create_output(
@@ -821,7 +821,7 @@ mod test {
         value: MicroMinotari,
         minimum_value_promise: MicroMinotari,
         range_proof_type: RangeProofType,
-        key_manager: &KM,
+        key_manager: &mut KM,
     ) -> TransactionOutput {
         // we need first to create a valid minimum value, regardless of the minimum_value_promise
         // because this test function should allow creating an invalid proof for later testing

--- a/base_layer/transaction_components/src/transaction_components/wallet_output.rs
+++ b/base_layer/transaction_components/src/transaction_components/wallet_output.rs
@@ -560,7 +560,7 @@ impl WalletOutput {
         encrypted_data: EncryptedData,
         sender_offset: &TariKeyId,
         payment_id: MemoField,
-        key_manager: &KM,
+        key_manager: &mut KM,
     ) -> Result<(), TransactionError> {
         self.input = OnceLock::new();
         self.output = OnceLock::new();

--- a/base_layer/transaction_components/src/transaction_components/wallet_output_builder.rs
+++ b/base_layer/transaction_components/src/transaction_components/wallet_output_builder.rs
@@ -168,7 +168,7 @@ impl WalletOutputBuilder {
 
     pub async fn sign_as_sender_and_receiver<KM: TransactionKeyManagerInterface>(
         mut self,
-        key_manager: &KM,
+        key_manager: &mut KM,
         sender_offset_key_id: &TariKeyId,
     ) -> Result<Self, TransactionError> {
         let script = self
@@ -203,7 +203,7 @@ impl WalletOutputBuilder {
 
     pub async fn sign_as_sender_and_receiver_verified<KM: TransactionKeyManagerInterface>(
         mut self,
-        key_manager: &KM,
+        key_manager: &mut KM,
         sender_offset_key_id: &TariKeyId,
         receiver_address: &TariAddress,
     ) -> Result<Self, TransactionError> {
@@ -242,7 +242,7 @@ impl WalletOutputBuilder {
     /// `ephemeral_pubkey_shares` from other participants are combined to enable creation of the challenge.
     pub async fn sign_partial_as_sender_and_receiver<KM: TransactionKeyManagerInterface>(
         mut self,
-        key_manager: &KM,
+        key_manager: &mut KM,
         sender_offset_key_id: &TariKeyId,
         aggregated_sender_offset_public_key_shares: &CompressedPublicKey,
         aggregated_ephemeral_public_key_shares: &CompressedPublicKey,
@@ -358,7 +358,7 @@ mod test {
 
     #[tokio::test]
     async fn test_try_build() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let (commitment_mask_key, script_key_id) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
         let value = MicroMinotari(100);
         let kmob = WalletOutputBuilder::new(value, commitment_mask_key.key_id.clone());
@@ -377,7 +377,7 @@ mod test {
             .encrypt_data_for_recovery(&key_manager, None, MemoField::new_empty())
             .await
             .unwrap()
-            .sign_as_sender_and_receiver(&key_manager, &sender_offset.key_id)
+            .sign_as_sender_and_receiver(&mut key_manager, &sender_offset.key_id)
             .await
             .unwrap();
         match kmob.clone().try_build(&key_manager).await {
@@ -412,7 +412,7 @@ mod test {
 
     #[tokio::test]
     async fn test_partial_metadata_signatures() {
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let (commitment_mask_key, script_key) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
         let value = MicroMinotari(100);
         let kmob = WalletOutputBuilder::new(value, commitment_mask_key.key_id.clone());
@@ -429,7 +429,7 @@ mod test {
             .encrypt_data_for_recovery(&key_manager, None, MemoField::new_empty())
             .await
             .unwrap()
-            .sign_as_sender_and_receiver(&key_manager, &sender_offset.key_id)
+            .sign_as_sender_and_receiver(&mut key_manager, &sender_offset.key_id)
             .await
             .unwrap();
         match kmob.clone().try_build(&key_manager).await {

--- a/base_layer/transaction_components/src/validation/aggregate_body/aggregate_body_internal_validator.rs
+++ b/base_layer/transaction_components/src/validation/aggregate_body/aggregate_body_internal_validator.rs
@@ -592,10 +592,10 @@ mod test {
         let mut kernel1 = test_helpers::create_test_kernel(0.into(), 0, KernelFeatures::create_burn());
         let mut kernel2 = test_helpers::create_test_kernel(0.into(), 0, KernelFeatures::create_burn());
 
-        let key_manager = create_memory_key_manager().await.unwrap();
+        let mut key_manager = create_memory_key_manager().await.unwrap();
         let (output1, _, _) = test_helpers::create_utxo(
             100.into(),
-            &key_manager,
+            &mut key_manager,
             &OutputFeatures::create_burn_output(),
             &script!(Nop).unwrap(),
             &Covenant::default(),
@@ -604,7 +604,7 @@ mod test {
         .await;
         let (output2, _, _) = test_helpers::create_utxo(
             101.into(),
-            &key_manager,
+            &mut key_manager,
             &OutputFeatures::create_burn_output(),
             &script!(Nop).unwrap(),
             &Covenant::default(),
@@ -613,7 +613,7 @@ mod test {
         .await;
         let (output3, _, _) = test_helpers::create_utxo(
             102.into(),
-            &key_manager,
+            &mut key_manager,
             &OutputFeatures::create_burn_output(),
             &script!(Nop).unwrap(),
             &Covenant::default(),
@@ -654,12 +654,12 @@ mod test {
             // Sort the kernels, we'll check that the outputs fail the sorting check
             kernels.sort();
 
-            let key_manager = create_memory_key_manager().await.unwrap();
+            let mut key_manager = create_memory_key_manager().await.unwrap();
             let mut outputs = Vec::new();
             for _ in 0..10 {
                 let (o, _, _) = test_helpers::create_utxo(
                     100.into(),
-                    &key_manager,
+                    &mut key_manager,
                     &OutputFeatures::create_burn_output(),
                     &script!(Nop).unwrap(),
                     &Covenant::default(),

--- a/base_layer/transaction_components/src/validation/helpers.rs
+++ b/base_layer/transaction_components/src/validation/helpers.rs
@@ -263,21 +263,21 @@ mod test {
         #[tokio::test]
         async fn it_succeeds_for_valid_coinbase() {
             let height = 1;
-            let key_manager = create_memory_key_manager().await.unwrap();
-            let test_params = TestParams::new(&key_manager).await;
+            let mut key_manager = create_memory_key_manager().await.unwrap();
+            let test_params = TestParams::new(&mut key_manager).await;
             let rules = test_helpers::create_consensus_manager();
-            let key_manager = create_memory_key_manager().await.unwrap();
+            let mut key_manager = create_memory_key_manager().await.unwrap();
             let coinbase = test_helpers::create_coinbase_wallet_output(
                 &test_params,
                 height,
                 None,
                 RangeProofType::RevealedValue,
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             let coinbase_output = coinbase.to_transaction_output().unwrap();
             let coinbase_kernel =
-                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &key_manager).await;
+                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &mut key_manager).await;
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
 
@@ -290,15 +290,15 @@ mod test {
         #[tokio::test]
         async fn it_returns_error_for_invalid_coinbase_maturity() {
             let height = 1;
-            let key_manager = create_memory_key_manager().await.unwrap();
-            let test_params = TestParams::new(&key_manager).await;
+            let mut key_manager = create_memory_key_manager().await.unwrap();
+            let test_params = TestParams::new(&mut key_manager).await;
             let rules = test_helpers::create_consensus_manager();
             let mut coinbase = test_helpers::create_coinbase_wallet_output(
                 &test_params,
                 height,
                 None,
                 RangeProofType::RevealedValue,
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             let mut features = coinbase.features().clone();
@@ -306,7 +306,7 @@ mod test {
             coinbase.set_features(features);
             let coinbase_output = coinbase.to_transaction_output().unwrap();
             let coinbase_kernel =
-                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &key_manager).await;
+                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &mut key_manager).await;
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
 
@@ -322,21 +322,21 @@ mod test {
         #[tokio::test]
         async fn it_returns_error_for_invalid_coinbase_reward() {
             let height = 1;
-            let key_manager = create_memory_key_manager().await.unwrap();
-            let test_params = TestParams::new(&key_manager).await;
+            let mut key_manager = create_memory_key_manager().await.unwrap();
+            let test_params = TestParams::new(&mut key_manager).await;
             let rules = test_helpers::create_consensus_manager();
             let mut coinbase = test_helpers::create_coinbase_wallet_output(
                 &test_params,
                 height,
                 None,
                 RangeProofType::BulletProofPlus,
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             coinbase.set_value(123.into(), &key_manager).await.unwrap();
             let coinbase_output = coinbase.to_transaction_output().unwrap();
             let coinbase_kernel =
-                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &key_manager).await;
+                test_helpers::create_coinbase_kernel(coinbase.commitment_mask_key_id(), &mut key_manager).await;
 
             let body = AggregateBody::new(vec![], vec![coinbase_output], vec![coinbase_kernel]);
             let reward = rules.calculate_coinbase_and_fees(height, body.kernels()).unwrap();

--- a/base_layer/transaction_components/src/validation/helpers.rs
+++ b/base_layer/transaction_components/src/validation/helpers.rs
@@ -266,7 +266,6 @@ mod test {
             let mut key_manager = create_memory_key_manager().await.unwrap();
             let test_params = TestParams::new(&mut key_manager).await;
             let rules = test_helpers::create_consensus_manager();
-            let mut key_manager = create_memory_key_manager().await.unwrap();
             let coinbase = test_helpers::create_coinbase_wallet_output(
                 &test_params,
                 height,

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1014,7 +1014,7 @@ where
                 .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
                 .await?;
             wallet_output = wallet_output
-                .sign_as_sender_and_receiver(&self.resources.key_manager, &sender_offset_key.key_id)
+                .sign_as_sender_and_receiver(&mut self.resources.key_manager, &sender_offset_key.key_id)
                 .await?;
             let ub = wallet_output.try_build(&self.resources.key_manager).await?;
 
@@ -1324,7 +1324,7 @@ where
             .with_script_key(self.resources.key_manager.get_spend_key().await?.key_id)
             .with_minimum_value_promise(minimum_value_promise)
             .sign_partial_as_sender_and_receiver(
-                &self.resources.key_manager,
+                &mut self.resources.key_manager,
                 &sender_offset_private_key_id_self.key_id,
                 &CompressedPublicKey::new_from_pk(aggregated_sender_offset_public_key_shares),
                 &CompressedPublicKey::new_from_pk(aggregated_metadata_ephemeral_public_key_shares.clone()),
@@ -1592,7 +1592,7 @@ where
             .with_script_key(TariKeyId::Zero)
             .with_minimum_value_promise(minimum_value_promise)
             .sign_as_sender_and_receiver_verified(
-                &self.resources.key_manager,
+                &mut self.resources.key_manager,
                 &sender_offset_private_key_id_self.key_id,
                 &recipient_address,
             )

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -1544,7 +1544,10 @@ mod test {
         OutputSource,
     };
 
-    pub async fn make_input(val: MicroMinotari, key_manager: &MemoryDbKeyManager) -> (TransactionInput, WalletOutput) {
+    pub async fn make_input(
+        val: MicroMinotari,
+        key_manager: &mut MemoryDbKeyManager,
+    ) -> (TransactionInput, WalletOutput) {
         let test_params = TestParams::new(key_manager).await;
 
         let wallet_output = create_wallet_output_with_data(
@@ -1591,9 +1594,9 @@ mod test {
         let mut outputs_spent = Vec::new();
         let mut outputs_unspent = Vec::new();
 
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         for _i in 0..2 {
-            let (_, uo) = make_input(MicroMinotari::from(100 + OsRng.next_u64() % 1000), &key_manager).await;
+            let (_, uo) = make_input(MicroMinotari::from(100 + OsRng.next_u64() % 1000), &mut key_manager).await;
             let uo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
             let o = NewOutputSql::new(uo, Some(OutputStatus::Unspent), None).unwrap();
             outputs.push(o.clone());
@@ -1602,7 +1605,7 @@ mod test {
         }
 
         for _i in 0..3 {
-            let (_, uo) = make_input(MicroMinotari::from(100 + OsRng.next_u64() % 1000), &key_manager).await;
+            let (_, uo) = make_input(MicroMinotari::from(100 + OsRng.next_u64() % 1000), &mut key_manager).await;
             let uo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
             let o = NewOutputSql::new(uo, Some(OutputStatus::Spent), None).unwrap();
             outputs.push(o.clone());

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -663,12 +663,12 @@ where
                 ))
             },
             TransactionServiceRequest::SignOneSidedTransaction { request } => {
-                let offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
+                let mut offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
                 let res = offline_signing.sign_locked_transaction(request).await?;
                 Ok(TransactionServiceResponse::SignedOneSidedTransaction(Box::new(res)))
             },
             TransactionServiceRequest::SignOneSidedDepositMultisigTransaction { request } => {
-                let offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
+                let mut offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
                 let res = offline_signing
                     .sign_locked_deposit_multisig_transaction(request)
                     .await?;
@@ -678,7 +678,7 @@ where
             },
             TransactionServiceRequest::SignOneSidedWithdrawMultisigTransaction { request } => {
                 let key_manager = self.resources.transaction_key_manager_service.clone();
-                let offline_signing = OfflineSigner::new(key_manager.clone());
+                let mut offline_signing = OfflineSigner::new(key_manager.clone());
                 let mut request = request;
 
                 for pair_output in &mut request.info.inputs.iter_mut() {
@@ -1250,7 +1250,7 @@ where
                         Covenant::default(),
                     )
                     .await?;
-                let multisig_session = MultisigSession::new(self.resources.transaction_key_manager_service.clone());
+                let mut multisig_session = MultisigSession::new(self.resources.transaction_key_manager_service.clone());
                 let uuid = Uuid::new_v4();
                 let (tx, payment_id, sent_hashes, change_hashes, change) = multisig_session
                     .create_deposit_multisig_transaction(
@@ -1952,7 +1952,7 @@ where
             )
             .with_minimum_value_promise(minimum_value_promise)
             .sign_as_sender_and_receiver(
-                &self.resources.transaction_key_manager_service,
+                &mut self.resources.transaction_key_manager_service,
                 &sender_offset_private_key.key_id,
             )
             .await
@@ -2245,7 +2245,7 @@ where
             .with_script_key(TariKeyId::Zero)
             .with_minimum_value_promise(minimum_value_promise)
             .sign_as_sender_and_receiver_verified(
-                &self.resources.transaction_key_manager_service,
+                &mut self.resources.transaction_key_manager_service,
                 &sender_offset_private_key.key_id,
                 &dest_address,
             )
@@ -2588,7 +2588,7 @@ where
             .with_script_key(TariKeyId::Zero)
             .with_minimum_value_promise(MicroMinotari::zero())
             .sign_as_sender_and_receiver(
-                &self.resources.transaction_key_manager_service,
+                &mut self.resources.transaction_key_manager_service,
                 &sender_offset_private_key.key_id,
             )
             .await?

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -2738,7 +2738,7 @@ mod test {
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn test_crud() {
-        let key_manager = create_memory_db_key_manager().await.unwrap();
+        let mut key_manager = create_memory_db_key_manager().await.unwrap();
         let db_name = format!("{}.sqlite3", string(8).as_str());
         let temp_dir = tempdir().unwrap();
         let db_folder = temp_dir.path().to_str().unwrap().to_string();
@@ -2771,13 +2771,13 @@ mod test {
         let mut builder = TransactionBuilder::new(constants, key_manager.clone(), Network::LocalNet)
             .await
             .unwrap();
-        let test_params = TestParams::new(&key_manager).await;
+        let test_params = TestParams::new(&mut key_manager).await;
         let input = create_wallet_output_with_data(
             script!(Nop).unwrap(),
             OutputFeatures::default(),
             &test_params,
             MicroMinotari::from(100_000),
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();
@@ -2863,13 +2863,13 @@ mod test {
                 .unwrap()
         );
 
-        let receiver_test_params = TestParams::new(&key_manager).await;
+        let receiver_test_params = TestParams::new(&mut key_manager).await;
         let output = create_wallet_output_with_data(
             script!(Nop).unwrap(),
             OutputFeatures::default(),
             &receiver_test_params,
             MicroMinotari::from(100_000),
-            &key_manager,
+            &mut key_manager,
         )
         .await
         .unwrap();

--- a/base_layer/wallet/tests/key_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/key_manager_service_tests/service.rs
@@ -42,7 +42,7 @@ async fn get_key_at_test_with_encryption() {
     let key_ga = Key::from_slice(&key);
     let db_cipher = XChaCha20Poly1305::new(key_ga);
     let factory = CryptoFactories::new(64);
-    let key_manager = TransactionKeyManagerWrapper::<TransactionKeyManagerSqliteDatabase<WalletDbConnection>>::new_with_legacy_storage(
+    let mut key_manager = TransactionKeyManagerWrapper::<TransactionKeyManagerSqliteDatabase<WalletDbConnection>>::new_with_legacy_storage(
         cipher,
         TransactionKeyManagerSqliteDatabase::init(connection, db_cipher),
         factory,
@@ -80,7 +80,7 @@ async fn key_manager_multiple_branches() {
     let db_cipher = XChaCha20Poly1305::new(key_ga);
 
     let factory = CryptoFactories::new(64);
-    let key_manager = TransactionKeyManagerWrapper::<TransactionKeyManagerSqliteDatabase<WalletDbConnection>>::new_with_legacy_storage(
+    let mut key_manager = TransactionKeyManagerWrapper::<TransactionKeyManagerSqliteDatabase<WalletDbConnection>>::new_with_legacy_storage(
         cipher,
         TransactionKeyManagerSqliteDatabase::init(connection, db_cipher),
         factory,

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -229,7 +229,7 @@ async fn fee_estimate() {
         &mut OsRng.clone(),
         MicroMinotari::from(3000),
         &OutputFeatures::default(),
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await;
     oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
@@ -312,7 +312,7 @@ async fn test_utxo_selection_no_chain_metadata() {
 
     let backend = OutputManagerSqliteDatabase::new(connection.clone());
     // no chain metadata
-    let (mut oms, _shutdown, _, _, _, key_manager) = setup_oms_with_bn_state(backend.clone()).await;
+    let (mut oms, _shutdown, _, _, _, mut key_manager) = setup_oms_with_bn_state(backend.clone()).await;
 
     let fee_calc = Fee::new(*create_consensus_constants(0).transaction_weight_params());
     // no utxos - not enough funds
@@ -342,7 +342,7 @@ async fn test_utxo_selection_no_chain_metadata() {
                 maturity: i,
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         oms.add_output(uo.clone(), None).await.unwrap();
@@ -440,7 +440,7 @@ async fn test_utxo_selection_with_chain_metadata() {
         timestamp: Utc::now().naive_utc(),
     };
     backend.save_last_scanned_height(scanned_block).unwrap();
-    let (mut oms, _shutdown, _, _, _, key_manager) = setup_oms_with_bn_state(backend.clone()).await;
+    let (mut oms, _shutdown, _, _, _, mut key_manager) = setup_oms_with_bn_state(backend.clone()).await;
     let fee_calc = Fee::new(*create_consensus_constants(0).transaction_weight_params());
 
     // no utxos - not enough funds
@@ -470,7 +470,7 @@ async fn test_utxo_selection_with_chain_metadata() {
                 maturity: i,
                 ..Default::default()
             },
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         oms.add_output(uo.clone(), None).await.unwrap();
@@ -585,7 +585,7 @@ async fn test_utxo_selection_with_tx_priority() {
         timestamp: Utc::now().naive_utc(),
     };
     backend.save_last_scanned_height(scanned_block).unwrap();
-    let (mut oms, _shutdown, _, _, _, key_manager) = setup_oms_with_bn_state(backend.clone()).await;
+    let (mut oms, _shutdown, _, _, _, mut key_manager) = setup_oms_with_bn_state(backend.clone()).await;
 
     let amount = MicroMinotari::from(2000);
     let fee_per_gram = MicroMinotari::from(2);
@@ -598,7 +598,7 @@ async fn test_utxo_selection_with_tx_priority() {
             maturity: 1,
             ..Default::default()
         },
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     oms.add_output(uo_low_1.clone(), None).await.unwrap();
@@ -610,7 +610,7 @@ async fn test_utxo_selection_with_tx_priority() {
             maturity: 1,
             ..Default::default()
         },
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     oms.add_output(uo_high.clone(), Some(SpendingPriority::HtlcSpendAsap))
@@ -627,7 +627,7 @@ async fn test_utxo_selection_with_tx_priority() {
             maturity: 1,
             ..Default::default()
         },
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     oms.add_output(uo_low_2.clone(), None).await.unwrap();
@@ -694,7 +694,7 @@ async fn send_not_enough_funds() {
             &mut OsRng.clone(),
             MicroMinotari::from(200 + OsRng.next_u64() % 1000),
             &OutputFeatures::default(),
-            &oms.key_manager_handle,
+            &mut oms.key_manager_handle,
         )
         .await;
         oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
@@ -740,9 +740,9 @@ async fn send_no_change() {
     let uo_1 = create_wallet_output_with_data(
         script!(Nop).unwrap(),
         OutputFeatures::default(),
-        &TestParams::new(&oms.key_manager_handle).await,
+        &TestParams::new(&mut oms.key_manager_handle).await,
         MicroMinotari::from(value1),
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await
     .unwrap();
@@ -755,9 +755,9 @@ async fn send_no_change() {
     let uo_2 = create_wallet_output_with_data(
         script!(Nop).unwrap(),
         OutputFeatures::default(),
-        &TestParams::new(&oms.key_manager_handle).await,
+        &TestParams::new(&mut oms.key_manager_handle).await,
         MicroMinotari::from(value2),
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await
     .unwrap();
@@ -803,9 +803,9 @@ async fn send_not_enough_for_change() {
     let uo_1 = create_wallet_output_with_data(
         script!(Nop).unwrap(),
         OutputFeatures::default(),
-        &TestParams::new(&oms.key_manager_handle).await,
+        &TestParams::new(&mut oms.key_manager_handle).await,
         value1,
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await
     .unwrap();
@@ -817,9 +817,9 @@ async fn send_not_enough_for_change() {
     let uo_2 = create_wallet_output_with_data(
         script!(Nop).unwrap(),
         OutputFeatures::default(),
-        &TestParams::new(&oms.key_manager_handle).await,
+        &TestParams::new(&mut oms.key_manager_handle).await,
         value2,
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await
     .unwrap();
@@ -859,7 +859,7 @@ async fn cancel_transaction() {
             &mut OsRng.clone(),
             MicroMinotari::from(100 + OsRng.next_u64() % 1000),
             &OutputFeatures::default(),
-            &oms.key_manager_handle,
+            &mut oms.key_manager_handle,
         )
         .await;
         oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
@@ -905,7 +905,7 @@ async fn sending_transaction_persisted_while_offline() {
         &mut OsRng.clone(),
         available_balance / 2,
         &OutputFeatures::default(),
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await;
     oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
@@ -914,7 +914,7 @@ async fn sending_transaction_persisted_while_offline() {
         &mut OsRng.clone(),
         available_balance / 2,
         &OutputFeatures::default(),
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await;
     oms.output_manager_handle.add_output(uo.clone(), None).await.unwrap();
@@ -993,9 +993,27 @@ async fn coin_split_with_change() {
     let val1 = 6_000 * uT;
     let val2 = 7_000 * uT;
     let val3 = 8_000 * uT;
-    let uo1 = make_input(&mut OsRng, val1, &OutputFeatures::default(), &oms.key_manager_handle).await;
-    let uo2 = make_input(&mut OsRng, val2, &OutputFeatures::default(), &oms.key_manager_handle).await;
-    let uo3 = make_input(&mut OsRng, val3, &OutputFeatures::default(), &oms.key_manager_handle).await;
+    let uo1 = make_input(
+        &mut OsRng,
+        val1,
+        &OutputFeatures::default(),
+        &mut oms.key_manager_handle,
+    )
+    .await;
+    let uo2 = make_input(
+        &mut OsRng,
+        val2,
+        &OutputFeatures::default(),
+        &mut oms.key_manager_handle,
+    )
+    .await;
+    let uo3 = make_input(
+        &mut OsRng,
+        val3,
+        &OutputFeatures::default(),
+        &mut oms.key_manager_handle,
+    )
+    .await;
     assert!(oms.output_manager_handle.add_output(uo1.clone(), None).await.is_ok());
     assert!(oms.output_manager_handle.add_output(uo2.clone(), None).await.is_ok());
     assert!(oms.output_manager_handle.add_output(uo3.clone(), None).await.is_ok());
@@ -1057,9 +1075,27 @@ async fn coin_split_no_change() {
     let val1 = 4_000 * uT;
     let val2 = 5_000 * uT;
     let val3 = 6_000 * uT + expected_fee;
-    let uo1 = make_input(&mut OsRng, val1, &OutputFeatures::default(), &oms.key_manager_handle).await;
-    let uo2 = make_input(&mut OsRng, val2, &OutputFeatures::default(), &oms.key_manager_handle).await;
-    let uo3 = make_input(&mut OsRng, val3, &OutputFeatures::default(), &oms.key_manager_handle).await;
+    let uo1 = make_input(
+        &mut OsRng,
+        val1,
+        &OutputFeatures::default(),
+        &mut oms.key_manager_handle,
+    )
+    .await;
+    let uo2 = make_input(
+        &mut OsRng,
+        val2,
+        &OutputFeatures::default(),
+        &mut oms.key_manager_handle,
+    )
+    .await;
+    let uo3 = make_input(
+        &mut OsRng,
+        val3,
+        &OutputFeatures::default(),
+        &mut oms.key_manager_handle,
+    )
+    .await;
     assert!(oms.output_manager_handle.add_output(uo1.clone(), None).await.is_ok());
     assert!(oms.output_manager_handle.add_output(uo2.clone(), None).await.is_ok());
     assert!(oms.output_manager_handle.add_output(uo3.clone(), None).await.is_ok());
@@ -1091,7 +1127,7 @@ async fn it_handles_large_coin_splits() {
     let mut oms = setup_output_manager_service(backend.clone(), true).await;
 
     let val = 20 * T;
-    let uo = make_input(&mut OsRng, val, &OutputFeatures::default(), &oms.key_manager_handle).await;
+    let uo = make_input(&mut OsRng, val, &OutputFeatures::default(), &mut oms.key_manager_handle).await;
     assert!(oms.output_manager_handle.add_output(uo.clone(), None).await.is_ok());
     // lets mark them as unspent so we can use them
     backend.mark_outputs_as_unspent(vec![(uo.output_hash(), true)]).unwrap();
@@ -1900,7 +1936,7 @@ async fn test_get_status_by_tx_id() {
         &mut OsRng.clone(),
         MicroMinotari::from(10000),
         &OutputFeatures::default(),
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await;
     oms.output_manager_handle
@@ -1912,7 +1948,7 @@ async fn test_get_status_by_tx_id() {
         &mut OsRng.clone(),
         MicroMinotari::from(10000),
         &OutputFeatures::default(),
-        &oms.key_manager_handle,
+        &mut oms.key_manager_handle,
     )
     .await;
     oms.output_manager_handle
@@ -1991,13 +2027,13 @@ async fn scan_for_recovery_test() {
 
     let mut non_recoverable_wallet_outputs = Vec::new();
     // we need to create a new key_manager to make the outputs non recoverable
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     for i in 1..=NUM_NON_RECOVERABLE {
         let uo = make_input(
             &mut OsRng,
             MicroMinotari::from(1000 * i as u64),
             &OutputFeatures::default(),
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         non_recoverable_wallet_outputs.push(uo)
@@ -2058,12 +2094,12 @@ async fn recovered_output_key_not_in_keychain() {
     let backend = OutputManagerSqliteDatabase::new(connection.clone());
     let mut oms = setup_output_manager_service(backend.clone(), true).await;
     // we need to create a new key manager here as we dont want the input be recoverable from oms key chain
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let uo = make_input(
         &mut OsRng,
         MicroMinotari::from(1000u64),
         &OutputFeatures::default(),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
 

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -53,14 +53,14 @@ pub async fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
 
     // Add some unspent outputs
     let mut unspent_outputs = Vec::new();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let mut unspent = Vec::with_capacity(5);
     for i in 0..5 {
         let uo = make_input(
             &mut OsRng,
             MicroMinotari::from(100 + OsRng.next_u64() % 1000),
             &OutputFeatures::default(),
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut kmo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -113,7 +113,7 @@ pub async fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 &mut OsRng,
                 MicroMinotari::from(100 + OsRng.next_u64() % 1000),
                 &OutputFeatures::default(),
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             let kmo = DbWalletOutput::from_wallet_output(kmo, None, OutputSource::Standard, None, None);
@@ -126,7 +126,7 @@ pub async fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
                 &mut OsRng,
                 MicroMinotari::from(100 + OsRng.next_u64() % 1000),
                 &OutputFeatures::default(),
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             let kmo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -288,7 +288,7 @@ pub async fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         &mut OsRng,
         MicroMinotari::from(100 + OsRng.next_u64() % 1000),
         &OutputFeatures::default(),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let output_to_be_received = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -375,7 +375,7 @@ pub async fn test_must_include_filter() {
     let (connection, _tempdir) = get_temp_sqlite_database_connection();
     let backend = OutputManagerSqliteDatabase::new(connection);
     let db = OutputManagerDatabase::new(backend);
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
 
     // Create test outputs with specific values
     let mut outputs = Vec::new();
@@ -387,7 +387,7 @@ pub async fn test_must_include_filter() {
             &mut OsRng,
             MicroMinotari::from(value),
             &OutputFeatures::default(),
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let output = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -455,14 +455,14 @@ pub async fn test_raw_custom_queries_regression() {
 
     // Add some unspent outputs
     let mut unspent_outputs = Vec::new();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let mut unspent = Vec::with_capacity(5);
     for i in 0..5 {
         let uo = make_input(
             &mut OsRng,
             MicroMinotari::from(100 + OsRng.next_u64() % 1000),
             &OutputFeatures::default(),
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut kmo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -500,7 +500,7 @@ pub async fn test_raw_custom_queries_regression() {
                 &mut OsRng,
                 MicroMinotari::from(100 + OsRng.next_u64() % 1000),
                 &OutputFeatures::default(),
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             let kmo = DbWalletOutput::from_wallet_output(kmo, None, OutputSource::Standard, None, None);
@@ -513,7 +513,7 @@ pub async fn test_raw_custom_queries_regression() {
                 &mut OsRng,
                 MicroMinotari::from(100 + OsRng.next_u64() % 1000),
                 &OutputFeatures::default(),
-                &key_manager,
+                &mut key_manager,
             )
             .await;
             let kmo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -553,7 +553,7 @@ pub async fn test_raw_custom_queries_regression() {
         &mut OsRng,
         MicroMinotari::from(100 + OsRng.next_u64() % 1000),
         &OutputFeatures::default(),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let unknown = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -634,13 +634,13 @@ pub async fn test_short_term_encumberance() {
     let db = OutputManagerDatabase::new(backend);
 
     let mut unspent_outputs = Vec::new();
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     for i in 0..5 {
         let kmo = make_input(
             &mut OsRng,
             MicroMinotari::from(100 + OsRng.next_u64() % 1000),
             &OutputFeatures::default(),
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let mut kmo = DbWalletOutput::from_wallet_output(kmo, None, OutputSource::Standard, None, None);
@@ -695,12 +695,12 @@ pub async fn test_no_duplicate_outputs() {
     let db = OutputManagerDatabase::new(backend);
 
     // create an output
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let uo = make_input(
         &mut OsRng,
         MicroMinotari::from(1000),
         &OutputFeatures::default(),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let kmo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -741,12 +741,12 @@ pub async fn test_mark_as_unmined() {
     let db = OutputManagerDatabase::new(backend);
 
     // create an output
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let uo = make_input(
         &mut OsRng,
         MicroMinotari::from(1000),
         &OutputFeatures::default(),
-        &key_manager,
+        &mut key_manager,
     )
     .await;
     let kmo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
@@ -781,7 +781,7 @@ pub async fn test_mark_as_unmined() {
             &mut OsRng,
             MicroMinotari::from(1000),
             &OutputFeatures::default(),
-            &key_manager,
+            &mut key_manager,
         )
         .await;
         let kmo = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -34,7 +34,7 @@ pub async fn make_input<R: Rng + CryptoRng>(
     _rng: &mut R,
     val: MicroMinotari,
     features: &OutputFeatures,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> WalletOutput {
     let test_params = TestParams::new(key_manager).await;
     create_wallet_output_with_data(TariScript::default(), features.clone(), &test_params, val, key_manager)
@@ -44,7 +44,7 @@ pub async fn make_input<R: Rng + CryptoRng>(
 
 pub async fn make_fake_input_from_copy(
     wallet_output: &mut WalletOutput,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> WalletOutput {
     let (commitment_mask_key, script_key) = key_manager.get_next_commitment_mask_and_script_key().await.unwrap();
     wallet_output
@@ -59,7 +59,7 @@ pub async fn make_input_with_features<R: Rng + CryptoRng>(
     _rng: &mut R,
     value: MicroMinotari,
     features: OutputFeatures,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> WalletOutput {
     let test_params = TestParams::new(key_manager).await;
     create_wallet_output_with_data(script!(Nop).unwrap(), features, &test_params, value, key_manager)

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -416,21 +416,22 @@ async fn large_coin_split_transaction() {
     let db_connection = make_wallet_database_memory_connection();
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, mut alice_oms, _alice_connectivity, key_manager_handle, alice_db) = setup_transaction_service(
-        alice_node_identity.clone(),
-        consensus_manager,
-        factories.clone(),
-        db_connection,
-        shutdown.to_signal(),
-    )
-    .await;
+    let (mut alice_ts, mut alice_oms, _alice_connectivity, mut key_manager_handle, alice_db) =
+        setup_transaction_service(
+            alice_node_identity.clone(),
+            consensus_manager,
+            factories.clone(),
+            db_connection,
+            shutdown.to_signal(),
+        )
+        .await;
 
     let initial_wallet_value = 20 * T;
     let uo1 = make_input(
         &mut OsRng,
         initial_wallet_value,
         &OutputFeatures::default(),
-        &key_manager_handle,
+        &mut key_manager_handle,
     )
     .await;
 
@@ -499,20 +500,21 @@ async fn single_transaction_burn_tari() {
     let db_connection = make_wallet_database_memory_connection();
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, mut alice_oms, _alice_connectivity, key_manager_handle, alice_db) = setup_transaction_service(
-        alice_node_identity.clone(),
-        consensus_manager,
-        factories.clone(),
-        db_connection,
-        shutdown.to_signal(),
-    )
-    .await;
+    let (mut alice_ts, mut alice_oms, _alice_connectivity, mut key_manager_handle, alice_db) =
+        setup_transaction_service(
+            alice_node_identity.clone(),
+            consensus_manager,
+            factories.clone(),
+            db_connection,
+            shutdown.to_signal(),
+        )
+        .await;
     let initial_wallet_value = 25000.into();
     let uo1 = make_input(
         &mut OsRng,
         initial_wallet_value,
         &OutputFeatures::default(),
-        &key_manager_handle,
+        &mut key_manager_handle,
     )
     .await;
 
@@ -625,14 +627,15 @@ async fn send_one_sided_transaction_to_other() {
     let db_connection = make_wallet_database_memory_connection();
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, mut alice_oms, _alice_connectivity, key_manager_handle, alice_db) = setup_transaction_service(
-        alice_node_identity,
-        consensus_manager,
-        factories.clone(),
-        db_connection,
-        shutdown.to_signal(),
-    )
-    .await;
+    let (mut alice_ts, mut alice_oms, _alice_connectivity, mut key_manager_handle, alice_db) =
+        setup_transaction_service(
+            alice_node_identity,
+            consensus_manager,
+            factories.clone(),
+            db_connection,
+            shutdown.to_signal(),
+        )
+        .await;
 
     let mut alice_event_stream = alice_ts.get_event_stream();
 
@@ -641,7 +644,7 @@ async fn send_one_sided_transaction_to_other() {
         &mut OsRng,
         initial_wallet_value,
         &OutputFeatures::default(),
-        &key_manager_handle,
+        &mut key_manager_handle,
     )
     .await;
     let mut alice_oms_clone = alice_oms.clone();
@@ -739,14 +742,15 @@ async fn recover_one_sided_transaction() {
 
     let alice_connection = make_wallet_database_memory_connection();
     let shutdown = Shutdown::new();
-    let (mut alice_ts, alice_oms, _alice_connectivity, alice_key_manager_handle, alice_db) = setup_transaction_service(
-        alice_node_identity,
-        consensus_manager.clone(),
-        factories.clone(),
-        alice_connection,
-        shutdown.to_signal(),
-    )
-    .await;
+    let (mut alice_ts, alice_oms, _alice_connectivity, mut alice_key_manager_handle, alice_db) =
+        setup_transaction_service(
+            alice_node_identity,
+            consensus_manager.clone(),
+            factories.clone(),
+            alice_connection,
+            shutdown.to_signal(),
+        )
+        .await;
 
     let bob_connection = make_wallet_database_memory_connection();
     let (_bob_ts, mut bob_oms, _bob_connectivity, bob_key_manager_handle, _bob_db) = setup_transaction_service(
@@ -776,7 +780,7 @@ async fn recover_one_sided_transaction() {
         &mut OsRng,
         initial_wallet_value,
         &OutputFeatures::default(),
-        &alice_key_manager_handle,
+        &mut alice_key_manager_handle,
     )
     .await;
     let mut alice_oms_clone = alice_oms;
@@ -862,14 +866,15 @@ async fn recover_stealth_one_sided_transaction() {
 
     let alice_connection = make_wallet_database_memory_connection();
     let shutdown = Shutdown::new();
-    let (mut alice_ts, alice_oms, _alice_connectivity, alice_key_manager_handle, alice_db) = setup_transaction_service(
-        alice_node_identity,
-        consensus_manager.clone(),
-        factories.clone(),
-        alice_connection,
-        shutdown.to_signal(),
-    )
-    .await;
+    let (mut alice_ts, alice_oms, _alice_connectivity, mut alice_key_manager_handle, alice_db) =
+        setup_transaction_service(
+            alice_node_identity,
+            consensus_manager.clone(),
+            factories.clone(),
+            alice_connection,
+            shutdown.to_signal(),
+        )
+        .await;
 
     let bob_connection = make_wallet_database_memory_connection();
     let (_bob_ts, mut bob_oms, _bob_connectivity, bob_key_manager_handle, _bob_db) = setup_transaction_service(
@@ -888,7 +893,7 @@ async fn recover_stealth_one_sided_transaction() {
         &mut OsRng,
         initial_wallet_value,
         &OutputFeatures::default(),
-        &alice_key_manager_handle,
+        &mut alice_key_manager_handle,
     )
     .await;
     let mut alice_oms_clone = alice_oms;
@@ -968,14 +973,15 @@ async fn test_htlc_send_and_claim() {
     let alice_connection = make_wallet_database_memory_connection();
 
     let shutdown = Shutdown::new();
-    let (mut alice_ts, mut alice_oms, _alice_connectivity, key_manager_handle, alice_db) = setup_transaction_service(
-        alice_node_identity,
-        consensus_manager,
-        factories.clone(),
-        alice_connection,
-        shutdown.to_signal(),
-    )
-    .await;
+    let (mut alice_ts, mut alice_oms, _alice_connectivity, mut key_manager_handle, alice_db) =
+        setup_transaction_service(
+            alice_node_identity,
+            consensus_manager,
+            factories.clone(),
+            alice_connection,
+            shutdown.to_signal(),
+        )
+        .await;
 
     let bob_temp_dir = tempdir().unwrap();
     let bob_db_path_string = bob_temp_dir.path().to_str().unwrap().to_string();
@@ -996,7 +1002,7 @@ async fn test_htlc_send_and_claim() {
         &mut OsRng,
         initial_wallet_value,
         &OutputFeatures::default(),
-        &key_manager_handle,
+        &mut key_manager_handle,
     )
     .await;
     alice_oms.add_output(uo1.clone(), None).await.unwrap();
@@ -1668,21 +1674,21 @@ async fn test_update_faux_tx_on_oms_validation() {
         &mut OsRng.clone(),
         MicroMinotari::from(10000),
         &OutputFeatures::default(),
-        &alice_ts_interface.key_manager_handle,
+        &mut alice_ts_interface.key_manager_handle,
     )
     .await;
     let uo_2 = make_input(
         &mut OsRng.clone(),
         MicroMinotari::from(20000),
         &OutputFeatures::default(),
-        &alice_ts_interface.key_manager_handle,
+        &mut alice_ts_interface.key_manager_handle,
     )
     .await;
     let uo_3 = make_input(
         &mut OsRng.clone(),
         MicroMinotari::from(30000),
         &OutputFeatures::default(),
-        &alice_ts_interface.key_manager_handle,
+        &mut alice_ts_interface.key_manager_handle,
     )
     .await;
 
@@ -1848,21 +1854,21 @@ async fn test_update_coinbase_tx_on_oms_validation() {
         &mut OsRng.clone(),
         MicroMinotari::from(10000),
         &OutputFeatures::create_coinbase(5, None, RangeProofType::BulletProofPlus),
-        &alice_ts_interface.key_manager_handle,
+        &mut alice_ts_interface.key_manager_handle,
     )
     .await;
     let uo_2 = make_input(
         &mut OsRng.clone(),
         MicroMinotari::from(20000),
         &OutputFeatures::create_coinbase(5, None, RangeProofType::BulletProofPlus),
-        &alice_ts_interface.key_manager_handle,
+        &mut alice_ts_interface.key_manager_handle,
     )
     .await;
     let uo_3 = make_input(
         &mut OsRng.clone(),
         MicroMinotari::from(30000),
         &OutputFeatures::create_coinbase(5, None, RangeProofType::BulletProofPlus),
-        &alice_ts_interface.key_manager_handle,
+        &mut alice_ts_interface.key_manager_handle,
     )
     .await;
 

--- a/base_layer/wallet/tests/transaction_service_tests/storage.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/storage.rs
@@ -71,18 +71,18 @@ use tempfile::tempdir;
 
 pub async fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     let mut db = TransactionDatabase::new(backend);
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let input = create_wallet_output_with_data(
         script!(Nop).unwrap(),
         OutputFeatures::default(),
-        &TestParams::new(&key_manager).await,
+        &TestParams::new(&mut key_manager).await,
         MicroMinotari::from(100_000),
-        &key_manager,
+        &mut key_manager,
     )
     .await
     .unwrap();
     let constants = create_consensus_constants(0);
-    let key_manager = create_memory_db_key_manager().await.unwrap();
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
     let mut builder = TransactionBuilder::new(constants.clone(), key_manager.clone(), Network::LocalNet)
         .await
         .unwrap();

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -10666,7 +10666,7 @@ mod test {
                 error_ptr,
             );
             let alice_wallet_runtime = &(*alice_wallet).runtime;
-            let key_manager = &(*alice_wallet).wallet.key_manager_service;
+            let key_manager = &mut (*alice_wallet).wallet.key_manager_service;
 
             assert_eq!(error, 0);
             let mut test_outputs = Vec::with_capacity(10);
@@ -10867,7 +10867,7 @@ mod test {
                 let uo = (*alice_wallet).runtime.block_on(create_test_input(
                     (1000 * i).into(),
                     0,
-                    &(*alice_wallet).wallet.key_manager_service,
+                    &mut (*alice_wallet).wallet.key_manager_service,
                     vec![],
                     None,
                 ));
@@ -11022,7 +11022,7 @@ mod test {
                     let wallet_output = (*alice_wallet).runtime.block_on(create_test_input(
                         15000.into(),
                         0,
-                        &(*alice_wallet).wallet.key_manager_service,
+                        &mut (*alice_wallet).wallet.key_manager_service,
                         vec![],
                         Some(payment_id.clone()),
                     ));
@@ -11116,7 +11116,7 @@ mod test {
                 let uo = (*alice_wallet).runtime.block_on(create_test_input(
                     (15000 * i).into(),
                     0,
-                    &(*alice_wallet).wallet.key_manager_service,
+                    &mut (*alice_wallet).wallet.key_manager_service,
                     vec![],
                     None,
                 ));
@@ -11364,7 +11364,7 @@ mod test {
                 let uo = (*alice_wallet).runtime.block_on(create_test_input(
                     (15000 * i).into(),
                     0,
-                    &(*alice_wallet).wallet.key_manager_service,
+                    &mut (*alice_wallet).wallet.key_manager_service,
                     vec![],
                     None,
                 ));
@@ -11617,7 +11617,7 @@ mod test {
             );
             assert_eq!(error, 0);
 
-            let key_manager = &(*alice_wallet).wallet.key_manager_service;
+            let key_manager = &mut (*alice_wallet).wallet.key_manager_service;
             for i in 1..=5 {
                 (*alice_wallet)
                     .runtime
@@ -11742,13 +11742,13 @@ mod test {
             let mut error = 0;
             let error_ptr = &mut error as *mut c_int;
             // Test the consistent features case
-            let key_manager = create_memory_db_key_manager().await.unwrap();
+            let mut key_manager = create_memory_db_key_manager().await.unwrap();
             let utxo_1 = create_wallet_output_with_data(
                 script!(Nop).unwrap(),
                 OutputFeatures::default(),
-                &TestParams::new(&key_manager).await,
+                &TestParams::new(&mut key_manager).await,
                 MicroMinotari(1234u64),
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap();
@@ -11869,7 +11869,7 @@ mod test {
                 error_ptr,
             );
             assert_eq!(error, 0);
-            let key_manager = &(*wallet_ptr).wallet.key_manager_service;
+            let key_manager = &mut (*wallet_ptr).wallet.key_manager_service;
 
             let node_identity =
                 NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
@@ -12108,13 +12108,13 @@ mod test {
             let mut error = 0;
             let error_ptr = &mut error as *mut c_int;
 
-            let key_manager = create_memory_db_key_manager().await.unwrap();
+            let mut key_manager = create_memory_db_key_manager().await.unwrap();
             let utxo_1 = create_wallet_output_with_data(
                 script!(Nop).unwrap(),
                 OutputFeatures::default(),
-                &TestParams::new(&key_manager).await,
+                &TestParams::new(&mut key_manager).await,
                 MicroMinotari(1234u64),
-                &key_manager,
+                &mut key_manager,
             )
             .await
             .unwrap();

--- a/integration_tests/src/miner.rs
+++ b/integration_tests/src/miner.rs
@@ -174,7 +174,7 @@ pub async fn mine_blocks_without_wallet(
     base_client: &mut BaseNodeClient,
     num_blocks: u64,
     weight: u64,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     script_key_id: &TariKeyId,
     wallet_payment_address: &TariAddress,
     stealth_payment: bool,
@@ -200,7 +200,7 @@ pub async fn mine_blocks_without_wallet(
 
 pub async fn mine_block(
     base_client: &mut BaseNodeClient,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     script_key_id: &TariKeyId,
     wallet_payment_address: &TariAddress,
     stealth_payment: bool,
@@ -236,7 +236,7 @@ pub async fn mine_block(
 async fn mine_block_without_wallet(
     base_client: &mut BaseNodeClient,
     weight: u64,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     script_key_id: &TariKeyId,
     wallet_payment_address: &TariAddress,
     stealth_payment: bool,
@@ -275,7 +275,7 @@ async fn mine_block_without_wallet_with_template(base_client: &mut BaseNodeClien
 async fn create_block_template_with_coinbase(
     base_client: &mut BaseNodeClient,
     weight: u64,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     script_key_id: &TariKeyId,
     wallet_payment_address: &TariAddress,
     stealth_payment: bool,
@@ -340,7 +340,7 @@ pub async fn mine_block_with_coinbase_on_node(world: &mut TariWorld, base_node: 
     let (template, wallet_output) = create_block_template_with_coinbase(
         &mut client,
         0,
-        &world.key_manager,
+        &mut world.key_manager,
         script_key_id,
         &world.default_payment_address.clone(),
         false,
@@ -353,7 +353,7 @@ pub async fn mine_block_with_coinbase_on_node(world: &mut TariWorld, base_node: 
 
 pub async fn mine_block_before_submit(
     client: &mut BaseNodeClient,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
     script_key_id: &TariKeyId,
     wallet_payment_address: &TariAddress,
     stealth_payment: bool,

--- a/integration_tests/src/transaction.rs
+++ b/integration_tests/src/transaction.rs
@@ -51,7 +51,7 @@ struct TestTransactionBuilder {
 }
 
 impl TestTransactionBuilder {
-    pub async fn new(key_manager: &MemoryDbKeyManager) -> Self {
+    pub async fn new(key_manager: &mut MemoryDbKeyManager) -> Self {
         Self {
             amount: MicroMinotari(0),
             fee_per_gram: MicroMinotari(1),
@@ -94,7 +94,7 @@ impl TestTransactionBuilder {
         self
     }
 
-    pub async fn build(mut self, key_manager: &MemoryDbKeyManager) -> (Transaction, WalletOutput) {
+    pub async fn build(mut self, key_manager: &mut MemoryDbKeyManager) -> (Transaction, WalletOutput) {
         self.create_utxo(key_manager, self.inputs.len()).await;
 
         let inputs = self.inputs.iter().map(|f| f.1.clone()).collect();
@@ -104,7 +104,7 @@ impl TestTransactionBuilder {
         (tx, self.output.clone().unwrap().1)
     }
 
-    async fn create_utxo(&mut self, key_manager: &MemoryDbKeyManager, num_inputs: usize) {
+    async fn create_utxo(&mut self, key_manager: &mut MemoryDbKeyManager, num_inputs: usize) {
         let script = script!(Nop).unwrap();
         let features = OutputFeatures::default();
         let covenant = Covenant::default();
@@ -147,7 +147,7 @@ impl TestTransactionBuilder {
 pub async fn build_transaction_with_output_and_fee_per_gram(
     utxos: Vec<WalletOutput>,
     fee_per_gram: u64,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (Transaction, WalletOutput) {
     let mut builder = TestTransactionBuilder::new(key_manager).await;
     for wallet_output in utxos {
@@ -161,7 +161,7 @@ pub async fn build_transaction_with_output_and_fee_per_gram(
 pub async fn build_transaction_with_output_and_lockheight(
     utxos: Vec<WalletOutput>,
     lockheight: u64,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (Transaction, WalletOutput) {
     let mut builder = TestTransactionBuilder::new(key_manager).await;
     for wallet_output in utxos {
@@ -174,7 +174,7 @@ pub async fn build_transaction_with_output_and_lockheight(
 
 pub async fn build_transaction_with_output(
     utxos: Vec<WalletOutput>,
-    key_manager: &MemoryDbKeyManager,
+    key_manager: &mut MemoryDbKeyManager,
 ) -> (Transaction, WalletOutput) {
     let mut builder = TestTransactionBuilder::new(key_manager).await;
     for wallet_output in utxos {

--- a/integration_tests/tests/steps/mining_steps.rs
+++ b/integration_tests/tests/steps/mining_steps.rs
@@ -76,7 +76,7 @@ async fn mine_blocks_on(world: &mut TariWorld, blocks: u64, base_node: String) {
         &mut client,
         blocks,
         0,
-        &world.key_manager,
+        &mut world.key_manager,
         script_key_id,
         &world.default_payment_address.clone(),
         false,
@@ -116,7 +116,7 @@ async fn mine_custom_weight_blocks_with_height(world: &mut TariWorld, num_blocks
         &mut client,
         num_blocks,
         weight,
-        &world.key_manager,
+        &mut world.key_manager,
         script_key_id,
         &world.default_payment_address.clone(),
         false,
@@ -231,7 +231,7 @@ async fn while_mining_in_node_all_txs_in_wallet_are_mined_confirmed(
             println!("Mine a block for tx_id {tx_id} to have status Mined_or_OneSidedConfirmed");
             mine_block(
                 &mut node_client,
-                &world.key_manager,
+                &mut world.key_manager,
                 script_key_id,
                 &world.default_payment_address.clone(),
                 false,
@@ -364,7 +364,7 @@ async fn mine_without_submit(world: &mut TariWorld, block: String, node: String)
     let unmined_block: Block = Block::try_from(
         mine_block_before_submit(
             &mut client,
-            &world.key_manager,
+            &mut world.key_manager,
             script_key_id,
             &world.default_payment_address.clone(),
             false,

--- a/integration_tests/tests/steps/node_steps.rs
+++ b/integration_tests/tests/steps/node_steps.rs
@@ -652,7 +652,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
     let script_key_id = &world.script_key_id().await;
     let block = mine_block_before_submit(
         &mut client,
-        &world.key_manager,
+        &mut world.key_manager,
         script_key_id,
         &world.default_payment_address.clone(),
         false,
@@ -677,7 +677,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
     let mut block: Block = Block::try_from(
         mine_block_before_submit(
             &mut client,
-            &world.key_manager,
+            &mut world.key_manager,
             script_key_id,
             &world.default_payment_address.clone(),
             false,
@@ -702,7 +702,7 @@ async fn no_meddling_with_data(world: &mut TariWorld, node: String) {
     let mut block: Block = Block::try_from(
         mine_block_before_submit(
             &mut client,
-            &world.key_manager,
+            &mut world.key_manager,
             script_key_id,
             &world.default_payment_address.clone(),
             false,

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -606,7 +606,7 @@ pub async fn create_tx_spending_coinbase(world: &mut TariWorld, transaction: Str
         .map(|i| world.utxos.get(&i.to_string()).unwrap().clone())
         .collect::<Vec<_>>();
 
-    let (tx, utxo) = build_transaction_with_output(utxos, &world.key_manager).await;
+    let (tx, utxo) = build_transaction_with_output(utxos, &mut world.key_manager).await;
     world.utxos.insert(output, utxo);
     world.transactions.insert(transaction, tx);
 }
@@ -625,7 +625,7 @@ async fn create_tx_custom_fee_per_gram(
         .map(|i| world.utxos.get(&i.to_string()).unwrap().clone())
         .collect::<Vec<_>>();
 
-    let (tx, utxo) = build_transaction_with_output_and_fee_per_gram(utxos, fee, &world.key_manager).await;
+    let (tx, utxo) = build_transaction_with_output_and_fee_per_gram(utxos, fee, &mut world.key_manager).await;
     world.utxos.insert(output, utxo);
     world.transactions.insert(transaction, tx);
 }
@@ -644,7 +644,7 @@ async fn create_tx_custom_lock(
         .map(|i| world.utxos.get(&i.to_string()).unwrap().clone())
         .collect::<Vec<_>>();
 
-    let (tx, utxo) = build_transaction_with_output_and_lockheight(utxos, lockheight, &world.key_manager).await;
+    let (tx, utxo) = build_transaction_with_output_and_lockheight(utxos, lockheight, &mut world.key_manager).await;
     world.utxos.insert(output, utxo);
     world.transactions.insert(transaction, tx);
 }


### PR DESCRIPTION
Description
---

This change removes the `RwLock` from the `TransactionKeyManagerWrapper`.

Motivation and Context
---

The key manager is a central component for many parts of the system. Previously, its internal implementation used an `RwLock` on the entire object. Consequently, every operation had to wait for the lock to be released before the next one could begin (if one of them was a write operation).

Following recent changes, the database is no longer part of the key manager. This modification makes it possible to clone the key manager and use a separate copy in each thread.

This change also makes it explicit which operations mutate the key manager. This leads to multiple changes in the codebase to specify mutability, especially in tests.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Key management now uses mutable access across mining, wallet, node, and transaction flows, streamlining internal state handling.

- **Performance**
  - Reduced internal locking around key management, lowering contention and improving responsiveness for mining and signing.

- **Tests**
  - Unit, integration, and helper tests updated to the new key-manager access patterns; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->