### PR TITLE
fix: multi_address_with_stats merging to only retain the newest valid claims in the peer_db

### DIFF
--- a/comms/core/src/connection_manager/common.rs
+++ b/comms/core/src/connection_manager/common.rs
@@ -241,10 +241,12 @@ pub(super) fn create_or_update_peer_from_validated_peer_identity(
                 "Peer '{}' already exists in peer list. Updating.",
                 peer.node_id.short_str()
             );
-            peer.addresses
-                .update_addresses(&peer_identity.claim.addresses, &PeerAddressSource::FromPeerConnection {
+            peer.addresses.add_or_update_addresses(
+                &peer_identity.claim.addresses,
+                &PeerAddressSource::FromPeerConnection {
                     peer_identity_claim: peer_identity.claim.clone(),
-                });
+                },
+            );
 
             // For inbound connections we cannot distinguish between the peer's addresses, so we mark all as seen
             peer.addresses

--- a/comms/core/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/core/src/net_address/mutliaddresses_with_stats.rs
@@ -85,44 +85,16 @@ impl MultiaddressesWithStats {
             .and_then(|a| a.last_attempted())
     }
 
-    /// Adds a new net address to the peer. This function will not add a duplicate if the address
-    /// already exists.
-    pub fn add_address(&mut self, net_address: &Multiaddr, source: &PeerAddressSource) {
-        if let Some(addr_mut) = self.addresses.iter_mut().find(|x| x.address() == net_address) {
-            addr_mut.update_source_if_better(source);
-        } else {
-            self.addresses
-                .push(MultiaddrWithStats::new(net_address.clone(), source.clone()));
-        }
-
-        // Ensure that the addresses are sorted by quality
-        self.sort_addresses();
-    }
-
     pub fn contains(&self, net_address: &Multiaddr) -> bool {
         self.addresses.iter().any(|x| x.address() == net_address)
     }
 
