### PR TITLE
fix: proactive dialler not selecting new peers to dial

### DIFF
--- a/comms/core/src/connectivity/proactive_dialer.rs
+++ b/comms/core/src/connectivity/proactive_dialer.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "comms::connectivity::proactive_dialer";
-const MAX_CONCURRENT_DIALS: usize = 20;
+const MAX_CONCURRENT_DIALS: usize = 30;
 
 /// Proactive peer dialing logic for maintaining target connection counts
 pub struct ProactiveDialer {

--- a/comms/core/src/connectivity/proactive_dialer.rs
+++ b/comms/core/src/connectivity/proactive_dialer.rs
@@ -74,24 +74,29 @@ impl ProactiveDialer {
             return Ok(0);
         }
 
-        let current_connections = pool.count_connected_nodes();
+        let eligible_connections = pool
+            .get_connected_node_ids()
+            .iter()
+            .filter(|p| !excluded_peers.contains(p))
+            .count();
         let target = self.config.target_connection_count;
 
         // Update metrics
 
-        if current_connections >= target {
+        if eligible_connections >= target {
             debug!(
                 target: LOG_TARGET,
-                "({task_id}) Current connections ({current_connections}) meet or exceed target ({target}), no proactive dialing needed",
+                "({task_id}) Eligible connections ({eligible_connections}) meet or exceed target ({target}), no \
+                proactive dialing needed",
             );
 
             return Ok(0);
         }
 
-        let needed = target.saturating_sub(current_connections);
+        let needed = target.saturating_sub(eligible_connections);
         debug!(
             target: LOG_TARGET,
-            "({task_id}) Proactive dialing: need {needed} more connections ({current_connections}/{target})",
+            "({task_id}) Proactive dialing: need {needed} more connections ({eligible_connections}/{target})",
 
         );
 

--- a/comms/core/src/connectivity/proactive_dialer.rs
+++ b/comms/core/src/connectivity/proactive_dialer.rs
@@ -193,18 +193,19 @@ impl ProactiveDialer {
         let mut managed_and_excluded = managed.clone();
         managed_and_excluded.append(&mut excluded_peers.to_vec());
 
-        // Get available dial candidates using SQL-based filtering
+        // Get available dial candidates
         let mut candidates = self
             .peer_manager
-            .get_available_dial_candidates(&managed_and_excluded, Some(count * 3)) // Get 3x more for health scoring
+            .get_available_dial_candidates(&managed_and_excluded, Some(count * 3), true, true) // Get 3x more for health scoring
             .await?;
         if candidates.len() < count * 3 {
             // Only exclude managed and current selected nodes to get more candidates (thus include 'excluded_peers')
             let mut to_be_excluded = candidates.iter().map(|p| p.node_id.clone()).collect::<Vec<_>>();
             to_be_excluded.append(&mut managed);
+            // Now also allow selection from previously failed peers
             let mut random = self
                 .peer_manager
-                .random_peers(count * 3 - candidates.len(), &to_be_excluded, None)
+                .get_available_dial_candidates(&to_be_excluded, Some(count * 3 - candidates.len()), false, true)
                 .await?;
             candidates.append(&mut random);
         }

--- a/comms/core/src/connectivity/proactive_dialer.rs
+++ b/comms/core/src/connectivity/proactive_dialer.rs
@@ -74,29 +74,24 @@ impl ProactiveDialer {
             return Ok(0);
         }
 
-        let eligible_connections = pool
-            .get_connected_node_ids()
-            .iter()
-            .filter(|p| !excluded_peers.contains(p))
-            .count();
+        let current_connections = pool.count_connected_nodes();
         let target = self.config.target_connection_count;
 
         // Update metrics
 
-        if eligible_connections >= target {
+        if current_connections >= target {
             debug!(
                 target: LOG_TARGET,
-                "({task_id}) Eligible connections ({eligible_connections}) meet or exceed target ({target}), no \
-                proactive dialing needed",
+                "({task_id}) Current connections ({current_connections}) meet or exceed target ({target}), no proactive dialing needed",
             );
 
             return Ok(0);
         }
 
-        let needed = target.saturating_sub(eligible_connections);
+        let needed = target.saturating_sub(current_connections);
         debug!(
             target: LOG_TARGET,
-            "({task_id}) Proactive dialing: need {needed} more connections ({eligible_connections}/{target})",
+            "({task_id}) Proactive dialing: need {needed} more connections ({current_connections}/{target})",
 
         );
 
@@ -110,20 +105,15 @@ impl ProactiveDialer {
 
         );
 
-        // Select healthy peers for dialing
-        let mut candidates = self
-            .select_healthy_dial_candidates(pool, connection_stats, excluded_peers, dial_count, task_id)
+        // Select peers for dialing
+        let candidates = self
+            .select_dial_candidates(pool, connection_stats, excluded_peers, dial_count, task_id)
             .await?;
-        if candidates.is_empty() {
-            candidates = self
-                .select_healthy_dial_candidates(pool, connection_stats, &[], dial_count, task_id)
-                .await?;
-        }
 
         if candidates.is_empty() {
             warn!(
                 target: LOG_TARGET,
-                "({task_id}) No healthy peer candidates available for proactive dialing"
+                "({task_id}) No peer candidates available for proactive dialing"
 
             );
 
@@ -178,8 +168,8 @@ impl ProactiveDialer {
         final_count.max(needed).min(MAX_CONCURRENT_DIALS)
     }
 
-    /// Select healthy peer candidates for dialing
-    async fn select_healthy_dial_candidates(
+    /// Select peer candidates for dialing, prioritizing the most healthy
+    async fn select_dial_candidates(
         &self,
         pool: &ConnectionPool,
         connection_stats: &std::collections::HashMap<NodeId, super::connection_stats::PeerConnectionStats>,
@@ -200,13 +190,24 @@ impl ProactiveDialer {
             .map(|state| state.node_id().clone())
             .collect();
         // Add nominated excluded peers to the managed list so they will not be selected as candidates
-        managed.append(&mut excluded_peers.to_vec());
+        let mut managed_and_excluded = managed.clone();
+        managed_and_excluded.append(&mut excluded_peers.to_vec());
 
         // Get available dial candidates using SQL-based filtering
-        let candidates = self
+        let mut candidates = self
             .peer_manager
-            .get_available_dial_candidates(&managed, Some(count * 3)) // Get 3x more for health scoring
+            .get_available_dial_candidates(&managed_and_excluded, Some(count * 3)) // Get 3x more for health scoring
             .await?;
+        if candidates.len() < count * 3 {
+            // Only exclude managed and current selected nodes to get more candidates (thus include 'excluded_peers')
+            let mut to_be_excluded = candidates.iter().map(|p| p.node_id.clone()).collect::<Vec<_>>();
+            to_be_excluded.append(&mut managed);
+            let mut random = self
+                .peer_manager
+                .random_peers(count * 3 - candidates.len(), &to_be_excluded, None)
+                .await?;
+            candidates.append(&mut random);
+        }
 
         // Apply health-based filtering and ranking
         let mut final_candidates = Vec::new();

--- a/comms/core/src/connectivity/proactive_dialer.rs
+++ b/comms/core/src/connectivity/proactive_dialer.rs
@@ -328,12 +328,12 @@ mod tests {
         // Low success rate should significantly increase dial count but be capped
         let result = calculate_dial_count(4, 0.1, 2.0);
         assert!(result >= 4); // At least the needed amount
-        assert!(result <= 20); // But capped at max concurrent
+        assert!(result <= MAX_CONCURRENT_DIALS); // But capped at max concurrent
 
         // Edge case: needed > MAX_CONCURRENT_DIALS to verify proper capping
-        assert_eq!(calculate_dial_count(25, 0.8, 1.5), 20); // Should cap at MAX_CONCURRENT_DIALS
-        assert_eq!(calculate_dial_count(25, 0.1, 2.0), 20); // Very low success rate, should still cap
-        assert_eq!(calculate_dial_count(15, 0.5, 3.0), 20); // Should still cap despite multiplier
+        assert_eq!(calculate_dial_count(25, 0.8, 1.5), MAX_CONCURRENT_DIALS); // Should cap at MAX_CONCURRENT_DIALS
+        assert_eq!(calculate_dial_count(25, 0.1, 2.0), MAX_CONCURRENT_DIALS); // Very low success rate, should still cap
+        assert_eq!(calculate_dial_count(15, 0.5, 3.0), MAX_CONCURRENT_DIALS); // Should still cap despite multiplier
     }
 
     #[test]

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -154,14 +154,21 @@ impl PeerManager {
     }
 
     /// Get available dial candidates that are communication nodes, not banned, not deleted, reachable
-    /// and not in the excluded node IDs list
+    /// optionally not failed, optionally at random, and not in the excluded node IDs list
     pub async fn get_available_dial_candidates(
         &self,
         exclude_node_ids: &[NodeId],
         limit: Option<usize>,
+        exclude_failed: bool,
+        randomize: bool,
     ) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql
-            .get_available_dial_candidates(exclude_node_ids, limit, &self.transport_protocols)
+        self.peer_storage_sql.get_available_dial_candidates(
+            exclude_node_ids,
+            limit,
+            &self.transport_protocols,
+            exclude_failed,
+            randomize,
+        )
     }
 
     /// Return "good" peers for syncing

--- a/comms/core/src/peer_manager/peer_storage_sql.rs
+++ b/comms/core/src/peer_manager/peer_storage_sql.rs
@@ -224,16 +224,22 @@ impl PeerStorageSql {
     }
 
     /// Get available dial candidates that are communication nodes, not banned, not deleted, reachable,
-    /// and not in the excluded node IDs list
+    /// optionally not failed, optionally at random, and not in the excluded node IDs list
     pub fn get_available_dial_candidates(
         &self,
         exclude_node_ids: &[NodeId],
         limit: Option<usize>,
         transport_protocols: &[TransportProtocol],
+        exclude_failed: bool,
+        randomize: bool,
     ) -> Result<Vec<Peer>, PeerManagerError> {
-        Ok(self
-            .peer_db
-            .get_available_dial_candidates(exclude_node_ids, limit, transport_protocols)?)
+        Ok(self.peer_db.get_available_dial_candidates(
+            exclude_node_ids,
+            limit,
+            transport_protocols,
+            exclude_failed,
+            randomize,
+        )?)
     }
 
     /// Compile a list of closest `n` active peers

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -1173,13 +1173,21 @@ impl PeerDatabaseSql {
     }
 
     /// Return available dial candidates that are communication nodes, not banned, not deleted,
-    /// not failed and not in the excluded node IDs list.
+    /// optionally not failed, optionally at random, and not in the excluded node IDs list.
     pub fn get_available_dial_candidates(
         &self,
         exclude_node_ids: &[NodeId],
-        limit: Option<usize>,
+        n: Option<usize>,
         transport_protocols: &[TransportProtocol],
+        exclude_failed: bool,
+        randomize: bool,
     ) -> Result<Vec<Peer>, StorageError> {
+        if let Some(n) = n {
+            if n == 0 {
+                warn!(target: LOG_TARGET, "'0' requested for 'get_available_dial_candidates'");
+                return Ok(Vec::new());
+            }
+        }
         let mut conn = self.connection.get_pooled_connection()?;
         let addr_filter_sql = Self::build_addr_filter_sql(transport_protocols);
 
@@ -1192,12 +1200,21 @@ impl PeerDatabaseSql {
                     .or(peers::banned_until.lt(chrono::Utc::now().naive_utc())),
             )
             .filter(peers::deleted_at.is_null())
-            .filter(multi_addresses::last_failed_reason.is_null())
             .filter(diesel::dsl::sql::<diesel::sql_types::Bool>(&format!(
                 "features & {} != 0",
                 PeerFeatures::COMMUNICATION_NODE.to_i32()
             )))
+            .select(peers::node_id)
+            .distinct()
             .into_boxed();
+
+        if exclude_failed {
+            query = query.filter(multi_addresses::last_failed_reason.is_null());
+        }
+
+        if randomize {
+            query = query.order_by(diesel::dsl::sql::<diesel::sql_types::Integer>("RANDOM()"));
+        }
 
         if let Some(filter_sql) = addr_filter_sql {
             query = query.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(&filter_sql));
@@ -1210,14 +1227,19 @@ impl PeerDatabaseSql {
         }
 
         // Apply limit if specified
-        if let Some(limit) = limit {
+        if let Some(limit) = n {
             // Safely convert usize to i64, using try_into with fallback to i64::MAX
             let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
             query = query.limit(limit_i64);
         }
 
-        let results = query.load::<(NewPeerSql, NewMultiaddrWithStatsSql)>(&mut conn)?;
-        PeerDatabaseSql::peers_from_join_query(results)
+        let node_ids = query.load::<String>(&mut conn)?;
+
+        if node_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        self.get_peers_by_node_ids_str(&node_ids, false, &mut conn)
     }
 
     /// Get a peer by its node ID
@@ -1417,6 +1439,7 @@ impl PeerDatabaseSql {
         features: PeerFeatures,
     ) -> Result<Vec<NodeId>, StorageError> {
         if n == 0 {
+            warn!(target: LOG_TARGET, "'0' requested for 'get_closest_n_good_standing_peer_node_ids'");
             return Ok(Vec::new());
         }
 
@@ -1433,6 +1456,10 @@ impl PeerDatabaseSql {
         n: usize,
         features: PeerFeatures,
     ) -> Result<Vec<Peer>, StorageError> {
+        if n == 0 {
+            warn!(target: LOG_TARGET, "'0' requested for 'get_closest_n_good_standing_peers'");
+            return Ok(Vec::new());
+        }
         let mut conn = self.connection.get_pooled_connection()?;
 
         conn.transaction::<_, StorageError, _>(|conn| {
@@ -1465,6 +1492,12 @@ impl PeerDatabaseSql {
         conn: &mut PooledConnection<ConnectionManager<SqliteConnection>>,
         transport_protocols: &[TransportProtocol],
     ) -> Result<Vec<String>, StorageError> {
+        if let Some(n) = n {
+            if n == 0 {
+                warn!(target: LOG_TARGET, "'0' requested for 'get_active_peer_node_ids'");
+                return Ok(Vec::new());
+            }
+        }
         let excluded_node_ids_hex = excluded_peers.iter().map(|id| id.to_hex()).collect::<Vec<_>>();
         let addr_filter_sql = Self::build_addr_filter_sql(transport_protocols);
 
@@ -1557,6 +1590,7 @@ impl PeerDatabaseSql {
         transport_protocols: &[TransportProtocol],
     ) -> Result<Vec<Peer>, StorageError> {
         if n == 0 {
+            warn!(target: LOG_TARGET, "'0' requested for 'get_closest_n_active_peers'");
             return Ok(Vec::new());
         }
 
@@ -1613,6 +1647,7 @@ impl PeerDatabaseSql {
         transport_protocols: &[TransportProtocol],
     ) -> Result<Vec<Peer>, StorageError> {
         if n == 0 {
+            warn!(target: LOG_TARGET, "'0' requested for 'get_n_random_active_peers'");
             return Ok(Vec::new());
         }
 
@@ -1647,6 +1682,7 @@ impl PeerDatabaseSql {
         transport_protocols: &[TransportProtocol],
     ) -> Result<Vec<Peer>, StorageError> {
         if n == 0 {
+            warn!(target: LOG_TARGET, "'0' requested for 'get_n_random_peers'");
             return Ok(Vec::new());
         }
 
@@ -3195,5 +3231,120 @@ mod tests {
             .load::<NewMultiaddrWithStatsSql>(&mut conn)
             .unwrap();
         assert!(addresses_query.is_empty());
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_get_available_dial_candidates() {
+        let db_connection = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
+        let peers_db = PeerDatabaseSql::new(
+            db_connection,
+            &create_test_peer(false, PeerFeatures::COMMUNICATION_NODE),
+        )
+        .unwrap();
+        let transport_protocols = TransportProtocol::get_all();
+
+        // Create new node peers each with one known good address
+        let mut node_peers = Vec::with_capacity(100);
+        for i in 0..100 {
+            let mut peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+            if i % 4 == 0 {
+                peer.flags = PeerFlags::SEED;
+            }
+            node_peers.push(peer.clone());
+            peers_db.add_or_update_peer(peer).unwrap();
+        }
+
+        // Set 'deleted_at' [1]
+        peers_db.soft_delete_peer(&node_peers[1].node_id).unwrap();
+
+        // Set 'banned_until' [5]
+        peers_db
+            .set_banned(
+                &node_peers[5].node_id,
+                Duration::from_secs(12345),
+                "Misbehaviour is punished".to_string(),
+            )
+            .unwrap();
+
+        // Set 'last_failed_reason' [7]
+        for address in node_peers[7].addresses.addresses() {
+            peers_db
+                .set_last_failed_reason(
+                    &node_peers[7].node_id,
+                    "not playing with".to_string(),
+                    address.address(),
+                )
+                .unwrap();
+        }
+
+        // Pre-amble
+        let all_peers = peers_db.get_all_peers(None).unwrap();
+        assert_eq!(all_peers.len(), 100);
+        let seed_peers = peers_db
+            .get_seed_peers()
+            .unwrap()
+            .iter()
+            .map(|p| p.node_id.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(seed_peers.len(), 25);
+
+        // Test case 1: Only non-failed peers, no exclusions
+        let dial_candidates = peers_db
+            .get_available_dial_candidates(&[], None, &transport_protocols, true, false)
+            .unwrap();
+        assert_eq!(dial_candidates.len(), 97);
+        // Verify deleted, banned and failed are not returned
+        assert!(!dial_candidates.iter().any(|n| n.node_id == node_peers[1].node_id ||
+            n.node_id == node_peers[5].node_id ||
+            n.node_id == node_peers[7].node_id));
+
+        // Test case 2: Only non-failed peers, with exclusions
+        let dial_candidates = peers_db
+            .get_available_dial_candidates(&seed_peers, None, &transport_protocols, true, false)
+            .unwrap();
+        assert_eq!(dial_candidates.len(), 72);
+        // Verify deleted, banned and failed are not returned
+        assert!(!dial_candidates.iter().any(|n| n.node_id == node_peers[1].node_id ||
+            n.node_id == node_peers[5].node_id ||
+            n.node_id == node_peers[7].node_id));
+        // Verify excluded are not returned
+        for seed_node_id in &seed_peers {
+            assert!(!dial_candidates.iter().any(|n| n.node_id == *seed_node_id));
+        }
+
+        // Test case 3: Verify randomness
+        let limit = 17;
+        let mut dial_candidates_1 = peers_db
+            .get_available_dial_candidates(&[], Some(limit), &transport_protocols, true, false)
+            .unwrap()
+            .iter()
+            .map(|p| p.node_id.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(dial_candidates_1.len(), limit);
+        dial_candidates_1.sort();
+
+        let mut dial_candidates_2 = peers_db
+            .get_available_dial_candidates(&[], Some(limit), &transport_protocols, true, false)
+            .unwrap()
+            .iter()
+            .map(|p| p.node_id.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(dial_candidates_2.len(), limit);
+        dial_candidates_2.sort();
+
+        let mut dial_candidates_3 = peers_db
+            .get_available_dial_candidates(&[], Some(limit), &transport_protocols, true, true)
+            .unwrap()
+            .iter()
+            .map(|p| p.node_id.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(dial_candidates_3.len(), limit);
+        dial_candidates_3.sort();
+
+        // - With no randomness, results should be the same
+        assert_eq!(dial_candidates_1, dial_candidates_2);
+        // - With randomness, results should differ
+        assert_ne!(dial_candidates_1, dial_candidates_3);
     }
 }

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -1146,7 +1146,7 @@ impl PeerDatabaseSql {
     }
 
     /// Return available dial candidates that are communication nodes, not banned, not deleted,
-    /// and not in the excluded node IDs list
+    /// not failed and not in the excluded node IDs list.
     pub fn get_available_dial_candidates(
         &self,
         exclude_node_ids: &[NodeId],
@@ -1165,6 +1165,7 @@ impl PeerDatabaseSql {
                     .or(peers::banned_until.lt(chrono::Utc::now().naive_utc())),
             )
             .filter(peers::deleted_at.is_null())
+            .filter(multi_addresses::last_failed_reason.is_null())
             .filter(diesel::dsl::sql::<diesel::sql_types::Bool>(&format!(
                 "features & {} != 0",
                 PeerFeatures::COMMUNICATION_NODE.to_i32()

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -1239,6 +1239,9 @@ impl PeerDatabaseSql {
             return Ok(Vec::new());
         }
 
+        // A peer can have more than one valid address, so that if the join-limit-load query is not returning node IDs,
+        // it will give the requested number of unique peer-adress combinations, which will result in less peer records
+        // than what was required. For that reason, we need a 2nd query to fetch the peers by node IDs.
         self.get_peers_by_node_ids_str(&node_ids, false, &mut conn)
     }
 


### PR DESCRIPTION
Description
---
Fixed the proactive dialler in that it never selected new peers to dial, improved the initial peer selection logic and increased the MAX_CONCURRENT_DIALS to enable covering the peer database quicker to find connections.

Fixed a bug in `PeerDatabaseSql::get_available_dial_candidates`, whereby it sometimes returned less than the requested number of peers.

Fixes #7510.

Motivation and Context
---
The proactive dialler did not select new peers to dial if it could not find any connections; it always selected the same peers.
To test, re-start a base node, but delete its peer_db so it has to create it from scratch, then when it connects to the seed peers, wait till the seed strap completes, then ban all the seed peers. Monitor active connections in the base node console and all "proactive" entries in the network log file. 

How Has This Been Tested?
---
System-level testing.

What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Performance Improvements
  - Increased parallel proactive-dial cap to 30 for faster connection attempts.

- Bug Fixes
  - Dialing now respects "exclude failed" and returns early with a clear warning when no candidates.
  - Candidate selection refined to avoid repeated failed dials and improve health-aware ranking.

- Enhancements
  - Candidate pool can be augmented via optional randomized selection when insufficient.

- Tests
  - Unit tests updated to cover new limits, exclusion, and randomization behaviors.

- Chores
  - Updated warning and log messages to reflect the new selection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->