### PR TITLE
fix: change how pagination works on utxo scanning

### DIFF
--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -284,11 +284,11 @@ impl<B: BlockchainBackend + 'static> Service<B> {
             }
             if fetched_utxos >= request.limit {
                 next_header_to_request = current_header.hash().to_vec();
-                // this is a special edge case, our request has reached the page limit, but we are also not done with
+                // This is a special edge case, our request has reached the page limit, but we are also not done with
                 // the block. We also dont want to split up the block over two requests. So we need to ensure that we
                 // remove the partial block we added so that it can be requested fully in the next request. We also dont
                 // want to get in a loop where the block cannot fit into the page limit, so if the block is the same as
-                // the first one, we just send it as it, partial. If net we remove it and let it be sent in the next
+                // the first one, we just send it as is, partial. If not we remove it and let it be sent in the next
                 // request.
                 if utxos.first().ok_or(Error::General(anyhow::anyhow!("No utxos founds")))? // should never happen as we always add at least one block
                     .header_hash ==
@@ -299,12 +299,11 @@ impl<B: BlockchainBackend + 'static> Service<B> {
                     break;
                 }
                 while !utxos.is_empty() &&
-                    utxos.last().ok_or(Error::General(anyhow::anyhow!("No utxos founds")))? // should never happen as we always add at least one block
+                    utxos.last().ok_or(Error::General(anyhow::anyhow!("No utxos found")))? // should never happen as we always add at least one block
                     .header_hash ==
                         current_header.hash().to_vec()
                 {
                     utxos.pop();
-                    fetched_utxos -= 1;
                 }
                 break;
             }

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -284,6 +284,28 @@ impl<B: BlockchainBackend + 'static> Service<B> {
             }
             if fetched_utxos >= request.limit {
                 next_header_to_request = current_header.hash().to_vec();
+                // this is a special edge case, our request has reached the page limit, but we are also not done with
+                // the block. We also dont want to split up the block over two requests. So we need to ensure that we
+                // remove the partial block we added so that it can be requested fully in the next request. We also dont
+                // want to get in a loop where the block cannot fit into the page limit, so if the block is the same as
+                // the first one, we just send it as it, partial. If net we remove it and let it be sent in the next
+                // request.
+                if utxos.first().ok_or(Error::General(anyhow::anyhow!("No utxos founds")))? // should never happen as we always add at least one block
+                    .header_hash ==
+                    current_header.hash().to_vec()
+                {
+                    // special edge case where the first block is also the last block we can send, so we just send it as
+                    // is, partial
+                    break;
+                }
+                while !utxos.is_empty() &&
+                    utxos.last().ok_or(Error::General(anyhow::anyhow!("No utxos founds")))? // should never happen as we always add at least one block
+                    .header_hash ==
+                        current_header.hash().to_vec()
+                {
+                    utxos.pop();
+                    fetched_utxos -= 1;
+                }
                 break;
             }
 


### PR DESCRIPTION
Description
---
Properly handle the special edge case, where the request has reached the page limit, but we are also not done with the block. We also dont want to split up the block over two requests. So we need to ensure that we remove the partial block we added so that it can be requested fully in the next request. We also dont want to get in a loop where the block cannot fit into the page limit, so if the block is the same as the first one, we just send it as it, partial. If net we remove it and let it be sent in the next request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge cases in paginated UTXO queries when a page ends mid-block to prevent partial or duplicated results.
  * Ensures correct continuation across block boundaries and early exit when the first block is also the last that can be sent.
  * Removes trailing blocks or partial entries so subsequent pages request the correct data.
  * Improves error reporting for rare pagination inconsistencies.
  * Preserves behavior when limits aren’t reached or the chain end is encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->