### PR TITLE
feat: expand transport channel errors

### DIFF
--- a/base_layer/service_framework/src/reply_channel.rs
+++ b/base_layer/service_framework/src/reply_channel.rs
@@ -91,8 +91,8 @@ impl<TReq, TRes> Service<TReq> for SenderService<TReq, TRes> {
 
 #[derive(Debug, Error, Eq, PartialEq, Clone)]
 pub enum TransportChannelError {
-    #[error("Request was canceled")]
-    Canceled,
+    #[error("Request was canceled: {0}")]
+    Canceled(#[from] oneshot::error::RecvError),
     #[error("The response channel has closed")]
     ChannelClosed,
 }
@@ -120,7 +120,7 @@ impl<T> Future for TransportResponseFuture<T> {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.rx {
-            Some(ref mut rx) => rx.poll_unpin(cx).map_err(|_| TransportChannelError::Canceled),
+            Some(ref mut rx) => rx.poll_unpin(cx).map_err(TransportChannelError::from),
             None => Poll::Ready(Err(TransportChannelError::ChannelClosed)),
         }
     }
@@ -278,7 +278,13 @@ mod test {
         block_on(future::join(
             async move {
                 let err = requestor.ready().await.unwrap().call("PING").await.unwrap_err();
-                assert_eq!(err, TransportChannelError::Canceled);
+                assert_eq!(&format!("{}", err), "Request was canceled: channel closed");
+                match err {
+                    TransportChannelError::Canceled(e) => {
+                        assert_eq!(&format!("{}", e), "channel closed");
+                    },
+                    _ => panic!("Expected Canceled error"),
+                }
             },
             async move {
                 let req = request_stream.next().await.unwrap();

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -31,7 +31,7 @@ use tari_comms::{
     peer_manager::{node_id::NodeIdError, PeerManagerError},
 };
 use tari_p2p::{initialization::CommsInitializationError, services::liveness::error::LivenessError};
-use tari_service_framework::{reply_channel::TransportChannelError, ServiceInitializationError};
+use tari_service_framework::ServiceInitializationError;
 use tari_transaction_components::{
     key_manager::error::KeyManagerServiceError,
     transaction_components::TransactionError,
@@ -93,8 +93,6 @@ pub enum WalletError {
     CipherError(#[from] tari_common_types::seeds::error::CipherError),
     #[error("Key manager service error: `{0}`")]
     KeyManagerServiceError(#[from] KeyManagerServiceError),
-    #[error("Transport channel error: `{0}`")]
-    TransportChannelError(#[from] TransportChannelError),
     #[error("Unexpected API Response while calling method `{method}` on `{api}`")]
     UnexpectedApiResponse { method: String, api: String },
     #[error("Public address not set for this wallet")]

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -77,8 +77,8 @@ pub enum OutputManagerError {
     ApiSendFailed,
     #[error("Error receiving a message from the public API")]
     ApiReceiveFailed,
-    #[error("API returned something unexpected.")]
-    UnexpectedApiResponse,
+    #[error("Unexpected API response with `{0}`")]
+    UnexpectedApiResponse(String),
     #[error("Invalid config provided to Output Manager")]
     InvalidConfig,
     #[error("The response received from another service is an incorrect variant: `{0}`")]

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use std::{collections::HashMap, fmt, fmt::Formatter, sync::Arc};
 
+use log::warn;
 use tari_common_types::{
     tari_address::TariAddress,
     transaction::TxId,
@@ -55,6 +56,8 @@ use crate::output_manager_service::{
     },
     UtxoSelectionCriteria,
 };
+
+const LOG_TARGET: &str = "wallet::output_manager_service::handle";
 
 /// API Request enum
 pub enum OutputManagerRequest {
@@ -273,7 +276,7 @@ impl fmt::Display for OutputManagerRequest {
             },
             ClearShortTermEncumberances => write!(f, "ClearShortTermEncumberances"),
             GetOutputsByQuery(query) => write!(f, "GetOutputsByQuery: {:?}", query),
-            ScanOutputsForMultisig(outputs) => write!(f, "ScanOutputsForMultisig: {:?}", outputs),
+            ScanOutputsForMultisig(_) => write!(f, "ScanOutputsForMultisig"),
             GetManyOutputs { outputs } => write!(f, "GetManyOutputs ({})", outputs.len()),
         }
     }
@@ -407,10 +410,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::AddOutput((Box::new(output), spend_priority)))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::AddOutput({e})"))??
         {
             OutputManagerResponse::OutputAdded => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::AddOutput".to_string(),
+            )),
         }
     }
 
@@ -427,10 +433,13 @@ where KM: TransactionKeyManagerInterface
                 Box::new(output),
                 spend_priority,
             )))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::AddOutputWithTxId({e})"))??
         {
             OutputManagerResponse::OutputAdded => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::AddOutputWithTxId".to_string(),
+            )),
         }
     }
 
@@ -447,10 +456,13 @@ where KM: TransactionKeyManagerInterface
                 Box::new(output),
                 spend_priority,
             )))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::AddUnvalidatedOutput({e})"))??
         {
             OutputManagerResponse::OutputAdded => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::AddUnvalidatedOutput".to_string(),
+            )),
         }
     }
 
@@ -465,10 +477,13 @@ where KM: TransactionKeyManagerInterface
                 value,
                 features: Box::new(features),
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::CreateOutputWithFeatures({e})"))??
         {
             OutputManagerResponse::CreateOutputWithFeatures { output } => Ok(*output),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::CreateOutputWithFeatures".to_string(),
+            )),
         }
     }
 
@@ -479,17 +494,27 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::UpdateOutputMetadataSignature(Box::new(output)))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::UpdateOutputMetadataSignature({e})"))??
         {
             OutputManagerResponse::OutputMetadataSignatureUpdated => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::UpdateOutputMetadataSignature".to_string(),
+            )),
         }
     }
 
     pub async fn get_balance(&mut self) -> Result<Balance, OutputManagerError> {
-        match self.handle.call(OutputManagerRequest::GetBalance).await?? {
+        match self
+            .handle
+            .call(OutputManagerRequest::GetBalance)
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetBalance({e})"))??
+        {
             OutputManagerResponse::Balance(b) => Ok(b),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetBalance".to_string(),
+            )),
         }
     }
 
@@ -497,17 +522,27 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::GetBalancePaymentId(payment_id))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetBalancePaymentId({e})"))??
         {
             OutputManagerResponse::Balance(b) => Ok(b),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetBalancePaymentId".to_string(),
+            )),
         }
     }
 
     pub async fn revalidate_all_outputs(&mut self) -> Result<u64, OutputManagerError> {
-        match self.handle.call(OutputManagerRequest::RevalidateTxos).await?? {
+        match self
+            .handle
+            .call(OutputManagerRequest::RevalidateTxos)
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::RevalidateTxos({e})"))??
+        {
             OutputManagerResponse::TxoValidationStarted(request_key) => Ok(request_key),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::RevalidateTxos".to_string(),
+            )),
         }
     }
 
@@ -532,10 +567,13 @@ where KM: TransactionKeyManagerInterface
                 script,
                 covenant,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetTransactionBuilder({e})"))??
         {
             OutputManagerResponse::TransactionBuilderToSend(stp) => Ok(*stp),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetTransactionBuilder".to_string(),
+            )),
         }
     }
 
@@ -547,10 +585,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::ScrapeWallet { tx_id, fee_per_gram })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ScrapeWallet({e})"))??
         {
             OutputManagerResponse::TransactionBuilderToSend(tx_builder) => Ok(*tx_builder),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ScrapeWallet".to_string(),
+            )),
         }
     }
 
@@ -573,10 +614,13 @@ where KM: TransactionKeyManagerInterface
                 num_kernels,
                 num_outputs,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::FeeEstimate({e})"))??
         {
             OutputManagerResponse::FeeEstimate(fee) => Ok(fee),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::FeeEstimate".to_string(),
+            )),
         }
     }
 
@@ -588,10 +632,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::ConfirmPendingTransaction(tx_id, change_outputs))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ConfirmPendingTransaction({e})"))??
         {
             OutputManagerResponse::PendingTransactionConfirmed => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ConfirmPendingTransaction".to_string(),
+            )),
         }
     }
 
@@ -599,10 +646,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::CancelTransaction(tx_id))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::CancelTransaction({e})"))??
         {
             OutputManagerResponse::TransactionCancelled => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::CancelTransaction".to_string(),
+            )),
         }
     }
 
