### PR TITLE
feat: dynamic cache control

### DIFF
--- a/applications/minotari_node/src/http/cache_config.rs
+++ b/applications/minotari_node/src/http/cache_config.rs
@@ -10,6 +10,9 @@ pub struct HttpCacheConfig {
     /// If not enabled (false), no Cache-Control header is set anywhere.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+    /// If true, dynamic Cache-Control headers will be overridden by dynamic values depending on the height
+    #[serde(default = "default_enabled")]
+    dynamic: bool,
     /// The Cache-Control string to use for the 'get_tip_info' handler.
     /// Default: "public, max-age=15, s-maxage=15, stale-while-revalidate=15"
     #[serde(default = "default_get_tip_info_cache_control")]
@@ -73,6 +76,7 @@ impl Default for HttpCacheConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            dynamic: true,
             get_tip_info: default_get_tip_info_cache_control(),
             get_header_by_height: default_get_header_by_height_cache_control(),
             get_utxos_by_block: default_get_utxos_by_block_cache_control(),
@@ -100,27 +104,61 @@ pub enum RouteKey {
 
 impl HttpCacheConfig {
     /// Returns a mapping of route keys to their Cache-Control strings.
-    pub fn cache_control_for(&self, key: RouteKey) -> &str {
+    pub fn cache_control_for(&self, key: RouteKey, tip_height: u64, height: u64) -> String {
+        let default = match key {
+            RouteKey::GetTipInfo => self.get_tip_info.clone(),
+            RouteKey::GetHeaderByHeight => self.get_header_by_height.clone(),
+            RouteKey::GetUtxosByBlock => self.get_utxos_by_block.clone(),
+            RouteKey::SyncUtxosByBlock => self.sync_utxos_by_block.clone(),
+            RouteKey::GetHeightAtTime => self.get_height_at_time.clone(),
+            RouteKey::TransactionQuery => self.transaction_query.clone(),
+            RouteKey::GetUtxosDeletedInfo => self.get_utxos_deleted_info.clone(),
+            RouteKey::GetUtxosMinedInfo => self.get_utxos_mined_info.clone(),
+        };
+        if !self.dynamic {
+            return default;
+        }
+        let (max_age, s_maxage, stale_while_revalidate) = match tip_height.saturating_sub(height) {
+            0..=10 => (30, 15, 15),            // within 10 blocks of tip (30s)
+            11..=100 => (300, 150, 75),        // within 100 blocks of tip (11 blocks = 22min, cache 5 mins)
+            101..=1000 => (1200, 600, 300),    // within 1000 blocks of tip (101 blocks = 6.7 hours, cache 20 mins)
+            1001..=2000 => (1800, 900, 450),   // within 2000 blocks of tip (1001 blocks = 2.7 days, cache 30 mins)
+            2001..=10000 => (3600, 1800, 900), // within 10000 blocks of tip (11 blocks = 5.5 days, cache 1 hour)
+            _ => (86400, 43200, 21600),        /* more than 10000 blocks from tip (10001 blocks = 27 days, cache 30
+                                                 * days) */
+        };
         match key {
-            RouteKey::GetTipInfo => self.get_tip_info.as_str(),
-            RouteKey::GetHeaderByHeight => self.get_header_by_height.as_str(),
-            RouteKey::GetUtxosByBlock => self.get_utxos_by_block.as_str(),
-            RouteKey::SyncUtxosByBlock => self.sync_utxos_by_block.as_str(),
-            RouteKey::GetHeightAtTime => self.get_height_at_time.as_str(),
-            RouteKey::TransactionQuery => self.transaction_query.as_str(),
-            RouteKey::GetUtxosDeletedInfo => self.get_utxos_deleted_info.as_str(),
-            RouteKey::GetUtxosMinedInfo => self.get_utxos_mined_info.as_str(),
+            RouteKey::GetTipInfo => default,
+            RouteKey::GetHeaderByHeight => format!(
+                "public, max-age={max_age}, s-maxage={s_maxage}, stale-while-revalidate={stale_while_revalidate}"
+            ),
+            RouteKey::GetUtxosByBlock => format!(
+                "public, max-age={max_age}, s-maxage={s_maxage}, stale-while-revalidate={stale_while_revalidate}"
+            ),
+            RouteKey::SyncUtxosByBlock => format!(
+                "public, max-age={max_age}, s-maxage={s_maxage}, stale-while-revalidate={stale_while_revalidate}"
+            ),
+            RouteKey::GetHeightAtTime => default,
+            RouteKey::TransactionQuery => default,
+            RouteKey::GetUtxosDeletedInfo => default,
+            RouteKey::GetUtxosMinedInfo => default,
         }
     }
 }
 
 /// Apply Cache-Control for the given handler key (no-op if disabled)
-pub fn apply_cache_control(headers: &mut HeaderMap, cfg: &HttpCacheConfig, key: RouteKey) {
+pub fn apply_cache_control(
+    headers: &mut HeaderMap,
+    cfg: &HttpCacheConfig,
+    key: RouteKey,
+    tip_height: u64,
+    height: u64,
+) {
     if !cfg.enabled {
         return;
     }
-    let value = cfg.cache_control_for(key);
-    if let Ok(hv) = HeaderValue::from_str(value) {
+    let value = cfg.cache_control_for(key, tip_height, height);
+    if let Ok(hv) = HeaderValue::from_str(&value) {
         headers.insert("Cache-Control", hv);
     }
 }
@@ -139,13 +177,16 @@ mod tests {
         };
         let mut headers = HeaderMap::new();
 
-        apply_cache_control(&mut headers, &cfg, RouteKey::GetTipInfo);
+        apply_cache_control(&mut headers, &cfg, RouteKey::GetTipInfo, 0, 0);
         assert!(headers.get("Cache-Control").is_none());
     }
 
     #[test]
     fn test_apply_cache_control_all_keys() {
-        let cfg = HttpCacheConfig::default();
+        let cfg = HttpCacheConfig {
+            dynamic: false,
+            ..Default::default()
+        };
         let mut headers = HeaderMap::new();
 
         for key in [
@@ -159,7 +200,7 @@ mod tests {
             RouteKey::GetUtxosMinedInfo,
         ] {
             headers.clear();
-            apply_cache_control(&mut headers, &cfg, key);
+            apply_cache_control(&mut headers, &cfg, key, 0, 0);
             match key {
                 RouteKey::GetTipInfo => {
                     assert_eq!(
@@ -211,5 +252,88 @@ mod tests {
                 },
             }
         }
+    }
+
+    #[test]
+    fn test_cache_control_for_dynamic_buckets_boundaries() {
+        let cfg = HttpCacheConfig {
+            dynamic: true,
+            ..Default::default()
+        };
+        // (delta_from_tip, expected max-age, s-maxage, swr)
+        let cases = [
+            (0u64, 30, 15, 15),
+            (10, 30, 15, 15),
+            (11, 300, 150, 75),
+            (100, 300, 150, 75),
+            (101, 1200, 600, 300),
+            (1000, 1200, 600, 300),
+            (1001, 1800, 900, 450),
+            (2000, 1800, 900, 450),
+            (2001, 3600, 1800, 900),
+            (10000, 3600, 1800, 900),
+            (10001, 86400, 43200, 21600),
+        ];
+        let tip = 50_000u64;
+        for (delta, max_age, s_maxage, swr) in cases {
+            let height = tip.saturating_sub(delta);
+            for key in [
+                RouteKey::GetHeaderByHeight,
+                RouteKey::GetUtxosByBlock,
+                RouteKey::SyncUtxosByBlock,
+            ] {
+                let got = cfg.cache_control_for(key, tip, height);
+                let expected = format!(
+                    "public, max-age={}, s-maxage={}, stale-while-revalidate={}",
+                    max_age, s_maxage, swr
+                );
+                assert_eq!(got, expected, "key={:?} delta={}", key, delta);
+            }
+        }
+    }
+
+    #[test]
+    fn test_cache_control_for_height_greater_than_tip_uses_lowest_bucket() {
+        let cfg = HttpCacheConfig {
+            dynamic: true,
+            ..Default::default()
+        };
+        // height > tip should saturate to 0 delta and thus use the 0..=10 bucket
+        let tip = 100;
+        let height = 200; // greater than tip
+        let expected = "public, max-age=30, s-maxage=15, stale-while-revalidate=15";
+        let got = cfg.cache_control_for(RouteKey::GetHeaderByHeight, tip, height);
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn test_cache_control_for_dynamic_keeps_default_for_non_dynamic_routes() {
+        let cfg = HttpCacheConfig {
+            dynamic: true,
+            ..Default::default()
+        };
+        let tip = 10_000u64;
+        let height = 1;
+        // These keys should always use their configured defaults even when dynamic is enabled
+        assert_eq!(
+            cfg.cache_control_for(RouteKey::GetTipInfo, tip, height),
+            cfg.get_tip_info
+        );
+        assert_eq!(
+            cfg.cache_control_for(RouteKey::GetHeightAtTime, tip, height),
+            cfg.get_height_at_time
+        );
+        assert_eq!(
+            cfg.cache_control_for(RouteKey::TransactionQuery, tip, height),
+            cfg.transaction_query
+        );
+        assert_eq!(
+            cfg.cache_control_for(RouteKey::GetUtxosDeletedInfo, tip, height),
+            cfg.get_utxos_deleted_info
+        );
+        assert_eq!(
+            cfg.cache_control_for(RouteKey::GetUtxosMinedInfo, tip, height),
+            cfg.get_utxos_mined_info
+        );
     }
 }

--- a/applications/minotari_node/src/http/cache_config.rs
+++ b/applications/minotari_node/src/http/cache_config.rs
@@ -118,14 +118,21 @@ impl HttpCacheConfig {
         if !self.dynamic {
             return default;
         }
+        // The variables are as follows:
+        // max_age: how long the client can cache the response
+        // s_maxage: how long shared caches (e.g., CDNs) can cache
+        // stale_while_revalidate: how long the client/shared cache can use a stale response while revalidating
+        // So for us the important one is the s_maxage, as that determines how long intermediaries can cache responses.
+        // The max_age is more about client-side caching, which is less critical for us as our wallets wont do caching
+        // as it will only be called once.
         let (max_age, s_maxage, stale_while_revalidate) = match tip_height.saturating_sub(height) {
-            0..=10 => (30, 15, 15),            // within 10 blocks of tip (30s)
-            11..=100 => (300, 150, 75),        // within 100 blocks of tip (11 blocks = 22min, cache 5 mins)
-            101..=1000 => (1200, 600, 300),    // within 1000 blocks of tip (101 blocks = 6.7 hours, cache 20 mins)
-            1001..=2000 => (1800, 900, 450),   // within 2000 blocks of tip (1001 blocks = 2.7 days, cache 30 mins)
-            2001..=10000 => (3600, 1800, 900), // within 10000 blocks of tip (11 blocks = 5.5 days, cache 1 hour)
-            _ => (86400, 43200, 21600),        /* more than 10000 blocks from tip (10001 blocks = 27 days, cache 30
-                                                 * days) */
+            0..=10 => (30, 30, 15),          // within 10 blocks of tip (30s)
+            11..=100 => (300, 300, 60),      // within 100 blocks of tip (11 blocks = 22min, cache 5 mins)
+            101..=1000 => (360, 1200, 60),   // within 1000 blocks of tip (101 blocks = 6.7 hours, cache 20 mins)
+            1001..=2000 => (360, 1800, 60),  // within 2000 blocks of tip (1001 blocks = 2.7 days, cache 30 mins)
+            2001..=10000 => (360, 3600, 60), // within 10000 blocks of tip (11 blocks = 5.5 days, cache 1 hour)
+            _ => (360, 86400, 60),           /* more than 10000 blocks from tip (10001 blocks = 27 days, cache 30
+                                               * days) */
         };
         match key {
             RouteKey::GetTipInfo => default,

--- a/applications/minotari_node/src/http/cache_config.rs
+++ b/applications/minotari_node/src/http/cache_config.rs
@@ -269,17 +269,17 @@ mod tests {
         };
         // (delta_from_tip, expected max-age, s-maxage, swr)
         let cases = [
-            (0u64, 30, 15, 15),
-            (10, 30, 15, 15),
-            (11, 300, 150, 75),
-            (100, 300, 150, 75),
-            (101, 1200, 600, 300),
-            (1000, 1200, 600, 300),
-            (1001, 1800, 900, 450),
-            (2000, 1800, 900, 450),
-            (2001, 3600, 1800, 900),
-            (10000, 3600, 1800, 900),
-            (10001, 86400, 43200, 21600),
+            (0u64, 30, 30, 15),
+            (10, 30, 30, 15),
+            (11, 300, 300, 60),
+            (100, 300, 300, 60),
+            (101, 360, 1200, 60),
+            (1000, 360, 1200, 60),
+            (1001, 360, 1800, 60),
+            (2000, 360, 1800, 60),
+            (2001, 360, 3600, 60),
+            (10000, 360, 3600, 60),
+            (10001, 360, 86400, 60),
         ];
         let tip = 50_000u64;
         for (delta, max_age, s_maxage, swr) in cases {
@@ -308,7 +308,7 @@ mod tests {
         // height > tip should saturate to 0 delta and thus use the 0..=10 bucket
         let tip = 100;
         let height = 200; // greater than tip
-        let expected = "public, max-age=30, s-maxage=15, stale-while-revalidate=15";
+        let expected = "public, max-age=30, s-maxage=30, stale-while-revalidate=15";
         let got = cfg.cache_control_for(RouteKey::GetHeaderByHeight, tip, height);
         assert_eq!(got, expected);
     }

--- a/applications/minotari_node/src/http/handler/get_header_by_height.rs
+++ b/applications/minotari_node/src/http/handler/get_header_by_height.rs
@@ -48,13 +48,20 @@ pub async fn handle<B: BlockchainBackend + 'static>(
     Extension(cache_cfg): Extension<Arc<HttpCacheConfig>>,
 ) -> Result<Response<AxumBody>, (StatusCode, Json<ErrorResponse>)> {
     debug!(target: LOG_TARGET, "Received get_header_by_height request: {}", params.height);
-
+    let tip_info = query_service.get_tip_info().await.map_err(error_handler_with_message)?;
+    let tip_height = tip_info.metadata.map(|m| m.best_block_height()).unwrap_or(0);
     let response = query_service
         .get_header_by_height(params.height)
         .await
         .map_err(error_handler_with_message)?;
     let body = Json(response);
     let mut response = body.into_response();
-    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetHeaderByHeight);
+    apply_cache_control(
+        response.headers_mut(),
+        &cache_cfg,
+        RouteKey::GetHeaderByHeight,
+        tip_height,
+        params.height,
+    );
     Ok(response)
 }

--- a/applications/minotari_node/src/http/handler/get_height_at_time.rs
+++ b/applications/minotari_node/src/http/handler/get_height_at_time.rs
@@ -58,6 +58,6 @@ pub async fn handle<B: BlockchainBackend + 'static>(
         .map_err(error_handler_with_message)?;
     let body = Json(response);
     let mut response = body.into_response();
-    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetHeightAtTime);
+    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetHeightAtTime, 0, 0);
     Ok(response)
 }

--- a/applications/minotari_node/src/http/handler/get_tip_info.rs
+++ b/applications/minotari_node/src/http/handler/get_tip_info.rs
@@ -45,6 +45,6 @@ pub async fn handle<B: BlockchainBackend + 'static>(
     let tip_info = query_service.get_tip_info().await.map_err(error_handler_with_message)?;
     let body = Json(tip_info);
     let mut response = body.into_response();
-    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetTipInfo);
+    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetTipInfo, 0, 0);
     Ok(response)
 }

--- a/applications/minotari_node/src/http/handler/get_utxos_by_block.rs
+++ b/applications/minotari_node/src/http/handler/get_utxos_by_block.rs
@@ -60,15 +60,25 @@ pub async fn handle<B: BlockchainBackend + 'static>(
     Extension(cache_cfg): Extension<Arc<HttpCacheConfig>>,
 ) -> Result<Response<AxumBody>, (StatusCode, Json<ErrorResponse>)> {
     debug!(target: LOG_TARGET, "Received get_utxos_by_block request: {params:?}");
+
+    let tip_info = query_service.get_tip_info().await.map_err(error_handler_with_message)?;
+    let tip_height = tip_info.metadata.map(|m| m.best_block_height()).unwrap_or(0);
+
     let request = params.into();
 
     let response = query_service
         .get_utxos_by_block(request)
         .await
         .map_err(error_handler_with_message)?;
-
+    let height = response.height;
     let body = Json(response);
     let mut response = body.into_response();
-    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetUtxosByBlock);
+    apply_cache_control(
+        response.headers_mut(),
+        &cache_cfg,
+        RouteKey::GetUtxosByBlock,
+        tip_height,
+        height,
+    );
     Ok(response)
 }

