### PR TITLE
chore(ci): remove bitnami docker images for debian slim images and minor updates

### DIFF
--- a/buildtools/docker_rig/monerod.Dockerfile
+++ b/buildtools/docker_rig/monerod.Dockerfile
@@ -10,11 +10,11 @@
 # https://github.com/monero-project/monero/releases
 ARG MONERO_VERSION=0.18.3.4
 
-# https://hub.docker.com/r/bitnami/minideb
+# https://hub.docker.com/_/debian
 ARG OS_BASE=bookworm
 
 # Declare stage using linux/amd64 base image
-FROM --platform=linux/amd64 bitnami/minideb:${OS_BASE} AS build-stage-amd64
+FROM --platform=linux/amd64 debian:${OS_BASE}-slim AS build-stage-amd64
 
 # Platform Args
 ARG MONERO_ARCH=x64
@@ -26,7 +26,7 @@ ARG MONERO_AMD64_SHA256=51ba03928d189c1c11b5379cab17dd9ae8d2230056dc05c872d0f8db
 ARG MONERO_VERSION
 
 # Declare stage using linux/arm64 base image
-FROM --platform=linux/arm64 bitnami/minideb:${OS_BASE} AS build-stage-arm64
+FROM --platform=linux/arm64 debian:${OS_BASE}-slim AS build-stage-arm64
 
 # Platform Args
 ARG MONERO_ARCH=armv8
@@ -69,7 +69,7 @@ RUN curl https://dlsrc.getmonero.org/cli/monero-linux-$MONERO_ARCH-v$MONERO_VERS
   rm -r monero-*
 
 
-FROM bitnami/minideb:${OS_BASE} AS runtime-stage
+FROM debian:${OS_BASE}-slim AS runtime-stage
 
 # Bring over the Args from platform selection
 ARG BUILDPLATFORM

--- a/buildtools/docker_rig/tarilabs.Dockerfile
+++ b/buildtools/docker_rig/tarilabs.Dockerfile
@@ -1,11 +1,11 @@
 # syntax = docker/dockerfile:1.3
 
 # https://hub.docker.com/_/rust
-ARG RUST_VERSION=1.84
-ARG OS_BASE=bookworm
+ARG RUST_VERSION=1.90.0
+ARG OS_BASE=trixie
 
 # rust source compile with cross platform build support
-FROM --platform=$BUILDPLATFORM rust:$RUST_VERSION-${OS_BASE} as builder
+FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-${OS_BASE} as builder
 
 # Declare to make available
 ARG BUILDPLATFORM
@@ -84,8 +84,9 @@ RUN cargo build ${RUST_TARGET} \
     # Copy executable out of the cache so it is available in the runtime image.
     cp -v /tari/target/${BUILD_TARGET}release/${APP_EXEC} /tari/${APP_EXEC}
 
+# https://hub.docker.com/_/debian
 # Create runtime base minimal image for the target platform executables
-FROM --platform=$TARGETPLATFORM bitnami/minideb:${OS_BASE} as runtime
+FROM --platform=$TARGETPLATFORM debian:${OS_BASE}-slim as runtime
 
 ARG BUILDPLATFORM
 ARG TARGETOS

--- a/buildtools/docker_rig/tor.Dockerfile
+++ b/buildtools/docker_rig/tor.Dockerfile
@@ -2,14 +2,14 @@
 
 ARG ALPINE_VERSION=3.22
 
-FROM alpine:$ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION}
 
 ARG ALPINE_VERSION
 ARG BUILDPLATFORM
 ARG VERSION=1.0.1
 
-# https://pkgs.alpinelinux.org/packages?name=tor&branch=v3.18&repo=community&arch=&maintainer=
-ARG TOR_VERSION=0.4.8.16-r0
+# https://pkgs.alpinelinux.org/packages?name=tor&branch=v3.22&repo=community&arch=&origin=&flagged=&maintainer=
+ARG TOR_VERSION=0.4.8.19-r0
 
 # Install tor with a minimum version
 RUN apk add --no-cache grep curl tor>${TOR_VERSION}


### PR DESCRIPTION
Description
remove bitnami docker images for debian slim images
minor updates and tor version bump

Motivation and Context
Move away from bitnami docker images as they going pay for use

How Has This Been Tested?
Builds in local fork, runnings in local container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - None
- Chores
  - Switched build and runtime base images to Debian slim variants for improved consistency.
  - Updated Rust toolchain to 1.90.0 and moved OS base to Debian “trixie.”
  - Bumped Tor package to 0.4.8.19-r0.
- Documentation
  - Refreshed inline comments to reflect new base image sources and Tor branch reference.
- Tests
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->