### PR TITLE
chore(ci): bump macos intel runner for bin builds due to github runner retirement

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -30,7 +30,7 @@
   },
   {
     "name": "macos-x86_64",
-    "runs-on": "macos-13",
+    "runs-on": "macos-15-intel",
     "rust": "stable",
     "target": "x86_64-apple-darwin",
     "cross": false


### PR DESCRIPTION
Description
bump macos intel runner for bin builds due to github runner retirement

Motivation and Context
keep macos-intel building without interruptions as github retire older runners

How Has This Been Tested?
builds in branch, but did fail in local fork. Might have been a point in time problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new calculation option available wherever calculations are used.

* **Refactor**
  * Updated an existing calculation to require an additional parameter; update any integrations accordingly.
  * Renamed a related global setting for clarity.

* **Chores**
  * Updated macOS build environment to use macOS 15 (Intel) for macOS binary builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->