@@ -610,25 +660,42 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::GetManyOutputs { outputs })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetManyOutputs({e})"))??
         {
             OutputManagerResponse::Outputs(s) => Ok(s),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetManyOutputs".to_string(),
+            )),
         }
     }
 
     pub async fn get_spent_outputs(&mut self) -> Result<Vec<DbWalletOutput>, OutputManagerError> {
-        match self.handle.call(OutputManagerRequest::GetSpentOutputs).await?? {
+        match self
+            .handle
+            .call(OutputManagerRequest::GetSpentOutputs)
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetSpentOutputs({e})"))??
+        {
             OutputManagerResponse::SpentOutputs(s) => Ok(s),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetSpentOutputs".to_string(),
+            )),
         }
     }
 
     /// Sorted from lowest value to highest
     pub async fn get_unspent_outputs(&mut self) -> Result<Vec<DbWalletOutput>, OutputManagerError> {
-        match self.handle.call(OutputManagerRequest::GetUnspentOutputs).await?? {
+        match self
+            .handle
+            .call(OutputManagerRequest::GetUnspentOutputs)
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetUnspentOutputs({e})"))??
+        {
             OutputManagerResponse::UnspentOutputs(s) => Ok(s),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetUnspentOutputs".to_string(),
+            )),
         }
     }
 
@@ -640,24 +707,41 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::GetOutputsByQuery(query))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetOutputsByQuery({e})"))??
         {
             OutputManagerResponse::UnspentOutputs(s) => Ok(s),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetOutputsByQuery".to_string(),
+            )),
         }
     }
 
     pub async fn get_invalid_outputs(&mut self) -> Result<Vec<WalletOutput>, OutputManagerError> {
-        match self.handle.call(OutputManagerRequest::GetInvalidOutputs).await?? {
+        match self
+            .handle
+            .call(OutputManagerRequest::GetInvalidOutputs)
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetInvalidOutputs({e})"))??
+        {
             OutputManagerResponse::InvalidOutputs(s) => Ok(s),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetInvalidOutputs".to_string(),
+            )),
         }
     }
 
     pub async fn validate_txos(&mut self) -> Result<u64, OutputManagerError> {
-        match self.handle.call(OutputManagerRequest::ValidateTxos).await?? {
+        match self
+            .handle
+            .call(OutputManagerRequest::ValidateTxos)
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ValidateTxos({e})"))??
+        {
             OutputManagerResponse::TxoValidationStarted(request_key) => Ok(request_key),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ValidateTxos".to_string(),
+            )),
         }
     }
 
@@ -669,10 +753,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::PreviewCoinJoin((commitments, fee_per_gram)))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::PreviewCoinJoin({e})"))??
         {
             OutputManagerResponse::CoinPreview((expected_outputs, fee)) => Ok((expected_outputs, fee)),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::PreviewCoinJoin".to_string(),
+            )),
         }
     }
 
@@ -689,10 +776,13 @@ where KM: TransactionKeyManagerInterface
                 split_count,
                 fee_per_gram,
             )))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::PreviewCoinSplitEven({e})"))??
         {
             OutputManagerResponse::CoinPreview((expected_outputs, fee)) => Ok((expected_outputs, fee)),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::PreviewCoinSplitEven".to_string(),
+            )),
         }
     }
 
@@ -713,10 +803,13 @@ where KM: TransactionKeyManagerInterface
                 split_count,
                 fee_per_gram,
             )))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::CreateCoinSplit({e})"))??
         {
             OutputManagerResponse::Transaction(ct) => Ok(ct),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::CreateCoinSplit".to_string(),
+            )),
         }
     }
 
@@ -733,10 +826,13 @@ where KM: TransactionKeyManagerInterface
                 split_count,
                 fee_per_gram,
             )))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::CreateCoinSplitEven({e})"))??
         {
             OutputManagerResponse::Transaction(ct) => Ok(ct),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::CreateCoinSplitEven".to_string(),
+            )),
         }
     }
 
@@ -753,10 +849,13 @@ where KM: TransactionKeyManagerInterface
                 fee_per_gram,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::CreateCoinJoin({e})"))??
         {
             OutputManagerResponse::Transaction(result) => Ok(result),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::CreateCoinJoin".to_string(),
+            )),
         }
     }
 
@@ -768,10 +867,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::CreateHtlcRefundTransaction(output, fee_per_gram))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::CreateHtlcRefundTransaction({e})"))??
         {
             OutputManagerResponse::ClaimHtlcTransaction(ct) => Ok(ct),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::CreateHtlcRefundTransaction".to_string(),
+            )),
         }
     }
 
@@ -788,10 +890,14 @@ where KM: TransactionKeyManagerInterface
                 pre_image,
                 fee_per_gram,
             ))
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "OutputManagerRequest::CreateClaimShaAtomicSwapTransaction({e})"),
+            )?? {
             OutputManagerResponse::ClaimHtlcTransaction(ct) => Ok(ct),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::CreateClaimShaAtomicSwapTransaction".to_string(),
+            )),
         }
     }
 
@@ -802,10 +908,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::ScanForRecoverableOutputs(outputs))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ScanForRecoverableOutputs({e})"))??
         {
             OutputManagerResponse::RewoundOutputs(outputs) => Ok(outputs),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ScanForRecoverableOutputs".to_string(),
+            )),
         }
     }
 
@@ -813,9 +922,16 @@ where KM: TransactionKeyManagerInterface
         &mut self,
         outputs: Vec<(TransactionOutput, Option<TxId>)>,
     ) -> Result<Vec<RecoveredOutput>, OutputManagerError> {
-        match self.handle.call(OutputManagerRequest::ScanOutputs(outputs)).await?? {
+        match self
+            .handle
+            .call(OutputManagerRequest::ScanOutputs(outputs))
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ScanOutputs({e})"))??
+        {
             OutputManagerResponse::ScanOutputs(outputs) => Ok(outputs),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ScanOutputs".to_string(),
+            )),
         }
     }
 
@@ -826,10 +942,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::ScanOutputsForMultisig(outputs))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ScanOutputsForMultisig({e})"))??
         {
             OutputManagerResponse::ScanOutputs(outputs) => Ok(outputs),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ScanOutputsForMultisig".to_string(),
+            )),
         }
     }
 
@@ -837,10 +956,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::AddKnownOneSidedPaymentScript(script))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::AddKnownOneSidedPaymentScript({e})"))??
         {
             OutputManagerResponse::AddKnownOneSidedPaymentScript => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::AddKnownOneSidedPaymentScript".to_string(),
+            )),
         }
     }
 
@@ -887,7 +1009,8 @@ where KM: TransactionKeyManagerInterface
                 use_output,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::EncumberAggregateUtxo({e})"))??
         {
             OutputManagerResponse::EncumberAggregateUtxo(values) => {
                 let (
@@ -909,7 +1032,9 @@ where KM: TransactionKeyManagerInterface
                     shared_secret,
                 ))
             },
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::EncumberAggregateUtxo".to_string(),
+            )),
         }
     }
 
@@ -930,10 +1055,13 @@ where KM: TransactionKeyManagerInterface
                 expected_commitment,
                 recipient_address,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::SpendBackupPreMineUtxo({e})"))??
         {
             OutputManagerResponse::SpendBackupPreMineUtxo((transaction, amount, fee)) => Ok((transaction, amount, fee)),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::SpendBackupPreMineUtxo".to_string(),
+            )),
         }
     }
 
@@ -961,10 +1089,13 @@ where KM: TransactionKeyManagerInterface
                 payment_id,
                 minimum_value_promise,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::CreatePayToSelfTransaction({e})"))??
         {
             OutputManagerResponse::PayToSelfTransaction(outputs) => Ok(outputs),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::CreatePayToSelfTransaction".to_string(),
+            )),
         }
     }
 
@@ -975,10 +1106,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::ReinstateCancelledInboundTx(tx_id))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ReinstateCancelledInboundTx({e})"))??
         {
             OutputManagerResponse::ReinstatedCancelledInboundTx => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ReinstateCancelledInboundTx".to_string(),
+            )),
         }
     }
 
@@ -986,10 +1120,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::GetOutputInfoByTxId(tx_id))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetOutputInfoByTxId({e})"))??
         {
             OutputManagerResponse::OutputInfoByTxId(output_info_by_tx_id) => Ok(output_info_by_tx_id),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetOutputInfoByTxId".to_string(),
+            )),
         }
     }
 
@@ -1000,10 +1137,13 @@ where KM: TransactionKeyManagerInterface
         match self
             .handle
             .call(OutputManagerRequest::FetchUnspentOutputs(hashes))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::FetchUnspentOutputs({e})"))??
         {
             OutputManagerResponse::FetchUnspentOutputs(outputs) => Ok(outputs),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::FetchUnspentOutputs".to_string(),
+            )),
         }
     }
 
