### PR TITLE
chore: add more crates to workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -1814,6 +1823,18 @@ name = "derive_more-impl"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2882,7 +2903,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-platform-verifier",
- "thiserror 2.0.6",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -2907,7 +2928,7 @@ dependencies = [
  "resolv-conf",
  "rustls",
  "smallvec",
- "thiserror 2.0.6",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -3078,7 +3099,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3182,7 +3203,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -3516,12 +3537,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -3775,24 +3807,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ledger-transport"
-version = "0.11.0"
-source = "git+https://github.com/Zondax/ledger-rs?rev=4ed4cfdef0ae8b40e8997d849a3262bcf00c7d3c#4ed4cfdef0ae8b40e8997d849a3262bcf00c7d3c"
-dependencies = [
- "async-trait",
- "ledger-apdu",
-]
-
-[[package]]
 name = "ledger-transport-hid"
 version = "0.11.0"
-source = "git+https://github.com/Zondax/ledger-rs?rev=4ed4cfdef0ae8b40e8997d849a3262bcf00c7d3c#4ed4cfdef0ae8b40e8997d849a3262bcf00c7d3c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e34341e2708fbf805a9ada44ef6182170c6464c4fc068ab801abb7562fd5e8"
 dependencies = [
  "byteorder",
  "cfg-if",
  "hex",
  "hidapi",
- "ledger-transport 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ledger-transport",
  "libc",
  "log",
  "thiserror 1.0.69",
@@ -3963,7 +3987,7 @@ checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
 dependencies = [
  "libc",
  "neli",
- "thiserror 2.0.6",
+ "thiserror 2.0.17",
  "windows-sys 0.59.0",
 ]
 
@@ -3994,29 +4018,30 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
+checksum = "3e947bb896e702c711fccc2bf02ab2abb6072910693818d1d6b07ee2b9dfd86c"
 dependencies = [
  "anyhow",
  "arc-swap",
  "chrono",
- "derivative",
+ "derive_more 2.0.1",
  "fnv",
  "humantime 2.1.0",
  "libc",
  "log",
  "log-mdc",
- "once_cell",
+ "mock_instant",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde",
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "thread-id",
  "typemap-ors",
+ "unicode-segmentation",
  "winapi",
 ]
 
@@ -4192,7 +4217,7 @@ dependencies = [
  "tari_sidechain",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tonic 0.13.1",
  "tonic-build",
@@ -4217,7 +4242,7 @@ dependencies = [
  "tari_features",
  "tari_p2p",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tonic 0.13.1",
 ]
@@ -4267,7 +4292,7 @@ dependencies = [
  "tari_shutdown",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tonic 0.13.1",
  "tui",
@@ -4289,7 +4314,7 @@ version = "5.1.0-rc.1"
 dependencies = [
  "borsh",
  "dialoguer 0.11.0",
- "ledger-transport 0.11.0 (git+https://github.com/Zondax/ledger-rs?rev=4ed4cfdef0ae8b40e8997d849a3262bcf00c7d3c)",
+ "ledger-transport",
  "ledger-transport-hid",
  "log",
  "minotari_ledger_wallet_common",
@@ -4301,7 +4326,7 @@ dependencies = [
  "tari_crypto",
  "tari_script",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4343,7 +4368,7 @@ dependencies = [
  "tari_node_components",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tonic 0.13.1",
  "tracing",
@@ -4383,7 +4408,7 @@ dependencies = [
  "tari_transaction_components",
  "tari_transaction_key_manager",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tonic 0.13.1",
 ]
@@ -4434,7 +4459,7 @@ dependencies = [
  "tari_transaction_components",
  "tari_utilities",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "toml 0.5.11",
  "tonic 0.13.1",
@@ -4537,7 +4562,7 @@ dependencies = [
  "tari_transaction_key_manager",
  "tari_utilities",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tower 0.4.13",
  "url",
@@ -4580,7 +4605,7 @@ dependencies = [
  "tari_transaction_key_manager",
  "tari_utilities",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "zeroize",
 ]
@@ -4592,7 +4617,7 @@ dependencies = [
  "minotari_app_grpc",
  "tari_common",
  "tari_common_types",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tonic 0.13.1",
 ]
@@ -4632,6 +4657,12 @@ name = "mirai-annotations"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
+name = "mock_instant"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "moka"
@@ -5325,7 +5356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.6",
+ "thiserror 2.0.17",
  "ucd-trie",
 ]
 
@@ -5823,7 +5854,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.3",
  "protobuf",
- "thiserror 2.0.6",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7165,6 +7196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7532,7 +7573,7 @@ dependencies = [
  "tari_features",
  "tari_test_utils",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "toml 0.5.11",
 ]
 
@@ -7549,7 +7590,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
@@ -7585,7 +7626,7 @@ dependencies = [
  "tari_hashing",
  "tari_max_size",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "utoipa",
  "wasm-bindgen",
  "zeroize",
@@ -7632,7 +7673,7 @@ dependencies = [
  "tari_test_utils",
  "tari_utilities",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -7678,7 +7719,7 @@ dependencies = [
  "tari_test_utils",
  "tari_utilities",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -7763,7 +7804,7 @@ dependencies = [
  "tari_transaction_key_manager",
  "tari_utilities",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "url",
@@ -7847,7 +7888,7 @@ dependencies = [
  "tari_transaction_key_manager",
  "tari_utilities",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "time",
  "tokio",
  "tonic 0.13.1",
@@ -7863,7 +7904,7 @@ dependencies = [
  "serde",
  "tari_crypto",
  "tari_hashing",
- "thiserror 2.0.6",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7886,7 +7927,7 @@ dependencies = [
  "borsh",
  "serde",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7899,7 +7940,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "reqwest 0.11.27",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "warp",
 ]
@@ -7919,7 +7960,7 @@ dependencies = [
  "serde_json",
  "tari_crypto",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7938,7 +7979,7 @@ dependencies = [
  "tari_hashing",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "wasm-bindgen",
 ]
 
@@ -7968,7 +8009,7 @@ dependencies = [
  "tari_test_utils",
  "tari_utilities",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "toml 0.5.11",
@@ -7990,7 +8031,7 @@ dependencies = [
  "tari_crypto",
  "tari_max_size",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -8004,7 +8045,7 @@ dependencies = [
  "log",
  "tari_shutdown",
  "tari_test_utils",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tower 0.4.13",
  "tower-service",
@@ -8032,7 +8073,7 @@ dependencies = [
  "tari_hashing",
  "tari_jellyfish",
  "tari_utilities",
- "thiserror 2.0.6",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -8045,7 +8086,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -8105,7 +8146,7 @@ dependencies = [
  "tari_sidechain",
  "tari_test_utils",
  "tari_utilities",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "toml 0.5.11",
  "utoipa",
@@ -8227,11 +8268,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -8247,9 +8288,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8284,12 +8325,12 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread-id"
-version = "4.2.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+checksum = "99043e46c5a15af379c06add30d9c93a6c0e8849de00d244c4a2c417da128d80"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8379,20 +8420,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes 1.9.0",
+ "io-uring",
  "libc",
  "mio 1.0.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8530,7 +8573,7 @@ dependencies = [
  "percent-encoding",
  "pin-project 1.1.7",
  "prost 0.13.4",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -8560,7 +8603,7 @@ dependencies = [
  "pin-project 1.1.7",
  "prost 0.13.4",
  "rustls-native-certs",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ resolver = "2"
 
 
 [workspace.dependencies]
-anyhow = { version = "1.0" }
 tari_jellyfish = { path = "infrastructure/jellyfish" }
 tari_common = { path = "common" }
 tari_common_sqlite = { path = "common_sqlite" }
@@ -59,7 +58,6 @@ tari_comms = { path = "comms/core" }
 tari_comms_dht = { path = "comms/dht", default-features = false }
 tari_comms_rpc_macros = { path = "comms/rpc_macros" }
 tari_core = { path = "base_layer/core", default-features = false }
-tari_crypto = { version = "0.22.1" }
 tari_features = { path = "common/tari_features" }
 tari_hashing = { path = "hashing" }
 tari_libtor = { path = "infrastructure/libtor" }
@@ -76,7 +74,6 @@ tari_storage = { path = "infrastructure/storage" }
 tari_transaction_components = { path = "base_layer/transaction_components" }
 tari_transaction_key_manager = { path = "base_layer/transaction_key_manager" }
 tari_test_utils = { path = "infrastructure/test_utils" }
-tari_utilities = { version = "0.8" }
 minotari_app_grpc = { path = "applications/minotari_app_grpc" }
 minotari_app_utilities = { path = "applications/minotari_app_utilities" }
 minotari_wallet = { path = "base_layer/wallet" }
@@ -90,9 +87,20 @@ minotari_wallet_ffi = { path = "base_layer/wallet_ffi" }
 minotari_wallet_grpc_client = { path = "clients/rust/wallet_grpc_client" }
 minotari_ledger_wallet_comms = { path = "applications/minotari_ledger_wallet/comms" }
 minotari_ledger_wallet_common = { path = "applications/minotari_ledger_wallet/common" }
-serde_json = "1.0.39"
-serde = "1.0.119"
 minotari_mcp_common = { path = "applications/minotari_mcp_common" }
+
+tari_utilities = { version = "0.8" }
+tari_crypto = { version = "0.22.1" }
+
+anyhow = { version = "1.0" }
+serde_json = "1"
+serde = "1"
+rand = { version = "0.8" }
+thiserror = { version = "2" }
+borsh = { version = "1.5.7" }
+tokio = { version = "1.47" }
+log = { version = "0.4" }
+log4rs = { version = "1.4", default-features = false}
 
 [profile.release]
 # By default, Rust will wrap an integer in release mode instead of throwing the overflow error

--- a/applications/minotari_app_grpc/Cargo.toml
+++ b/applications/minotari_app_grpc/Cargo.toml
@@ -27,14 +27,14 @@ tari_transaction_components = { workspace = true }
 
 argon2 = { version = "0.4.1", features = ["std", "password-hash"] }
 base64 = "0.13.0"
-borsh = "1.5.7"
-log = "0.4"
+borsh = { workspace = true }
+log = { workspace = true }
 prost = "0.13.3"
-rand = "0.8"
+rand = { workspace = true }
 rcgen = "0.12.1"
 subtle = "2.5.0"
-thiserror = "1"
-tokio = { version = "1.44", features = ["fs"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 tonic = { version = "0.13.1", features = ["tls-ring"] }
 zeroize = "1"
 

--- a/applications/minotari_app_utilities/Cargo.toml
+++ b/applications/minotari_app_utilities/Cargo.toml
@@ -19,11 +19,11 @@ futures = { version = "^0.3.16", default-features = false, features = [
     "alloc",
 ] }
 json5 = "0.4"
-log = { version = "0.4.8", features = ["std"] }
-rand = "0.8"
-tokio = { version = "1.44", features = ["signal"] }
-serde = "1.0.126"
-thiserror = "^1.0.26"
+log = { workspace = true, features = ["std"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
+serde = { workspace = true }
+thiserror = { workspace = true }
 dialoguer = { version = "0.10" }
 tonic = "0.13.1"
 tari_p2p.workspace = true

--- a/applications/minotari_app_utilities/Cargo.toml
+++ b/applications/minotari_app_utilities/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "minotari_app_utilities"
+description = "Utilities for Minotari applications"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -28,9 +28,9 @@ tari_hashing = { workspace = true }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
 console-subscriber = "0.4"
-#tokio = { version = "1.36", features = ["signal", "tracing"] }
+#tokio = { workspace = true, features = ["signal", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.44", features = ["signal"] }
+tokio = { workspace = true, features = ["signal"] }
 
 blake2 = "0.10"
 chrono = { version = "0.4", default-features = false }
@@ -44,8 +44,8 @@ dirs-next = "2.0"
 futures = { version = "^0.3.16", default-features = false, features = [
     "alloc",
 ] }
-log = { version = "0.4.8", features = ["std"] }
-log4rs = { version = "1.3.0", default-features = false, features = [
+log = { workspace = true, features = ["std"] }
+log4rs = { workspace = true, default-features = false, features = [
     "config_parsing",
     "threshold_filter",
     "yaml_format",
@@ -57,16 +57,16 @@ log4rs = { version = "1.3.0", default-features = false, features = [
     "delete_roller",
 ] }
 qrcode = { version = "0.12" }
-rand = "0.8"
+rand = { workspace = true }
 regex = "1.5.4"
 reqwest = "0.11.18"
 rpassword = "5.0"
 rustyline = "9.0"
-serde = "1.0.136"
+serde = { workspace = true }
 serde_json = "1.0.79"
 sha2 = "0.10"
 strum = "0.22"
-thiserror = "1.0.26"
+thiserror = { workspace = true }
 tonic = "0.13.1"
 unicode-width = "0.1"
 url = "2.3.1"

--- a/applications/minotari_ledger_wallet/comms/Cargo.toml
+++ b/applications/minotari_ledger_wallet/comms/Cargo.toml
@@ -7,19 +7,19 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-tari_utilities = { version = "0.8" }
-tari_common = { path = "../../../common" }
-tari_common_types = { path = "../../../base_layer/common_types" }
-tari_script = { path = "../../../infrastructure/tari_script" }
-tari_crypto = { version = "0.22.1" }
+tari_utilities = { workspace = true }
+tari_common = { workspace = true }
+tari_common_types = { workspace = true }
+tari_script = { workspace = true }
+tari_crypto = { workspace = true }
 
-minotari_ledger_wallet_common = { path = "../common" }
+minotari_ledger_wallet_common = { workspace = true }
 semver = "1.0"
-borsh = "1.5.7"
+borsh = { workspace = true }
 dialoguer = { version = "0.11" }
-ledger-transport = { git = "https://github.com/Zondax/ledger-rs", rev = "4ed4cfdef0ae8b40e8997d849a3262bcf00c7d3c" }
-ledger-transport-hid = { git = "https://github.com/Zondax/ledger-rs", rev = "4ed4cfdef0ae8b40e8997d849a3262bcf00c7d3c" }
-log = "0.4.20"
-rand = "0.8"
-serde = { version = "1.0.106", features = ["derive"] }
-thiserror = "1.0.26"
+ledger-transport = { version = "0.11" }
+ledger-transport-hid = { version = "0.11" }
+log = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = {  workspace = true }

--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -11,7 +11,7 @@ minotari_ledger_wallet_common = { path = "../common" }
 tari_utilities = { version = "0.8", default-features = false }
 
 blake2 = { version = "0.10", default-features = false }
-borsh = { version = "1.5.7", default-features = false }
+borsh = { workspace = true, default-features = false }
 digest = { version = "0.10", default-features = false }
 include_gif = "1.2"
 ledger_device_sdk = "=1.25.0"

--- a/applications/minotari_ledger_wallet/wallet/Cargo.toml
+++ b/applications/minotari_ledger_wallet/wallet/Cargo.toml
@@ -11,7 +11,7 @@ minotari_ledger_wallet_common = { path = "../common" }
 tari_utilities = { version = "0.8", default-features = false }
 
 blake2 = { version = "0.10", default-features = false }
-borsh = { workspace = true, default-features = false }
+borsh = { version = "1.5.7", default-features = false }
 digest = { version = "0.10", default-features = false }
 include_gif = "1.2"
 ledger_device_sdk = "=1.25.0"

--- a/applications/minotari_mcp_common/Cargo.toml
+++ b/applications/minotari_mcp_common/Cargo.toml
@@ -8,12 +8,12 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tokio = { version = "1.44", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-anyhow = "1.0"
-thiserror = "1.0"
-log = "0.4"
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }
 async-trait = "0.1"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/applications/minotari_mcp_node/Cargo.toml
+++ b/applications/minotari_mcp_node/Cargo.toml
@@ -27,12 +27,12 @@ minotari_app_utilities = { workspace = true }
 minotari_app_grpc = { workspace = true }
 minotari_node_grpc_client = { workspace = true }
 tari_common = { workspace = true }
-tokio = { version = "1.44", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 clap = { version = "3.2", features = ["derive", "env"] }
-log = "0.4"
+log = { workspace = true }
 async-trait = "0.1"
 tonic = { version = "0.13.1", default-features = false, features = ["codegen", "transport", "tls-ring"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/applications/minotari_mcp_wallet/Cargo.toml
+++ b/applications/minotari_mcp_wallet/Cargo.toml
@@ -30,11 +30,11 @@ minotari_app_grpc = { workspace = true }
 minotari_wallet_grpc_client = { workspace = true }
 tari_common = { workspace = true }
 tari_utilities = { workspace = true }
-tokio = { version = "1.44", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = {  workspace = true  }
 clap = { version = "3.2", features = ["derive", "env"] }
-log = "0.4"
+log = { workspace = true }
 async-trait = "0.1"
 tonic = { version = "0.13.1", default-features = false, features = ["codegen", "transport", "tls-ring"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -33,7 +33,7 @@ tonic = { version = "0.13.1", features = ["tls-webpki-roots"] }
 tracing = "0.1"
 anyhow = "1.0.53"
 bincode = "1.3.1"
-borsh = "1.5.7"
+borsh = { workspace = true }
 bytes = "1.1"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }
@@ -44,17 +44,17 @@ futures = { version = "^0.3.16", features = ["async-await"] }
 hex = "0.4.2"
 hyper = { version = "0.14.12", features = ["default","server"] }
 jsonrpc = "0.12.0"
-log = { version = "0.4.8", features = ["std"] }
+log = { workspace = true, features = ["std"] }
 markup5ever = "0.12.1"
 monero = { version = "0.21.0", features = ["serde"] }
 reqwest = { version = "0.11.4", features = ["json"] }
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.57"
-thiserror = "1.0.26"
-tokio = { version = "1.44", features = ["macros"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 url = "2.1.1"
 scraper = "0.19.0"
-rand = "0.8"
+rand = { workspace = true }
 blake2 = "0.10"
 
 [build-dependencies]

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -23,7 +23,7 @@ minotari_app_grpc = { path = "../minotari_app_grpc" }
 tari_utilities = { version = "0.8" }
 
 base64 = "0.13.0"
-borsh = "1.5.7"
+borsh = { workspace = true }
 bufstream = "0.1"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3.2", features = ["derive"] }
@@ -32,8 +32,8 @@ crossterm = { version = "0.28" }
 derivative = "2.2.0"
 futures = "0.3"
 hex = "0.4.2"
-log = { version = "0.4", features = ["std"] }
-log4rs = { version = "1.3.0", default-features = false, features = [
+log = { workspace = true, features = ["std"] }
+log4rs = { workspace = true, default-features = false, features = [
     "config_parsing",
     "threshold_filter",
     "yaml_format",
@@ -45,11 +45,11 @@ log4rs = { version = "1.3.0", default-features = false, features = [
 ] }
 native-tls = "0.2"
 num_cpus = "1.13"
-rand = "0.8"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde_json = "1.0.57"
-thiserror = "1.0"
-tokio = { version = "1.44", default-features = false, features = [
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [
     "rt-multi-thread",
 ] }
 tonic = { version = "0.13.1", features = ["tls-ring", "tls-native-roots"] }

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -27,7 +27,7 @@ tari_utilities = { workspace = true }
 anyhow = "1.0.53"
 async-trait = "0.1.52"
 bincode = "1.3.1"
-borsh = "1.5.7"
+borsh = { workspace = true }
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }
 console-subscriber = "0.4"
@@ -47,8 +47,8 @@ futures = { version = "^0.3.16", default-features = false, features = [
     "alloc",
 ] }
 qrcode = { version = "0.12" }
-log = { version = "0.4.8", features = ["std"] }
-log4rs = { version = "1.3.0", default-features = false, features = [
+log = { workspace = true, features = ["std"] }
+log4rs = { workspace = true, default-features = false, features = [
     "config_parsing",
     "threshold_filter",
     "yaml_format",
@@ -61,11 +61,11 @@ log4rs = { version = "1.3.0", default-features = false, features = [
 nom = "7.1"
 rustyline = "9.0"
 rustyline-derive = "0.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 strum = { version = "0.22", features = ["derive"] }
-thiserror = "^1.0.26"
-tokio = { version = "1.44", features = ["signal"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
 tonic = { version = "0.13.1", features = ["tls-ring", "tls-native-roots"] }
 tari_metrics = { workspace = true, optional = true, features = ["server"] }
 url = { version = "2.5.4", features = ["default", "serde"] }

--- a/applications/minotari_utils/Cargo.toml
+++ b/applications/minotari_utils/Cargo.toml
@@ -18,7 +18,7 @@ lmdb-zero = "0.4.4"
 rusqlite = "0.32"
 
 clap = { version = "4.0", features = ["derive", "env"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 csv = "1.3"
 tabled = "0.15"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -28,18 +28,18 @@ base64 = "0.21.0"
 blake2 = "0.10"
 bitflags = { version = "2.4", features = ["serde"] }
 bs58 = "0.5.1"
-borsh = "1.5.7"
+borsh = { workspace = true }
 chacha20 = "0.7.1"
 chacha20poly1305 = "0.10.1"
 crc32fast = "1.2.1"
 digest = "0.10"
 newtype-ops = "0.1"
 once_cell = "1.8.0"
-rand = "0.8"
-serde = { version = "1.0.106", features = ["derive"] }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 strum = "0.22"
 strum_macros = "0.22"
-thiserror = "1.0.29"
+thiserror = { workspace = true }
 primitive-types = { version = "0.12", features = ["serde"] }
 utoipa = "5.3.1"
 wasm-bindgen = { version = "0.2.100", optional = true }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -39,11 +39,11 @@ tari_transaction_key_manager = { workspace = true }
 tari_test_utils = { workspace = true }
 tari_utilities = { workspace = true, features = ["borsh"] }
 
-anyhow = "1.0.53"
+anyhow = { workspace = true }
 async-trait = { version = "0.1.50" }
 bincode = "1.1.4"
 blake2 = "0.10"
-borsh = { version = "1.5.7", features = ["derive"] }
+borsh = { workspace = true, features = ["derive"] }
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 digest = "0.10"
@@ -55,14 +55,14 @@ hickory-proto = { version = "0.26.0-alpha.1" }
 integer-encoding = "3.0"
 jmt = { version = "0.11.0", features = ["mocks"] }
 lmdb-zero = "0.4.4"
-log = "0.4"
+log = { workspace = true }
 monero = { version = "0.21.0", features = ["serde-crate"] }
 once_cell = "1.8.0"
 prost = "0.13.3"
-rand = "0.8"
+rand = { workspace = true }
 randomx-rs = { version = "1.4" }
-serde = { version = "1.0.106", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 serde_valid = "1.0.5"
 sha3 = "0.10"
 sha2 = "0.10"
@@ -70,8 +70,8 @@ strum_macros = "0.22"
 tiny-keccak = { package = "tari-tiny-keccak", version = "2.0.2", features = [
     "keccak",
 ] }
-thiserror = "1.0.26"
-tokio = { version = "1.44", features = ["time", "sync", "macros", "net"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["time", "sync", "macros", "net"] }
 tracing = "0.1.26"
 primitive-types = { version = "0.12", features = ["serde"] }
 url = "2.5.4"

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -14,14 +14,14 @@ default = []
 [dependencies]
 tari_utilities = { workspace = true }
 tari_crypto = { workspace = true }
-thiserror = "1.0"
-borsh = "1.5.7"
+thiserror = { workspace = true }
+borsh = { workspace = true }
 digest = "0.10"
-log = "0.4"
-serde = { version = "1.0", features = ["derive"] }
+log = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-rand = "0.8"
+rand = { workspace = true }
 blake2 = "0.10"
 serde_json = "1.0"
 bincode = "1.1"

--- a/base_layer/node_components/Cargo.toml
+++ b/base_layer/node_components/Cargo.toml
@@ -19,13 +19,13 @@ tari_transaction_components = { workspace = true }
 tari_utilities = { workspace = true, features = ["borsh"] }
 
 blake2 = "0.10"
-borsh = { version = "1.5.7", features = ["derive"] }
+borsh = { workspace = true, features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 digest = "0.10"
-log = "0.4"
+log = { workspace = true }
 primitive-types = { version = "0.12", features = ["serde"] }
-serde = { version = "1.0.106", features = ["derive"] }
-thiserror = "1.0.26"
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
 wasm-bindgen = { version = "0.2.100", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -18,17 +18,17 @@ tari_service_framework = { workspace = true }
 tari_shutdown = { workspace = true }
 tari_utilities = { workspace = true }
 
-anyhow = "1.0.53"
+anyhow = { workspace = true }
 futures = { version = "^0.3.1" }
-log = "0.4.6"
+log = { workspace = true }
 pgp = { version = "0.14.2", optional = true }
 prost = "0.13.3"
-rand = "0.8"
+rand = { workspace = true }
 reqwest = { version = "0.11", optional = true, default-features = false }
 semver = { version = "1.0.1", optional = true }
-serde = "1.0.90"
-thiserror = "1.0.26"
-tokio = { version = "1.44", features = ["macros"] }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 tokio-stream = { version = "0.1.9", default-features = false, features = [
     "time",
 ] }

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -13,17 +13,17 @@ license.workspace = true
 [dependencies]
 tari_shutdown = { workspace = true }
 
-anyhow = "1.0.53"
+anyhow = { workspace = true }
 async-trait = "0.1.50"
 futures = { version = "^0.3.16", features = ["async-await"] }
-log = "0.4.8"
-thiserror = "1.0.26"
-tokio = { version = "1.44", features = ["rt", "sync"] }
+log = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
 tower-service = { version = "0.3" }
 
 [dev-dependencies]
 tari_test_utils = { workspace = true }
 
-tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 futures-test = { version = "0.3.3" }
 tower = "0.4"

--- a/base_layer/sidechain/Cargo.toml
+++ b/base_layer/sidechain/Cargo.toml
@@ -12,11 +12,11 @@ tari_utilities = { workspace = true }
 tari_common_types = { workspace = true }
 tari_jellyfish = { workspace = true }
 
-log = "0.4.22"
-thiserror = "2.0"
-borsh = "1.5"
+log = { workspace = true }
+thiserror = { workspace = true }
+borsh = { workspace = true }
 hex = "0.4.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.108"

--- a/base_layer/transaction_components/Cargo.toml
+++ b/base_layer/transaction_components/Cargo.toml
@@ -23,10 +23,10 @@ tari_script = { workspace = true }
 tari_service_framework = { workspace = true }
 tari_utilities = { workspace = true }
 
-anyhow = "1.0.53"
+anyhow = { workspace = true }
 async-trait = { version = "0.1.50" }
 bitflags = { version = "2.4", features = ["serde"] }
-borsh = { version = "1.5.7", features = ["derive"] }
+borsh = { workspace = true, features = ["derive"] }
 
 bytes = "0.5"
 chacha20poly1305 = "0.10.1"
@@ -43,18 +43,18 @@ num-traits = "0.2.15"
 num-derive = "0.4.2"
 
 primitive-types = { version = "0.12", features = ["serde"] }
-tokio = { version = "1.44", features = ["sync"] }
-log = "0.4"
-rand = "0.8"
+tokio = { workspace = true, features = ["sync"] }
+log = { workspace = true }
+rand = { workspace = true }
 serde_repr = "0.1.8"
 serde_valid = "1.0.5"
 strum = "0.22"
 strum_macros = "0.22"
 tari_crypto = { workspace = true, features = ["borsh"] }
 
-thiserror = "1.0.26"
-serde = { version = "1.0.106", features = ["derive"] }
-serde_json = "1.0.39"
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 blake2 = "0.10"
 semver = { version = "1.0", features = ["serde"] }
 uuid = "1.17.0"

--- a/base_layer/transaction_key_manager/Cargo.toml
+++ b/base_layer/transaction_key_manager/Cargo.toml
@@ -27,9 +27,9 @@ diesel = { version = "2.2.10", features = [
     "64-column-tables",
 ] }
 diesel_migrations = { version = "2.2" }
-log = "0.4"
-rand = "0.8"
-tokio = { version = "1.44", features = ["sync"] }
+log = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 zeroize = "1"
 
 [dev-dependencies]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -39,16 +39,16 @@ minotari_node_wallet_client = { workspace = true }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" features)
 #console-subscriber = "0.4"
-#tokio = { version = "1.36", features = ["sync", "macros", "tracing"] }
+#tokio = { workspace = true, features = ["sync", "macros", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.44", features = ["sync", "macros"] }
+tokio = { workspace = true, features = ["sync", "macros"] }
 
 anyhow = { workspace = true }
 async-trait = "0.1.50"
 argon2 = "0.4.1"
 bincode = "1.3.1"
 blake2 = "0.10"
-borsh = "1.5.7"
+borsh = { workspace = true }
 sha2 = "0.10"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
@@ -63,14 +63,14 @@ digest = "0.10"
 fs2 = "0.4.0"
 futures = { version = "^0.3.1", features = ["compat", "std"] }
 libsqlite3-sys = { version = "0.30.1", features = ["bundled"], optional = true }
-log = "0.4.6"
-rand = "0.8"
-serde = { version = "1.0.89", features = ["derive"] }
-serde_json = "1.0.39"
+log = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 strum = { version = "0.22", features = ["derive"] }
 strum_macros = "0.22"
 tempfile = "3.1.0"
-thiserror = "1.0.26"
+thiserror = { workspace = true }
 tower = "0.4"
 prost = "0.13.3"
 itertools = "0.10.3"

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -25,19 +25,20 @@ chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 futures = { version = "^0.3.1", features = ["compat", "std"] }
 libc = "0.2.65"
-log = "0.4.6"
-log4rs = { version = "1.3.0", features = [
+log = { workspace = true }
+log4rs = { workspace = true, features = [
+    "default",
     "console_appender",
     "file_appender",
     "yaml_format",
 ] }
-rand = "0.8"
-thiserror = "1.0.26"
-tokio = "1.44"
+rand = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 num-traits = "0.2.15"
 itertools = "0.10.3"
 zeroize = "1"
-serde_json = "1.0"
+serde_json = { workspace = true }
 
 [target.'cfg(target_os="android")'.dependencies]
 openssl = { version = "0.10.72", features = ["vendored"] }
@@ -52,7 +53,7 @@ tempfile = "3.1.0"
 tari_common_types = { workspace = true }
 tari_test_utils = { workspace = true }
 tari_service_framework = { workspace = true }
-borsh = "1.5.7"
+borsh = { workspace = true }
 env_logger = "0.7.1"
 
 [build-dependencies]

--- a/buildtools/deps_only/Cargo.toml
+++ b/buildtools/deps_only/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.14"
+log = { workspace = true }

--- a/clients/rust/base_node_grpc_client/Cargo.toml
+++ b/clients/rust/base_node_grpc_client/Cargo.toml
@@ -16,11 +16,11 @@ minotari_app_grpc = { workspace = true }
 #tonic = { version = "0.13.1", default-features = false, features = ["codegen", "transport", "prost"] }
 #prost = "0.11.0"
 #prost-types = "0.11.1"
-#thiserror = "1.0.35"
+#thiserror = { workspace = true }
 #url = "2.3"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 
 #[build-dependencies]
 #tonic-build = "0.13.1"

--- a/clients/rust/base_node_wallet_client/Cargo.toml
+++ b/clients/rust/base_node_wallet_client/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 url = { version = "2.5.4", features = ["default", "serde"] }
 reqwest = { version = "0.12.15", features = ["default", "json"] }
 async-trait = "0.1.88"
-tokio = { version = "1.45.1", features = ["sync"] }
-log = { version = "0.4.22", features = [] }
+tokio = { workspace = true, features = ["sync"] }
+log = { workspace = true, features = [] }
 serde_json = { workspace = true }
 serde = { workspace = true }

--- a/clients/rust/wallet_grpc_client/Cargo.toml
+++ b/clients/rust/wallet_grpc_client/Cargo.toml
@@ -11,12 +11,12 @@ readme = "README.md"
 license.workspace = true
 
 [dependencies]
-minotari_app_grpc = { path = "../../../applications/minotari_app_grpc" }
-tari_common_types = { path = "../../../base_layer/common_types" }
-tari_common = { path = "../../../common" }
+minotari_app_grpc = { workspace = true }
+tari_common_types = { workspace = true }
+tari_common = { workspace = true }
 
-thiserror = "1.0.35"
+thiserror = { workspace = true }
 tonic = { version = "0.13.1", default-features = false, features = ["codegen", "transport", "tls-ring"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,13 +16,13 @@ static-application-info = ["git2"]
 [dependencies]
 tari_features = { workspace = true }
 
-anyhow = "1.0.53"
+anyhow = { workspace = true }
 cargo_toml = { version = "0.20.4" }
 config = { version = "0.14.0", default-features = false, features = ["toml"] }
 dirs-next = "1.0.2"
 git2 = { version = "0.18", default-features = false, optional = true }
-log = "0.4.8"
-log4rs = { version = "1.3.0", default-features = false, features = [
+log = { workspace = true }
+log4rs = { workspace = true, default-features = false, features = [
     "config_parsing",
     "threshold_filter",
     "yaml_format",
@@ -30,13 +30,13 @@ log4rs = { version = "1.3.0", default-features = false, features = [
 multiaddr = { version = "0.14.0" }
 path-clean = "0.1.0"
 prost-build = { version = "0.11.9", optional = true }
-serde = { version = "1.0.106", default-features = false }
-serde_json = "1.0.51"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.9.17"
 sha2 = "0.10"
 structopt = { version = "0.3.13", default-features = false }
 tempfile = "3.1.0"
-thiserror = "1.0.29"
+thiserror = { workspace = true }
 toml = { version = "0.5", optional = true }
 
 [dev-dependencies]

--- a/common_sqlite/Cargo.toml
+++ b/common_sqlite/Cargo.toml
@@ -22,17 +22,17 @@ diesel = { version = "2.2.10", features = [
     "64-column-tables",
 ] }
 diesel_migrations = "2.2"
-log = "0.4.6"
-rand = "0.8"
-serde = "1.0.90"
-serde_json = "1.0.133"
-thiserror = "1.0.26"
-tokio = { version = "1.44", features = ["sync", "macros", "rt"] }
+log = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "rt"] }
 lazy_static = "1.5.0"
 libsqlite3-sys = { version = "0.30.1", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.44", features = ["sync", "macros", "rt", "time", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["sync", "macros", "rt", "time", "rt-multi-thread"] }
 
 [package.metadata.cargo-machete]
 ignored = ["libsqlite3-sys"]

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -17,7 +17,7 @@ tari_storage = { workspace = true }
 tari_shutdown = { workspace = true }
 tari_utilities = { workspace = true }
 
-anyhow = "1.0.53"
+anyhow = { workspace = true }
 async-trait = "0.1.36"
 bitflags = { version = "2.4", features = ["serde"] }
 blake2 = "0.10"
@@ -38,20 +38,20 @@ diesel = { version = "2.2.10", features = [
 diesel_migrations = "2.2.0"
 digest = "0.10"
 futures = { version = "^0.3", features = ["async-await"] }
-log = { version = "0.4.0", features = ["std"] }
+log = { workspace = true, features = ["std"] }
 multiaddr = { version = "0.14.0" }
 nom = { version = "7.1", features = ["std"], default-features = false }
 once_cell = "1.8.0"
 pin-project = "1.0.8"
 prost = "0.13.3"
-rand = "0.8"
-serde = "1.0.119"
-serde_json = "1.0.39"
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_derive = "1.0.119"
 sha3 = "0.10"
 snow = { version = "0.9.5", features = ["default-resolver"] }
-thiserror = "1.0.26"
-tokio = { version = "1.44", features = [
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [
     "rt-multi-thread",
     "time",
     "sync",

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -18,7 +18,7 @@ tari_crypto = { workspace = true }
 tari_utilities = { workspace = true }
 tari_shutdown = { workspace = true }
 
-anyhow = "1.0.53"
+anyhow = { workspace = true }
 bitflags = { version = "2.4", features = ["serde"] }
 blake2 = "0.10"
 chacha20 = "0.7.1"
@@ -34,19 +34,19 @@ diesel_migrations = "2.2.0"
 digest = "0.10"
 futures = "^0.3.1"
 futures-util = "^0.3.1"
-log = "0.4.8"
+log = { workspace = true }
 prost = "0.13.3"
-rand = "0.8"
-serde = "1.0.90"
-thiserror = "1.0.26"
+rand = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 tower = { version = "0.4", features = ["full"] }
 zeroize = "1"
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" features)
 #console-subscriber = "0.4"
-#tokio = { version = "1.36", features = ["rt", "macros", "tracing"] }
+#tokio = { workspace = true, features = ["rt", "macros", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
-tokio = { version = "1.44", features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 # tower-filter dependencies
 pin-project = "0.4"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -24,5 +24,5 @@ tari_test_utils = { path = "../../infrastructure/test_utils" }
 
 futures = "0.3.5"
 prost = "0.13.3"
-tokio = { version = "1", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 tower-service = "0.3"

--- a/hashing/Cargo.toml
+++ b/hashing/Cargo.toml
@@ -13,6 +13,6 @@ license.workspace = true
 
 [dependencies]
 tari_crypto = { workspace = true, features = ["borsh"] }
-borsh = { version = "1.5.7" }
+borsh = { workspace = true }
 digest = { version = "0.10" }
 blake2 = { version = "0.10", default-features = false }

--- a/infrastructure/jellyfish/Cargo.toml
+++ b/infrastructure/jellyfish/Cargo.toml
@@ -9,8 +9,8 @@ authors.workspace = true
 tari_hashing = { workspace = true }
 tari_crypto = { workspace = true }
 
-serde = { version = "1.0", features = ["derive"] }
-borsh = "1.5"
+serde = { workspace = true, features = ["derive"] }
+borsh = { workspace = true }
 digest = "0.10"
-thiserror = "2.0"
+thiserror = { workspace = true }
 indexmap = { version = "2.6", features = ["serde"] }

--- a/infrastructure/libtor/Cargo.toml
+++ b/infrastructure/libtor/Cargo.toml
@@ -12,8 +12,8 @@ tari_common = { workspace = true }
 tari_p2p = { workspace = true }
 
 derivative = "2.2.0"
-log = "0.4.8"
-rand = "0.8"
+log = { workspace = true }
+rand = { workspace = true }
 tor-hash-passwd = "1.0.1"
 
 [target.'cfg(unix)'.dependencies]

--- a/infrastructure/max_size/Cargo.toml
+++ b/infrastructure/max_size/Cargo.toml
@@ -13,6 +13,6 @@ license.workspace = true
 [dependencies]
 tari_utilities = { workspace = true }
 
-borsh = "1.5.7"
-serde = { version = "1.0.136", features = ["derive"] }
-thiserror = "1.0.30"
+borsh = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }

--- a/infrastructure/metrics/Cargo.toml
+++ b/infrastructure/metrics/Cargo.toml
@@ -10,19 +10,19 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-log = { version = "0.4.14", optional = true }
+log = { workspace = true, optional = true }
 once_cell = "1.8.0"
 prometheus = "0.14.0"
 
 futures = { version = "0.3.15", default-features = false, optional = true }
 reqwest = { version = "0.11.4", default-features = false, optional = true }
-tokio = { version = "1", optional = true, features = [
+tokio = { workspace = true, optional = true, features = [
     "time",
     "rt-multi-thread",
 ] }
 warp = { version = "0.3.1", optional = true, default-features = false }
-thiserror = "1.0.25"
-anyhow = { version = "1.0.53", optional = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true, optional = true }
 
 [features]
 pull = ["warp"]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -13,4 +13,4 @@ license.workspace = true
 futures = "^0.3"
 
 [dev-dependencies]
-tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -11,11 +11,11 @@ license.workspace = true
 
 [dependencies]
 bincode = "1.1"
-log = "0.4.0"
+log = { workspace = true }
 lmdb-zero = "0.4.4"
-thiserror = "1.0.26"
-serde = { version = "1.0.80", features = ["derive"] }
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-rand = "0.8"
+rand = { workspace = true }
 tari_utilities = { workspace = true, features = ["borsh"] }

--- a/infrastructure/tari_script/Cargo.toml
+++ b/infrastructure/tari_script/Cargo.toml
@@ -16,13 +16,13 @@ tari_max_size = { workspace = true }
 tari_utilities = { workspace = true }
 
 blake2 = "0.10"
-borsh = "1.5.7"
+borsh = { workspace = true }
 digest = "0.10"
 integer-encoding = "3.0.2"
-serde = "1.0.136"
+serde = { workspace = true }
 sha2 = "0.10"
 sha3 = "0.10"
-thiserror = "1.0.30"
+thiserror = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8"
+rand = { workspace = true }

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -13,8 +13,8 @@ tari_shutdown = { workspace = true }
 tari_comms = { workspace = true }
 
 futures = { version = "^0.3.1" }
-rand = "0.8"
-tokio = { version = "1.44", features = ["rt-multi-thread", "time", "sync"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "time", "sync"] }
 tempfile = "3.1.0"
 
 [dev-dependencies]

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -37,7 +37,7 @@ minotari_wallet = { path = "../base_layer/wallet" }
 minotari_wallet_ffi = { path = "../base_layer/wallet_ffi" }
 minotari_wallet_grpc_client = { path = "../clients/rust/wallet_grpc_client" }
 
-anyhow = "1.0.53"
+anyhow = { workspace = true }
 async-trait = "0.1.50"
 chrono = { version = "0.4", default-features = false }
 csv = "1.1"
@@ -49,14 +49,14 @@ cucumber = { version = "0.21.1", features = [
 futures = { version = "^0.3.1" }
 indexmap = "1.9.1"
 libc = "0.2.65"
-log = { version = "0.4.8", features = ["std"] }
-rand = "0.8"
+log = { workspace = true, features = ["std"] }
+rand = { workspace = true }
 reqwest = "0.11.11"
-serde_json = "1.0.64"
+serde_json = { workspace = true }
 tempfile = "3.3.0"
-thiserror = "^1.0.20"
+thiserror = { workspace = true }
 time = "0.3.36"
-tokio = { version = "1.44", features = [
+tokio = { workspace = true, features = [
     "macros",
     "time",
     "sync",


### PR DESCRIPTION
Description
---
add the common most used crates to workspaces to be better managed 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized dependencies across the workspace for core libraries (tokio, serde, serde_json, log, log4rs, rand, borsh, thiserror, anyhow), replacing per-crate version pins.
  - Unified feature flags (e.g., logging and async runtime) to ensure consistent behavior across apps and services.
  - Updated multiple application and infrastructure crates to use workspace-managed dependencies.

- Documentation
  - Added package description to Minotari App Utilities.

Impact: More consistent builds, easier updates, and improved reliability across the suite. No functional/API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->