### PR TITLE
chore(docs): add some badges for ci and builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<!-- CI / Build Status -->
+[![CI](../../actions/workflows/ci.yml/badge.svg?branch=development)](../../actions/workflows/ci.yml)
+[![Integration Tests](../../actions/workflows/integration_tests.yml/badge.svg?branch=development)](../../actions/workflows/integration_tests.yml)
+[![Docker Build](../../actions/workflows/build_dockers.yml/badge.svg?branch=development)](../../actions/workflows/build_dockers.yml)
+[![Binary Build](../../actions/workflows/build_binaries.yml/badge.svg?branch=development)](../../actions/workflows/build_binaries.yml)
+
+<!-- Release & License -->
+[![Release](https://img.shields.io/github/v/release/tari-project/tari?sort=semver)](https://github.com/tari-project/tari/releases)
+[![License](https://img.shields.io/github/license/tari-project/tari)](https://github.com/tari-project/tari/blob/development/LICENSE)
+
 [![Coverage Status](https://coveralls.io/repos/github/tari-project/tari/badge.svg?branch=development)](https://coveralls.io/github/tari-project/tari?branch=development)
 
 # The Tari protocol


### PR DESCRIPTION
Description
add a few badges to the ReadMe file for ci and builds

Motivation and Context
make it easier for readers to see that ci and builds are passing

How Has This Been Tested?
Reflects in my fork with workflows that have run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added CI status, release, and license badges to the README header for immediate visibility into build health, versioning, and licensing.
  * Enhances project discoverability and credibility on the repository homepage, helping users and contributors assess project status at a glance.
  * No changes to runtime behavior, APIs, or dependencies; purely content updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->