### PR TITLE
feat: list all orphan headers

### DIFF
--- a/applications/minotari_node/src/commands/command/fetch_all_orphan_headers.rs
+++ b/applications/minotari_node/src/commands/command/fetch_all_orphan_headers.rs
@@ -1,0 +1,49 @@
+//  Copyright 2022, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use anyhow::Error;
+use async_trait::async_trait;
+use clap::Parser;
+
+use super::{CommandContext, HandleCommand};
+
+/// List tracked reorgs
+/// This feature must be enabled by
+/// setting `track_reorgs = true` in
+/// the [base_node] section of your config."
+#[derive(Debug, Parser)]
+pub struct Args {}
+
+#[async_trait]
+impl HandleCommand<Args> for CommandContext {
+    async fn handle_command(&mut self, _: Args) -> Result<(), Error> {
+        println!("Looking for reorgs");
+        let headers = self.blockchain_db.inner().fetch_all_orphans()?;
+        if headers.is_empty() {
+            println!("No orphans founds");
+        }
+        for header in headers {
+            println!("{}", header);
+        }
+        Ok(())
+    }
+}

--- a/applications/minotari_node/src/commands/command/mod.rs
+++ b/applications/minotari_node/src/commands/command/mod.rs
@@ -28,6 +28,7 @@ mod check_for_updates;
 mod create_tls_certs;
 mod dial_peer;
 mod discover_peer;
+mod fetch_all_orphan_headers;
 mod get_block;
 mod get_chain_metadata;
 mod get_db_stats;
@@ -133,6 +134,7 @@ pub enum Command {
     HeaderStats(header_stats::Args),
     BlockTiming(block_timing::Args),
     ListReorgs(list_reorgs::Args),
+    FetchAllOrphanHeaders(fetch_all_orphan_headers::Args),
     ListBadBlocks(list_bad_blocks::Args),
     DiscoverPeer(discover_peer::Args),
     GetBlock(get_block::Args),
@@ -231,6 +233,7 @@ impl CommandContext {
                 Command::GetDbStats(_) |
                 Command::GetStateInfo(_) |
                 Command::ListReorgs(_) |
+                Command::FetchAllOrphanHeaders(_) |
                 Command::ListBadBlocks(_) |
                 Command::GetBlock(_) |
                 Command::ListHeaders(_) |
@@ -300,6 +303,7 @@ impl HandleCommand<Command> for CommandContext {
             Command::HeaderStats(args) => self.handle_command(args).await,
             Command::BlockTiming(args) => self.handle_command(args).await,
             Command::ListReorgs(args) => self.handle_command(args).await,
+            Command::FetchAllOrphanHeaders(args) => self.handle_command(args).await,
             Command::ListBadBlocks(args) => self.handle_command(args).await,
             Command::DiscoverPeer(args) => self.handle_command(args).await,
             Command::GetBlock(args) => self.handle_command(args).await,

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -254,6 +254,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_block_by_hash(hash: HashOutput, compact: bool) -> Option<HistoricalBlock>, "fetch_block_by_hash");
 
+    make_async_fn!(fetch_orphan_blocks() -> Vec<ChainHeader>, "fetch_orphan_blocks");
+
     make_async_fn!(fetch_block_with_kernel(excess_sig: CompressedSignature) -> Option<HistoricalBlock>, "fetch_block_with_kernel");
 
     make_async_fn!(fetch_block_with_utxo(commitment: CompressedCommitment) -> Option<HistoricalBlock>, "fetch_block_with_utxo");

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -284,4 +284,6 @@ pub trait BlockchainBackend: Send + Sync + 'static {
     fn set_stats_total_height(&self, total: u64);
     /// Update the current progress step
     fn update_stats_progress(&self, current: u64);
+
+    fn fetch_all_orphans(&self) -> Result<Vec<ChainHeader>, ChainStorageError>;
 }

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1434,6 +1434,12 @@ where B: BlockchainBackend
         fetch_block_by_hash(&*db, hash, compact)
     }
 