@@ -1012,21 +1152,30 @@ where KM: TransactionKeyManagerInterface
         tx_id: TxId,
         change_outputs: Vec<WalletOutput>,
     ) -> Result<(), OutputManagerError> {
-        self.handle
+        match self
+            .handle
             .call(OutputManagerRequest::ConfirmEncumberance(tx_id, change_outputs))
-            .await??;
-
-        Ok(())
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ConfirmEncumberance({e})"))??
+        {
+            OutputManagerResponse::ConfirmEncumberance => Ok(()),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ConfirmEncumberance".to_string(),
+            )),
+        }
     }
 
     pub async fn clear_short_term_encumberances(&mut self) -> Result<(), OutputManagerError> {
         match self
             .handle
             .call(OutputManagerRequest::ClearShortTermEncumberances)
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::ClearShortTermEncumberances({e})"))??
         {
             OutputManagerResponse::ClearShortTermEncumberances => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::ClearShortTermEncumberances".to_string(),
+            )),
         }
     }
 }

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -238,7 +238,6 @@ where
                     }
                 },
                 Some(request_context) = request_stream.next() => {
-                trace!(target: LOG_TARGET, "Handling Service API Request");
                     let (request, reply_tx) = request_context.split();
                     let response = self.handle_request(request).await.inspect_err(|e| {
                         warn!(target: LOG_TARGET, "Error handling request: {e:?}");

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -534,7 +534,7 @@ where
                     output: output.clone(),
                     mined_at_height: returned_output.mined_in_height,
                     mined_block_hash: FixedHash::try_from(returned_output.mined_in_hash.clone())
-                        .map_err(|_| OutputManagerError::UnexpectedApiResponse)?,
+                        .map_err(|_| OutputManagerError::UnexpectedApiResponse("FixedHash".to_string()))?,
                     mined_timestamp: returned_output.mined_in_timestamp,
                 });
             } else {

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -73,8 +73,8 @@ pub enum TransactionServiceError {
     TransactionDoesNotExistError,
     #[error("The Outbound Message Service is not initialized")]
     OutboundMessageServiceNotInitialized,
-    #[error("Received an unexpected API response")]
-    UnexpectedApiResponse,
+    #[error("Unexpected API response with `{0}`")]
+    UnexpectedApiResponse(String),
     #[error("Failed to send from API")]
     ApiSendFailed,
     #[error("Failed to receive in API from service")]

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
+use log::warn;
 use tari_common_types::{
     burn_proof::BurnClaimProof,
     epoch::VnEpoch,
@@ -80,6 +81,8 @@ use crate::{
     },
     OperationId,
 };
+
+const LOG_TARGET: &str = "wallet::transaction_service::handle";
 
 /// API Request enum
 #[allow(clippy::large_enum_variant)]
@@ -809,10 +812,13 @@ impl TransactionServiceHandle {
                 destination,
                 fee_per_gram,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::ScrapeWallet({e})"))??
         {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::ScrapeWallet".to_string(),
+            )),
         }
     }
 
@@ -841,10 +847,13 @@ impl TransactionServiceHandle {
                 fee_per_gram,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::RegisterValidatorNode({e})"))??
         {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::RegisterValidatorNode".to_string(),
+            )),
         }
     }
 
@@ -871,10 +880,13 @@ impl TransactionServiceHandle {
                 fee_per_gram,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SubmitValidatorNodeExit({e})"))??
         {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SubmitValidatorNodeExit".to_string(),
+            )),
         }
     }
 
@@ -901,13 +913,16 @@ impl TransactionServiceHandle {
                 fee_per_gram,
                 sidechain_deployment_key,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::RegisterCodeTemplate({e})"))??
         {
             TransactionServiceResponse::CodeRegistrationTransactionSent {
                 tx_id,
                 template_address,
             } => Ok((tx_id, template_address)),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::RegisterCodeTemplate".to_string(),
+            )),
         }
     }
 
@@ -928,10 +943,14 @@ impl TransactionServiceHandle {
                 payment_id,
                 sidechain_deployment_key,
             })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SubmitValidatorEvictionProof({e})"),
+            )?? {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SubmitValidatorEvictionProof".to_string(),
+            )),
         }
     }
 
@@ -954,10 +973,14 @@ impl TransactionServiceHandle {
                 fee_per_gram,
                 payment_id,
             })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::PrepareOneSidedTransactionForSigning({e})"),
+            )?? {
             TransactionServiceResponse::OneSidedTransactionPreparedForSigning(result) => Ok(*result),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::PrepareOneSidedTransactionForSigning".to_string(),
+            )),
         }
     }
 
@@ -968,10 +991,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::SignOneSidedTransaction { request })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SignOneSidedTransaction({e})"))??
         {
             TransactionServiceResponse::SignedOneSidedTransaction(result) => Ok(*result),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SignOneSidedTransaction".to_string(),
+            )),
         }
     }
 
@@ -982,10 +1008,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::SignOneSidedDepositMultisigTransaction { request })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SignOneSidedDepositMultisigTransaction({e})"),
+            )?? {
             TransactionServiceResponse::SignedOneSidedDepositMultisigTransaction(result) => Ok(*result),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SignOneSidedDepositMultisigTransaction".to_string(),
+            )),
         }
     }
 
@@ -996,10 +1026,11 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::SignOneSidedWithdrawMultisigTransaction { request })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SignOneSidedWithdrawMultisigTransaction({e})"))??
         {
             TransactionServiceResponse::SignedOneSidedWithdrawMultisigTransaction(result) => Ok(*result),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse("TransactionServiceRequest::SignOneSidedWithdrawMultisigTransaction".to_string())),
         }
     }
 
@@ -1010,10 +1041,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::BroadcastSignedOneSidedTransaction { request })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::BroadcastSignedOneSidedTransaction({e})"),
+            )?? {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::BroadcastSignedOneSidedTransaction".to_string(),
+            )),
         }
     }
 
@@ -1032,10 +1067,14 @@ impl TransactionServiceHandle {
                 output_features: Box::new(output_features),
                 fee_per_gram,
             })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SendManyOneSidedTransactions({e})"),
+            )?? {
             TransactionServiceResponse::TransactionsSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SendManyOneSidedTransactions".to_string(),
+            )),
         }
     }
 
@@ -1058,10 +1097,13 @@ impl TransactionServiceHandle {
                 fee_per_gram,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SendOneSidedTransaction({e})"))??
         {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SendOneSidedTransaction".to_string(),
+            )),
         }
     }
 
@@ -1087,10 +1129,13 @@ impl TransactionServiceHandle {
                 claim_public_key,
                 sidechain_deployment_key,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::BurnTari({e})"))??
         {
             TransactionServiceResponse::BurntTransactionSent { tx_id, proof } => Ok((tx_id, proof.map(|p| *p))),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::BurnTari".to_string(),
+            )),
         }
     }
 
@@ -1134,7 +1179,8 @@ impl TransactionServiceHandle {
                 use_output,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::EncumberAggregateUtxo({e})"))??
         {
             TransactionServiceResponse::EncumberAggregateUtxo(
                 tx_id,
@@ -1151,7 +1197,9 @@ impl TransactionServiceHandle {
                 *total_script_nonce,
                 *shared_secret,
             )),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::EncumberAggregateUtxo".to_string(),
+            )),
         }
     }
 
@@ -1172,10 +1220,13 @@ impl TransactionServiceHandle {
                 recipient_address,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SpendBackupPreMineUtxo({e})"))??
         {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SpendBackupPreMineUtxo".to_string(),
+            )),
         }
     }
 
@@ -1186,10 +1237,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::FetchUnspentOutputs { output_hashes })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::FetchUnspentOutputs({e})"))??
         {
             TransactionServiceResponse::UnspentOutputs(outputs) => Ok(outputs),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::FetchUnspentOutputs".to_string(),
+            )),
         }
     }
 
@@ -1208,10 +1262,14 @@ impl TransactionServiceHandle {
                 total_script_data_signature,
                 script_offset,
             })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::FinalizeSentAggregateTransaction({e})"),
+            )?? {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::FinalizeSentAggregateTransaction".to_string(),
+            )),
         }
     }
 
@@ -1234,10 +1292,11 @@ impl TransactionServiceHandle {
                 fee_per_gram,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest:SendOneSidedToStealthAddressTransaction:({e})"))??
         {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse("TransactionServiceRequest::SendOneSidedToStealthAddressTransaction".to_string())),
         }
     }
 
@@ -1245,10 +1304,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::CancelTransaction(tx_id))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::CancelTransaction({e})"))??
         {
             TransactionServiceResponse::TransactionCancelled => Ok(()),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::CancelTransaction".to_string(),
+            )),
         }
     }
 
@@ -1258,10 +1320,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetPendingInboundTransactions)
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetPendingInboundTransactions({e})"),
+            )?? {
             TransactionServiceResponse::PendingInboundTransactions(p) => Ok(p),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetPendingInboundTransactions".to_string(),
+            )),
         }
     }
 
@@ -1271,10 +1337,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetCancelledPendingInboundTransactions)
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetCancelledPendingInboundTransactions({e})"),
+            )?? {
             TransactionServiceResponse::PendingInboundTransactions(p) => Ok(p),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetCancelledPendingInboundTransactions".to_string(),
+            )),
         }
     }
 
@@ -1284,10 +1354,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetPendingOutboundTransactions)
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetPendingOutboundTransactions({e})"),
+            )?? {
             TransactionServiceResponse::PendingOutboundTransactions(p) => Ok(p),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetPendingOutboundTransactions".to_string(),
+            )),
         }
     }
 
