### PR TITLE
feat: add noreadahead to lmdb as config option 

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -332,10 +332,15 @@ fn build_lmdb_store<P: AsRef<Path>>(path: P, config: LMDBConfig) -> Result<(LMDB
 
     let file_lock = acquire_exclusive_file_lock(path.as_ref())?;
 
+    let env_flags = if config.no_read_ahead() {
+        open::NOLOCK | open::NORDAHEAD
+    } else {
+        open::NOLOCK
+    };
     let lmdb_store = LMDBBuilder::new()
         .set_path(path)
         // NOLOCK - No lock required because we manage the DB locking using a RwLock
-        .set_env_flags(open::NOLOCK)
+        .set_env_flags(env_flags)
         .set_env_config(config)
         .set_max_number_of_databases(40)
         .add_database(LMDB_DB_METADATA, flags | db::INTEGERKEY)

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -58,6 +58,10 @@
 #init_size_bytes = 16_777_216 # 16 *1024 * 1024
 #grow_size_bytes = 16_777_216 # 16 *1024 * 1024
 #resize_threshold_bytes = 4_194_304 # 4 *1024 * 1024
+# Turn off readahead. Most operating systems perform readahead on read requests by default. This option turns it
+# off if the OS supports it. Turning it off may help random read performance when the DB is larger than RAM and system
+# RAM is full. The option is not implemented on Windows. (Default: false)
+#no_read_ahread = false
 
 [base_node.storage]
 # The maximum number of orphans that can be stored in the Orphan block pool.

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -61,7 +61,7 @@
 # Turn off readahead. Most operating systems perform readahead on read requests by default. This option turns it
 # off if the OS supports it. Turning it off may help random read performance when the DB is larger than RAM and system
 # RAM is full. The option is not implemented on Windows. (Default: false)
-#no_read_ahread = false
+#no_read_ahead = false
 
 [base_node.storage]
 # The maximum number of orphans that can be stored in the Orphan block pool.

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -53,24 +53,40 @@ pub struct LMDBConfig {
     init_size_bytes: usize,
     grow_size_bytes: usize,
     resize_threshold_bytes: usize,
+    /// Turn off readahead. Most operating systems perform readahead on read requests by default. This option turns it
+    /// off if the OS supports it. Turning it off may help random read performance when the DB is larger than RAM and
+    /// system RAM is full. The option is not implemented on Windows. (Default: false)
+    no_read_ahead: bool,
 }
 
 impl LMDBConfig {
     /// Specify LMDB config in bytes.
-    pub fn new(init_size_bytes: usize, grow_size_bytes: usize, resize_threshold_bytes: usize) -> Self {
+    pub fn new(
+        init_size_bytes: usize,
+        grow_size_bytes: usize,
+        resize_threshold_bytes: usize,
+        no_read_ahead: bool,
+    ) -> Self {
         Self {
             init_size_bytes,
             grow_size_bytes,
             resize_threshold_bytes,
+            no_read_ahead,
         }
     }
 
     /// Specify LMDB config in megabytes.
-    pub fn new_from_mb(init_size_mb: usize, grow_size_mb: usize, resize_threshold_mb: usize) -> Self {
+    pub fn new_from_mb(
+        init_size_mb: usize,
+        grow_size_mb: usize,
+        resize_threshold_mb: usize,
+        no_read_ahead: bool,
+    ) -> Self {
         Self {
             init_size_bytes: init_size_mb * BYTES_PER_MB,
             grow_size_bytes: grow_size_mb * BYTES_PER_MB,
             resize_threshold_bytes: resize_threshold_mb * BYTES_PER_MB,
+            no_read_ahead,
         }
     }
 
@@ -89,12 +105,17 @@ impl LMDBConfig {
     pub fn resize_threshold_bytes(&self) -> usize {
         self.resize_threshold_bytes
     }
+
+    /// Get the `no_read_ahead` flag option. If true, readahead is disabled where supported.
+    pub fn no_read_ahead(&self) -> bool {
+        self.no_read_ahead
+    }
 }
 
 impl Default for LMDBConfig {
     fn default() -> Self {
         // Do not choose these values too small, as the entire SMT is replaced for every new block
-        Self::new_from_mb(128, 128, 64)
+        Self::new_from_mb(128, 128, 64, false)
     }
 }
 

--- a/infrastructure/storage/tests/lmdb.rs
+++ b/infrastructure/storage/tests/lmdb.rs
@@ -285,6 +285,7 @@ fn test_lmdb_resize_on_create() {
                     100 * PRESET_SIZE * 1024 * 1024,
                     1024 * 1024,
                     512 * 1024,
+                    false,
                 ))
                 .set_max_number_of_databases(1)
                 .add_database(db_name, db::CREATE)
@@ -308,7 +309,12 @@ fn test_lmdb_resize_on_create() {
             // Load existing db environment
             let env = LMDBBuilder::new()
                 .set_path(&path)
-                .set_env_config(LMDBConfig::new(PRESET_SIZE * 1024 * 1024, 1024 * 1024, 512 * 1024))
+                .set_env_config(LMDBConfig::new(
+                    PRESET_SIZE * 1024 * 1024,
+                    1024 * 1024,
+                    512 * 1024,
+                    false,
+                ))
                 .set_max_number_of_databases(1)
                 .add_database(db_name, db::CREATE)
                 .build()
@@ -337,7 +343,7 @@ fn test_lmdb_resize_before_full() {
             // Create db with 1MB capacity
             let store = LMDBBuilder::new()
                 .set_path(&path)
-                .set_env_config(LMDBConfig::new(1024 * 1024, 512 * 1024, 100 * 1024))
+                .set_env_config(LMDBConfig::new(1024 * 1024, 512 * 1024, 100 * 1024, false))
                 .set_max_number_of_databases(1)
                 .add_database(db_name, db::CREATE)
                 .build()


### PR DESCRIPTION
Description
---
Added `open::NORDAHEAD` flag to the LMDB builder as config option.

_"**Quote:** Most operating systems perform readahead on read requests by default. This option turns it off if the OS supports it. Turning it off may help random read performance when the DB is larger than RAM and system RAM is full. The option is not implemented on Windows."_

As per LMDB documentation, this might help with the seed nodes' RAM usage when needed, or for other Linux users.

Motivation and Context
---
See #7578 for background.

How Has This Been Tested?
---
Not tested.

What process can a PR reviewer use to test or verify this change?
---
Code review.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control OS readahead behavior for database storage; can be disabled for performance tuning (defaults preserve prior behavior).
* **Chores**
  * Storage initialization now respects the new readahead setting.
* **Tests**
  * Internal tests updated to reflect the new configuration parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->