### PR TITLE
feat: custom db timeout for grpc

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -295,7 +295,7 @@ impl WalletGrpcServer {
                 .get_wallet_one_sided_address()
                 .await
                 .map_err(|e| Status::internal(format!("{e:?}")))?;
-            let wallet_tx = timeout(Duration::from_millis(100), async {
+            let wallet_tx = timeout(Duration::from_millis(self.wallet.config.grpc_db_write_timeout), async {
                 loop {
                     let tx = self
                         .get_transaction_service()
@@ -1126,7 +1126,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         .get_wallet_one_sided_address()
                         .await
                         .map_err(|e| Status::internal(format!("{e:?}")))?;
-                    let wallet_tx = timeout(Duration::from_millis(100), async {
+                    let wallet_tx = timeout(Duration::from_millis(self.wallet.config.grpc_db_write_timeout), async {
                         loop {
                             let tx = self
                                 .get_transaction_service()
@@ -2558,7 +2558,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         .get_wallet_one_sided_address()
                         .await
                         .map_err(|e| Status::internal(format!("{e:?}")))?;
-                    let wallet_tx = timeout(Duration::from_millis(100), async {
+                    let wallet_tx = timeout(Duration::from_millis(self.wallet.config.grpc_db_write_timeout), async {
                         loop {
                             let tx = self
                                 .get_transaction_service()

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -135,6 +135,10 @@ pub struct WalletConfig {
     pub fallback_http_server_url: String,
     /// the scanning interval for the utxo scanner service
     pub scanning_interval: u64,
+    /// grpc database write timeout in ms. This is how long the grpc server will wait for a database write to complete
+    /// before returning an error to the client. This should be long enough to cover the majority of database writes
+    /// but short enough to avoid blocking the grpc server for too long. Default = 100ms
+    pub grpc_db_write_timeout: u64,
 }
 
 impl Default for WalletConfig {
@@ -179,6 +183,7 @@ impl Default for WalletConfig {
             http_server_url,
             fallback_http_server_url,
             scanning_interval: 60,
+            grpc_db_write_timeout: 100,
         }
     }
 }

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -98,6 +98,10 @@
 #birthday_offset = 2
 #The scanning interval in secs to poll the base node for new blocks
 #scanning_interval = 60
+#grpc database write timeout in ms. This is how long the grpc server will wait for a database write to complete
+#before returning an error to the client. This should be long enough to cover the majority of database writes
+#but short enough to avoid blocking the grpc server for too long.
+#grpc_db_write_timeout= 100
 # The URL of the HTTP client to use for base node service requests
 #http_server_url="http://127.0.0.1:9000"
 # The fallback url address to use if the base node at http_server_url does not respond

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -101,7 +101,7 @@
 #grpc database write timeout in ms. This is how long the grpc server will wait for a database write to complete
 #before returning an error to the client. This should be long enough to cover the majority of database writes
 #but short enough to avoid blocking the grpc server for too long.
-#grpc_db_write_timeout= 100
+#grpc_db_write_timeout = 100
 # The URL of the HTTP client to use for base node service requests
 #http_server_url="http://127.0.0.1:9000"
 # The fallback url address to use if the base node at http_server_url does not respond


### PR DESCRIPTION
Description
---
Grpc create transaction calls have a timeout while waiting for a database write. This timeout is 100ms, and should be sufficient, but can be too long. This creates a custom config option to make this longer, or shorter. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for wallet gRPC database write operations to control how long the system waits before reporting a timeout.
  * Default timeout set to 100 ms; adjustable via wallet configuration.
  * Helps avoid premature timeouts on slower systems and permits tighter responsiveness on faster setups.
  * Preset configuration updated to include the new option for easier setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->