@@ -1297,10 +1371,11 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetCancelledPendingOutboundTransactions)
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetCancelledPendingOutboundTransactions({e})"))??
         {
             TransactionServiceResponse::PendingOutboundTransactions(p) => Ok(p),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse("TransactionServiceRequest::GetCancelledPendingOutboundTransactions".to_string())),
         }
     }
 
@@ -1319,10 +1394,13 @@ impl TransactionServiceHandle {
                 block_height,
                 max_limit,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetCompletedTransactions({e})"))??
         {
             TransactionServiceResponse::CompletedTransactions(c) => Ok(c),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetCompletedTransactions".to_string(),
+            )),
         }
     }
 
@@ -1339,10 +1417,14 @@ impl TransactionServiceHandle {
                 limit,
                 status_filter,
             })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetCompletedTransactionsPaginated({e})"),
+            )?? {
             TransactionServiceResponse::CompletedTransactions(c) => Ok(c),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetCompletedTransactionsPaginated".to_string(),
+            )),
         }
     }
 
@@ -1357,10 +1439,14 @@ impl TransactionServiceHandle {
                 source_address,
                 destination_address,
             })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetCompletedTransactionsByAddresses({e})"),
+            )?? {
             TransactionServiceResponse::CompletedTransactions(c) => Ok(c),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetCompletedTransactionsByAddresses".to_string(),
+            )),
         }
     }
 
@@ -1371,10 +1457,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetCancelledCompletedTransactions(max_limit))
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetCancelledCompletedTransactions({e})"),
+            )?? {
             TransactionServiceResponse::CompletedTransactions(c) => Ok(c),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetCancelledCompletedTransactions".to_string(),
+            )),
         }
     }
 
@@ -1385,10 +1475,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetCompletedTransaction(tx_id))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::TransactionServiceRequest({e})"))??
         {
             TransactionServiceResponse::CompletedTransaction(t) => Ok(*t),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::TransactionServiceRequest".to_string(),
+            )),
         }
     }
 
@@ -1399,10 +1492,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetAnyTransaction(tx_id))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetAnyTransaction({e})"))??
         {
             TransactionServiceResponse::AnyTransaction(t) => Ok(*t),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetAnyTransaction".to_string(),
+            )),
         }
     }
 
@@ -1410,10 +1506,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::ImportTransaction(tx))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::ImportTransaction({e})"))??
         {
             TransactionServiceResponse::TransactionImported(t) => Ok(t),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::ImportTransaction".to_string(),
+            )),
         }
     }
 
@@ -1440,10 +1539,13 @@ impl TransactionServiceHandle {
                 scanned_output,
                 payment_id,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::ImportUtxoWithStatus({e})"))??
         {
             TransactionServiceResponse::UtxoImported(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::ImportUtxoWithStatus".to_string(),
+            )),
         }
     }
 
@@ -1460,17 +1562,27 @@ impl TransactionServiceHandle {
             .call(TransactionServiceRequest::SubmitTransactionToSelf(
                 tx_id, tx, fee, amount, payment_id,
             ))
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SubmitTransactionToSelf({e})"))??
         {
             TransactionServiceResponse::TransactionSubmitted => Ok(()),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SubmitTransactionToSelf".to_string(),
+            )),
         }
     }
 
     pub async fn set_low_power_mode(&mut self) -> Result<(), TransactionServiceError> {
-        match self.handle.call(TransactionServiceRequest::SetLowPowerMode).await?? {
+        match self
+            .handle
+            .call(TransactionServiceRequest::SetLowPowerMode)
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SetLowPowerMode({e})"))??
+        {
             TransactionServiceResponse::LowPowerModeSet => Ok(()),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SetLowPowerMode".to_string(),
+            )),
         }
     }
 
@@ -1478,10 +1590,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::ReValidateRejectedTransactions)
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::ReValidateRejectedTransactions({e})"),
+            )?? {
             TransactionServiceResponse::ValidationStarted(_) => Ok(()),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::ReValidateRejectedTransactions".to_string(),
+            )),
         }
     }
 
@@ -1489,10 +1605,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::SetNormalPowerMode)
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SetNormalPowerMode({e})"))??
         {
             TransactionServiceResponse::NormalPowerModeSet => Ok(()),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SetNormalPowerMode".to_string(),
+            )),
         }
     }
 
@@ -1500,10 +1619,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetNumConfirmationsRequired)
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetNumConfirmationsRequired({e})"),
+            )?? {
             TransactionServiceResponse::NumConfirmationsRequired(confirmations) => Ok(confirmations),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetNumConfirmationsRequired".to_string(),
+            )),
         }
     }
 
@@ -1511,10 +1634,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::SetNumConfirmationsRequired(number))
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SetNumConfirmationsRequired({e})"),
+            )?? {
             TransactionServiceResponse::NumConfirmationsSet => Ok(()),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SetNumConfirmationsRequired".to_string(),
+            )),
         }
     }
 
@@ -1522,10 +1649,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::RestartBroadcastProtocols)
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::RestartBroadcastProtocols({e})"))??
         {
             TransactionServiceResponse::ProtocolsRestarted => Ok(()),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::RestartBroadcastProtocols".to_string(),
+            )),
         }
     }
 
@@ -1533,10 +1663,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::ValidateTransactions)
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::ValidateTransactions({e})"))??
         {
             TransactionServiceResponse::ValidationStarted(id) => Ok(id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::ValidateTransactions".to_string(),
+            )),
         }
     }
 
@@ -1556,10 +1689,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::PrepareDepositMultisigTransaction { request })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::PrepareDepositMultisigTransaction({e})"),
+            )?? {
             TransactionServiceResponse::PrepareDepositMultisigTransaction(result) => Ok(*result),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::PrepareDepositMultisigTransaction".to_string(),
+            )),
         }
     }
 
@@ -1577,10 +1714,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::PrepareWithdrawMultisigTransaction { request })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::PrepareWithdrawMultisigTransaction({e})"),
+            )?? {
             TransactionServiceResponse::PrepareWithdrawMultisigTransaction(result) => Ok(*result),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::PrepareWithdrawMultisigTransaction".to_string(),
+            )),
         }
     }
 
@@ -1600,10 +1741,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::CreateMultisigUtxo { request })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::CreateMultisigUtxo({e})"))??
         {
             TransactionServiceResponse::CreateMultisigUtxo(id) => Ok(id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::CreateMultisigUtxo".to_string(),
+            )),
         }
     }
 
@@ -1614,10 +1758,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetMultisigUtxoData { utxo_commitment })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetMultisigUtxoData({e})"))??
         {
             TransactionServiceResponse::GetMultisigUtxoData(output) => Ok(*output),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetMultisigUtxoData".to_string(),
+            )),
         }
     }
 
@@ -1634,10 +1781,13 @@ impl TransactionServiceHandle {
                 recipient_address,
                 signatures,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SendMultisigUtxo({e})"))??
         {
             TransactionServiceResponse::SendMultisigUtxo(output) => Ok(output),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SendMultisigUtxo".to_string(),
+            )),
         }
     }
 
@@ -1658,13 +1808,17 @@ impl TransactionServiceHandle {
                 fee_per_gram,
                 payment_id,
             ))
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::SendShaAtomicSwapTransaction({e})"),
+            )?? {
             TransactionServiceResponse::ShaAtomicSwapTransactionSent(boxed) => {
                 let (tx_id, pre_image, output) = *boxed;
                 Ok((tx_id, pre_image, output))
             },
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SendShaAtomicSwapTransaction".to_string(),
+            )),
         }
     }
 
@@ -1676,10 +1830,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetFeePerGramStatsPerBlock { count })
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetFeePerGramStatsPerBlock({e})"),
+            )?? {
             TransactionServiceResponse::FeePerGramStatsPerBlock(resp) => Ok(resp),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetFeePerGramStatsPerBlock".to_string(),
+            )),
         }
     }
 
@@ -1691,10 +1849,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetPaymentByReference { payref })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetPaymentByReference({e})"))??
         {
             TransactionServiceResponse::PaymentDetails(details) => Ok(details),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetPaymentByReference".to_string(),
+            )),
         }
     }
 
@@ -1706,10 +1867,14 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::GetTransactionByPaymentReference(payref))
-            .await??
-        {
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetTransactionByPaymentReference({e})"),
+            )?? {
             TransactionServiceResponse::CompletedTransaction(tx) => Ok(*tx),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::GetTransactionByPaymentReference".to_string(),
+            )),
         }
     }
 
@@ -1729,10 +1894,13 @@ impl TransactionServiceHandle {
         match self
             .handle
             .call(TransactionServiceRequest::ReplaceByFee { tx_id, fee_increase })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::ReplaceByFee({e})"))??
         {
             TransactionServiceResponse::TransactionReplaced(new_tx_id) => Ok(new_tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::ReplaceByFee".to_string(),
+            )),
         }
     }
 