-    /// Compares the existing set of addresses to the provided address set and remove missing addresses and
-    /// add new addresses without discarding the usage stats of the existing and remaining addresses.
-    pub fn update_addresses(&mut self, addresses: &[Multiaddr], source: &PeerAddressSource) {
-        for address in addresses {
-            if let Some(addr) = self.addresses.iter_mut().find(|a| a.address() == address) {
-                addr.update_source_if_better(source);
-            }
-        }
-
-        let to_add = addresses
-            .iter()
-            .filter(|addr| !self.addresses.iter().any(|a| &a.address() == addr))
-            .collect::<Vec<_>>();
-
-        for address in to_add {
-            self.addresses
-                .push(MultiaddrWithStats::new(address.clone(), source.clone()));
-        }
-
-        self.sort_addresses();
+    /// Compares the existing set of addresses to the provided address set and remove missing addresses and add new
+    /// addresses without discarding the usage stats of the existing and remaining addresses. Where the source contains
+    /// a claim, only the most recent claim set will be retained. [Delegates to `merge()`]
+    pub fn add_or_update_addresses(&mut self, addresses: &[Multiaddr], source: &PeerAddressSource) {
+        let incoming = Self::from_addresses_with_source(addresses.to_vec(), source);
+        self.merge(&incoming);
     }
 
     /// Returns an iterator of addresses with states ordered from 'best' to 'worst' according to heuristics such as
@@ -479,8 +451,8 @@ mod test {
         let net_address3 = "/ip4/175.6.3.145/tcp/8000".parse::<Multiaddr>().unwrap();
         let mut net_addresses =
             MultiaddressesWithStats::from_addresses_with_source(vec![net_address1.clone()], &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address2, &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address3, &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(std::slice::from_ref(&net_address2), &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(std::slice::from_ref(&net_address3), &PeerAddressSource::Config);
 
         assert!(net_addresses.mark_last_seen_now(&net_address3));
         assert!(net_addresses.mark_last_seen_now(&net_address1));
@@ -501,10 +473,10 @@ mod test {
         let net_address3 = "/ip4/175.6.3.145/tcp/8000".parse::<Multiaddr>().unwrap();
         let mut net_addresses =
             MultiaddressesWithStats::from_addresses_with_source(vec![net_address1.clone()], &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address2, &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address3, &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(std::slice::from_ref(&net_address2), &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(std::slice::from_ref(&net_address3), &PeerAddressSource::Config);
         // Add duplicate address, this resets the quality score
-        net_addresses.add_address(&net_address2, &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(std::slice::from_ref(&net_address2), &PeerAddressSource::Config);
         assert_eq!(net_addresses.addresses.len(), 3);
         assert_eq!(net_addresses.addresses[0].address(), &net_address1);
         assert_eq!(net_addresses.addresses[1].address(), &net_address2);
@@ -518,8 +490,8 @@ mod test {
         let net_address3 = "/ip4/175.6.3.145/tcp/8000".parse::<Multiaddr>().unwrap();
         let mut net_addresses =
             MultiaddressesWithStats::from_addresses_with_source(vec![net_address1.clone()], &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address2, &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address3, &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(std::slice::from_ref(&net_address2), &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(std::slice::from_ref(&net_address3), &PeerAddressSource::Config);
 
         let priority_address = net_addresses.address_iter().next().unwrap();
         assert_eq!(priority_address, &net_address1);

--- a/comms/core/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/core/src/net_address/mutliaddresses_with_stats.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
-    cmp,
+    collections::HashMap,
     fmt::{Display, Formatter},
     ops::Index,
     time::Duration,
 };
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use log::trace;
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
@@ -39,6 +39,14 @@ impl MultiaddressesWithStats {
         };
         addresses.sort_addresses();
         addresses
+    }
+
+    /// Returns the newest `updated_at` among signed address sources in this set.
+    pub fn newest_claim_updated_at(&self) -> Option<DateTime<Utc>> {
+        self.addresses
+            .iter()
+            .filter_map(|a| a.source().peer_identity_claim().map(|c| c.signature.updated_at()))
+            .max()
     }
 
     pub fn empty() -> Self {
@@ -129,8 +137,65 @@ impl MultiaddressesWithStats {
         self.addresses.iter().map(|addr| addr.address())
     }
 
-    pub fn merge(&mut self, other: &MultiaddressesWithStats) {
-        for addr in &other.addresses {
+    /// Merges another set of addresses into this set, preserving usage stats where possible.
+    ///
+    /// Merge logic:
+    /// - If the incoming set has a strictly newer signed claim, all non-config addresses are replaced by the incoming
+    ///   set.
+    /// - If the incoming set is older, only usage stats for known addresses are updated.
+    /// - If neither set has a signed claim or timestamps are equal, addresses are merged individually.
+    ///
+    /// After merging, addresses are sorted by quality and truncated to the maximum allowed.
+    pub fn merge(&mut self, incoming: &MultiaddressesWithStats) {
+        // Only allow the newest signed advertised addresses.
+        let this_newest = self.newest_claim_updated_at();
+        let other_newest = incoming.newest_claim_updated_at();
+
+        match (this_newest, other_newest) {
+            // Incoming claim is strictly newer -> replace non-config addrs with incoming set
+            (Some(this), Some(other)) if other > this => {
+                // 1) Keep config addresses
+                let mut by_addr: HashMap<Multiaddr, MultiaddrWithStats> = self
+                    .addresses
+                    .iter()
+                    .filter(|a| a.source().is_config())
+                    .cloned()
+                    .map(|a| (a.address().clone(), a))
+                    .collect();
+
+                // 2) Insert/override with incoming advertised set
+                for item in &incoming.addresses {
+                    match by_addr.get_mut(item.address()) {
+                        Some(existing) => {
+                            // Merge stats and prefer newer/better source
+                            existing.merge(item);
+                        },
+                        None => {
+                            by_addr.insert(item.address().clone(), item.clone());
+                        },
+                    }
+                }
+
+                self.addresses = by_addr.into_values().collect();
+                self.sort_addresses();
+                return;
+            },
+
+            // Incoming set is older -> only update stats for known addresses; don't append stale ones
+            (Some(this), Some(other)) if other < this => {
+                for addr in &incoming.addresses {
+                    if let Some(existing) = self.find_address_mut(addr.address()) {
+                        existing.merge(addr);
+                    }
+                }
+                self.sort_addresses();
+                return;
+            },
+            // No signed timestamps or equal -> fall back to address-by-address merge
+            _ => {},
+        }
+
+        for addr in &incoming.addresses {
             if let Some(existing) = self.find_address_mut(addr.address()) {
                 existing.merge(addr);
             } else {
@@ -259,10 +324,22 @@ impl MultiaddressesWithStats {
         &self.addresses
     }
 
-    /// Sort the addresses with the greatest quality score first
+    /// Sort the addresses with the greatest quality score first. In case of a tie, advertised
+    /// addresses are preferred.
     fn sort_addresses(&mut self) {
-        self.addresses
-            .sort_by_key(|addr| cmp::Reverse(addr.quality_score().unwrap_or_default()));
+        self.addresses.sort_by(|a, b| {
+            let qual_a = a.quality_score().unwrap_or_default();
+            let qual_b = b.quality_score().unwrap_or_default();
+            match qual_b.cmp(&qual_a) {
+                std::cmp::Ordering::Equal => {
+                    // Advertised > Config on tie
+                    let a_if_config = if a.source().is_config() { 0 } else { 1 };
+                    let b_if_config = if b.source().is_config() { 0 } else { 1 };
+                    b_if_config.cmp(&a_if_config)
+                },
+                ord => ord,
+            }
+        });
         self.addresses.truncate(MAX_ADDRESSES)
     }
 }
@@ -316,7 +393,14 @@ impl Display for MultiaddressesWithStats {
 #[cfg(test)]
 mod test {
     #![allow(clippy::indexing_slicing)]
+    use digest::crypto_common::rand_core::OsRng;
+    use tari_crypto::keys::SecretKey;
+
     use super::*;
+    use crate::{
+        peer_manager::{IdentitySignature, PeerFeatures, PeerIdentityClaim},
+        types::{CommsPublicKey, CommsSecretKey},
+    };
 
     #[test]
     fn test_index_impl() {
@@ -483,5 +567,191 @@ mod test {
         assert!(net_addresses.addresses[0].last_failed_reason().is_none());
         assert!(net_addresses.addresses[1].last_failed_reason().is_none());
         assert!(net_addresses.addresses[2].last_failed_reason().is_none());
+    }
+
+    #[test]
+    fn it_merges_addresses_with_stats_correctly() {
+        use crate::net_address::multiaddr_with_stats::PeerAddressSource;
+
+        let addr1 = "/ip4/1.1.1.1/tcp/1000".parse::<Multiaddr>().unwrap();
+        let addr2 = "/ip4/2.2.2.2/tcp/2000".parse::<Multiaddr>().unwrap();
+        let addr3 = "/ip4/3.3.3.3/tcp/3000".parse::<Multiaddr>().unwrap();
+
+        let addr_set_1 = vec![addr1.clone(), addr2.clone()];
+        let set1 = MultiaddressesWithStats::from_addresses_with_source(
+            addr_set_1.clone(),
+            &PeerAddressSource::FromPeerConnection {
+                peer_identity_claim: PeerIdentityClaim {
+                    addresses: addr_set_1.clone(),
+                    features: PeerFeatures::COMMUNICATION_NODE,
+                    signature: create_identity_signature(&addr_set_1),
+                },
+            },
+        );
+        assert!(set1.contains(&addr1));
+        assert!(set1.contains(&addr2));
+        assert_eq!(set1.len(), 2);
+
+        // Sleep to ensure different timestamp
+        std::thread::sleep(Duration::from_millis(150));
+        let addr_set_2 = vec![addr2.clone(), addr3.clone()];
+        let set2 = MultiaddressesWithStats::from_addresses_with_source(
+            addr_set_2.clone(),
+            &PeerAddressSource::FromPeerConnection {
+                peer_identity_claim: PeerIdentityClaim {
+                    addresses: addr_set_2.clone(),
+                    features: PeerFeatures::COMMUNICATION_NODE,
+                    signature: create_identity_signature(&addr_set_2),
+                },
+            },
+        );
+
+        let set3 = MultiaddressesWithStats::from_addresses_with_source(
+            vec![addr1.clone(), addr3.clone()],
+            &PeerAddressSource::Config,
+        );
+
+        // Test case 1 - set1 is older, so only set should be retained
+
+        let mut set1_merge = set1.clone();
+        set1_merge.merge(&set2);
+
+        // Only addr2 and addr3 from set_2 should be present
+        assert_eq!(set1_merge.len(), 2);
+        assert!(set1_merge.contains(&addr2));
+        assert!(set1_merge.contains(&addr3));
+
+        // Test case 2 - set1 is older, only update stats for known addresses; don't append stale ones
+
+        let mut set1_update = set1.clone();
+        let addr_1_mut = set1_update.find_address_mut(&addr1).unwrap();
+        addr_1_mut.update_latency(Duration::from_secs(1));
+        let addr_2_mut = set1_update.find_address_mut(&addr2).unwrap();
+        addr_2_mut.update_latency(Duration::from_secs(2));
+
+        let mut set2_merge = set2.clone();
+        set2_merge.merge(&set1_update);
+
+        // Only addr2 and addr3 should be present
+
+        assert_eq!(set2_merge.len(), 2);
+        assert!(!set2_merge.contains(&addr1));
+        assert!(set2_merge.contains(&addr2));
+        assert!(set2_merge.contains(&addr3));
+
+        // Latency should be updated for addr2
+
+        assert_eq!(
+            set2_merge.find_address_mut(&addr2).unwrap().avg_latency(),
+            Some(Duration::from_secs(2))
+        );
+
+        // Test case 3 - merge with config addresses, which are always accepted
+
+        let mut set3_update = set3.clone();
+        let addr_1_mut = set3_update.find_address_mut(&addr1).unwrap();
+        addr_1_mut.update_latency(Duration::from_secs(4));
+        let addr_3_mut = set3_update.find_address_mut(&addr3).unwrap();
+        addr_3_mut.update_latency(Duration::from_secs(3));
+        set2_merge.merge(&set3_update);
+
+        // Only addr1, addr2 and addr3 should be present
+
+        assert_eq!(set2_merge.len(), 3);
+        assert!(set2_merge.contains(&addr1));
+        assert!(set2_merge.contains(&addr2));
+        assert!(set2_merge.contains(&addr3));
+
+        // Latency should be updated for addr1 and addr3
+
+        assert_eq!(
+            set2_merge.find_address_mut(&addr1).unwrap().avg_latency(),
+            Some(Duration::from_secs(4))
+        );
+        assert_eq!(
+            set2_merge.find_address_mut(&addr2).unwrap().avg_latency(),
+            Some(Duration::from_secs(2))
+        );
+        assert_eq!(
+            set2_merge.find_address_mut(&addr3).unwrap().avg_latency(),
+            Some(Duration::from_secs(3))
+        );
+    }
+
+    fn create_identity_signature(addresses: &[Multiaddr]) -> IdentitySignature {
+        let secret = CommsSecretKey::random(&mut OsRng);
+        let public_key = CommsPublicKey::from_secret_key(&secret);
+        let updated_at = Utc::now();
+        let identity = IdentitySignature::sign_new(&secret, PeerFeatures::COMMUNICATION_NODE, addresses, updated_at);
+        assert!(
+            identity
+                .is_valid(&public_key, PeerFeatures::COMMUNICATION_NODE, addresses)
+                .unwrap(),
+            "Signature is not valid"
+        );
+        identity
+    }
+
+    #[test]
+    fn it_merges_when_config_overlaps() {
+        let addr_1 = "/ip4/9.9.9.9/tcp/9999".parse::<Multiaddr>().unwrap();
+        let addr_2 = "/ip4/7.7.7.7/tcp/7777".parse::<Multiaddr>().unwrap();
+
+        // Base has address as Config
+        let mut base = MultiaddressesWithStats::from_addresses_with_source(
+            vec![addr_1.clone(), addr_2.clone()],
+            &PeerAddressSource::Config,
+        );
+
+        // Incoming has the same address as base, but newer with an advertised source
+        let incoming = MultiaddressesWithStats::from_addresses_with_source(
+            vec![addr_1.clone()],
+            &PeerAddressSource::FromPeerConnection {
+                peer_identity_claim: PeerIdentityClaim {
+                    addresses: vec![addr_1.clone()],
+                    features: PeerFeatures::COMMUNICATION_NODE,
+                    signature: create_identity_signature(std::slice::from_ref(&addr_1)),
+                },
+            },
+        );
+
+        base.merge(&incoming);
+        let a1 = base.find_address_mut(&addr_1).unwrap();
+        assert!(!a1.source().is_config());
+        let a2 = base.find_address_mut(&addr_2).unwrap();
+        assert!(a2.source().is_config());
+    }
+
+    #[test]
+    fn it_prefers_advertised_addresses_over_config_on_tie() {
+        use crate::net_address::multiaddr_with_stats::PeerAddressSource;
+
+        let addr_1 = "/ip4/1.1.1.1/tcp/1000".parse::<Multiaddr>().unwrap();
+        let addr_2 = "/ip4/2.2.2.2/tcp/2000".parse::<Multiaddr>().unwrap();
+
+        // Both addresses have the same quality score
+        let mut stats_1 = MultiaddrWithStats::new(addr_1.clone(), PeerAddressSource::Config);
+        let mut stats_2 = MultiaddrWithStats::new(addr_2.clone(), PeerAddressSource::FromPeerConnection {
+            peer_identity_claim: PeerIdentityClaim {
+                addresses: vec![addr_2.clone()],
+                features: PeerFeatures::COMMUNICATION_NODE,
+                signature: create_identity_signature(std::slice::from_ref(&addr_2)),
+            },
+        });
+
+        // Set the same quality score for both
+        stats_1.update_latency(Duration::from_millis(100));
+        stats_2.update_latency(Duration::from_millis(100));
+
+        let mut addresses = MultiaddressesWithStats::new(vec![stats_1, stats_2]);
+
+        assert_eq!(addresses.addresses()[0].address(), &addr_1);
+        assert_eq!(addresses.addresses()[1].address(), &addr_2);
+
+        addresses.sort_addresses();
+
+        // Advertised (addr2) should come before config (addr1)
+        assert_eq!(addresses.addresses()[0].address(), &addr_2);
+        assert_eq!(addresses.addresses()[1].address(), &addr_1);
     }
 }

--- a/comms/core/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/core/src/net_address/mutliaddresses_with_stats.rs
@@ -37,11 +37,12 @@ impl MultiaddressesWithStats {
         let mut addresses = MultiaddressesWithStats {
             addresses: addresses_with_stats,
         };
-        addresses.sort_addresses();
+        addresses.sort_and_truncate_addresses();
         addresses
     }
 
-    /// Returns the newest `updated_at` among signed address sources in this set.
+    /// Returns the newest `updated_at` among signed address sources in this set - this can only be `None` if the source
+    /// is from config.
     pub fn newest_claim_updated_at(&self) -> Option<DateTime<Utc>> {
         self.addresses
             .iter()
@@ -115,7 +116,8 @@ impl MultiaddressesWithStats {
     /// - If the incoming set has a strictly newer signed claim, all non-config addresses are replaced by the incoming
     ///   set.
     /// - If the incoming set is older, only usage stats for known addresses are updated.
-    /// - If neither set has a signed claim or timestamps are equal, addresses are merged individually.
+    /// - If neither set has a signed claim (i.e. source from config) or timestamps are equal, addresses are merged
+    ///   individually.
     ///
     /// After merging, addresses are sorted by quality and truncated to the maximum allowed.
     pub fn merge(&mut self, incoming: &MultiaddressesWithStats) {
@@ -149,8 +151,7 @@ impl MultiaddressesWithStats {
                 }
 
                 self.addresses = by_addr.into_values().collect();
-                self.sort_addresses();
-                return;
+                self.sort_and_truncate_addresses();
             },
 
             // Incoming set is older -> only update stats for known addresses; don't append stale ones
@@ -160,21 +161,23 @@ impl MultiaddressesWithStats {
                         existing.merge(addr);
                     }
                 }
-                self.sort_addresses();
-                return;
+                self.sort_and_truncate_addresses();
             },
-            // No signed timestamps or equal -> fall back to address-by-address merge
-            _ => {},
-        }
 
-        for addr in &incoming.addresses {
-            if let Some(existing) = self.find_address_mut(addr.address()) {
-                existing.merge(addr);
-            } else {
-                self.addresses.push(addr.clone());
-            }
+            // Fall back to address-by-address merge:
+            //   `this_newest(DateTime)` == `other_newest(DateTime)`, or
+            //   `this_newest` and/or `other_newest` is config
+            _ => {
+                for addr in &incoming.addresses {
+                    if let Some(existing) = self.find_address_mut(addr.address()) {
+                        existing.merge(addr);
+                    } else {
+                        self.addresses.push(addr.clone());
+                    }
+                }
+                self.sort_and_truncate_addresses();
+            },
         }
-        self.sort_addresses();
     }
 
     /// Finds the specified address in the set and allow updating of its variables such as its usage stats
@@ -197,7 +200,7 @@ impl MultiaddressesWithStats {
         match self.find_address_mut(address) {
             Some(addr) => {
                 addr.update_latency(latency_measurement);
-                self.sort_addresses();
+                self.sort_and_truncate_addresses();
                 true
             },
             None => false,
@@ -208,7 +211,7 @@ impl MultiaddressesWithStats {
     where F: FnOnce(&mut MultiaddrWithStats) {
         if let Some(addr) = self.find_address_mut(address) {
             f(addr);
-            self.sort_addresses();
+            self.sort_and_truncate_addresses();
         }
     }
 
@@ -219,7 +222,7 @@ impl MultiaddressesWithStats {
         match self.find_address_mut(address) {
             Some(addr) => {
                 addr.mark_last_seen_now().mark_last_attempted_now();
-                self.sort_addresses();
+                self.sort_and_truncate_addresses();
                 true
             },
             None => false,
@@ -246,7 +249,7 @@ impl MultiaddressesWithStats {
                 },
             }
         }
-        self.sort_addresses();
+        self.sort_and_truncate_addresses();
         all_exist
     }
 
@@ -258,7 +261,7 @@ impl MultiaddressesWithStats {
             Some(addr) => {
                 addr.mark_failed_connection_attempt(failed_reason);
                 addr.mark_last_attempted_now();
-                self.sort_addresses();
+                self.sort_and_truncate_addresses();
                 true
             },
             None => {
@@ -275,7 +278,7 @@ impl MultiaddressesWithStats {
         for a in &mut self.addresses {
             a.reset_connection_attempts();
         }
-        self.sort_addresses();
+        self.sort_and_truncate_addresses();
     }
 
     /// Returns the number of addresses
@@ -297,8 +300,8 @@ impl MultiaddressesWithStats {
     }
 
     /// Sort the addresses with the greatest quality score first. In case of a tie, advertised
-    /// addresses are preferred.
-    fn sort_addresses(&mut self) {
+    /// addresses are preferred. Truncates the list to the maximum allowed number of addresses.
+    fn sort_and_truncate_addresses(&mut self) {
         self.addresses.sort_by(|a, b| {
             let qual_a = a.quality_score().unwrap_or_default();
             let qual_b = b.quality_score().unwrap_or_default();
@@ -720,7 +723,7 @@ mod test {
         assert_eq!(addresses.addresses()[0].address(), &addr_1);
         assert_eq!(addresses.addresses()[1].address(), &addr_2);
 
-        addresses.sort_addresses();
+        addresses.sort_and_truncate_addresses();
 
         // Advertised (addr2) should come before config (addr1)
         assert_eq!(addresses.addresses()[0].address(), &addr_2);

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -595,9 +595,10 @@ fn add_internal_addresses(peer: &mut Peer) {
     addresses.push(address_7);
     addresses.shuffle(&mut rand::thread_rng());
 
-    let peer_address_source = create_peer_address_source_with_claim(addresses.clone(), peer.features);
-
-    peer.addresses.update_addresses(&addresses, &peer_address_source);
+    // Do not create a new PeerAddressSource with PeerIdentityClaim - use PeerAddressSource::Config - otherwise the
+    // previous claims and associated addresses will be discarded.
+    peer.addresses
+        .add_or_update_addresses(&addresses, &PeerAddressSource::Config);
 }
 
 #[cfg(test)]
@@ -979,7 +980,8 @@ mod test {
             .collect::<Vec<_>>();
         let peer_address_source = create_peer_address_source_with_claim(peer_addresses.clone(), peer.features);
         // Update the peer's addresses with a new claim
-        peer.addresses.update_addresses(&peer_addresses, &peer_address_source);
+        peer.addresses
+            .add_or_update_addresses(&peer_addresses, &peer_address_source);
 
         // Update the peer in the database
         peer_manager.add_or_update_peer(peer.clone()).await.unwrap();

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -383,9 +383,9 @@ pub fn create_test_peer(ban_flag: bool, features: PeerFeatures) -> Peer {
     use crate::peer_manager::PeerFlags;
     let (_sk, pk) = CommsPublicKey::random_keypair(&mut OsRng);
     let node_id = NodeId::from_key(&pk);
-    let mut net_addresses = MultiaddressesWithStats::from_addresses_with_source(vec![], &PeerAddressSource::Config);
 
     // Create 1 to 4 random addresses
+    let mut addresses = Vec::new();
     for _i in 1..=rand::thread_rng().gen_range(1..4) {
         let n = [
             match rand::thread_rng().gen_range(0..3) {
@@ -398,11 +398,15 @@ pub fn create_test_peer(ban_flag: bool, features: PeerFeatures) -> Peer {
             rand::thread_rng().gen_range(1..255),
             rand::thread_rng().gen_range(5000..9000),
         ];
-        let net_address = format!("/ip4/{}.{}.{}.{}/tcp/{}", n[0], n[1], n[2], n[3], n[4])
+        let address = format!("/ip4/{}.{}.{}.{}/tcp/{}", n[0], n[1], n[2], n[3], n[4])
             .parse::<Multiaddr>()
             .unwrap();
-        net_addresses.add_address(&net_address, &PeerAddressSource::Config);
+        addresses.push(address);
     }
+    let net_addresses = MultiaddressesWithStats::from_addresses_with_source(
+        addresses.clone(),
+        &create_peer_address_source_with_claim(addresses, features),
+    );
 
     let mut peer = Peer::new(
         pk,
@@ -456,18 +460,22 @@ pub fn create_test_peer_with_onion_address(ban_flag: bool, features: PeerFeature
     use crate::peer_manager::PeerFlags;
     let (_sk, pk) = CommsPublicKey::random_keypair(&mut OsRng);
     let node_id = NodeId::from_key(&pk);
-    let mut net_addresses = MultiaddressesWithStats::from_addresses_with_source(vec![], &PeerAddressSource::Config);
 
     // Create 1 to 4 random onion addresses
+    let mut addresses = Vec::new();
     for _i in 1..=rand::thread_rng().gen_range(1..4) {
         use std::str::FromStr;
 
         let host = random_onion3_host();
         let port = rand::thread_rng().gen_range(1024..=65535);
         let addr_str = format!("/onion3/{}:{}", host, port);
-        let maddr = Multiaddr::from_str(&addr_str).expect("valid onion3 multiaddr");
-        net_addresses.add_address(&maddr, &PeerAddressSource::Config);
+        let address = Multiaddr::from_str(&addr_str).expect("valid onion3 multiaddr");
+        addresses.push(address);
     }
+    let net_addresses = MultiaddressesWithStats::from_addresses_with_source(
+        addresses.clone(),
+        &create_peer_address_source_with_claim(addresses, features),
+    );
 
     let mut peer = Peer::new(
         pk,
@@ -526,9 +534,9 @@ pub fn create_test_peer_internal_addresses_only(ban_flag: bool, features: PeerFe
 fn add_internal_addresses(peer: &mut Peer) {
     use rand::{prelude::SliceRandom, Rng};
 
-    let mut net_addresses = Vec::new();
+    let mut addresses = Vec::new();
     // IPv4 Loopback
-    let net_address = format!(
+    let address_1 = format!(
         "/ip4/127.{}.{}.{}/tcp/{}",
         rand::thread_rng().gen_range(0..255),
         rand::thread_rng().gen_range(0..255),
@@ -537,14 +545,14 @@ fn add_internal_addresses(peer: &mut Peer) {
     )
     .parse::<Multiaddr>()
     .unwrap();
-    net_addresses.push(net_address);
+    addresses.push(address_1);
     // IPv4 Unspecified
-    let net_address = format!("/ip4/0.0.0.0/tcp/{}", rand::thread_rng().gen_range(9100..9200))
+    let address_2 = format!("/ip4/0.0.0.0/tcp/{}", rand::thread_rng().gen_range(9100..9200))
         .parse::<Multiaddr>()
         .unwrap();
-    net_addresses.push(net_address);
+    addresses.push(address_2);
     // IPv4 Private
-    let net_address = format!(
+    let address_3 = format!(
         "/ip4/10.{}.{}.{}/tcp/{}",
         rand::thread_rng().gen_range(0..255),
         rand::thread_rng().gen_range(0..255),
@@ -553,9 +561,9 @@ fn add_internal_addresses(peer: &mut Peer) {
     )
     .parse::<Multiaddr>()
     .unwrap();
-    net_addresses.push(net_address);
+    addresses.push(address_3);
     // IPv4 Private
-    let net_address = format!(
+    let address_4 = format!(
         "/ip4/172.{}.{}.{}/tcp/{}",
         rand::thread_rng().gen_range(16..=31),
         rand::thread_rng().gen_range(0..255),
@@ -564,9 +572,9 @@ fn add_internal_addresses(peer: &mut Peer) {
     )
     .parse::<Multiaddr>()
     .unwrap();
-    net_addresses.push(net_address);
+    addresses.push(address_4);
     // IPv4 Private
-    let net_address = format!(
+    let address_5 = format!(
         "/ip4/192.168.{}.{}/tcp/{}",
         rand::thread_rng().gen_range(0..255),
         rand::thread_rng().gen_range(0..255),
@@ -574,27 +582,63 @@ fn add_internal_addresses(peer: &mut Peer) {
     )
     .parse::<Multiaddr>()
     .unwrap();
-    net_addresses.push(net_address);
+    addresses.push(address_5);
     // IPv6 Loopback
-    let net_address = format!("/ip6/::1/tcp/{}", rand::thread_rng().gen_range(9500..9600))
+    let address_6 = format!("/ip6/::1/tcp/{}", rand::thread_rng().gen_range(9500..9600))
         .parse::<Multiaddr>()
         .unwrap();
-    net_addresses.push(net_address);
+    addresses.push(address_6);
     // IPv6 Unspecified
-    let net_address = format!("/ip6/::/tcp/{}", rand::thread_rng().gen_range(9600..9700))
+    let address_7 = format!("/ip6/::/tcp/{}", rand::thread_rng().gen_range(9600..9700))
         .parse::<Multiaddr>()
         .unwrap();
-    net_addresses.push(net_address);
-    net_addresses.shuffle(&mut rand::thread_rng());
+    addresses.push(address_7);
+    addresses.shuffle(&mut rand::thread_rng());
 
-    for net_address in net_addresses.iter().take(2) {
-        peer.addresses.add_address(net_address, &PeerAddressSource::Config);
+    let peer_address_source = create_peer_address_source_with_claim(addresses.clone(), peer.features);
+
+    peer.addresses.update_addresses(&addresses, &peer_address_source);
+}
+
+#[cfg(test)]
+pub fn create_peer_address_source_with_claim(
+    addresses: Vec<Multiaddr>,
+    peer_features: PeerFeatures,
+) -> PeerAddressSource {
+    use chrono::Utc;
+    use rand::rngs::OsRng;
+    use tari_crypto::keys::SecretKey;
+
+    use crate::{
+        peer_manager::{IdentitySignature, PeerIdentityClaim},
+        types::CommsSecretKey,
+    };
+
+    fn create_identity_signature(addresses: &[Multiaddr], peer_features: PeerFeatures) -> IdentitySignature {
+        let secret = CommsSecretKey::random(&mut OsRng);
+        let public_key = CommsPublicKey::from_secret_key(&secret);
+        let updated_at = Utc::now();
+        let identity = IdentitySignature::sign_new(&secret, peer_features, addresses, updated_at);
+        assert!(
+            identity.is_valid(&public_key, peer_features, addresses).unwrap(),
+            "Signature is not valid"
+        );
+        identity
+    }
+
+    PeerAddressSource::FromPeerConnection {
+        peer_identity_claim: PeerIdentityClaim {
+            addresses: addresses.clone(),
+            features: peer_features,
+            signature: create_identity_signature(&addresses, peer_features),
+        },
     }
 }
 
 #[cfg(test)]
 mod test {
     #![allow(clippy::indexing_slicing)]
+    use chrono::{DateTime, Utc};
     use tari_common_sqlite::connection::DbConnection;
 
     use super::*;
@@ -857,6 +901,111 @@ mod test {
             .unwrap();
 
         assert!(!peer.is_offline());
+    }
+
+    async fn validate_claim_bump_by_newer(
+        peer_manager: &PeerManager,
+        update_peer: &Peer,
+        previous_claim_time: Option<DateTime<Utc>>,
+        expected_count: usize,
+    ) -> DateTime<Utc> {
+        let peer_from_db = peer_manager
+            .find_by_node_id(&update_peer.node_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let newest_time = peer_from_db.addresses.newest_claim_updated_at().unwrap();
+
+        if let Some(prev_time) = previous_claim_time {
+            assert!(
+                newest_time > prev_time,
+                "New claim time was not newer than previous claim time"
+            );
+        }
+
+        for addr in peer_from_db.addresses.addresses() {
+            let claim_time = match addr.source() {
+                PeerAddressSource::FromPeerConnection { peer_identity_claim } => {
+                    peer_identity_claim.signature.updated_at()
+                },
+                _ => panic!("Expected FromPeerConnection source for address: {}", addr.address()),
+            };
+            assert_eq!(
+                claim_time, newest_time,
+                "Address claim time inconsistent among addresses"
+            );
+        }
+
+        assert_eq!(peer_manager.count().await, expected_count, "Peer count mismatch");
+
+        let mut expected_addresses = update_peer
+            .addresses
+            .addresses()
+            .iter()
+            .map(|a| a.address().clone())
+            .collect::<Vec<_>>();
+        let mut addresses_from_db = peer_from_db
+            .addresses
+            .addresses()
+            .iter()
+            .map(|a| a.address().clone())
+            .collect::<Vec<_>>();
+        expected_addresses.sort();
+        addresses_from_db.sort();
+        assert_eq!(expected_addresses, addresses_from_db);
+
+        newest_time
+    }
+
+    #[tokio::test]
+    async fn it_correctly_merges_old_and_new_address_claims() {
+        // Create a PeerManager and a test peer
+        let peer_manager = create_peer_manager();
+        let mut peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+
+        // Add the original peer to the database
+        peer_manager.add_or_update_peer(peer.clone()).await.unwrap();
+
+        // Verify that the peer from the database has consistent claim timestamps
+        let claim_1_time = validate_claim_bump_by_newer(&peer_manager, &peer, None, 1).await;
+
+        // Create a new claim with the same addresses but a new timestamp
+        tokio::time::sleep(Duration::from_millis(150)).await; // Sleep to ensure different timestamp
+        let peer_addresses = peer
+            .addresses
+            .addresses()
+            .iter()
+            .map(|a| a.address().clone())
+            .collect::<Vec<_>>();
+        let peer_address_source = create_peer_address_source_with_claim(peer_addresses.clone(), peer.features);
+        // Update the peer's addresses with a new claim
+        peer.addresses.update_addresses(&peer_addresses, &peer_address_source);
+
+        // Update the peer in the database
+        peer_manager.add_or_update_peer(peer.clone()).await.unwrap();
+
+        // Assert that the updated peer from the database has the new claim timestamp and that it is consistent
+        let claim_2_time = validate_claim_bump_by_newer(&peer_manager, &peer, Some(claim_1_time), 1).await;
+
+        // Create a total new set addresses and claim with a new timestamp for the same peer
+        tokio::time::sleep(Duration::from_millis(150)).await; // Sleep to ensure different timestamp
+        let mut update_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        update_peer.node_id = peer.node_id.clone();
+        update_peer.public_key = peer.public_key.clone();
+
+        // Add the updated peer to the database
+        peer_manager.add_or_update_peer(update_peer.clone()).await.unwrap();
+
+        // Assert that the database still contains only one peer and that the peer from the database has the new claim
+        // timestamp and that it is consistent
+        let _claim_3_time = validate_claim_bump_by_newer(&peer_manager, &update_peer, Some(claim_2_time), 1).await;
+
+        // Update the peer in the database with the old peer (which has an older claim timestamp)
+        // This should NOT update the claim timestamp
+        peer_manager.add_or_update_peer(peer.clone()).await.unwrap();
+
+        // Assert that the database still contains only one peer with the latest claim and addresses
+        let _claim_3_time = validate_claim_bump_by_newer(&peer_manager, &update_peer, Some(claim_2_time), 1).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]

--- a/comms/core/src/peer_manager/peer.rs
+++ b/comms/core/src/peer_manager/peer.rs
@@ -300,7 +300,7 @@ impl Peer {
 
     /// Update the peer's addresses. This call will invalidate the identity signature.
     pub fn update_addresses(&mut self, addresses: &[Multiaddr], source: &PeerAddressSource) -> &mut Self {
-        self.addresses.update_addresses(addresses, source);
+        self.addresses.add_or_update_addresses(addresses, source);
         self
     }
 

--- a/comms/core/src/peer_manager/peer_storage_sql.rs
+++ b/comms/core/src/peer_manager/peer_storage_sql.rs
@@ -444,8 +444,8 @@ mod test {
         let net_address3 = "/ip4/5.6.7.8/tcp/7000".parse::<Multiaddr>().unwrap();
         let mut net_addresses =
             MultiaddressesWithStats::from_addresses_with_source(vec![net_address1], &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address2, &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address3, &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(&[net_address2], &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(&[net_address3], &PeerAddressSource::Config);
         let peer1 = Peer::new(
             pk,
             node_id,
@@ -477,7 +477,7 @@ mod test {
         let net_address6 = "/ip4/17.18.19.20/tcp/8000".parse::<Multiaddr>().unwrap();
         let mut net_addresses =
             MultiaddressesWithStats::from_addresses_with_source(vec![net_address5], &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address6, &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(&[net_address6], &PeerAddressSource::Config);
         let peer3 = Peer::new(
             pk,
             node_id,
@@ -527,8 +527,8 @@ mod test {
         let net_address3 = "/ip4/5.6.7.8/tcp/7000".parse::<Multiaddr>().unwrap();
         let mut net_addresses =
             MultiaddressesWithStats::from_addresses_with_source(vec![net_address1], &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address2, &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address3, &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(&[net_address2], &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(&[net_address3], &PeerAddressSource::Config);
         let peer1 = Peer::new(
             pk,
             node_id,
@@ -560,7 +560,7 @@ mod test {
         let net_address6 = "/ip4/17.18.19.20/tcp/8000".parse::<Multiaddr>().unwrap();
         let mut net_addresses =
             MultiaddressesWithStats::from_addresses_with_source(vec![net_address5], &PeerAddressSource::Config);
-        net_addresses.add_address(&net_address6, &PeerAddressSource::Config);
+        net_addresses.add_or_update_addresses(&[net_address6], &PeerAddressSource::Config);
         let peer3 = Peer::new(
             pk,
             node_id,
@@ -704,7 +704,7 @@ mod test {
             let net_address = format!("/ip4/{}.{}.{}.{}/tcp/{}", n[0], n[1], n[2], n[3], n[4])
                 .parse::<Multiaddr>()
                 .unwrap();
-            net_addresses.add_address(&net_address, &PeerAddressSource::Config);
+            net_addresses.add_or_update_addresses(&[net_address], &PeerAddressSource::Config);
         }
 
         let mut peer = Peer::new(

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -543,7 +543,7 @@ impl PeerDatabaseSql {
             match self.get_peer_by_node_id_inner(node_id, conn)? {
                 Some(mut peer) => {
                     // Update existing
-                    peer.addresses.update_addresses(addresses, source);
+                    peer.addresses.add_or_update_addresses(addresses, source);
                     peer.features = *peer_features;
                     let update_peer_sql = PeerDatabaseSql::update_peer_sql(peer.clone())?;
                     self.update_peer_inner(update_peer_sql, conn)?;
@@ -2110,10 +2110,10 @@ mod tests {
         new_peer.metadata.insert(1, vec![1, 2, 3]);
         new_peer.metadata.insert(2, vec![4, 5, 6]);
         // - add another multi-address
-        let new_addr_str = "/ip4/127.0.0.1/udt/sctp/5678";
+        let new_addr: Multiaddr = "/ip4/127.0.0.1/udt/sctp/5678".parse().unwrap();
         new_peer
             .addresses
-            .add_address(&new_addr_str.parse().unwrap(), &PeerAddressSource::Config);
+            .add_or_update_addresses(std::slice::from_ref(&new_addr), &PeerAddressSource::Config);
         // - new stats for the first multi-address
         let mut address_to_update = new_peer.addresses.addresses().first().unwrap().clone();
         address_to_update.update_latency(Duration::from_millis(123));
@@ -2881,7 +2881,8 @@ mod tests {
             .cloned()
             .collect::<Vec<_>>();
         for address in &duplicate_address {
-            peer.addresses.add_address(address, &PeerAddressSource::Config)
+            peer.addresses
+                .add_or_update_addresses(std::slice::from_ref(address), &PeerAddressSource::Config)
         }
         peers_db.add_or_update_peer(peer.clone()).unwrap();
 

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -26,6 +26,7 @@ use bytes::Bytes;
 use chrono::{NaiveDateTime, TimeDelta};
 use diesel::{
     self,
+    dsl::not,
     prelude::*,
     r2d2::{ConnectionManager, PooledConnection},
     ExpressionMethods,
@@ -733,6 +734,20 @@ impl PeerDatabaseSql {
             .first::<i64>(conn)?;
 
         // Update the associated multi-addresses
+        // - Remove all stale addresses that are not in the update list
+        let final_addr_list: Vec<String> = update_peer_sql
+            .addresses
+            .iter()
+            .filter_map(|a| a.address.clone())
+            .collect();
+
+        diesel::delete(
+            multi_addresses::table
+                .filter(multi_addresses::peer_id.eq(peer_id))
+                .filter(not(multi_addresses::address.eq_any(&final_addr_list))),
+        )
+        .execute(conn)?;
+        // - Update existing addresses and add new ones
         for address_update in update_peer_sql.addresses {
             let updated = diesel::update(
                 multi_addresses::table
@@ -3132,7 +3147,7 @@ mod tests {
         )
         .unwrap();
 
-        // Create a new peer and add a failure reason
+        // Create a new peer and remove all addresses
         let mut peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
         peer.addresses = MultiaddressesWithStats::new(vec![]);
 

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -149,20 +149,21 @@ mod tests {
         let mut peer = node_identity.to_peer();
         peer.addresses = MultiaddressesWithStats::new(vec![]);
         let addr = Multiaddr::from_str("/ip4/23.23.23.23/tcp/80").unwrap();
-        peer.addresses.add_address(&addr, &PeerAddressSource::FromDiscovery {
-            peer_identity_claim: PeerIdentityClaim {
-                addresses: vec![addr.clone()],
-                features: PeerFeatures::COMMUNICATION_NODE,
-                signature: IdentitySignature::new(
-                    0,
-                    CompressedSignature::new_from_schnorr(Signature::new(
-                        RistrettoPublicKey::from_canonical_bytes(&[0u8; 32]).unwrap(),
-                        RistrettoSecretKey::from_canonical_bytes(&[0u8; 32]).unwrap(),
-                    )),
-                    Default::default(),
-                ),
-            },
-        });
+        peer.addresses
+            .add_or_update_addresses(std::slice::from_ref(&addr), &PeerAddressSource::FromDiscovery {
+                peer_identity_claim: PeerIdentityClaim {
+                    addresses: vec![addr.clone()],
+                    features: PeerFeatures::COMMUNICATION_NODE,
+                    signature: IdentitySignature::new(
+                        0,
+                        CompressedSignature::new_from_schnorr(Signature::new(
+                            RistrettoPublicKey::from_canonical_bytes(&[0u8; 32]).unwrap(),
+                            RistrettoSecretKey::from_canonical_bytes(&[0u8; 32]).unwrap(),
+                        )),
+                        Default::default(),
+                    ),
+                },
+            });
         let validator = PeerValidator::new(&config);
         let err = validator
             .validate_peer(UnvalidatedPeerInfo::from_peer_limited_claims(peer.clone(), 5, 5), None)


### PR DESCRIPTION
Description
---
The peer_db now only retains the latest claims, and peer multi-address merges cleans out old data.

Closes #7491.

Motivation and Context
---
See #7491.

How Has This Been Tested?
---
Added new unit tests:
- MultiAddressWithStats
  - `fn it_merges_addresses_with_stats_correctly()`
  - `fn it_merges_when_config_overlaps()`
  - `fn it_prefers_advertised_addresses_over_config_on_tie()`
- PeerManager
  - `async fn it_correctly_merges_old_and_new_address_claims()`

System-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Claim-aware peer address merging that prefers newer signed claims, preserves configured addresses, enforces capacity limits, and deterministically breaks ties in favor of advertised addresses.
  - Batch-style address updates with automatic pruning of stale addresses to keep peers’ address lists current.

- Bug Fixes
  - Eliminates inconsistent ordering, duplicates, and outdated addresses after updates; preserves and propagates usage/latency stats correctly.

- Documentation
  - Clarified merge, replacement, and tie-breaking behavior.

- Tests
  - Added tests for claim timestamps, merge scenarios, tie-breaking, config overlap, and database consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->