### PR TITLE
fix(sidechain)!: adds shard group accumulated data to checkpoint

### DIFF
--- a/applications/minotari_app_grpc/proto/sidechain_types.proto
+++ b/applications/minotari_app_grpc/proto/sidechain_types.proto
@@ -140,8 +140,9 @@ message SidechainBlockHeader {
   bytes proposed_by = 7;
   bytes state_merkle_root = 8;
   bytes command_merkle_root = 9;
-  Signature signature = 11;
   bytes metadata_hash = 10;
+  Signature signature = 11;
+  ShardGroupAccumulatedData accumulated_data = 12;
 }
 
 message ShardGroup {
@@ -170,3 +171,7 @@ message ValidatorSignature {
   Signature signature = 2;
 }
 
+message ShardGroupAccumulatedData {
+  uint64 total_exhaust_burn_msb = 1;
+  uint64 total_exhaust_burn_lsb = 2;
+}

--- a/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
@@ -35,6 +35,7 @@ use tari_sidechain::{
     QuorumCertificate,
     QuorumDecision,
     ShardGroup,
+    ShardGroupAccumulatedData,
     SidechainBlockCommitProof,
     SidechainBlockHeader,
     ValidatorQcSignature,
@@ -475,6 +476,10 @@ impl TryFrom<grpc::SidechainBlockHeader> for SidechainBlockHeader {
                 .signature
                 .ok_or("SidechainBlockHeader signature not provided")?
                 .try_into()?,
+            accumulated_data: value
+                .accumulated_data
+                .ok_or("accumulated_data not provided")?
+                .try_into()?,
             metadata_hash: value.metadata_hash.try_into().map_err(|_| "Invalid metadata hash")?,
         })
     }
@@ -493,6 +498,7 @@ impl From<&SidechainBlockHeader> for grpc::SidechainBlockHeader {
             state_merkle_root: value.state_merkle_root.to_vec(),
             command_merkle_root: value.command_merkle_root.to_vec(),
             signature: Some(value.signature().into()),
+            accumulated_data: Some(value.accumulated_data().into()),
             metadata_hash: value.metadata_hash.to_vec(),
         }
     }
@@ -668,6 +674,31 @@ impl From<ShardGroup> for grpc::ShardGroup {
         Self {
             start: value.start,
             end_inclusive: value.end_inclusive,
+        }
+    }
+}
+
+// -------------------------------- AccumulatedData -------------------------------- //
+
+impl TryFrom<grpc::ShardGroupAccumulatedData> for ShardGroupAccumulatedData {
+    type Error = String;
+
+    fn try_from(value: grpc::ShardGroupAccumulatedData) -> Result<Self, Self::Error> {
+        let total_exhaust_burn =
+            (u128::from(value.total_exhaust_burn_msb) << 64) | u128::from(value.total_exhaust_burn_lsb);
+        Ok(Self { total_exhaust_burn })
+    }
+}
+
+impl From<&ShardGroupAccumulatedData> for grpc::ShardGroupAccumulatedData {
+    fn from(value: &ShardGroupAccumulatedData) -> Self {
+        let total_exhaust_burn_msb = (value.total_exhaust_burn >> 64) as u64;
+        #[allow(clippy::cast_possible_truncation)]
+        let total_exhaust_burn_lsb = (value.total_exhaust_burn & u128::from(u64::MAX)) as u64;
+
+        Self {
+            total_exhaust_burn_msb,
+            total_exhaust_burn_lsb,
         }
     }
 }

--- a/base_layer/core/src/proto/sidechain_feature.proto
+++ b/base_layer/core/src/proto/sidechain_feature.proto
@@ -124,6 +124,7 @@ message SidechainBlockHeader {
   bytes command_merkle_root = 9;
   Signature signature = 10;
   bytes metadata_hash = 11;
+  ShardGroupAccumulatedData accumulated_data = 12;
 }
 
 message EvictAtom {
@@ -150,4 +151,9 @@ message ValidatorSignature {
 message ShardGroup {
   uint32 start = 1;
   uint32 end_inclusive = 2;
+}
+
+message ShardGroupAccumulatedData {
+  uint64 total_exhaust_burn_msb = 1;
+  uint64 total_exhaust_burn_lsb = 2;
 }

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -469,6 +469,7 @@ impl TryFrom<proto::types::SidechainBlockHeader> for SidechainBlockHeader {
                 .signature
                 .ok_or("SidechainBlockHeader signature not provided")?
                 .try_into()?,
+            accumulated_data: value.accumulated_data.ok_or("missing accumulated_data")?.try_into()?,
             metadata_hash: value.metadata_hash.try_into().map_err(|_| "Invalid metadata hash")?,
         })
     }
@@ -487,6 +488,7 @@ impl From<&SidechainBlockHeader> for proto::types::SidechainBlockHeader {
             state_merkle_root: value.state_merkle_root.to_vec(),
             command_merkle_root: value.command_merkle_root.to_vec(),
             signature: Some(value.signature().into()),
+            accumulated_data: Some(value.accumulated_data.into()),
             metadata_hash: value.metadata_hash.to_vec(),
         }
     }