--- a/applications/minotari_node/src/http/handler/get_utxos_deleted_info.rs
+++ b/applications/minotari_node/src/http/handler/get_utxos_deleted_info.rs
@@ -74,6 +74,6 @@ pub async fn handle<B: BlockchainBackend + 'static>(
 
     let body = Json(response);
     let mut response = body.into_response();
-    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetUtxosDeletedInfo);
+    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetUtxosDeletedInfo, 0, 0);
     Ok(response)
 }

--- a/applications/minotari_node/src/http/handler/get_utxos_mined_info.rs
+++ b/applications/minotari_node/src/http/handler/get_utxos_mined_info.rs
@@ -64,6 +64,6 @@ pub async fn handle<B: BlockchainBackend + 'static>(
         .map_err(error_handler_with_message)?;
     let body = Json(response);
     let mut response = body.into_response();
-    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetUtxosMinedInfo);
+    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::GetUtxosMinedInfo, 0, 0);
     Ok(response)
 }

--- a/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
+++ b/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
@@ -69,14 +69,22 @@ pub async fn handle<B: BlockchainBackend + 'static>(
 ) -> Result<Response<AxumBody>, (StatusCode, Json<ErrorResponse>)> {
     debug!(target: LOG_TARGET, "Received sync_utxos_by_block request: {params:?}");
     let request = params.into();
-
+    let tip_info = query_service.get_tip_info().await.map_err(error_handler_with_message)?;
+    let tip_height = tip_info.metadata.map(|m| m.best_block_height()).unwrap_or(0);
     let response = query_service
         .sync_utxos_by_block(request)
         .await
         .map_err(error_handler_with_message)?;
+    let last_height = response.blocks.last().map(|b| b.height).unwrap_or(0);
 
     let body = Json(response);
     let mut response = body.into_response();
-    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::SyncUtxosByBlock);
+    apply_cache_control(
+        response.headers_mut(),
+        &cache_cfg,
+        RouteKey::SyncUtxosByBlock,
+        tip_height,
+        last_height,
+    );
     Ok(response)
 }