+    /// Attempt to fetch the block corresponding to the provided hash from the main chain
+    pub fn fetch_orphan_blocks(&self) -> Result<Vec<ChainHeader>, ChainStorageError> {
+        let db = self.db_read_access()?;
+        fetch_orphan_blocks(&*db)
+    }
+
     /// Attempt to fetch the block corresponding to the provided kernel hash from the main chain, if the block is past
     /// pruning horizon, it will return Ok<None>
     pub fn fetch_block_with_kernel(
@@ -1550,6 +1556,11 @@ where B: BlockchainBackend
     ) -> Result<Vec<ValidatorNodeRegistrationInfo>, ChainStorageError> {
         let db = self.db_read_access()?;
         db.fetch_all_active_validator_nodes(height)
+    }
+
+    pub fn fetch_all_orphans(&self) -> Result<Vec<ChainHeader>, ChainStorageError> {
+        let db = self.db_read_access()?;
+        db.fetch_all_orphans()
     }
 
     pub fn fetch_active_validator_nodes(
@@ -2140,6 +2151,10 @@ fn fetch_block_by_hash<T: BlockchainBackend>(
         return Ok(Some(fetch_block(db, header.height, compact)?));
     }
     Ok(None)
+}
+
+fn fetch_orphan_blocks<T: BlockchainBackend>(db: &T) -> Result<Vec<ChainHeader>, ChainStorageError> {
+    db.fetch_all_orphans()
 }
 
 fn check_for_valid_height<T: BlockchainBackend>(db: &T, height: u64) -> Result<(u64, bool), ChainStorageError> {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -3341,6 +3341,31 @@ impl BlockchainBackend for LMDBDatabase {
         lmdb_filter_map_values(&txn, &self.reorgs, Some)
     }
 
+    fn fetch_all_orphans(&self) -> Result<Vec<ChainHeader>, ChainStorageError> {
+        let txn = self.read_transaction()?;
+        let mut headers = Vec::new();
+        let orphans: Vec<(Vec<u8>, HashOutput)> = lmdb_all(&txn, &self.orphan_parent_map_index)?;
+        for (_parent, hash) in orphans {
+            if let Some(orphan) = lmdb_get_typed(&txn, &self.orphans_typed, hash.deref())? {
+                let orphan_accum = self
+                    .fetch_orphan_header_accumulated_data(&txn, orphan.header.version, hash.deref())?
+                    .ok_or_else(|| ChainStorageError::ValueNotFound {
+                        entity: "orphan header accumulated data",
+                        field: "hash",
+                        value: hash.to_hex(),
+                    })?;
+                let chain_header = ChainHeader::try_construct(orphan.header, orphan_accum).ok_or_else(|| {
+                    ChainStorageError::DataInconsistencyDetected {
+                        function: "fetch_chain_header_in_all_chains",
+                        details: format!("accumulated data mismatch for orphan header {}", hash.to_hex()),
+                    }
+                })?;
+                headers.push(chain_header);
+            }
+        }
+        Ok(headers)
+    }
+
     fn fetch_all_active_validator_nodes(
         &self,
         height: u64,

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -226,6 +226,10 @@ impl BlockchainBackend for TempDatabase {
         self.db.as_mut().unwrap().write(tx)
     }
 
+    fn fetch_all_orphans(&self) -> Result<Vec<ChainHeader>, ChainStorageError> {
+        self.db.as_ref().unwrap().fetch_all_orphans()
+    }
+
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ChainStorageError> {
         self.db.as_ref().unwrap().fetch(key)
     }

--- a/base_layer/node_components/src/blocks/block_header_accumulated_data.rs
+++ b/base_layer/node_components/src/blocks/block_header_accumulated_data.rs
@@ -100,6 +100,11 @@ impl Display for BlockHeaderAccumulatedData {
             self.accumulated_tari_randomx_difficulty
         )?;
         writeln!(f, "Accumulated sha3 difficulty: {}", self.accumulated_sha3x_difficulty)?;
+        writeln!(
+            f,
+            "Accumulated cuckaroo difficulty: {}",
+            self.accumulated_cuckaroo_difficulty
+        )?;
         writeln!(f, "Target difficulty: {}", self.target_difficulty)?;
         Ok(())
     }


### PR DESCRIPTION
Description
---
Adds a command to view all orphan headers. 
Fixes the accumulated view to display c29 difficulty as well,.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New CLI command to fetch and display orphan headers stored in the blockchain database, enabling users to query reorg-related data.

* **Improvements**
  * Blockchain information display now includes accumulated cuckaroo difficulty metrics for enhanced chain state analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->