### PR TITLE
fix: bad peer selection when syncing

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -240,7 +240,7 @@ mod tests {
         let state = HeaderSyncState::new(vec![p1.clone(), p2.clone(), p3.clone(), p4.clone()], local);
         let ordered = state.into_sync_peers();
 
-        // Expect ascending by difficulty, then by latency (Some before None, lower is better)
+        // Expect descending by difficulty (highest first), then by latency (Some before None, lower is better)
         let lens: Vec<(u128, Option<u128>)> = ordered
             .iter()
             .map(|p| (p.claimed_difficulty().low_u128(), p.latency().map(|d| d.as_millis())))

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -49,7 +49,7 @@ pub struct HeaderSyncState {
 impl HeaderSyncState {
     pub fn new(mut sync_peers: Vec<SyncPeer>, local_metadata: ChainMetadata) -> Self {
         // Sort by latency lowest to highest
-        sync_peers.sort_by(|a, b| match a.claimed_difficulty().cmp(&b.claimed_difficulty()) {
+        sync_peers.sort_by(|a, b| match b.claimed_difficulty().cmp(&a.claimed_difficulty()) {
             Ordering::Less => Ordering::Less,
             // No latency goes to the end
             Ordering::Greater => Ordering::Greater,
@@ -202,5 +202,89 @@ impl HeaderSyncState {
                 }
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    use std::time::Duration;
+
+    use primitive_types::U512;
+    use tari_common_types::{chain_metadata::ChainMetadata, types::FixedHash};
+    use tari_comms::peer_manager::NodeId;
+
+    use super::HeaderSyncState;
+    use crate::base_node::{chain_metadata_service::PeerChainMetadata, sync::SyncPeer};
+
+    fn make_chain_metadata(difficulty: u64) -> ChainMetadata {
+        ChainMetadata::new(0, FixedHash::zero(), 0, 0, U512::from(difficulty), 0).expect("valid chain metadata")
+    }
+
+    fn make_sync_peer(difficulty: u64, latency: Option<Duration>) -> SyncPeer {
+        let node_id = NodeId::new();
+        let cm = make_chain_metadata(difficulty);
+        let pcm = PeerChainMetadata::new(node_id, cm, latency);
+        SyncPeer::from(pcm)
+    }
+
+    #[test]
+    fn sort_by_difficulty_then_latency() {
+        // Mixed peers
+        let p1 = make_sync_peer(1, Some(Duration::from_millis(50)));
+        let p2 = make_sync_peer(2, Some(Duration::from_millis(10)));
+        let p3 = make_sync_peer(2, None);
+        let p4 = make_sync_peer(1, Some(Duration::from_millis(20)));
+
+        let local = make_chain_metadata(1);
+        let state = HeaderSyncState::new(vec![p1.clone(), p2.clone(), p3.clone(), p4.clone()], local);
+        let ordered = state.into_sync_peers();
+
+        // Expect ascending by difficulty, then by latency (Some before None, lower is better)
+        let lens: Vec<(u128, Option<u128>)> = ordered
+            .iter()
+            .map(|p| (p.claimed_difficulty().low_u128(), p.latency().map(|d| d.as_millis())))
+            .collect();
+
+        assert_eq!(lens.len(), 4);
+        assert_eq!(lens[0], (2, Some(10)));
+        assert_eq!(lens[1], (2, None));
+        assert_eq!(lens[2], (1, Some(20)));
+        assert_eq!(lens[3], (1, Some(50)));
+    }
+
+    #[test]
+    fn none_latency_goes_to_end_for_equal_difficulty() {
+        let a = make_sync_peer(5, Some(Duration::from_millis(30)));
+        let b = make_sync_peer(5, None);
+        let c = make_sync_peer(5, Some(Duration::from_millis(10)));
+
+        let local = make_chain_metadata(1);
+        let state = HeaderSyncState::new(vec![a.clone(), b.clone(), c.clone()], local);
+        let ordered = state.into_sync_peers();
+
+        let lens: Vec<(u128, Option<u128>)> = ordered
+            .iter()
+            .map(|p| (p.claimed_difficulty().low_u128(), p.latency().map(|d| d.as_millis())))
+            .collect();
+
+        assert_eq!(lens, vec![(5, Some(10)), (5, Some(30)), (5, None)]);
+    }
+
+    #[test]
+    fn equal_none_latencies_are_last_with_equal_difficulty() {
+        let a = make_sync_peer(7, Some(Duration::from_millis(5)));
+        let b = make_sync_peer(7, None);
+        let c = make_sync_peer(7, None);
+
+        let local = make_chain_metadata(1);
+        let state = HeaderSyncState::new(vec![b, a, c], local);
+        let ordered = state.into_sync_peers();
+
+        // First should be the one with latency, last two should have None (order between them may vary)
+        assert_eq!(ordered[0].claimed_difficulty().low_u128(), 7);
+        assert_eq!(ordered[0].latency().map(|d| d.as_millis()), Some(5));
+        assert!(ordered[1].latency().is_none());
+        assert!(ordered[2].latency().is_none());
     }
 }

--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -54,7 +54,7 @@ pub struct BlockchainSyncConfig {
     /// The number of initial rounds of seed peer based bootstrapping.
     #[serde(default = "default_num_initial_sync_rounds_seed_bootstrap")]
     pub num_initial_sync_rounds_seed_bootstrap: usize,
-    /// The number of initial rounds of seed peer based bootstrapping.
+    /// The maximum reorg depth allowed during header synchronization.
     #[serde(default = "max_reorg_depth_allowed")]
     pub max_reorg_depth_allowed: usize,
 }

--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -54,6 +54,9 @@ pub struct BlockchainSyncConfig {
     /// The number of initial rounds of seed peer based bootstrapping.
     #[serde(default = "default_num_initial_sync_rounds_seed_bootstrap")]
     pub num_initial_sync_rounds_seed_bootstrap: usize,
+    /// The number of initial rounds of seed peer based bootstrapping.
+    #[serde(default = "max_reorg_depth_allowed")]
+    pub max_reorg_depth_allowed: usize,
 }
 
 fn default_num_initial_sync_rounds_seed_bootstrap() -> usize {
@@ -61,6 +64,10 @@ fn default_num_initial_sync_rounds_seed_bootstrap() -> usize {
     // For now, a sensible default. This will be overridden by DhtEvent if DhtNetworkDiscoveryRoundInfo provides
     // total_rounds.
     5
+}
+
+fn max_reorg_depth_allowed() -> usize {
+    10000
 }
 
 impl Default for BlockchainSyncConfig {
@@ -74,6 +81,7 @@ impl Default for BlockchainSyncConfig {
             validation_concurrency: 6,
             rpc_deadline: Duration::from_secs(240), // Syncing many full blocks over tor require this
             num_initial_sync_rounds_seed_bootstrap: default_num_initial_sync_rounds_seed_bootstrap(),
+            max_reorg_depth_allowed: max_reorg_depth_allowed(),
         }
     }
 }

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -282,7 +282,13 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
         //   peer, but they claimed better POW before we attempted sync.
         // - This method will return ban-able errors for certain offenses.
         let (header_sync_status, peer_response) = self
-            .determine_sync_status(sync_peer, best_header.clone(), best_block_header.clone(), &mut client)
+            .determine_sync_status(
+                sync_peer,
+                best_header.clone(),
+                best_block_header.clone(),
+                self.config.max_reorg_depth_allowed,
+                &mut client,
+            )
             .await?;
 
         match header_sync_status.clone() {
@@ -323,25 +329,26 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
     async fn find_chain_split(
         &mut self,
         peer_node_id: &NodeId,
+        max_reorg_depth_allowed: usize,
         client: &mut rpc::BaseNodeSyncRpcClient,
         header_count: u64,
     ) -> Result<FindChainSplitResult, BlockHeaderSyncError> {
         const NUM_CHAIN_SPLIT_HEADERS: usize = 500;
         // Limit how far back we're willing to go. A peer might just say it does not have a chain split
         // and keep us busy going back until the genesis.
-        // 20 x 500 = max 10,000 block split can be detected
-        const MAX_CHAIN_SPLIT_ITERS: usize = 20;
+        // 20 x 500 = max 10,000 block split can be detected. The 10_000 limit is default, but can be overridden
+        let max_chain_split_iters = max_reorg_depth_allowed.saturating_div(NUM_CHAIN_SPLIT_HEADERS);
 
         let mut offset = 0;
         let mut iter_count = 0;
         loop {
             iter_count += 1;
-            if iter_count > MAX_CHAIN_SPLIT_ITERS {
+            if iter_count > max_chain_split_iters {
                 warn!(
                     target: LOG_TARGET,
                     "Peer `{}` did not provide a chain split after {} headers requested. Peer will be banned.",
                     peer_node_id,
-                    NUM_CHAIN_SPLIT_HEADERS * MAX_CHAIN_SPLIT_ITERS,
+                    NUM_CHAIN_SPLIT_HEADERS * max_chain_split_iters,
                 );
                 return Err(BlockHeaderSyncError::ChainSplitNotFound(peer_node_id.clone()));
             }
@@ -365,7 +372,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                     target: LOG_TARGET,
                     "Peer `{}` did not provide a chain split after {} headers requested. Peer will be banned.",
                     peer_node_id,
-                    NUM_CHAIN_SPLIT_HEADERS * MAX_CHAIN_SPLIT_ITERS,
+                    NUM_CHAIN_SPLIT_HEADERS * max_chain_split_iters,
                 );
                 return Err(BlockHeaderSyncError::ChainSplitNotFound(peer_node_id.clone()));
             }
@@ -385,7 +392,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                             target: LOG_TARGET,
                             "Peer `{}` did not provide a chain split after {} headers requested. Peer will be banned.",
                             peer_node_id,
-                            NUM_CHAIN_SPLIT_HEADERS * MAX_CHAIN_SPLIT_ITERS,
+                            NUM_CHAIN_SPLIT_HEADERS * max_chain_split_iters,
                         );
                         return Err(BlockHeaderSyncError::ChainSplitNotFound(peer_node_id.clone()));
                     }
@@ -461,11 +468,17 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
         sync_peer: &SyncPeer,
         best_header: ChainHeader,
         best_block_header: ChainHeader,
+        max_reorg_depth_allowed: usize,
         client: &mut rpc::BaseNodeSyncRpcClient,
     ) -> Result<(HeaderSyncStatus, FindChainSplitResult), BlockHeaderSyncError> {
         // This method will return ban-able errors for certain offenses.
         let chain_split_result = self
-            .find_chain_split(sync_peer.node_id(), client, HEADER_SYNC_INITIAL_MAX_HEADERS as u64)
+            .find_chain_split(
+                sync_peer.node_id(),
+                max_reorg_depth_allowed,
+                client,
+                HEADER_SYNC_INITIAL_MAX_HEADERS as u64,
+            )
             .await?;
         if chain_split_result.reorg_steps_back > 0 {
             debug!(

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -109,6 +109,8 @@ blockchain_sync_config.max_latency_increase = 10
 # The RPC deadline to set on sync clients. If this deadline is reached, a new sync peer will be selected for sync.
 # [default = 240]
 blockchain_sync_config.rpc_deadline = 240
+# The maximum allowed reorg depth which a node will accept
+# blockchain_sync_config.max_reorg_depth_allowed = 1000
 
 # The maximum amount of VMs that RandomX will be use (default = 0)
 #max_randomx_vms = 0


### PR DESCRIPTION
Description
---
Fixes bad peer selection in which header sync will choose the peer with the latest accumulated difficulty to sync to. 
Allows users to select a custom max reorg depth height. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum reorganization depth limit to improve blockchain synchronization control and stability.

* **Improvements**
  * Sync now bounds header-fetch and chain-split detection work using the new reorg limit, reducing excessive iterations and improving decision consistency.
  * Peer ordering updated to prefer higher claimed difficulty and then lower latency for more efficient synchronization.

* **Tests**
  * Added unit tests covering peer ordering by difficulty and latency.

* **Documentation**
  * Added commented config example for the new reorg depth setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->