@@ -1758,10 +1926,13 @@ impl TransactionServiceHandle {
                 destination,
                 fee,
             })
-            .await??
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::UserPayForFee({e})"))??
         {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
-            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::UserPayForFee".to_string(),
+            )),
         }
     }
 }

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -1476,11 +1476,11 @@ impl TransactionServiceHandle {
             .handle
             .call(TransactionServiceRequest::GetCompletedTransaction(tx_id))
             .await
-            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::TransactionServiceRequest({e})"))??
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::GetCompletedTransaction({e})"))??
         {
             TransactionServiceResponse::CompletedTransaction(t) => Ok(*t),
             _ => Err(TransactionServiceError::UnexpectedApiResponse(
-                "TransactionServiceRequest::TransactionServiceRequest".to_string(),
+                "TransactionServiceRequest::GetCompletedTransaction".to_string(),
             )),
         }
     }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -81,7 +81,6 @@ use tari_transaction_components::{
     key_manager::{SerializedKeyString, TariKeyId, TransactionKeyManagerInterface},
     multisig::{script::get_multi_sig_script_components, session::MultisigSession, types::GetMultisigUtxoDataOutput},
     offline_signing::{models::SignedOneSidedTransactionResult, offline_signer::OfflineSigner},
-    rpc::models::FeePerGramStat,
     transaction_components::{
         covenants::Covenant,
         memo_field::{MemoField, TxType},
@@ -404,6 +403,8 @@ where
         >,
         reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
     ) -> Result<(), TransactionServiceError> {
+        let mut reply_channel = Some(reply_channel);
+
         trace!(target: LOG_TARGET, "Handling Service Request: {request}");
         let response: Result<TransactionServiceResponse, TransactionServiceError> = match request {
 
@@ -1264,10 +1265,11 @@ where
                 Ok(TransactionServiceResponse::TransactionSent(tx_id))
             }.await,
 
-            TransactionServiceRequest::GetFeePerGramStatsPerBlock { count } => async {
-                let resp = self.handle_get_fee_per_gram_stats_per_block_request(count).await?;
-                Ok(TransactionServiceResponse::FeePerGramStatsPerBlock(resp))
-            }.await,
+            TransactionServiceRequest::GetFeePerGramStatsPerBlock { count } => {
+                let reply_channel = reply_channel.take().expect("reply_channel is Some");
+                self.handle_get_fee_per_gram_stats_per_block_request(count, reply_channel);
+                return Ok(());
+            },
 
             TransactionServiceRequest::GetPaymentByReference { payref } => async {
                 let res = self.get_payment_by_reference(payref)?;
@@ -1481,28 +1483,50 @@ where
             }.await,
         };
 
-        let _result = reply_channel
-            .send(response.inspect_err(|e1| warn!(target: LOG_TARGET, "{}", e1)))
-            .inspect_err(|e2| {
-                warn!(target: LOG_TARGET, "Failed to send reply: {:?}", e2);
-            });
+        // If the individual handlers did not already send the API response then do it here.
+        if let Some(rp) = reply_channel {
+            let _result = rp
+                .send(response.inspect_err(|e1| warn!(target: LOG_TARGET, "{}", e1)))
+                .inspect_err(|e2| {
+                    warn!(target: LOG_TARGET, "Failed to send reply: {:?}", e2);
+                });
+        }
 
         Ok(())
     }
 
-    async fn handle_get_fee_per_gram_stats_per_block_request(
+    fn handle_get_fee_per_gram_stats_per_block_request(
         &self,
         count: u64,
-    ) -> Result<FeePerGramStat, TransactionServiceError> {
+        reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
+    ) {
         let connectivity = self.resources.connectivity.clone();
 
-        let client = connectivity.obtain_base_node_wallet_rpc_client().await;
+        let query_base_node_fut = async move {
+            let client = connectivity.obtain_base_node_wallet_rpc_client().await;
 
-        let resp = client
-            .get_mempool_fee_per_gram_stats(count)
-            .await
-            .map_err(|e| TransactionServiceError::Other(e.to_string()))?;
-        Ok(resp)
+            match client.get_mempool_fee_per_gram_stats(count).await {
+                Ok(resp) => Ok(TransactionServiceResponse::FeePerGramStatsPerBlock(resp)),
+                Err(e) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Error handling 'TransactionServiceRequest::GetFeePerGramStatsPerBlock' {:?}",
+                        e
+                    );
+                    Err(TransactionServiceError::Other(e.to_string()))
+                },
+            }
+        };
+
+        tokio::spawn(async move {
+            let resp = query_base_node_fut.await;
+            if reply_channel.send(resp).is_err() {
+                warn!(
+                    target: LOG_TARGET,
+                    "handle_get_fee_per_gram_stats_per_block_request: service reply cancelled"
+                );
+            }
+        });
     }
 
     async fn handle_base_node_service_event(&mut self, event: Arc<BaseNodeEvent>) {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -81,6 +81,7 @@ use tari_transaction_components::{
     key_manager::{SerializedKeyString, TariKeyId, TransactionKeyManagerInterface},
     multisig::{script::get_multi_sig_script_components, session::MultisigSession, types::GetMultisigUtxoDataOutput},
     offline_signing::{models::SignedOneSidedTransactionResult, offline_signer::OfflineSigner},
+    rpc::models::FeePerGramStat,
     transaction_components::{
         covenants::Covenant,
         memo_field::{MemoField, TxType},
@@ -403,10 +404,9 @@ where
         >,
         reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
     ) -> Result<(), TransactionServiceError> {
-        let mut reply_channel = Some(reply_channel);
-
         trace!(target: LOG_TARGET, "Handling Service Request: {request}");
         let response: Result<TransactionServiceResponse, TransactionServiceError> = match request {
+
             TransactionServiceRequest::PrepareOneSidedTransactionForSigning {
                 destination,
                 amount,
@@ -414,7 +414,7 @@ where
                 output_features,
                 fee_per_gram,
                 mut payment_id,
-            } => {
+            } => async {
                 self.verify_send(&destination, TariAddressFeatures::create_one_sided_only())?;
                 debug!(target: LOG_TARGET, "Locking one sided transaction to {destination} with {amount}");
                 let tx_id = TxId::new_random();
@@ -479,8 +479,9 @@ where
                 Ok(TransactionServiceResponse::OneSidedTransactionPreparedForSigning(
                     Box::new(res),
                 ))
-            },
-            TransactionServiceRequest::PrepareDepositMultisigTransaction { request } => {
+            }.await,
+
+            TransactionServiceRequest::PrepareDepositMultisigTransaction { request } => async {
                 self.verify_send(&request.recipient_address, TariAddressFeatures::create_one_sided_only())?;
                 let offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
 
@@ -539,9 +540,9 @@ where
                 Ok(TransactionServiceResponse::PrepareDepositMultisigTransaction(Box::new(
                     response,
                 )))
-            },
+            }.await,
 
-            TransactionServiceRequest::PrepareWithdrawMultisigTransaction { request } => {
+            TransactionServiceRequest::PrepareWithdrawMultisigTransaction { request } => async {
                 self.verify_send(&request.recipient_address, TariAddressFeatures::create_one_sided_only())?;
                 let offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
 
@@ -666,13 +667,15 @@ where
                 Ok(TransactionServiceResponse::PrepareWithdrawMultisigTransaction(
                     Box::new(response),
                 ))
-            },
-            TransactionServiceRequest::SignOneSidedTransaction { request } => {
+            }.await,
+
+            TransactionServiceRequest::SignOneSidedTransaction { request } => async {
                 let mut offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
                 let res = offline_signing.sign_locked_transaction(request).await?;
                 Ok(TransactionServiceResponse::SignedOneSidedTransaction(Box::new(res)))
-            },
-            TransactionServiceRequest::SignOneSidedDepositMultisigTransaction { request } => {
+            }.await,
+
+            TransactionServiceRequest::SignOneSidedDepositMultisigTransaction { request } => async {
                 let mut offline_signing = OfflineSigner::new(self.resources.transaction_key_manager_service.clone());
                 let res = offline_signing
                     .sign_locked_deposit_multisig_transaction(request)
@@ -680,8 +683,9 @@ where
                 Ok(TransactionServiceResponse::SignedOneSidedDepositMultisigTransaction(
                     Box::new(res),
                 ))
-            },
-            TransactionServiceRequest::SignOneSidedWithdrawMultisigTransaction { request } => {
+            }.await,
+
+            TransactionServiceRequest::SignOneSidedWithdrawMultisigTransaction { request } => async {
                 let key_manager = self.resources.transaction_key_manager_service.clone();
                 let mut offline_signing = OfflineSigner::new(key_manager.clone());
                 let mut request = request;
@@ -739,13 +743,15 @@ where
                 Ok(TransactionServiceResponse::SignedOneSidedWithdrawMultisigTransaction(
                     Box::new(res),
                 ))
-            },
-            TransactionServiceRequest::BroadcastSignedOneSidedTransaction { request } => {
+            }.await,
+
+            TransactionServiceRequest::BroadcastSignedOneSidedTransaction { request } => async {
                 let res = self
                     .submit_signed_one_sided_transaction(request, transaction_broadcast_join_handles)
                     .await?;
                 Ok(TransactionServiceResponse::TransactionSent(res))
-            },
+            }.await,
+
             TransactionServiceRequest::SendOneSidedTransaction {
                 destination,
                 amount,
@@ -753,7 +759,7 @@ where
                 output_features,
                 fee_per_gram,
                 payment_id,
-            } => {
+            } => async {
                 let res = self
                     .send_one_sided_transaction(
                         destination,
@@ -766,13 +772,14 @@ where
                     )
                     .await?;
                 Ok(TransactionServiceResponse::TransactionSent(res))
-            },
+            }.await,
+
             TransactionServiceRequest::SendManyOneSidedTransactions {
                 destinations,
                 selection_criteria,
                 output_features,
                 fee_per_gram,
-            } => {
+            } => async {
                 let res = self
                     .send_many_one_sided_transactions(
                         destinations,
@@ -783,17 +790,18 @@ where
                     )
                     .await?;
                 Ok(TransactionServiceResponse::TransactionsSent(res))
-            },
+            }.await,
 
             TransactionServiceRequest::ScrapeWallet {
                 destination,
                 fee_per_gram,
-            } => {
+            } => async {
                 let res = self
                     .scrape_wallet(destination, fee_per_gram, transaction_broadcast_join_handles)
                     .await?;
                 Ok(TransactionServiceResponse::TransactionSent(res))
-            },
+            }.await,
+
             TransactionServiceRequest::SendOneSidedToStealthAddressTransaction {
                 destination,
                 amount,
@@ -801,7 +809,7 @@ where
                 output_features,
                 fee_per_gram,
                 payment_id,
-            } => {
+            } => async {
                 let res = self
                     .send_one_sided_to_stealth_address_transaction(
                         destination,
@@ -814,7 +822,8 @@ where
                     )
                     .await?;
                 Ok(TransactionServiceResponse::TransactionSent(res))
-            },
+            }.await,
+
             TransactionServiceRequest::BurnTari {
                 amount,
                 selection_criteria,
@@ -822,7 +831,7 @@ where
                 payment_id,
                 claim_public_key,
                 sidechain_deployment_key,
-            } => {
+            } => async {
                 let (tx_id, proof) = self
                     .burn_tari(
                         amount,
@@ -838,7 +847,8 @@ where
                     tx_id,
                     proof: proof.map(Box::new),
                 })