@@ -665,6 +667,31 @@ impl From<ShardGroup> for proto::types::ShardGroup {
         Self {
             start: value.start,
             end_inclusive: value.end_inclusive,
+        }
+    }
+}
+
+// -------------------------------- AccumulatedData -------------------------------- //
+impl TryFrom<proto::types::ShardGroupAccumulatedData> for tari_sidechain::ShardGroupAccumulatedData {
+    type Error = String;
+
+    fn try_from(value: proto::types::ShardGroupAccumulatedData) -> Result<Self, Self::Error> {
+        let total_exhaust_burn =
+            (u128::from(value.total_exhaust_burn_msb) << 64) | u128::from(value.total_exhaust_burn_lsb);
+
+        Ok(Self { total_exhaust_burn })
+    }
+}
+
+impl From<tari_sidechain::ShardGroupAccumulatedData> for proto::types::ShardGroupAccumulatedData {
+    fn from(value: tari_sidechain::ShardGroupAccumulatedData) -> Self {
+        let total_exhaust_burn_msb = (value.total_exhaust_burn >> 64) as u64;
+        #[allow(clippy::cast_possible_truncation)]
+        let total_exhaust_burn_lsb = (value.total_exhaust_burn & u128::from(u64::MAX)) as u64;
+
+        Self {
+            total_exhaust_burn_msb,
+            total_exhaust_burn_lsb,
         }
     }
 }

--- a/base_layer/sidechain/src/commit_proof.rs
+++ b/base_layer/sidechain/src/commit_proof.rs
@@ -199,6 +199,7 @@ pub struct SidechainBlockHeader {
     pub command_merkle_root: FixedHash,
     /// Signature of block by the proposer.
     pub signature: ValidatorBlockSignature,
+    pub accumulated_data: ShardGroupAccumulatedData,
     #[serde(with = "hex_or_bytes")]
     pub metadata_hash: FixedHash,
 }
@@ -214,6 +215,7 @@ impl SidechainBlockHeader {
             proposed_by: self.proposed_by.as_bytes(),
             state_merkle_root: &self.state_merkle_root,
             command_merkle_root: &self.command_merkle_root,
+            accumulated_data: &self.accumulated_data,
             metadata_hash: &self.metadata_hash,
         });
 
