### PR TITLE
fix: payment_id is not preserved for outbound transactions with wallet recovery

### DIFF
--- a/base_layer/transaction_components/src/offline_signing/offline_signer.rs
+++ b/base_layer/transaction_components/src/offline_signing/offline_signer.rs
@@ -70,7 +70,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         payment_id: MemoField,
         sender_address: TariAddress,
     ) -> Result<PrepareOneSidedTransactionForSigningResult, TransactionBuilderError> {
-        tx_builder.with_memo(payment_id.clone());
+        tx_builder.with_memo(payment_id.clone())
         // we do this to ensure the fee is calculated correctly
         tx_builder
             .add_stealth_recipient(
@@ -154,6 +154,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         sender: TariAddress,
         recipient: TariAddress,
     ) -> Result<PrepareDepositMultisigTransactionResult, TransactionBuilderError> {
+        tx_builder.with_memo(payment_id.clone())
         // we do this to ensure the fee is calculated correctly
         tx_builder
             .add_stealth_recipient(recipient.clone(), amount, output_features.clone(), payment_id.clone())
@@ -226,6 +227,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         sender: TariAddress,
         recipient: TariAddress,
     ) -> Result<PrepareWithdrawMultisigTransactionResult, TransactionBuilderError> {
+        tx_builder.with_memo(payment_id.clone())
         tx_builder
             .add_stealth_recipient(recipient.clone(), amount, output_features.clone(), payment_id.clone())
             .await?;

--- a/base_layer/transaction_components/src/offline_signing/offline_signer.rs
+++ b/base_layer/transaction_components/src/offline_signing/offline_signer.rs
@@ -70,6 +70,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         payment_id: MemoField,
         sender_address: TariAddress,
     ) -> Result<PrepareOneSidedTransactionForSigningResult, TransactionBuilderError> {
+        tx_builder.with_memo(payment_id.clone());
         // we do this to ensure the fee is calculated correctly
         tx_builder
             .add_stealth_recipient(

--- a/base_layer/transaction_components/src/offline_signing/offline_signer.rs
+++ b/base_layer/transaction_components/src/offline_signing/offline_signer.rs
@@ -70,7 +70,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         payment_id: MemoField,
         sender_address: TariAddress,
     ) -> Result<PrepareOneSidedTransactionForSigningResult, TransactionBuilderError> {
-        tx_builder.with_memo(payment_id.clone())
+        tx_builder.with_memo(payment_id.clone());
         // we do this to ensure the fee is calculated correctly
         tx_builder
             .add_stealth_recipient(
@@ -154,7 +154,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         sender: TariAddress,
         recipient: TariAddress,
     ) -> Result<PrepareDepositMultisigTransactionResult, TransactionBuilderError> {
-        tx_builder.with_memo(payment_id.clone())
+        tx_builder.with_memo(payment_id.clone());
         // we do this to ensure the fee is calculated correctly
         tx_builder
             .add_stealth_recipient(recipient.clone(), amount, output_features.clone(), payment_id.clone())
@@ -227,7 +227,7 @@ where TKeyManagerInterface: TransactionKeyManagerInterface
         sender: TariAddress,
         recipient: TariAddress,
     ) -> Result<PrepareWithdrawMultisigTransactionResult, TransactionBuilderError> {
-        tx_builder.with_memo(payment_id.clone())
+        tx_builder.with_memo(payment_id.clone());
         tx_builder
             .add_stealth_recipient(recipient.clone(), amount, output_features.clone(), payment_id.clone())
             .await?;

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1518,6 +1518,7 @@ where
             .with_fee_per_gram(fee_per_gram)
             .with_kernel_features(KernelFeatures::empty())
             .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount)
+            .with_memo(payment_id.clone())
             .with_input(input.clone())
             .await?;
         let sender_offset_private_key_id_self = self
@@ -1669,7 +1670,8 @@ where
             .with_lock_height(lock_height.unwrap_or(0))
             .with_fee_per_gram(fee_per_gram)
             .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount)
-            .with_kernel_features(KernelFeatures::empty());
+            .with_kernel_features(KernelFeatures::empty())
+            .with_memo(payment_id.clone());
 
         for kmo in input_selection.iter() {
             tx_builder.with_input(kmo.wallet_output.clone()).await?;

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2095,7 +2095,7 @@ where
                 )
                 .await?
         };
-
+        tx_builder.with_memo(payment_id.clone());
         let finalized = tx_builder.build().await?;
 
         // Finalize


### PR DESCRIPTION
Description
---

Fixes an issue  #7506, that recovered wallet does not have `payment_id`.

Motivation and Context
---

Outbound transactions in recovered wallet are missing `payment_id`.
When a payment is sent out, its change contains `payment_id` of type **TransactionInfo**, that contains recipient address, amount, fee and ORIGINAL enclosing `payment_id`.

The problem is, that the enclosed `payment_id` of the change was missing.
This PR fixes it.

How Has This Been Tested?
---

Sent out a payment from console wallet, and then recovered it. The outgoing payment was recovered and its payment ID was there.

<img width="1354" height="893" alt="Screenshot 2025-10-02 at 17 29 32" src="https://github.com/user-attachments/assets/b24563fd-894d-49f9-816c-3905ccb7804d" />



<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Ensures payment memos (payment IDs) are attached to transactions across wallet and offline-signing flows.
* Bug Fixes
  * Fixes missing/late memo attachment so memos are reliably included in one-sided, multisig deposit, and multisig withdrawal transactions.
* Improvements
  * Improves consistency and traceability by carrying memos throughout the transaction-building process, leading to clearer recipient/payment identification in finalized transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->