-            },
+            }.await,
+
             TransactionServiceRequest::EncumberAggregateUtxo {
                 fee_per_gram,
                 expected_commitment,
@@ -851,7 +861,7 @@ where
                 original_maturity,
                 use_output,
                 payment_id,
-            } => {
+            } => async {
                 let (
                     tx_id,
                     tx,
@@ -884,14 +894,15 @@ where
                         Box::new(shared_secret),
                     )
                 })
-            },
+            }.await,
+
             TransactionServiceRequest::SpendBackupPreMineUtxo {
                 fee_per_gram,
                 output_hash,
                 expected_commitment,
                 recipient_address,
                 payment_id,
-            } => {
+            } => async {
                 let res = self
                     .spend_backup_pre_mine_utxo(
                         fee_per_gram,
@@ -902,26 +913,31 @@ where
                     )
                     .await?;
                 Ok(TransactionServiceResponse::TransactionSent(res))
-            },
-            TransactionServiceRequest::FetchUnspentOutputs { output_hashes } => {
+            }.await,
+
+            TransactionServiceRequest::FetchUnspentOutputs { output_hashes } => async {
                 let unspent_outputs = self.fetch_unspent_outputs_from_node(output_hashes).await?;
                 Ok(TransactionServiceResponse::UnspentOutputs(unspent_outputs))
-            },
+            }.await,
+
             TransactionServiceRequest::FinalizeSentAggregateTransaction {
                 tx_id,
                 total_meta_data_signature,
                 total_script_data_signature,
                 script_offset,
-            } => Ok(TransactionServiceResponse::TransactionSent(
-                self.finalized_aggregate_encumbed_tx(
-                    tx_id.into(),
-                    total_meta_data_signature,
-                    total_script_data_signature,
-                    script_offset,
-                    transaction_broadcast_join_handles,
-                )
-                .await?,
-            )),
+            } => async {
+                Ok(TransactionServiceResponse::TransactionSent(
+                    self.finalized_aggregate_encumbed_tx(
+                        tx_id.into(),
+                        total_meta_data_signature,
+                        total_script_data_signature,
+                        script_offset,
+                        transaction_broadcast_join_handles,
+                    )
+                        .await?,
+                ))
+            }.await,
+
             TransactionServiceRequest::RegisterValidatorNode {
                 amount,
                 validator_node_public_key,
@@ -932,9 +948,8 @@ where
                 selection_criteria,
                 fee_per_gram,
                 payment_id,
-            } => {
-                let rp = reply_channel.take().expect("Cannot be missing");
-                self.register_validator_node(
+            } => async {
+                let tx_id = self.register_validator_node(
                     amount,
                     validator_node_public_key,
                     validator_node_signature,
@@ -945,11 +960,11 @@ where
                     fee_per_gram,
                     payment_id,
                     transaction_broadcast_join_handles,
-                    rp,
                 )
                 .await?;
-                return Ok(());
-            },
+                Ok(TransactionServiceResponse::TransactionSent(tx_id))
+            }.await,
+
             TransactionServiceRequest::SubmitValidatorNodeExit {
                 amount,
                 validator_node_public_key,
@@ -959,9 +974,8 @@ where
                 selection_criteria,
                 fee_per_gram,
                 payment_id,
-            } => {
-                let rp = reply_channel.take().expect("Cannot be missing");
-                self.submit_validator_exit(
+            } => async {
+                let tx_id = self.submit_validator_exit(
                     amount,
                     validator_node_public_key,
                     validator_node_signature,
@@ -971,11 +985,11 @@ where
                     fee_per_gram,
                     payment_id,
                     transaction_broadcast_join_handles,
-                    rp,
                 )
                 .await?;
-                return Ok(());
-            },
+                Ok(TransactionServiceResponse::TransactionSent(tx_id))
+            }.await,
+
             TransactionServiceRequest::RegisterCodeTemplate {
                 template_name,
                 template_version,
@@ -985,7 +999,7 @@ where
                 binary_url,
                 fee_per_gram,
                 sidechain_deployment_key,
-            } => {
+            } => async {
                 let payment_id = MemoField::new_open(
                     format!("Template Registration: {template_name}").into_bytes(),
                     TxType::CodeTemplateRegistration,
@@ -1010,16 +1024,16 @@ where
                     tx_id,
                     template_address,
                 })
