### PR TITLE
feat: increase fee estimate details

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -2323,6 +2323,10 @@ message GetFeeEstimateRequest {
 message GetFeeEstimateResponse {
   // Estimated fee for the transaction in microTari
   uint64 estimated_fee = 1;
+  // number of inputs
+  uint64 input_count = 2;
+  // will it have a change output or not
+  bool change_required = 3;
 }
 
 message GetFeePerGramStatsRequest {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -2473,7 +2473,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let output_count = usize::try_from(message.output_count)
             .map_err(|_| Status::internal("Count not convert u64 to usize".to_string()))?;
         let selection_criteria = UtxoSelectionCriteria::default();
-        let fee = oms
+        let (fee, inputs_selected, change) = oms
             .fee_estimate(
                 amount.into(),
                 selection_criteria,
@@ -2486,6 +2486,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         Ok(Response::new(GetFeeEstimateResponse {
             estimated_fee: fee.as_u64(),
+            input_count: inputs_selected as u64,
+            change_required: change,
         }))
     }
 

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -313,7 +313,7 @@ pub enum OutputManagerResponse<KM> {
     Transaction((TxId, Transaction, MicroMinotari)),
     PublicRewindKeys(Box<PublicRewindKeys>),
     RecoveryByte(u8),
-    FeeEstimate(MicroMinotari),
+    FeeEstimate(MicroMinotari, usize, bool),
     RewoundOutputs(Vec<RecoveredOutput>),
     ScanOutputs(Vec<RecoveredOutput>),
     AddKnownOneSidedPaymentScript,
@@ -600,7 +600,7 @@ where KM: TransactionKeyManagerInterface
         fee_per_gram: MicroMinotari,
         num_kernels: usize,
         num_outputs: usize,
-    ) -> Result<MicroMinotari, OutputManagerError> {
+    ) -> Result<(MicroMinotari, usize, bool), OutputManagerError> {
         match self
             .handle
             .call(OutputManagerRequest::FeeEstimate {
@@ -613,7 +613,7 @@ where KM: TransactionKeyManagerInterface
             .await
             .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::FeeEstimate({e})"))??
         {
-            OutputManagerResponse::FeeEstimate(fee) => Ok(fee),
+            OutputManagerResponse::FeeEstimate(fee, number_selected, change) => Ok((fee, number_selected, change)),
             _ => Err(OutputManagerError::UnexpectedApiResponse(
                 "OutputManagerRequest::FeeEstimate".to_string(),
             )),

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -382,7 +382,9 @@ where
             } => self
                 .fee_estimate(amount, selection_criteria, fee_per_gram, num_kernels, num_outputs)
                 .await
-                .map(OutputManagerResponse::FeeEstimate),
+                .map(|(fee, input_count_selected, change)| {
+                    OutputManagerResponse::FeeEstimate(fee, input_count_selected, change)
+                }),
             OutputManagerRequest::ConfirmPendingTransaction {
                 tx_id,
                 tx_id_update,
@@ -803,7 +805,7 @@ where
         fee_per_gram: MicroMinotari,
         num_kernels: usize,
         num_outputs: usize,
-    ) -> Result<MicroMinotari, OutputManagerError> {
+    ) -> Result<(MicroMinotari, usize, bool), OutputManagerError> {
         debug!(
             target: LOG_TARGET,
             "Getting fee estimate. Amount: {amount}. Fee per gram: {fee_per_gram}. Num kernels: {num_kernels}. Num outputs: {num_outputs}"
@@ -855,7 +857,8 @@ where
                             .get_serialized_size()
                             .map_err(|e| OutputManagerError::ConversionError(e.to_string()))?,
                 );
-                return Ok(fee_calc.calculate(fee_per_gram, 1, 1, num_outputs, default_features_and_scripts_size));
+                let fee = fee_calc.calculate(fee_per_gram, 1, 1, num_outputs, default_features_and_scripts_size);
+                return Ok((fee, 1, false));
             },
             Err(e) => Err(e),
         }?;
@@ -863,9 +866,11 @@ where
         debug!(target: LOG_TARGET, "{} utxos selected.", utxo_selection.utxos.len());
 
         let fee = utxo_selection.as_final_fee();
+        let utxo_count = utxo_selection.num_selected();
+        let change_count = utxo_selection.requires_change_output();
 
         debug!(target: LOG_TARGET, "Fee calculated: {fee}");
-        Ok(fee)
+        Ok((fee, utxo_count, change_count))
     }
 
     /// Prepare a Sender Transaction Protocol for the amount and fee_per_gram specified. If required a change output

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -248,7 +248,7 @@ async fn fee_estimate() {
         .await
         .unwrap();
     assert_eq!(
-        fee,
+        fee.0,
         fee_calc.calculate(
             fee_per_gram,
             1,
@@ -274,7 +274,7 @@ async fn fee_estimate() {
             .unwrap();
 
         assert_eq!(
-            fee,
+            fee.0,
             fee_calc.calculate(
                 fee_per_gram,
                 1,
@@ -299,7 +299,7 @@ async fn fee_estimate() {
         )
         .await
         .unwrap();
-    assert_eq!(fee, MicroMinotari::from(375));
+    assert_eq!(fee.0, MicroMinotari::from(375));
 }
 
 #[allow(clippy::identity_op)]
@@ -384,21 +384,21 @@ async fn test_utxo_selection_no_chain_metadata() {
             .expect("Failed to get default features and scripts size byte size") *
             3,
     );
-    assert_eq!(fee, expected_fee);
+    assert_eq!(fee.0, expected_fee);
 
     let spendable_amount = (3..=10).sum::<u64>() * amount;
     let fee = oms
         .fee_estimate(spendable_amount, UtxoSelectionCriteria::default(), fee_per_gram, 1, 2)
         .await
         .unwrap();
-    assert_eq!(fee, MicroMinotari::from(256));
+    assert_eq!(fee.0, MicroMinotari::from(256));
 
     let broke_amount = spendable_amount + MicroMinotari::from(2000);
     let fee = oms
         .fee_estimate(broke_amount, UtxoSelectionCriteria::default(), fee_per_gram, 1, 2)
         .await
         .unwrap();
-    assert_eq!(fee, MicroMinotari::from(256));
+    assert_eq!(fee.0, MicroMinotari::from(256));
 
     // coin split uses the "Largest" selection strategy
     let (_, tx, utxos_total_value) = oms.create_coin_split(vec![], amount, 5, fee_per_gram).await.unwrap();
@@ -493,14 +493,14 @@ async fn test_utxo_selection_with_chain_metadata() {
             .expect("Failed to get default features and scripts size byte size") *
             3,
     );
-    assert_eq!(fee, expected_fee);
+    assert_eq!(fee.0, expected_fee);
 
     let spendable_amount = (1..=6).sum::<u64>() * amount;
     let fee = oms
         .fee_estimate(spendable_amount, UtxoSelectionCriteria::default(), fee_per_gram, 1, 2)
         .await
         .unwrap();
-    assert_eq!(fee, MicroMinotari::from(256));
+    assert_eq!(fee.0, MicroMinotari::from(256));
 
     // test coin split is maturity aware
     let (_, tx, utxos_total_value) = oms.create_coin_split(vec![], amount, 5, fee_per_gram).await.unwrap();

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -7225,7 +7225,7 @@ pub unsafe extern "C" fn wallet_get_fee_estimate(
             num_kernels as usize,
             num_outputs as usize,
         )) {
-        Ok(fee) => fee.into(),
+        Ok((fee, _, _)) => fee.into(),
         Err(e) => {
             *error_out = LibWalletError::from(WalletError::OutputManagerError(e)).code;
             0


### PR DESCRIPTION
Description
---
Adds more detail to the get_fee_estimate grpc call. 

Fixes: #7570 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fee estimation response now includes additional transaction details: the number of inputs to be used and whether a change output will be generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->