@@ -232,6 +234,15 @@ impl SidechainBlockHeader {
     pub fn signature(&self) -> &ValidatorBlockSignature {
         &self.signature
     }
+
+    pub fn accumulated_data(&self) -> &ShardGroupAccumulatedData {
+        &self.accumulated_data
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
+pub struct ShardGroupAccumulatedData {
+    pub total_exhaust_burn: u128,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
@@ -358,6 +369,7 @@ pub struct BlockHeaderHashFieldsV1<'a> {
     pub height: u64,
     pub epoch: u64,
     pub shard_group: ShardGroup,
+    pub accumulated_data: &'a ShardGroupAccumulatedData,
     // NOTE this is borsh encoded as variable length bytes - technically should always be 32
     pub proposed_by: &'a [u8],
     pub state_merkle_root: &'a FixedHash,

--- a/base_layer/sidechain/tests/fixtures/commit_proof.json
+++ b/base_layer/sidechain/tests/fixtures/commit_proof.json
@@ -1,219 +1,136 @@
 {
   "header": {
-    "command_merkle_root": "eba764548cc89da444a0bf893c7e1fc2272a111d7bf355a10864705b5b678a7a",
-    "epoch": 1,
-    "height": 6,
-    "justify_id": "35815a82ed34b7c95bcfc54ccaf4e63c4890df2ee78f119694ab2dd47459dbad",
-    "metadata_hash": "f704f7085ae0b331b5f4923919d1f22db7c614cb8267e678e5f15f3b15a14d4a",
     "network": 16,
-    "parent_id": "3e959c86d36cae21c12cc917ad877b2efb00c4c56bc05920885dc0d50c77ce64",
-    "proposed_by": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
+    "parent_id": "80d8355520a36f1479a3f5042adab0b37b299420265e9b7d6b626a6a276859d1",
+    "justify_id": "69e54cd339f0c138ec0d797be7a21fb7bb33bf9c1906ee45a59828ae3857cd34",
+    "height": 20,
+    "epoch": 1,
     "shard_group": {
-      "end_inclusive": 128,
-      "start": 1
+      "start": 1,
+      "end_inclusive": 256
     },
+    "proposed_by": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
+    "state_merkle_root": "cc3b8382fb5c199dd7dcee291c7b03cf12d6a59a61638881815ed7a64d7f6f30",
+    "command_merkle_root": "89ea0f4a026ab60f17e826b64b132306c40e502e5b25d5faa4c4635b5f06e153",
     "signature": {
-      "public_nonce": "60a905900a989907e5cc177bc5b683922c952da900059df1110c85460bfa3d55",
-      "signature": "d651b266d207a09d8cc5b868c09ff49850f6458135cca47ba1ef9955b44c5d00"
+      "public_nonce": "aabfb198a2cdc524bb0dbb81cf7c810d40bca0cf8005b863e25e129c5d883457",
+      "signature": "0782f481fd4ca0281ad80f77461f1ba86352aa71737e39be83ecb9eeeccf0a06"
     },
-    "state_merkle_root": "1e2f15925f307325162c1e8afd16aecdd0ed0c7c36b62cf6d3fa7a70b6f05fbf"
+    "accumulated_data": {
+      "total_exhaust_burn": 0
+    },
+    "metadata_hash": "0356b697d0db4bb5adb6bc6bac7d9c9e82ee5a9c4d840049e1b62d9182fc03ef"
   },
   "proof_elements": [
     {
       "QuorumCertificate": {
-        "decision": "Accept",
-        "header_hash": "b055c5eae939e1f09eb55c9cd2bc449283e7533a3fbba031e0a360b787d56c52",
-        "parent_id": "40aeafb0e8adfc7f0bb0b86d88be3fd70e834d7f8a5f03806af173564517f55e",
+        "header_hash": "4d90d4c9226577f19e13723d37559085e7bfda2f6615355def5cbc257ff3d081",
+        "parent_id": "2942514688a08aed1fb8a1ccc350dc132d006fe7cf3939aa764519e29d4c3f60",
         "signatures": [
           {
-            "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
+            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
             "signature": {
-              "public_nonce": "7e2ade972d35218a613188443ef104ccc0b6ff7bb4dcf483e72d0b8795864379",
-              "signature": "d44c7d212aa35f08324cf60189531325ab8334a3657102c4858450cfc9fa740f"
+              "public_nonce": "16be2539aca91de5ad092834ebe97956f8fc88bdd4534cad74b72a5860b50034",
+              "signature": "2ee59c2d3aca471e6631222bc1ad604c2fc94548c237bb77d619509f44f3b70c"
             }
           },
           {
             "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
             "signature": {
-              "public_nonce": "68f7ac0649100e98f2235cbde8e3927fdb4e840be92ba03b91a5b081bb86db64",
-              "signature": "9721f284ce7604b796ccbc8fc205078bf2012eb5f3c7e66b41e9cc6023faff0e"
+              "public_nonce": "beac20141c3306e2193fdadfe7885660f3e8453d3459e4a15c3f882980ec5e39",
+              "signature": "f59fed3f5b7d0afaadf2f15282fb987a448454068d44d4d05706b39a7711300f"
             }
           },
           {
-            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
+            "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
             "signature": {
-              "public_nonce": "b090fa6d7b4bd972baab5d402af5324ca8163ff7b046535ff546728ea3a6a10e",
-              "signature": "c0b1e491c7f274a1046c4fadd8db5c398a1d139f1b5ef4baff2c5e56f07d250a"
+              "public_nonce": "4ee0cdab102629936eaac12639c2e638de2f598a898d2fb1c83dc22709a1660e",
+              "signature": "a6e51af802d9bbf5bb95229277a40132ac7c661df5ea7806393254adc5b65200"
             }
           },
           {
             "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
             "signature": {
-              "public_nonce": "8c67f48f329332edaa65b32d6e2a13631676b0a5ce003a8049e4d4b368c72b01",
-              "signature": "7ce89864a1b58153cda0cad949a66b58776164f9282981a29e5e5b272e25de06"
+              "public_nonce": "08d21b2a7d5f0727915fefdbfe9187dcd975f852d9e376196667a97126fe7b09",
+              "signature": "bc494bffa8f786ad9ad9677847ba59a7b06235a6ca3605efa7458ab4b9c87a06"
             }
           }
-        ]
+        ],
+        "decision": "Accept"
       }
     },
     {
       "QuorumCertificate": {
-        "decision": "Accept",
-        "header_hash": "76987f493372437e651c8c3ccb8e5289097d671ddcdc7a768ffdc70c4b50d882",
-        "parent_id": "5af304cb774f4cc81797b2ef0c8dd15e5bb802e13461fa32ddc7a577034b8355",
+        "header_hash": "61044f28ed76524b4f3f6721fea0215aeb78d2fcbfa990f459b5072f15e9f28a",
+        "parent_id": "76ee44f54236e63d64c8efc638135507be89ee4700af09f388b23bec2c39d88d",
         "signatures": [
           {
-            "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
+            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
             "signature": {
-              "public_nonce": "fac4ce300313c85dc5a0a412fd568d8b7f4d2e02fe6a10599f7e0c232a970a58",
-              "signature": "6ba07c757cef4d04b2c02387b37e7f168093d2265dadb85a2d4b56d24a5aee0d"
-            }
-          },
-          {
-            "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
-            "signature": {
-              "public_nonce": "f81e3378d7e26b06b63a2237ce1f68347e389152d4ed7c394f9c596a59eb405f",
-              "signature": "8bf78434ed132900c80541419a8bb27ec42e5fdd7f2d023f6c8fa4a2e38f1b0d"
+              "public_nonce": "e0d46ddba2480569479ef1749ee6374742575e0a87195dc301baa106561dd44d",
+              "signature": "1008cb5e8ee8ea7ea4e94eaa3a4be0a1beb74be7e4869e861628c6615d9e6d02"
             }
           },
           {
             "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
             "signature": {
-              "public_nonce": "8023775d92c7583db7cbad32c9d792b79d4d44db473d3a55cceca63c3c3f3d1e",
-              "signature": "5c846ec53a109b9647a2ab25c1614f32646fde7050fc6756515ba2547695e302"
+              "public_nonce": "184b1a031feaadead6086f6100e65ea01675ac8641c80c9ef25bca89dfc19533",
+              "signature": "8eb2a31fa5de5479224a877ebe5e0750bfa8419fbef3c13b17a0ef0023ce2502"
             }
           },
           {
-            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
+            "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
             "signature": {
-              "public_nonce": "34c7aebee123b96c848024c71232864f00a2c43425677ddf714b62c3c6308036",
-              "signature": "856e1ab1a4299b68272441c2e992554bb69108a781419adc61da9ea4a8bcaf01"
+              "public_nonce": "c803ab1f571a68d126a11553ca2423b56b17f8177f06b8af256bd80e2861e97b",
+              "signature": "9bb951f96ab3db2e75f16546b58fe1b2d6d09f3287cffca785d19377c301b206"
+            }
+          },
+          {
+            "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
+            "signature": {
+              "public_nonce": "9810bfb2c239af78bb44b5627554d21286be43362f61b1d2bf0e1866d292855e",
+              "signature": "dad0caa25adabc7d2aba47b332f054aedcb5578286c68e9ccb852182a855ee0e"
             }
           }
-        ]
+        ],
+        "decision": "Accept"
       }
     },
     {
       "QuorumCertificate": {
-        "decision": "Accept",
-        "header_hash": "668c078c0c5bb16ad272ebf784b7c4622d358907d435f64cabaaee45174aba21",
-        "parent_id": "acdc0f36ea0a5b891b6f81a162e2b61ff07568525fb24b48966ffe2ba644f042",
+        "header_hash": "d82abf6ca0c7ea1cb17baeb369f8e3e6076e5b4eedd187bbfc9a004abc0d9449",
+        "parent_id": "80d8355520a36f1479a3f5042adab0b37b299420265e9b7d6b626a6a276859d1",
         "signatures": [
           {
             "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
             "signature": {
-              "public_nonce": "981cd751f17a8976f91e853f636868be4cce0ac73e9e84902c62d20130a47455",
-              "signature": "5d338f52da237aecaa22b41deb2973bf8357ddb4f6cc761f66b1c5f64955da0d"
-            }
-          },
-          {
-            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
-            "signature": {
-              "public_nonce": "720da12d74e196d6bf4723e392172cc9eb8611c13d408012fda017310ebaca50",
-              "signature": "0428745eec1ff2798b043be43c1c7e8e3fe0283cee1b1b15c779c16ee6c6340f"
-            }
-          },
-          {
-            "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
-            "signature": {
-              "public_nonce": "ae2d053e3a58b4ea3348ce34b8de321188d63b250a8cdb1d03f676f26d7f675f",
-              "signature": "d7b0ca6b223b37a16cf64fcde2efeef888c5245335007c0009d12648c366db0d"
+              "public_nonce": "48b8fc9274594140ca847547ea85d333ce250c49d43f3ac11680e94f0de67117",
+              "signature": "9565dd6d9cb1e4be6ac7a29ed223ffbff9c859b8d6253f35933382484c509f06"
             }
           },
           {
             "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
             "signature": {
-              "public_nonce": "486cc7a58f16f631a5cf1064c5e3f033e7251aec9f38f7523fe150d37b80af20",
-              "signature": "8e64f740650708ae7d5b04ec951b9bb527e09e8d2d94e41bb79fd9d2a8e90308"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "ChainLinks": [
-        {
-          "header_hash": "fcddb1b6b0b38ddc6c2d608f9a39af3e14a4b782a12b570642cedcb0d12523dd",
-          "parent_id": "85d788f07afdcd8d0d7b7b22c820e754f32c1962dd2e5c673ce5dec4686a3516"
-        },
-        {
-          "header_hash": "075dc29e8a711c72c1d878030bbd64b02c65e0a196216724730ec439ea124c80",
-          "parent_id": "81965ec665e5f56e672528395d1ba315f638f2a35f16d876aec33bee902edf6b"
-        }
-      ]
-    },
-    {
-      "QuorumCertificate": {
-        "decision": "Accept",
-        "header_hash": "2db0dff152a8386dcbcb677cb90f70bf70a24053a9e76d24782e1789ef62edbe",
-        "parent_id": "08f420f3aa31e5dc27343df14835bfa2a1d3ab07210c4e2833476fe0d7ebdba0",
-        "signatures": [
-          {
-            "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
-            "signature": {
-              "public_nonce": "30f0a1bfc56e1183be63e530f2817769657c8f50859074f9335ace2053d2017c",
-              "signature": "c618f2b928e21a873b6b85bae774ae627e1be58bb75c65650cef1770e5d6000c"
-            }
-          },
-          {
-            "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
-            "signature": {
-              "public_nonce": "28a2f578df4675e9a8e88b5cf6d2a0e3483ca5185804deb1fd6dc9616a57bd3b",
-              "signature": "2c0464d173655817a42de0aff7360efe85c7d02c933f63c39756e5836ea97f0d"
-            }
-          },
-          {
-            "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
-            "signature": {
-              "public_nonce": "7e3b552f722edc23fba1c4658cdaeb97518750ca7b9134eae05eabb096679d7a",
-              "signature": "94f708e5e911cb2630f3ff18176e8ea25195f1787caac7a66ea98e6b5d2fa40f"
+              "public_nonce": "38f384433a3b0f27264cb3df8545658d2d32bc18a2379bcb948cf56f30e6ff1d",
+              "signature": "50ff1924c8aad7ac16d624178d8c45360aca680c83452c3f811292fc8de2ea05"
             }
           },
           {
             "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
             "signature": {
-              "public_nonce": "16283565d0107b06cf538381e02debbacc3ddc3c8cb1e11a8a6d47263a9aa50d",
-              "signature": "57e829d96fe1f2a0fd61cf9de17c64bc7c7c042d0f4aa39e1a21328e63755e06"
+              "public_nonce": "0860bf3fd73187ca4e7718256e7a31876758dda59b7fbb680d48624b5a54bc5a",
+              "signature": "930985a7662daa621761d1551a40d09629d525a5582a22d01d655c621178c908"
             }
-          }
-        ]
-      }
-    },
-    {
-      "QuorumCertificate": {
-        "decision": "Accept",
-        "header_hash": "ae2bd9917ed54527fcd2fc9fdbbda924545fad150bcda46fc6c300208d00c50e",
-        "parent_id": "3e959c86d36cae21c12cc917ad877b2efb00c4c56bc05920885dc0d50c77ce64",
-        "signatures": [
+          },
           {
             "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
             "signature": {
-              "public_nonce": "ce473d0277e7c97c3556a31b23ca801eb0d96445ccc82e68d16478f3084d014f",
-              "signature": "6db27e430b20abb82c8bd0af0e9bfb9adfd278c847eaed51e850136161ce3e04"
-            }
-          },
-          {
-            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
-            "signature": {
-              "public_nonce": "6070d0ed0282d048736dc9fa6d2bd096a688c2c15a21c20094d5f5bafc339c4e",
-              "signature": "6dad1172f41d9fdfc1d1c96b6fce7e8a965a63b87e4c2007ec36df9d2d50c900"
-            }
-          },
-          {
-            "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
-            "signature": {
-              "public_nonce": "a4a246f38380b57bd035415112a5f6316056ea5430888c87ea149e829849164d",
-              "signature": "578b39327a9c14f0bca3fe14a79f75d4904475af19043118b3ef440c25d9e802"
-            }
-          },
-          {
-            "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
-            "signature": {
-              "public_nonce": "b8bf14505673413e64e864422562d7c66928d67f788c4687c253ce96c8458613",
-              "signature": "df43626963d212d6ec932554785aa8415dcd9b8c689c2c8d2fb20c1de1f12e07"
+              "public_nonce": "e8aab61610a979b91643bce2d51750fb0846ee2c7d206e14d26b5601ab140e3d",
+              "signature": "4dd262eeabdd3f53f2f955424d93259f18f440def78ec5610567e7ad7698790d"
             }
           }
-        ]
+        ],
+        "decision": "Accept"
       }
     }
   ]

--- a/base_layer/sidechain/tests/fixtures/eviction_proof1.json
+++ b/base_layer/sidechain/tests/fixtures/eviction_proof1.json
@@ -7,8 +7,8 @@
       "commit_proof": {
         "header": {
           "network": 16,
-          "parent_id": "373e365a0d47b75d9e3275b29c28e053a85e2e26918b7cd8ee1b60f1b0ec6a9d",
-          "justify_id": "d2ff4c9fa3ac3787047257ef5e1504a08b6fbf623d3ba356ae59a9c599a82907",
+          "parent_id": "80d8355520a36f1479a3f5042adab0b37b299420265e9b7d6b626a6a276859d1",
+          "justify_id": "69e54cd339f0c138ec0d797be7a21fb7bb33bf9c1906ee45a59828ae3857cd34",
           "height": 20,
           "epoch": 1,
           "shard_group": {
@@ -16,46 +16,49 @@
             "end_inclusive": 256
           },
           "proposed_by": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
-          "state_merkle_root": "6904b5da2ff5e4838a9d0203f23494819bebeef91e93d4c31cfcd7ac98ad659f",
-          "command_merkle_root": "f9444d9011259b11b2cf52353ec69c3ec204e6ba59205d814a8d7bd4d39b2bc5",
+          "state_merkle_root": "cc3b8382fb5c199dd7dcee291c7b03cf12d6a59a61638881815ed7a64d7f6f30",
+          "command_merkle_root": "89ea0f4a026ab60f17e826b64b132306c40e502e5b25d5faa4c4635b5f06e153",
           "signature": {
-            "public_nonce": "909a3e470a9db0feaaf089075908d9b79a02f93f4ea136caa822683271f1cb3e",
-            "signature": "e733ca3af189eb88d39a492558448d224428c57241202491559206ce63337e01"
+            "public_nonce": "aabfb198a2cdc524bb0dbb81cf7c810d40bca0cf8005b863e25e129c5d883457",
+            "signature": "0782f481fd4ca0281ad80f77461f1ba86352aa71737e39be83ecb9eeeccf0a06"
           },
-          "metadata_hash": "161b14b011e83407df43cbdc79bfd445c1fedc9fe4ec767baa4b0c5304a00663"
+          "accumulated_data": {
+            "total_exhaust_burn": 0
+          },
+          "metadata_hash": "0356b697d0db4bb5adb6bc6bac7d9c9e82ee5a9c4d840049e1b62d9182fc03ef"
         },
         "proof_elements": [
           {
             "QuorumCertificate": {
-              "header_hash": "44d69846c54ff4fe79d90592017d62ca1158d87d362584f901e0d95e6fc5250b",
-              "parent_id": "f999a48dc5a06101294996972b2ea8d28e30eebe62d2d0369c15c6d2522c8380",
+              "header_hash": "4d90d4c9226577f19e13723d37559085e7bfda2f6615355def5cbc257ff3d081",
+              "parent_id": "2942514688a08aed1fb8a1ccc350dc132d006fe7cf3939aa764519e29d4c3f60",
               "signatures": [
-                {
-                  "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
-                  "signature": {
-                    "public_nonce": "3c3ac7c62413330fc0506e3dcdd8a701b0227a9fe39b4f0c9b73ce86133cca37",
-                    "signature": "882d203a52a917ac18cc12cc77b6b6083daf6e4e494e3ed0cf3ce744e5c31600"
-                  }
-                },
                 {
                   "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
                   "signature": {
-                    "public_nonce": "c056c2c23b167845b3077159713deb8ff9b1a5c6dae304b5bb9eb801e5123e69",
-                    "signature": "784f9798c78429c4686cc3829f28f541e7b7af33663d3899d5e59ccdd82cf60e"
+                    "public_nonce": "16be2539aca91de5ad092834ebe97956f8fc88bdd4534cad74b72a5860b50034",
+                    "signature": "2ee59c2d3aca471e6631222bc1ad604c2fc94548c237bb77d619509f44f3b70c"
                   }
                 },
                 {
-                  "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
+                  "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
                   "signature": {
-                    "public_nonce": "1805ccf51367680dcf06411e4c4733425654af042bd1e23b3a545c2f00dd4c07",
-                    "signature": "55a732eeb8a60cff656ae40164f9e74b9113752508d0a8d7c443418c701cca00"
+                    "public_nonce": "beac20141c3306e2193fdadfe7885660f3e8453d3459e4a15c3f882980ec5e39",
+                    "signature": "f59fed3f5b7d0afaadf2f15282fb987a448454068d44d4d05706b39a7711300f"
                   }
                 },
                 {
                   "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
                   "signature": {
-                    "public_nonce": "de26584722852e3a20dd2c1b23c1490b2992f7590bb0b81bee3bbf572e11a54e",
-                    "signature": "5b276ab2808c41aa618390d6d78b5de6a20399198b2e44cb8f50c8f3ac59c40b"
+                    "public_nonce": "4ee0cdab102629936eaac12639c2e638de2f598a898d2fb1c83dc22709a1660e",
+                    "signature": "a6e51af802d9bbf5bb95229277a40132ac7c661df5ea7806393254adc5b65200"
+                  }
+                },
+                {
+                  "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
+                  "signature": {
+                    "public_nonce": "08d21b2a7d5f0727915fefdbfe9187dcd975f852d9e376196667a97126fe7b09",
+                    "signature": "bc494bffa8f786ad9ad9677847ba59a7b06235a6ca3605efa7458ab4b9c87a06"
                   }
                 }
               ],
@@ -64,35 +67,35 @@
           },
           {
             "QuorumCertificate": {
-              "header_hash": "b9002d118e7fa444e5ba8f60c45a0fe6bb615c39e31a2dbf374c71ac9f83e4b3",
-              "parent_id": "2a1d88d2697bd84caf64128851e8cae3a9b59983325c19cb94ad80257b544e6f",
+              "header_hash": "61044f28ed76524b4f3f6721fea0215aeb78d2fcbfa990f459b5072f15e9f28a",
+              "parent_id": "76ee44f54236e63d64c8efc638135507be89ee4700af09f388b23bec2c39d88d",
               "signatures": [
                 {
-                  "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
+                  "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
                   "signature": {
-                    "public_nonce": "74d273b571a9cf81092642040d725ba461776d6712898f13d4a31307fd2c8a73",
-                    "signature": "e7e4f6a7b6b7fe42e2f4e85726224451de6ddd0e31a0d7faef57359c48c51a04"
-                  }
-                },
-                {
-                  "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
-                  "signature": {
-                    "public_nonce": "7e08f5348d760a3b5cafd62d904cfe71b52f9c27ae54abff2fbb00211c69356b",
-                    "signature": "e456cad736f74b38c30efda8dc0cef7fad801cc5f813af673ad5b505c9192500"
+                    "public_nonce": "e0d46ddba2480569479ef1749ee6374742575e0a87195dc301baa106561dd44d",
+                    "signature": "1008cb5e8ee8ea7ea4e94eaa3a4be0a1beb74be7e4869e861628c6615d9e6d02"
                   }
                 },
                 {
                   "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
                   "signature": {
-                    "public_nonce": "8e807a58a8aa3bf6a0e226e134e1e60f43b7ea3af42d78057c7dbca77ed19d47",
-                    "signature": "02faedd9586eef4d525f636e8d7c81f143df644cc0a183a780ba55cdff606b09"
+                    "public_nonce": "184b1a031feaadead6086f6100e65ea01675ac8641c80c9ef25bca89dfc19533",
+                    "signature": "8eb2a31fa5de5479224a877ebe5e0750bfa8419fbef3c13b17a0ef0023ce2502"
                   }
                 },
                 {
-                  "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
+                  "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
                   "signature": {
-                    "public_nonce": "e2f932f91b92f2fcfa3841ca551c1e874b6cc562afaa763937a7b68086c6c678",
-                    "signature": "3990835ca06ccf9261ef5535ecff271c4b39f1c76844c2d125f1cce9deaa5d00"
+                    "public_nonce": "c803ab1f571a68d126a11553ca2423b56b17f8177f06b8af256bd80e2861e97b",
+                    "signature": "9bb951f96ab3db2e75f16546b58fe1b2d6d09f3287cffca785d19377c301b206"
+                  }
+                },
+                {
+                  "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
+                  "signature": {
+                    "public_nonce": "9810bfb2c239af78bb44b5627554d21286be43362f61b1d2bf0e1866d292855e",
+                    "signature": "dad0caa25adabc7d2aba47b332f054aedcb5578286c68e9ccb852182a855ee0e"
                   }
                 }
               ],
@@ -101,35 +104,35 @@
           },
           {
             "QuorumCertificate": {
-              "header_hash": "210e83e969c7297050ce455df010f66437727bf584a23c14aeb2c547669d94c6",
-              "parent_id": "373e365a0d47b75d9e3275b29c28e053a85e2e26918b7cd8ee1b60f1b0ec6a9d",
+              "header_hash": "d82abf6ca0c7ea1cb17baeb369f8e3e6076e5b4eedd187bbfc9a004abc0d9449",
+              "parent_id": "80d8355520a36f1479a3f5042adab0b37b299420265e9b7d6b626a6a276859d1",
               "signatures": [
                 {
-                  "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
+                  "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
                   "signature": {
-                    "public_nonce": "a257249d5dcd5a206f4ca2fbc0d62204b9a71d55d3e928463e2066d361e9aa16",
-                    "signature": "dfbdc440f158de6b930e76e1fabe348c6edab40d71d57f017dd761dba65cde07"
+                    "public_nonce": "48b8fc9274594140ca847547ea85d333ce250c49d43f3ac11680e94f0de67117",
+                    "signature": "9565dd6d9cb1e4be6ac7a29ed223ffbff9c859b8d6253f35933382484c509f06"
                   }
                 },
                 {
                   "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
                   "signature": {
-                    "public_nonce": "66b8a3a9485c068e44d0ad29363e3669f0b795b675351ef9c219443f70fda826",
-                    "signature": "0cb09dc5fc72909b81b714b3e726fd8d25ed4bc01be02facf9ba18a0607ef300"
+                    "public_nonce": "38f384433a3b0f27264cb3df8545658d2d32bc18a2379bcb948cf56f30e6ff1d",
+                    "signature": "50ff1924c8aad7ac16d624178d8c45360aca680c83452c3f811292fc8de2ea05"
                   }
                 },
                 {
                   "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
                   "signature": {
-                    "public_nonce": "ce2c3890a29fb722ff6ed61c3348729bc02b657b4f53c5ebad7ee561f97e3c0d",
-                    "signature": "f0af359e2843afd17b624fd3e674a30ac99bd09731fece6a2820451deee15d0a"
+                    "public_nonce": "0860bf3fd73187ca4e7718256e7a31876758dda59b7fbb680d48624b5a54bc5a",
+                    "signature": "930985a7662daa621761d1551a40d09629d525a5582a22d01d655c621178c908"
                   }
                 },
                 {
-                  "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
+                  "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
                   "signature": {
-                    "public_nonce": "48fb927e132e8e30eb0ea33ea8e965e2197cdee8438b5ed386160b937a3e3557",
-                    "signature": "50566f5281203546a72a8035c2acf516dd188c2f9c398adec273e76115949700"
+                    "public_nonce": "e8aab61610a979b91643bce2d51750fb0846ee2c7d206e14d26b5601ab140e3d",
+                    "signature": "4dd262eeabdd3f53f2f955424d93259f18f440def78ec5610567e7ad7698790d"
                   }
                 }
               ],
@@ -216,330 +219,182 @@
             "Leaf": {
               "key": {
                 "bytes": [
-                  67,
+                  89,
+                  213,
+                  203,
+                  172,
+                  177,
                   134,
-                  66,
-                  36,
-                  245,
-                  153,
-                  117,
-                  179,
-                  65,
-                  216,
-                  13,
-                  207,
-                  99,
-                  125,
-                  215,
-                  193,
-                  161,
-                  221,
-                  56,
-                  40,
-                  73,
-                  251,
-                  214,
-                  253,
-                  237,
-                  114,
-                  36,
-                  135,
-                  137,
-                  114,
-                  101,
-                  249
-                ]
-              },
-              "value_hash": [
-                67,
-                134,
-                66,
-                36,
-                245,
-                153,
-                117,
-                179,
-                65,
-                216,
-                13,
-                207,
-                99,
-                125,
-                215,
-                193,
-                161,
-                221,
-                56,
-                40,
-                73,
-                251,
-                214,
-                253,
-                237,
-                114,
-                36,
-                135,
-                137,
-                114,
-                101,
-                249
-              ]
-            }
-          },
-          {
-            "Leaf": {
-              "key": {
-                "bytes": [
-                  73,
-                  176,
-                  192,
-                  102,
-                  5,
-                  240,
-                  77,
-                  134,
-                  208,
-                  179,
-                  171,
-                  36,
-                  243,
-                  44,
-                  65,
-                  239,
-                  250,
-                  192,
-                  244,
-                  127,
-                  159,
-                  169,
-                  81,
-                  205,
-                  6,
-                  5,
-                  153,
-                  137,
-                  215,
-                  81,
-                  123,
-                  36
-                ]
-              },
-              "value_hash": [
-                73,
-                176,
-                192,
-                102,
-                5,
-                240,
-                77,
-                134,
-                208,
-                179,
-                171,
-                36,
-                243,
-                44,
-                65,
-                239,
-                250,
-                192,
-                244,
-                127,
-                159,
-                169,
-                81,
-                205,
-                6,
-                5,
-                153,
-                137,
-                215,
-                81,
-                123,
-                36
-              ]
-            }
-          },
-          {
-            "Leaf": {
-              "key": {
-                "bytes": [
-                  81,
+                  100,
+                  131,
                   197,
-                  153,
-                  14,
-                  106,
-                  115,
-                  158,
-                  150,
-                  34,
-                  194,
-                  71,
-                  233,
-                  170,
-                  132,
-                  127,
-                  193,
-                  171,
-                  19,
-                  95,
-                  76,
-                  141,
-                  145,
-                  53,
+                  49,
                   20,
-                  144,
-                  97,
-                  76,
-                  209,
-                  182,
-                  180,
-                  62,
-                  23
+                  210,
+                  243,
+                  66,
+                  136,
+                  155,
+                  136,
+                  156,
+                  191,
+                  16,
+                  199,
+                  138,
+                  23,
+                  227,
+                  170,
+                  73,
+                  153,
+                  58,
+                  103,
+                  29,
+                  172,
+                  90
                 ]
               },
               "value_hash": [
-                81,
+                89,
+                213,
+                203,
+                172,
+                177,
+                134,
+                100,
+                131,
                 197,
-                153,
-                14,
-                106,
-                115,
-                158,
-                150,
-                34,
-                194,
-                71,
-                233,
-                170,
-                132,
-                127,
-                193,
-                171,
-                19,
-                95,
-                76,
-                141,
-                145,
-                53,
+                49,
                 20,
-                144,
-                97,
-                76,
-                209,
-                182,
-                180,
-                62,
-                23
+                210,
+                243,
+                66,
+                136,
+                155,
+                136,
+                156,
+                191,
+                16,
+                199,
+                138,
+                23,
+                227,
+                170,
+                73,
+                153,
+                58,
+                103,
+                29,
+                172,
+                90
               ]
             }
           },
           {
             "Other": [
-              77,
-              0,
-              43,
-              62,
-              49,
-              165,
-              23,
-              113,
-              245,
-              214,
-              127,
-              63,
-              140,
-              178,
-              90,
-              136,
-              253,
-              103,
-              159,
-              102,
-              1,
-              34,
-              21,
-              95,
-              116,
-              181,
-              7,
-              14,
-              107,
-              33,
-              139,
-              202
-            ]
-          },
-          {
-            "Other": [
-              199,
-              118,
-              150,
-              236,
-              161,
-              12,
-              211,
-              160,
-              138,
-              118,
-              186,
-              26,
-              247,
-              112,
-              53,
-              124,
-              120,
-              248,
-              197,
-              164,
-              34,
-              112,
-              3,
-              156,
-              100,
-              185,
-              46,
-              65,
-              187,
-              61,
-              148,
-              43
-            ]
-          },
-          {
-            "Other": [
-              31,
-              10,
-              160,
-              163,
-              119,
-              11,
               58,
-              125,
-              173,
-              2,
-              238,
-              30,
-              179,
+              252,
+              250,
+              39,
+              46,
+              210,
+              95,
               114,
-              75,
-              74,
-              16,
-              174,
-              168,
-              81,
-              42,
+              21,
+              101,
+              59,
+              51,
+              210,
+              88,
+              106,
+              167,
               160,
-              217,
-              85,
-              163,
-              110,
-              182,
-              247,
+              77,
+              142,
+              76,
+              134,
+              198,
+              212,
+              221,
+              211,
+              2,
+              126,
+              246,
+              188,
+              121,
+              165,
+              184
+            ]
+          },
+          {
+            "Other": [
+              238,
+              101,
+              204,
+              27,
+              136,
+              252,
+              224,
+              234,
+              114,
+              227,
+              34,
+              235,
+              248,
+              161,
+              179,
+              42,
+              101,
+              27,
+              38,
               109,
+              40,
+              69,
+              155,
+              56,
+              187,
+              49,
+              239,
+              199,
+              201,
+              14,
+              22,
+              137
+            ]
+          },
+          {
+            "Other": [
+              233,
+              219,
+              216,
+              243,
               175,
-              190,
-              67
+              174,
+              153,
+              53,
+              90,
+              93,
+              137,
+              96,
+              141,
+              253,
+              157,
+              132,
+              113,
+              20,
+              138,
+              60,
+              188,
+              156,
+              39,
+              255,
+              59,
+              149,
+              162,
+              108,
+              181,
+              202,
+              134,
+              216
             ]
           }
         ]


### PR DESCRIPTION
Description
---
fix(sidechain)!: adds shard group accumulated data to checkpoint

Motivation and Context
---
This PR adds accumulated data typ to the sidechain header used for epoch checkpoints.

Related https://github.com/tari-project/tari-ootle/pull/1639

How Has This Been Tested?
---
Updated fixtures for tests

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->

BREAKING CHANGE: Previous commit proofs (epoch checkpoints, etc.) are not compatible. These are not enabled on mainnet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added accumulated exhaust burn tracking to sidechain block headers, enabling storage and retrieval of total exhaust burn metrics within block validation data.

* **Chores**
  * Updated protocol definitions and conversion logic to support the new accumulated data structure.
  * Refreshed test fixtures and block header schemas to accommodate expanded metadata requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->