-            },
+            }.await,
+
             TransactionServiceRequest::SubmitValidatorEvictionProof {
                 amount,
                 proof,
                 fee_per_gram,
                 payment_id,
                 sidechain_deployment_key,
-            } => {
-                let rp = reply_channel.take().expect("Cannot be missing");
-                self.submit_validator_eviction_proof(
+            } => async {
+                let tx_id = self.submit_validator_eviction_proof(
                     amount,
                     proof,
                     sidechain_deployment_key,
@@ -1027,19 +1041,18 @@ where
                     fee_per_gram,
                     payment_id,
                     transaction_broadcast_join_handles,
-                    rp,
                 )
                 .await?;
+                Ok(TransactionServiceResponse::TransactionSent(tx_id))
+            }.await,
 
-                return Ok(());
-            },
             TransactionServiceRequest::SendShaAtomicSwapTransaction(
                 destination,
                 amount,
                 selection_criteria,
                 fee_per_gram,
                 payment_id,
-            ) => {
+            ) => async {
                 let res = self
                     .send_sha_atomic_swap_transaction(
                         destination,
@@ -1051,39 +1064,52 @@ where
                     )
                     .await?;
                 Ok(TransactionServiceResponse::ShaAtomicSwapTransactionSent(res))
-            },
-            TransactionServiceRequest::CancelTransaction(tx_id) => {
+            }.await,
+
+            TransactionServiceRequest::CancelTransaction(tx_id) => async {
                 self.cancel_pending_transaction(tx_id).await?;
                 Ok(TransactionServiceResponse::TransactionCancelled)
-            },
-            TransactionServiceRequest::GetPendingInboundTransactions => Ok(
-                TransactionServiceResponse::PendingInboundTransactions(self.db.get_pending_inbound_transactions()?),
-            ),
-            TransactionServiceRequest::GetPendingOutboundTransactions => Ok(
-                TransactionServiceResponse::PendingOutboundTransactions(self.db.get_pending_outbound_transactions()?),
-            ),
+            }.await,
+
+            TransactionServiceRequest::GetPendingInboundTransactions => async {
+                Ok(
+                    TransactionServiceResponse::PendingInboundTransactions(self.db.get_pending_inbound_transactions()?),
+                )
+            }.await,
+
+            TransactionServiceRequest::GetPendingOutboundTransactions => async {
+                Ok(
+                    TransactionServiceResponse::PendingOutboundTransactions(self.db.get_pending_outbound_transactions()?),
+                )
+            }.await,
 
             TransactionServiceRequest::GetCompletedTransactions {
                 payment_id,
                 block_hash,
                 block_height,
                 max_limit,
-            } => Ok(TransactionServiceResponse::CompletedTransactions(
-                self.db
-                    .get_completed_transactions(payment_id, block_hash, block_height, max_limit)?,
-            )),
+            } => async {
+                Ok(TransactionServiceResponse::CompletedTransactions(
+                    self.db
+                        .get_completed_transactions(payment_id, block_hash, block_height, max_limit)?,
+                ))
+            }.await,
+
             TransactionServiceRequest::GetCompletedTransactionsByAddresses {
                 source_address,
                 destination_address,
-            } => Ok(TransactionServiceResponse::CompletedTransactions(
-                self.db
-                    .get_completed_transactions_by_addresses(source_address, destination_address)?,
-            )),
+            } => async {
+                Ok(TransactionServiceResponse::CompletedTransactions(
+                    self.db
+                        .get_completed_transactions_by_addresses(source_address, destination_address)?,
+                ))
+            }.await,
+
             TransactionServiceRequest::GetCompletedTransactionsPaginated {
                 offset,
                 limit,
                 status_filter,
-            } => {
+            } => async {
                 if limit == 0 {
                     return Err(TransactionServiceError::InvalidArgument(
                         "limit must be greater than 0".to_string(),
@@ -1093,29 +1119,39 @@ where
                     self.db
                         .get_completed_transactions_paginated(offset, limit, status_filter)?,
                 ))
-            },
-            TransactionServiceRequest::GetCancelledPendingInboundTransactions => {
+            }.await,
+
+            TransactionServiceRequest::GetCancelledPendingInboundTransactions => async {
                 Ok(TransactionServiceResponse::PendingInboundTransactions(
                     self.db.get_cancelled_pending_inbound_transactions()?,
                 ))
-            },
-            TransactionServiceRequest::GetCancelledPendingOutboundTransactions => {
+            }.await,
+
+            TransactionServiceRequest::GetCancelledPendingOutboundTransactions => async {
                 Ok(TransactionServiceResponse::PendingOutboundTransactions(
                     self.db.get_cancelled_pending_outbound_transactions()?,
                 ))
-            },
-            TransactionServiceRequest::GetCancelledCompletedTransactions(max_limit) => {
+            }.await,
+
+            TransactionServiceRequest::GetCancelledCompletedTransactions(max_limit) => async {
                 Ok(TransactionServiceResponse::CompletedTransactions(
                     self.db.get_cancelled_completed_transactions(max_limit)?,
                 ))
-            },
-            TransactionServiceRequest::GetCompletedTransaction(tx_id) => Ok(
-                TransactionServiceResponse::CompletedTransaction(Box::new(self.db.get_completed_transaction(tx_id)?)),
-            ),
-            TransactionServiceRequest::GetAnyTransaction(tx_id) => Ok(TransactionServiceResponse::AnyTransaction(
-                Box::new(self.db.get_any_transaction(tx_id)?),
-            )),
-            TransactionServiceRequest::ImportTransaction(tx) => {
+            }.await,
+
+            TransactionServiceRequest::GetCompletedTransaction(tx_id) => async {
+                Ok(
+                    TransactionServiceResponse::CompletedTransaction(Box::new(self.db.get_completed_transaction(tx_id)?)),
+                )
+            }.await,
+
+            TransactionServiceRequest::GetAnyTransaction(tx_id) => async {
+                Ok(TransactionServiceResponse::AnyTransaction(
+                    Box::new(self.db.get_any_transaction(tx_id)?),
+                ))
+            }.await,
+
+            TransactionServiceRequest::ImportTransaction(tx) => async {
                 let tx_id = match tx {
                     PendingInbound(inbound_tx) => {
                         let tx_id = inbound_tx.tx_id;
@@ -1140,7 +1176,8 @@ where
                     .event_publisher
                     .send(Arc::new(TransactionEvent::TransactionImported(tx_id)));
                 Ok(TransactionServiceResponse::TransactionImported(tx_id))
-            },
+            }.await,
+
             TransactionServiceRequest::ImportUtxoWithStatus {
                 amount,
                 source_address,
@@ -1150,7 +1187,7 @@ where
                 mined_timestamp,
                 scanned_output,
                 payment_id,
-            } => {
+            } => async {
                 let res = self
                     .add_utxo_import_transaction_with_status(
                         amount,
@@ -1164,78 +1201,89 @@ where
                     )
                     .await?;
                 Ok(TransactionServiceResponse::UtxoImported(res))
-            },
-            TransactionServiceRequest::SubmitTransactionToSelf(tx_id, tx, fee, amount, payment_id) => {
+            }.await,
+
+            TransactionServiceRequest::SubmitTransactionToSelf(tx_id, tx, fee, amount, payment_id) => async {
                 self.submit_transaction_to_self(transaction_broadcast_join_handles, tx_id, tx, fee, amount, payment_id)
                     .await?;
                 Ok(TransactionServiceResponse::TransactionSubmitted)
-            },
-            TransactionServiceRequest::SetLowPowerMode => {
+            }.await,
+
+            TransactionServiceRequest::SetLowPowerMode => async {
                 self.set_power_mode(PowerMode::Low).await?;
                 Ok(TransactionServiceResponse::LowPowerModeSet)
-            },
-            TransactionServiceRequest::SetNormalPowerMode => {
+            }.await,
+
+            TransactionServiceRequest::SetNormalPowerMode => async {
                 self.set_power_mode(PowerMode::Normal).await?;
                 Ok(TransactionServiceResponse::NormalPowerModeSet)
-            },
-            TransactionServiceRequest::RestartBroadcastProtocols => {
+            }.await,
+
+            TransactionServiceRequest::RestartBroadcastProtocols => async {
                 self.restart_broadcast_protocols(transaction_broadcast_join_handles)?;
                 Ok(TransactionServiceResponse::ProtocolsRestarted)
-            },
+            }.await,
+
             TransactionServiceRequest::GetNumConfirmationsRequired => Ok(
                 TransactionServiceResponse::NumConfirmationsRequired(self.resources.config.num_confirmations_required),
             ),
+
             TransactionServiceRequest::SetNumConfirmationsRequired(number) => {
                 self.resources.config.num_confirmations_required = number;
                 Ok(TransactionServiceResponse::NumConfirmationsSet)
             },
-            TransactionServiceRequest::ValidateTransactions => {
+
+            TransactionServiceRequest::ValidateTransactions => async {
                 let res = self
                     .start_transaction_validation_protocol(transaction_validation_join_handles)
                     .await?;
                 Ok(TransactionServiceResponse::ValidationStarted(res))
-            },
-            TransactionServiceRequest::ReValidateRejectedTransactions => {
+            }.await,
+
+            TransactionServiceRequest::ReValidateRejectedTransactions => async {
                 let res = self
                     .start_rejected_transaction_revalidation(transaction_validation_join_handles)
                     .await?;
                 Ok(TransactionServiceResponse::ValidationStarted(res))
-            },
-            TransactionServiceRequest::ReplaceByFee { tx_id, fee_increase } => {
+            }.await,
+
+            TransactionServiceRequest::ReplaceByFee { tx_id, fee_increase } => async {
                 let res = self
                     .replace_by_fee(tx_id, fee_increase, transaction_broadcast_join_handles)
                     .await?;
                 Ok(TransactionServiceResponse::TransactionReplaced(res))
-            },
+            }.await,
+
             TransactionServiceRequest::UserPayForFee {
                 tx_id,
                 destination,
                 fee,
-            } => {
-                self.user_pay_for_fee(tx_id, destination, fee, transaction_broadcast_join_handles)
-                    .await
-                    .map(TransactionServiceResponse::TransactionSent)?;
-                return Ok(());
-            },
-            TransactionServiceRequest::GetFeePerGramStatsPerBlock { count } => {
-                let reply_channel = reply_channel.take().expect("reply_channel is Some");
-                self.handle_get_fee_per_gram_stats_per_block_request(count, reply_channel);
-                return Ok(());
-            },
-            TransactionServiceRequest::GetPaymentByReference { payref } => {
+            } => async {
+                let tx_id = self.user_pay_for_fee(tx_id, destination, fee, transaction_broadcast_join_handles)
+                    .await?;
+                Ok(TransactionServiceResponse::TransactionSent(tx_id))
+            }.await,
+
+            TransactionServiceRequest::GetFeePerGramStatsPerBlock { count } => async {
+                let resp = self.handle_get_fee_per_gram_stats_per_block_request(count).await?;
+                Ok(TransactionServiceResponse::FeePerGramStatsPerBlock(resp))
+            }.await,
+
+            TransactionServiceRequest::GetPaymentByReference { payref } => async {
                 let res = self.get_payment_by_reference(payref)?;
                 Ok(TransactionServiceResponse::PaymentDetails(res))
-            },
-            TransactionServiceRequest::GetTransactionByPaymentReference(payref) => {
+            }.await,
+
+            TransactionServiceRequest::GetTransactionByPaymentReference(payref) => async {
                 match self.get_transaction_with_payref(payref)? {
                     Some(tx) => Ok(TransactionServiceResponse::CompletedTransaction(Box::new(tx))),
                     None => Err(TransactionServiceError::TransactionStorageError(
                         TransactionStorageError::ValueNotFound(DbKey::CompletedTransactions(1)),
                     ))?,
                 }
-            },
+            }.await,
 
