### PR TITLE
feat: add monitored peers

### DIFF
--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -30,7 +30,7 @@ use tari_common::{
 };
 use tari_comms::{
     multiaddr::{Error as MultiaddrError, Multiaddr},
-    peer_manager::Peer,
+    peer_manager::{NodeId, Peer},
     protocol::rpc::RpcServer,
     tor::TorIdentity,
     NodeIdentity,
@@ -106,17 +106,29 @@ where B: BlockchainBackend + 'static
         let peer_message_subscriptions = Arc::new(peer_message_subscriptions);
         let mempool_config = base_node_config.mempool.service.clone();
 
-        let sync_peers = base_node_config
+        let force_sync_peers = base_node_config
             .force_sync_peers
             .iter()
             .map(|s| SeedPeer::from_str(s))
-            .map(|r| r.map(Peer::from).map(|p| p.node_id))
+            .map(|r| r.map(Peer::from))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+        let force_sync_node_ids: Vec<NodeId> = force_sync_peers.clone().into_iter().map(|p| p.node_id).collect();
 
-        base_node_config.state_machine.blockchain_sync_config.forced_sync_peers = sync_peers.clone();
+        let monitored_peers = base_node_config
+            .monitored_peers
+            .iter()
+            .map(|s| SeedPeer::from_str(s))
+            .map(|r| r.map(Peer::from))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+        let mut monitored_node_ids: Vec<NodeId> = monitored_peers.clone().into_iter().map(|p| p.node_id).collect();
+        let mut total_monitored_ids = force_sync_node_ids.clone();
+        total_monitored_ids.append(&mut monitored_node_ids);
 
-        debug!(target: LOG_TARGET, "{} sync peer(s) configured", sync_peers.len());
+        base_node_config.state_machine.blockchain_sync_config.forced_sync_peers = force_sync_node_ids.clone();
+
+        debug!(target: LOG_TARGET, "{} sync peer(s) configured", force_sync_node_ids.len());
 
         let mempool_sync = MempoolSyncInitializer::new(mempool_config, self.mempool.clone());
         let mempool_protocol = mempool_sync.get_protocol_extension();
@@ -159,7 +171,7 @@ where B: BlockchainBackend + 'static
             .add_initializer(LivenessInitializer::new(
                 LivenessConfig {
                     auto_ping_interval: Some(base_node_config.metadata_auto_ping_interval),
-                    monitored_peers: sync_peers.clone(),
+                    monitored_peers: total_monitored_ids,
                     ..Default::default()
                 },
                 peer_message_subscriptions,
@@ -239,7 +251,20 @@ where B: BlockchainBackend + 'static
                     .map_err(|e| ExitError::new(ExitCode::IdentityError, e))?;
             },
         };
-
+        for peer in force_sync_peers {
+            comms
+                .peer_manager()
+                .add_or_update_peer(peer)
+                .await
+                .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+        }
+        for peer in monitored_peers {
+            comms
+                .peer_manager()
+                .add_or_update_peer(peer)
+                .await
+                .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+        }
         handles.register(comms);
 
         Ok(handles)

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -132,6 +132,8 @@ pub struct BaseNodeConfig {
     pub p2p: P2pConfig,
     /// If set this node will only sync to the nodes in this set
     pub force_sync_peers: StringList,
+    /// If set this node will always try to keep connections open to these nodes
+    pub monitored_peers: StringList,
     /// The maximum amount of time to wait for remote base node responses for messaging-based requests.
     #[serde(with = "serializers::seconds")]
     pub messaging_request_timeout: Duration,
@@ -216,6 +218,7 @@ impl Default for BaseNodeConfig {
             max_randomx_vms: 5,
             bypass_range_proof_verification: false,
             force_sync_peers: StringList::default(),
+            monitored_peers: StringList::default(),
             messaging_request_timeout: Duration::from_secs(60),
             storage: Default::default(),
             mempool: Default::default(),

--- a/base_layer/core/src/base_node/sync/ban.rs
+++ b/base_layer/core/src/base_node/sync/ban.rs
@@ -42,7 +42,7 @@ impl PeerBanManager {
     }
 
     pub async fn ban_peer_if_required(&mut self, node_id: &NodeId, ban_reason: String, ban_duration: Duration) {
-        if self.config.forced_sync_peers.contains(node_id) {
+        if self.config.forced_sync_peers.contains(node_id) || self.config.monitored_peers.contains(node_id) {
             debug!(
                 target: LOG_TARGET,
                 "Not banning peer that is on the allow list for sync. Ban reason = {ban_reason}"

--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -45,6 +45,8 @@ pub struct BlockchainSyncConfig {
     /// An allowlist of sync peers from which to sync. No other peers will be selected for sync. If empty, sync peers
     /// are chosen based on their advertised chain metadata.
     pub forced_sync_peers: Vec<NodeId>,
+    /// An allowed list of nodes which should always be connected to
+    pub monitored_peers: Vec<NodeId>,
     /// Number of threads to use for validation
     pub validation_concurrency: usize,
     /// The RPC deadline to set on sync clients. If this deadline is reached, a new sync peer will be selected for
@@ -78,6 +80,7 @@ impl Default for BlockchainSyncConfig {
             ban_period: Duration::from_secs(60 * 60 * 2),       // 2 hours
             short_ban_period: Duration::from_secs(240),         // 4 mins
             forced_sync_peers: Default::default(),
+            monitored_peers: Default::default(),
             validation_concurrency: 6,
             rpc_deadline: Duration::from_secs(240), // Syncing many full blocks over tor require this
             num_initial_sync_rounds_seed_bootstrap: default_num_initial_sync_rounds_seed_bootstrap(),

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -29,6 +29,9 @@
 # couple of nodes that you always want to have in sync. If set this node will only sync to the nodes in this set.
 # force_sync_peers = ["public_key1::address1", "public_key2::address2",... ]
 
+# This allowlist provides a method to keep a connection open to the spesified nodes in this list.
+#monitored_peers= ["public_key1::address1", "public_key2::address2",... ]
+
 # The maximum amount of seconds wait for remote base node responses for messaging-based requests.
 #messaging_request_timeout = 60
 


### PR DESCRIPTION
Description
---
Add an option to keep a list of monitored peers so that it always keeps a connection to those peers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "monitored_peers" configuration option enabling node operators to designate specific peers that maintain persistent connections and are protected from automatic disconnection policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->