--- a/applications/minotari_node/src/http/handler/transaction_query.rs
+++ b/applications/minotari_node/src/http/handler/transaction_query.rs
@@ -61,6 +61,6 @@ pub async fn handle<B: BlockchainBackend + 'static>(
 
     let body = Json(response);
     let mut response = body.into_response();
-    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::TransactionQuery);
+    apply_cache_control(response.headers_mut(), &cache_cfg, RouteKey::TransactionQuery, 0, 0);
     Ok(response)
 }

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -419,7 +419,7 @@ where
             tip_height
         );
         // Setting how often the progress event and log should occur during scanning. Defined in blocks
-        const PROGRESS_REPORT_INTERVAL: u64 = 10;
+        const PROGRESS_REPORT_INTERVAL: u64 = 50;
 
         let mut total_scanned = 0;
         let mut total_num_recovered = 0;

--- a/clients/rust/base_node_wallet_client/src/client/http.rs
+++ b/clients/rust/base_node_wallet_client/src/client/http.rs
@@ -295,7 +295,7 @@ impl BaseNodeWalletClient for Client {
         let start_header_hash_hex = start_header_hash.to_hex();
         let client = self.http_client.clone();
 
-        let limit = 10;
+        let limit = 50;
         tokio::spawn(async move {
             let mut page = 0;
             let mut has_next_page = true;


### PR DESCRIPTION
Description
---
Changes the caching to be height dependant for better caching results
Changes the wallet to request 50 blocks per page and not 10. 

The blocks per page was tested with the following results, scanning 20_000 blocks against the seed nodes
# 10 blocks per page
1323.121449458s
605 ms per block avg

# 25 blocks per page
Scan complete. in 931.074894458s
Took on average 46ms per block.

# 50 blocks per page
Scan complete. in 173.591650917s
Took on average 30ms per block.

# 100 blocks per page
Scan complete. in 568.257418292s
Took on average 28ms per block.


When scanning against cached results, the results where almost the same with the time taking from 8ms-11ms per block, or around 220 seconds to complete

This means we need to cache the results for longer and request more data per packet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic HTTP Cache-Control is enabled by default and now adjusts directives based on current tip and response heights for height-dependent endpoints.
  * Handlers now provide height context so cache headers reflect live chain state.

* **Chores**
  * Increased UTXO-by-block sync page size to reduce requests.
  * Reduced frequency of progress reporting during UTXO scans.

* **Tests**
  * Expanded coverage for dynamic cache buckets, boundary cases, height > tip, and non-dynamic routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->