-            TransactionServiceRequest::CreateMultisigUtxo { request } => {
+            TransactionServiceRequest::CreateMultisigUtxo { request } => async {
                 let fee_per_gram = MicroMinotari::from(1);
                 let selected_criteria = UtxoSelectionCriteria {
                     excluding_multisig: true,
@@ -1304,9 +1352,9 @@ where
                 .await?;
 
                 Ok(TransactionServiceResponse::CreateMultisigUtxo(tx_id))
-            },
+            }.await,
 
-            TransactionServiceRequest::GetMultisigUtxoData { utxo_commitment } => {
+            TransactionServiceRequest::GetMultisigUtxoData { utxo_commitment } => async {
                 let mut query = OutputBackendQuery::default();
                 query.commitments.push(utxo_commitment.clone());
 
@@ -1347,13 +1395,13 @@ where
                 };
 
                 Ok(TransactionServiceResponse::GetMultisigUtxoData(Box::new(output)))
-            },
+            }.await,
 
             TransactionServiceRequest::SendMultisigUtxo {
                 utxo_commitment,
                 recipient_address,
                 signatures,
-            } => {
+            } => async {
                 let mut query = OutputBackendQuery::default();
                 query.commitments.push(utxo_commitment.clone());
 
@@ -1430,44 +1478,31 @@ where
                 )
                 .await?;
                 Ok(TransactionServiceResponse::SendMultisigUtxo(tx_id))
-            },
+            }.await,
         };
 
-        // If the individual handlers did not already send the API response then do it here.
-        if let Some(rp) = reply_channel {
-            let _result = rp.send(response).inspect_err(|_| {
-                warn!(target: LOG_TARGET, "Failed to send reply");
+        let _result = reply_channel
+            .send(response.inspect_err(|e1| warn!(target: LOG_TARGET, "{}", e1)))
+            .inspect_err(|e2| {
+                warn!(target: LOG_TARGET, "Failed to send reply: {:?}", e2);
             });
-        }
+
         Ok(())
     }
 
-    fn handle_get_fee_per_gram_stats_per_block_request(
+    async fn handle_get_fee_per_gram_stats_per_block_request(
         &self,
         count: u64,
-        reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
-    ) {
+    ) -> Result<FeePerGramStat, TransactionServiceError> {
         let connectivity = self.resources.connectivity.clone();
 
-        let query_base_node_fut = async move {
-            let client = connectivity.obtain_base_node_wallet_rpc_client().await;
+        let client = connectivity.obtain_base_node_wallet_rpc_client().await;
 
-            let resp = client
-                .get_mempool_fee_per_gram_stats(count)
-                .await
-                .map_err(|e| TransactionServiceError::Other(e.to_string()))?;
-            Ok(TransactionServiceResponse::FeePerGramStatsPerBlock(resp))
-        };
-
-        tokio::spawn(async move {
-            let resp = query_base_node_fut.await;
-            if reply_channel.send(resp).is_err() {
-                warn!(
-                    target: LOG_TARGET,
-                    "handle_get_fee_per_gram_stats_per_block_request: service reply cancelled"
-                );
-            }
-        });
+        let resp = client
+            .get_mempool_fee_per_gram_stats(count)
+            .await
+            .map_err(|e| TransactionServiceError::Other(e.to_string()))?;
+        Ok(resp)
     }
 
     async fn handle_base_node_service_event(&mut self, event: Arc<BaseNodeEvent>) {
@@ -2732,8 +2767,7 @@ where
         transaction_broadcast_join_handles: &mut FuturesUnordered<
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
-        reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
-    ) -> Result<(), TransactionServiceError> {
+    ) -> Result<TxId, TransactionServiceError> {
         let signature = ValidatorNodeSignature::new(validator_node_public_key, validator_node_signature);
         let sidechain_pk = sidechain_deployment_key
             .as_ref()
@@ -2805,13 +2839,7 @@ where
         )
         .await?;
 
-        let _result = reply_channel
-            .send(Ok(TransactionServiceResponse::TransactionSent(tx_id)))
-            .inspect_err(|_| {
-                warn!(target: LOG_TARGET, "Failed to send service reply");
-            });
-
-        Ok(())
+        Ok(tx_id)
     }
 
     async fn submit_validator_exit(
@@ -2827,8 +2855,7 @@ where
         transaction_broadcast_join_handles: &mut FuturesUnordered<
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
-        reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
-    ) -> Result<(), TransactionServiceError> {
+    ) -> Result<TxId, TransactionServiceError> {
         let signature = ValidatorNodeSignature::new(validator_node_public_key, validator_node_signature);
         let sidechain_pk = sidechain_deployment_key
             .as_ref()
@@ -2890,13 +2917,7 @@ where
         )
         .await?;
 
-        let _result = reply_channel
-            .send(Ok(TransactionServiceResponse::TransactionSent(tx_id)))
-            .inspect_err(|_| {
-                warn!(target: LOG_TARGET, "Failed to send service reply");
-            });
-
-        Ok(())
+        Ok(tx_id)
     }
 
     async fn submit_validator_eviction_proof(
@@ -2910,8 +2931,7 @@ where
         transaction_broadcast_join_handles: &mut FuturesUnordered<
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
-        reply_channel: oneshot::Sender<Result<TransactionServiceResponse, TransactionServiceError>>,
-    ) -> Result<(), TransactionServiceError> {
+    ) -> Result<TxId, TransactionServiceError> {
         let output_features =
             OutputFeatures::for_validator_node_eviction(eviction_proof, sidechain_deployment_key.as_ref());
 
@@ -2965,13 +2985,7 @@ where
         )
         .await?;
 
-        let _result = reply_channel
-            .send(Ok(TransactionServiceResponse::TransactionSent(tx_id)))
-            .inspect_err(|_| {
-                warn!(target: LOG_TARGET, "Failed to send service reply");
-            });
-
-        Ok(())
+        Ok(tx_id)
     }
 
     async fn register_code_template(

--- a/base_layer/wallet/src/utxo_scanner_service/service.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/service.rs
@@ -20,6 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::fmt::Display;
+
 use chrono::NaiveDateTime;
 use log::*;
 use tari_common_types::{tari_address::TariAddress, types::HashOutput};
@@ -179,4 +181,14 @@ pub struct ScannedBlock {
     pub header_hash: HashOutput,
     pub height: u64,
     pub timestamp: NaiveDateTime,
+}
+
+impl Display for ScannedBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ScannedBlock {{ height: {}, header_hash: {}, timestamp: {} }}",
+            self.height, self.header_hash, self.timestamp
+        )
+    }
 }

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanner_task.rs
@@ -494,7 +494,7 @@ where
                     let block_hash: FixedHash = current_header_hash.try_into()?;
                     trace!(
                         target: LOG_TARGET,
-                        "Scanned block at height {} with header hash {}, :{:?}",
+                        "Scanned block at height {} with header hash {}, previous: {:?}",
                         current_height,
                         block_hash.to_hex(), prev_scanned_block
                     );


### PR DESCRIPTION
Description
---
1. Ensure the TMS errors are transmitted on the reply channel.
2. Expanded transport channel errors in the transaction and output management service.
3. Remove/reduce spam log messages.

Closes #7545.

Motivation and Context
---
Many wallet gRPC methods did not provide proper error context.
Too little context is known when we encounter `Transport channel error: Request was canceled` errors in the log files.

See #7545.

How Has This Been Tested?
---
System-level testing

Example below (previously the error response would be `Transport channel error: Request was canceled`):
<img width="949" height="383" alt="image" src="https://github.com/user-attachments/assets/240fa0be-49d3-4474-97af-9e251e80b31c" />


What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Error messages now include the specific operation or API detail that failed for clearer diagnostics.
  * Added warning logs on failed API calls across wallet and transaction flows to improve observability.
  * Scanned block formatting and several error/display strings improved for clearer logs/readouts.
* **Refactor**
  * Service request handling streamlined to return results directly, simplifying internal flows and reducing reply-channel boilerplate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->