### PR TITLE
feat: add coin selection and spending via bins or buckets

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -632,7 +632,7 @@ service Wallet {
   // request.setUpperBound(100000);       // 0.1 T (exclusive)
   // request.setTotalFee(100);            // 0.0001 T
   // request.setFeePerGram(1);            // 0.000001 T
-  // request.setUserPaymentId("For you"); // 0.000001 T
+  // request.setUserPaymentId("For you");
   //
   // client.rangeLimitCoinJoin(request, (err, response) => {
   //   if (err) console.error(err);
@@ -1009,7 +1009,7 @@ service Wallet {
   // ### Request Parameters:
   //
   // - None
-  //   - This method uses an empty request body (CoinHistogramRequest)..
+  //   - This method uses an empty request body (CoinHistogramRequest).
   //
   // ### Example JavaScript gRPC client usage:
   //
@@ -1953,7 +1953,7 @@ message RangeLimitedCoinJoinRequest {
   // The target coin-joined amount to achieve - the total value of the inputs used will always be >= this amount.
   // Inputs are sorted in ascending order when selected, and the last input selected will either result in the total
   // being equal or greater than this amount.
-  uint64 target_amount = 2;
+  uint64 target_minimum_amount = 2;
   // The lower bound for coin values in this bucket (inclusive).
   uint64 lower_bound = 3;
   // The upper bound for coin values in this bucket (exclusive).

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -621,7 +621,49 @@ service Wallet {
   // inputs in the range, where the maximum will be determined by the individual input values and the target coin-joined
   // value. Either total fee or fee per gram can be specified, with preference given to the latter if both are
   // specified.
-  //    
+  //
+  // ### Request Parameters:
+  // - `maximum_inputs_per_transaction` (required):
+  //   - **Type**: `uint32`
+  //   - **Description**: The maximum number of inputs to include in each coin-join transaction.
+  //   - **Restrictions**:
+  //     - Must be greater than 0.
+  // - `target_amount` (required):
+  //   - **Type**: `uint64`
+  //   - **Description**: The minimum total amount to be coin-joined in each transaction (in MicroTari).
+  //   - **Restrictions**:
+  //    - Must be greater than 0.
+  //    - Must be greater than `upper_bound`
+  // `- `lower_bound` (required):
+  //   - **Type**: `uint64`
+  //   - **Description**: The inclusive lower bound of the input value range (in MicroTari).
+  //   - **Restrictions**:
+  //    - Must be greater than 0.
+  //    - Must be less than `upper_bound`.
+  // - `upper_bound` (required):
+  //   - **Type**: `uint64`
+  //   - **Description**: The exclusive upper bound of the input value range (in MicroTari).
+  //   - **Restrictions**:
+  //    - Must be greater than 0.
+  //    - Must be greater than `lower_bound`.
+  // - `total_fee` (optional):
+  //   - **Type**: `uint64`
+  //   - **Description**: The total fee to be paid for each coin-join transaction (in MicroTari).
+  //   - **Restrictions**:
+  //    - If specified, must be greater than 0.
+  // - `fee_per_gram` (optional):
+  //   - **Type**: `uint64`
+  //   - **Description**: The fee per gram to be paid for each coin-join transaction (in MicroTari).
+  //   - **Restrictions**:
+  //    - If specified, must be greater than 0.
+  //     - `user_payment_id`:
+  //       - **Type**: `UserPaymentId`
+  //       - **Description**: Flexible payment ID that can be one of the following:
+  //         - `u256`: Hex string representing a 256-bit ID
+  //         - `utf8_string`: A human-readable string
+  //         - `user_bytes`: Custom byte sequence
+  //       - **Restrictions**: Exactly one field must be populated. If multiple or none are provided, the request will fail.
+  //
   // ### Example JavaScript gRPC client usage:
   //
   // ```javascript
@@ -1007,6 +1049,18 @@ service Wallet {
   // composition of their wallet's funds. Lower bounds are inclusive, while upper bound are exclusive.
   //
   // ### Request Parameters:
+  // `- `lower_bound` (required):
+  //   - **Type**: `uint64`
+  //   - **Description**: The inclusive lower bound of the input value range (in MicroTari).
+  //   - **Restrictions**:
+  //    - Must be greater than 0.
+  //    - Must be less than `upper_bound`.
+  // - `upper_bound` (required):
+  //   - **Type**: `uint64`
+  //   - **Description**: The exclusive upper bound of the input value range (in MicroTari).
+  //   - **Restrictions**:
+  //    - Must be greater than 0.
+  //    - Must be greater than `lower_bound`.
   //
   // - None
   //   - This method uses an empty request body (CoinHistogramRequest).
@@ -2195,7 +2249,18 @@ message CoinSplitRequest {
 }
 
 // Request message for the CoinHistogram RPC.
-message CoinHistogramRequest { }
+message CoinHistogramRequest {
+  // List of coin ranges to get information for.
+  repeated CoinBucket buckets = 1;
+}
+
+// A bucket representing a range of coins.
+message CoinBucket {
+  // The lower bound for coin values in this bucket (inclusive).
+  uint64 lower_bound = 1;
+  // The upper bound for coin values in this bucket (exclusive).
+  uint64 upper_bound = 2;
+}
 
 // Response message containing the transaction ID of the coin split.
 message CoinSplitResponse {
@@ -2206,12 +2271,11 @@ message CoinSplitResponse {
 // Response message for CoinHistogram RPC.
 message CoinHistogramResponse {
   // List of coin buckets representing ranges of coin amounts and their counts.
-  repeated CoinBucket buckets = 1;
+  repeated CoinBucketStats buckets = 1;
 }
 
-// A bucket representing a range of coin amounts and their count. The lower range of the bucket follows on from the
-// previous bucket's upper range.
-message CoinBucket {
+// A bucket representing a range of coin amounts and associated statistics.
+message CoinBucketStats {
   // The number of coins in this bucket.
   uint64 count = 1;
   // The total amount of coins within this bucket.

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -628,23 +628,21 @@ service Wallet {
   //   - **Description**: The maximum number of inputs to include in each coin-join transaction.
   //   - **Restrictions**:
   //     - Must be greater than 0.
-  // - `target_amount` (required):
+  // - `target_minimum_amount` (required):
   //   - **Type**: `uint64`
   //   - **Description**: The minimum total amount to be coin-joined in each transaction (in MicroTari).
   //   - **Restrictions**:
   //    - Must be greater than 0.
   //    - Must be greater than `upper_bound`
-  // `- `lower_bound` (required):
+  // - `lower_bound` (required):
   //   - **Type**: `uint64`
   //   - **Description**: The inclusive lower bound of the input value range (in MicroTari).
   //   - **Restrictions**:
-  //    - Must be greater than 0.
   //    - Must be less than `upper_bound`.
   // - `upper_bound` (required):
   //   - **Type**: `uint64`
   //   - **Description**: The exclusive upper bound of the input value range (in MicroTari).
   //   - **Restrictions**:
-  //    - Must be greater than 0.
   //    - Must be greater than `lower_bound`.
   // - `total_fee` (optional):
   //   - **Type**: `uint64`
@@ -1049,17 +1047,15 @@ service Wallet {
   // composition of their wallet's funds. Lower bounds are inclusive, while upper bound are exclusive.
   //
   // ### Request Parameters:
-  // `- `lower_bound` (required):
+  // - `lower_bound` (required):
   //   - **Type**: `uint64`
   //   - **Description**: The inclusive lower bound of the input value range (in MicroTari).
   //   - **Restrictions**:
-  //    - Must be greater than 0.
   //    - Must be less than `upper_bound`.
   // - `upper_bound` (required):
   //   - **Type**: `uint64`
   //   - **Description**: The exclusive upper bound of the input value range (in MicroTari).
   //   - **Restrictions**:
-  //    - Must be greater than 0.
   //    - Must be greater than `lower_bound`.
   //
   // - None

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -619,16 +619,20 @@ service Wallet {
   // coin-join transactions. As an example, if the wallet has 10_000 inputs in a specified range, and the maximum inputs
   // per coin-join transaction is set to 1_000, then a minimum of 10 coin-join transactions will be created to cover all
   // inputs in the range, where the maximum will be determined by the individual input values and the target coin-joined
-  // value.
+  // value. Either total fee or fee per gram can be specified, with preference given to the latter if both are
+  // specified.
   //    
   // ### Example JavaScript gRPC client usage:
   //
   // ```javascript
   // const request = new RangeLimitedCoinJoinRequest();
   // request.setMaximumInputsPerTransaction(1000);
-  // request.setTargetAmount(100000000); // 100 T
-  // request.setLowerBound(0);          // 0 T
-  // request.setUpperBound(100000);     // 0.1 T
+  // request.setTargetAmount(100000000);  // 100 T
+  // request.setLowerBound(0);            // 0 T
+  // request.setUpperBound(100000);       // 0.1 T
+  // request.setTotalFee(100);            // 0.0001 T
+  // request.setFeePerGram(1);            // 0.000001 T
+  // request.setUserPaymentId("For you"); // 0.000001 T
   //
   // client.rangeLimitCoinJoin(request, (err, response) => {
   //   if (err) console.error(err);
@@ -1954,16 +1958,16 @@ message RangeLimitedCoinJoinRequest {
   uint64 lower_bound = 3;
   // The upper bound for coin values in this bucket (exclusive).
   uint64 upper_bound = 4;
-  enum FeeType {
-    // A total fee to use for the entire transaction.
-    TOTAL_FEE = 0;
-    // A fee per gram to use for the transaction.
-    FEE_PER_GRAM = 1;
+  // Optional total fee to use - if not specified, fee per gram will be used instead.
+  message TotalFee {
+    uint64 total_fee = 1;
   }
-  // Specify fee type as total fee or fee per gram.
-  FeeType fee_type = 5;
-  // Optional total fee or fee per gram to use - if not specified the lowest value will be selected.
-  uint64 total_fee_or_fee_per_gram = 6;
+  TotalFee total_fee = 5;
+  // Optional fee per gram to use - if not specified the lowest value will be selected.
+  message FeePerGram {
+    uint64 fee_per_gram = 1;
+  }
+  FeePerGram fee_per_gram = 6;
   // Optional user encrypted payment ID for reference (max 256 bytes).
   UserPaymentId user_payment_id = 7;
 }

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -611,7 +611,47 @@ service Wallet {
   //   ]
   // }
   rpc Transfer (TransferRequest)  returns (TransferResponse);
-
+  
+  // This call creates a CoinJoin transaction spending the output(s) to the owner wallet, ensuring that the inputs
+  // (currently unspent outputs) falls within a specified range and that the minimum coin-joined target amount is met.
+  // If the specified range does not allow for sufficient inputs to meet the target amount, the transaction will not be
+  // created. The process will continue until all unspent outputs in the specified range has been evaluated and used in
+  // coin-join transactions. As an example, if the wallet has 10_000 inputs in a specified range, and the maximum inputs
+  // per coin-join transaction is set to 1_000, then a minimum of 10 coin-join transactions will be created to cover all
+  // inputs in the range, where the maximum will be determined by the individual input values and the target coin-joined
+  // value.
+  //    
+  // ### Example JavaScript gRPC client usage:
+  //
+  // ```javascript
+  // const request = new RangeLimitedCoinJoinRequest();
+  // request.setMaximumInputsPerTransaction(1000);
+  // request.setTargetAmount(100000000); // 100 T
+  // request.setLowerBound(0);          // 0 T
+  // request.setUpperBound(100000);     // 0.1 T
+  //
+  // client.rangeLimitCoinJoin(request, (err, response) => {
+  //   if (err) console.error(err);
+  //   else console.log(response.toObject());
+  // });
+  // ```
+  //
+  // ### Sample JSON Response:
+  //
+  // ```json
+  // {
+  //   "results": [
+  //     {
+  //       "address": "14HVCEeZ...",
+  //       "transaction_id": 12345,
+  //       "is_success": true,
+  //       "failure_message": ""
+  //     }
+  //   ]
+  // }
+  // ```
+  rpc RangeLimitedCoinJoin (RangeLimitedCoinJoinRequest)  returns (TransferResponse);
+  
   // Returns the transaction details for the given transaction IDs.
   //
   // The GetTransactionInfo RPC retrieves detailed information about specific transactions based on their IDs.
@@ -955,6 +995,41 @@ service Wallet {
   // }
   // ```
   rpc CoinSplit (CoinSplitRequest) returns (CoinSplitResponse);
+
+  // Creates a histogram of coin (UTXO) sizes in the wallet.
+  //
+  // The `CoinHistogram` call generates a histogram representing the distribution of unspent transaction outputs (UTXOs)
+  // in the wallet. The histogram groups UTXOs into bins/buckets based on their amounts, allowing users to analyze the
+  // composition of their wallet's funds.
+  //
+  // ### Request Parameters:
+  //
+  // - None
+  //   - This method uses an empty request body (CoinHistogramRequest)..
+  //
+  // ### Example JavaScript gRPC client usage:
+  //
+  // ```javascript
+  // client.coinHistogram({}, (err, response) => {
+  //   if (err) console.error(err);
+  //   else console.log("Coin Histogram:", response.buckets);
+  // });
+  // ```
+  // ### Sample JSON Response:
+  //
+  // ```json
+  // {
+  //   "buckets": [
+  //     { "count": 212, "total_amount": 1234,         "lower_bound": 0,          "upper_bound": 10000 },
+  //     { "count": 5,   "total_amount": 56789,        "lower_bound": 10000,      "upper_bound": 100000 },
+  //     { "count": 0,   "total_amount": 0,            "lower_bound": 100000,     "upper_bound": 1000000 },
+  //     { "count": 0,   "total_amount": 0,            "lower_bound": 1000000,    "upper_bound": 1000000000 },
+  //     { "count": 1,   "total_amount": 111222333000, "lower_bound": 1000000000, "upper_bound": 1000000000000 }
+  //   ]
+  // }
+  // ```
+
+  rpc CoinHistogram (CoinHistogramRequest) returns (CoinHistogramResponse);
 
   // Imports UTXOs into the wallet as spendable outputs.
   //
@@ -1866,6 +1941,33 @@ message TransferRequest {
   bool single_tx = 2;
 }
 
+// A request to perform a range-limited coin-join to self operation.
+message RangeLimitedCoinJoinRequest {
+  // The maximum number of coins to use in any coin-join transaction (only limited by maximum transaction size limits
+  // of 4000 inputs).
+  uint64 maximum_inputs_per_transaction = 1;
+  // The target coin-joined amount to achieve - the total value of the inputs used will always be >= this amount.
+  // Inputs are sorted in ascending order when selected, and the last input selected will either result in the total
+  // being equal or greater than this amount.
+  uint64 target_amount = 2;
+  // The lower bound for coin values in this bucket (inclusive).
+  uint64 lower_bound = 3;
+  // The upper bound for coin values in this bucket (exclusive).
+  uint64 upper_bound = 4;
+  enum FeeType {
+    // A total fee to use for the entire transaction.
+    TOTAL_FEE = 0;
+    // A fee per gram to use for the transaction.
+    FEE_PER_GRAM = 1;
+  }
+  // Specify fee type as total fee or fee per gram.
+  FeeType fee_type = 5;
+  // Optional total fee or fee per gram to use - if not specified the lowest value will be selected.
+  uint64 total_fee_or_fee_per_gram = 6;
+  // Optional user encrypted payment ID for reference (max 256 bytes).
+  UserPaymentId user_payment_id = 7;
+}
+
 message SendShaAtomicSwapRequest {
   PaymentRecipient recipient = 1;
 }
@@ -2047,6 +2149,16 @@ message UserPaymentId {
   bytes user_bytes = 3;
 }
 
+// Optional fee per gram to use for transactions
+message FeePerGrem {
+  uint64 value = 1;
+}
+
+// Optional total fee to use for transactions
+message TotalFee {
+  uint64 value = 1;
+}
+
 message GetStateRequest {}
 
 message GetBalanceResponse {
@@ -2088,10 +2200,32 @@ message CoinSplitRequest {
   bytes payment_id = 6;
 }
 
+// Request message for the CoinHistogram RPC.
+message CoinHistogramRequest { }
+
 // Response message containing the transaction ID of the coin split.
 message CoinSplitResponse {
   // The unique ID of the transaction created.
   uint64 tx_id = 1;
+}
+
+// Response message for CoinHistogram RPC.
+message CoinHistogramResponse {
+  // List of coin buckets representing ranges of coin amounts and their counts.
+  repeated CoinBucket buckets = 1;
+}
+
+// A bucket representing a range of coin amounts and their count. The lower range of the bucket follows on from the
+// previous bucket's upper range.
+message CoinBucket {
+  // The number of coins in this bucket.
+  uint64 count = 1;
+  // The total amount of coins within this bucket.
+  uint64 total_amount = 2;
+  // The lower bound for coin values in this bucket (inclusive).
+  uint64 lower_bound = 3;
+  // The upper bound for coin values in this bucket (exclusive).
+  uint64 upper_bound = 4;
 }
 
 // Request message for importing UTXOs into the wallet.

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -628,8 +628,8 @@ service Wallet {
   // const request = new RangeLimitedCoinJoinRequest();
   // request.setMaximumInputsPerTransaction(1000);
   // request.setTargetAmount(100000000);  // 100 T
-  // request.setLowerBound(0);            // 0 T
-  // request.setUpperBound(100000);       // 0.1 T
+  // request.setLowerBound(0);            // 0 T (inclusive)
+  // request.setUpperBound(100000);       // 0.1 T (exclusive)
   // request.setTotalFee(100);            // 0.0001 T
   // request.setFeePerGram(1);            // 0.000001 T
   // request.setUserPaymentId("For you"); // 0.000001 T
@@ -1004,7 +1004,7 @@ service Wallet {
   //
   // The `CoinHistogram` call generates a histogram representing the distribution of unspent transaction outputs (UTXOs)
   // in the wallet. The histogram groups UTXOs into bins/buckets based on their amounts, allowing users to analyze the
-  // composition of their wallet's funds.
+  // composition of their wallet's funds. Lower bounds are inclusive, while upper bound are exclusive.
   //
   // ### Request Parameters:
   //
@@ -2151,16 +2151,6 @@ message UserPaymentId {
   bytes u256 = 1;
   string utf8_string = 2;
   bytes user_bytes = 3;
-}
-
-// Optional fee per gram to use for transactions
-message FeePerGrem {
-  uint64 value = 1;
-}
-
-// Optional total fee to use for transactions
-message TotalFee {
-  uint64 value = 1;
 }
 
 message GetStateRequest {}

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -38,7 +38,6 @@ use log::*;
 use minotari_app_grpc::tari_rpc::{
     self,
     payment_recipient::PaymentType,
-    range_limited_coin_join_request::FeeType as GrpcFeeType,
     wallet_server,
     BroadcastSignedOneSidedTransactionRequest,
     BroadcastSignedOneSidedTransactionResponse,
@@ -151,7 +150,7 @@ use rand::rngs::OsRng;
 use tari_common_types::{
     payment_reference::generate_payment_reference,
     tari_address::TariAddress,
-    transaction::TxId,
+    transaction::{LegacyTransactionStatus, TxId},
     types::{
         BlockHash,
         CompressedCommitment,
@@ -1208,15 +1207,18 @@ impl wallet_server::Wallet for WalletGrpcServer {
         )))?;
         if bucket.total_value < message.target_amount {
             return Err(Status::internal(format!(
-                "The wallet does not have sufficient funds in the specified range: {} < {}",
+                "The wallet does not have sufficient funds in the specified range: {} uT < {} uT",
                 bucket.total_value, message.target_amount
             )));
         }
 
         // Extract fee, payment id, and wallet address
-        let fee = match GrpcFeeType::try_from(message.fee_type).unwrap_or(GrpcFeeType::TotalFee) {
-            GrpcFeeType::TotalFee => FeeType::TotalFee(message.total_fee_or_fee_per_gram.max(1)),
-            GrpcFeeType::FeePerGram => FeeType::FeePerGram(message.total_fee_or_fee_per_gram.max(1)),
+        let fee = if let Some(val) = message.fee_per_gram {
+            FeeType::FeePerGram(val.fee_per_gram.max(1))
+        } else if let Some(val) = message.total_fee {
+            FeeType::TotalFee(val.total_fee.max(1))
+        } else {
+            FeeType::FeePerGram(1)
         };
         let payment_id = if let Some(user_pay_id) = message.user_payment_id {
             let bytes = match (
@@ -1283,22 +1285,48 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 },
             };
 
-            let wallet_tx = timeout(Duration::from_millis(self.wallet.config.grpc_db_write_timeout), async {
-                loop {
-                    let tx = self.get_transaction_service().get_any_transaction(tx_id).await;
+            let wallet_tx = timeout(
+                Duration::from_millis(self.wallet.config.grpc_broadcast_confirmation),
+                async {
+                    loop {
+                        let tx = self.get_transaction_service().get_any_transaction(tx_id).await;
 
-                    if let Ok(Some(tx)) = tx {
-                        break tx;
+                        if let Ok(Some(tx)) = tx {
+                            match tx.status() {
+                                LegacyTransactionStatus::Broadcast |
+                                LegacyTransactionStatus::MinedUnconfirmed |
+                                LegacyTransactionStatus::MinedConfirmed |
+                                LegacyTransactionStatus::OneSidedUnconfirmed |
+                                LegacyTransactionStatus::OneSidedConfirmed => break Ok(tx),
+                                LegacyTransactionStatus::Rejected => {
+                                    let error = if let Some(reason) = tx.cancelled_reason() {
+                                        TransactionServiceError::MempoolRejection {
+                                            reason: format!("{}", reason),
+                                        }
+                                    } else {
+                                        TransactionServiceError::MempoolRejection {
+                                            reason: "Unknown reason".to_string(),
+                                        }
+                                    };
+                                    break Err(error);
+                                },
+                                _ => {
+                                    sleep(Duration::from_millis(10)).await;
+                                    continue;
+                                },
+                            }
+                        }
                     }
-                    sleep(Duration::from_millis(10)).await;
-                }
-            })
+                },
+            )
             .await;
             let wallet_tx = match wallet_tx {
-                Ok(val) => val,
+                Ok(Ok(val)) => val,
+                Ok(Err(e)) => break Err(e),
                 Err(_) => {
                     break Err(TransactionServiceError::Other(format!(
-                        "Transaction {tx_id} not found within timeout"
+                        "Transaction {tx_id} not found within timeout of {:.2?}",
+                        self.wallet.config.grpc_db_write_timeout
                     )))
                 },
             };

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -46,7 +46,7 @@ use minotari_app_grpc::tari_rpc::{
     ClaimHtlcRefundResponse,
     ClaimShaAtomicSwapRequest,
     ClaimShaAtomicSwapResponse,
-    CoinBucket,
+    CoinBucketStats,
     CoinHistogramRequest,
     CoinHistogramResponse,
     CoinSplitRequest,
@@ -1195,6 +1195,23 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         // Simple verification of range and target amount
         let range = message.lower_bound..message.upper_bound;
+        if message.lower_bound * message.upper_bound == 0 || message.lower_bound >= message.upper_bound {
+            return Err(Status::invalid_argument(format!(
+                "Invalid range range: lower_bound..upper_bound {}..{}",
+                message.lower_bound, message.upper_bound
+            )));
+        }
+        if message.maximum_inputs_per_transaction == 0 {
+            return Err(Status::invalid_argument(
+                "maximum_inputs_per_transaction cannot be zero",
+            ));
+        }
+        if message.target_minimum_amount < message.upper_bound {
+            return Err(Status::invalid_argument(format!(
+                "target_minimum_amount must be > than upper_bound {} vs. {}",
+                message.target_minimum_amount, message.upper_bound
+            )));
+        }
         let mut wallet = self.wallet.clone();
         let mut results = Vec::new();
         let buckets = wallet
@@ -1334,7 +1351,14 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 },
             };
 
-            let address = wallet_tx.destination_address().expect("cannot fail").to_string();
+            let address = wallet_tx
+                .destination_address()
+                .unwrap_or_else(|| {
+                    error!(target: LOG_TARGET, "range_limit_coin_join: Missing destination address for tx {}", tx_id);
+                    TariAddress::default()
+                })
+                .to_string();
+
             let final_tx = convert_wallet_transaction_into_transaction_info(wallet_tx, &wallet_address);
             results.push(minotari_app_grpc::tari_rpc::TransferResult {
                 address,
@@ -2108,29 +2132,41 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
     async fn coin_histogram(
         &self,
-        _request: Request<CoinHistogramRequest>,
+        request: Request<CoinHistogramRequest>,
     ) -> Result<Response<CoinHistogramResponse>, Status> {
-        let mut wallet = self.wallet.clone();
+        let message = request.into_inner();
+        debug!(target: LOG_TARGET, "coin_histogram: {:?}", message);
 
-        // These ranges are hard-coded for now - easy enough to change later if needed
-        let bucket_ranges = vec![
-            0..1_000u64,                             // 0 - < 1,000 uT
-            1_000..100_000,                          // 1,000 uT - < 100,000 uT
-            100_000..1_000_000,                      // 100,000 uT - < 1 T
-            1_000_000..1_000_000_000,                // 1 T - < 1,000 T
-            1_000_000_000..100_000_000_000,          // 1,000 T - < 100,000 T
-            100_000_000_000..21_000_000_000_000_000, // 100,000 T - < 21,000,000 T (max supply)
-        ];
+        let bucket_ranges = if message.buckets.is_empty() {
+            vec![
+                0..1_000u64,                             // 0 - < 1,000 uT
+                1_000..100_000,                          // 1,000 uT - < 100,000 uT
+                100_000..10_000_000,                     // 100,000 uT - < 10 T
+                10_000_000..1_000_000_000,               // 10 T - < 1,000 T
+                1_000_000_000..100_000_000_000,          // 1,000 T - < 100,000 T
+                100_000_000_000..21_000_000_000_000_000, // 100,000 T - < 21,000,000 T (max supply)
+            ]
+        } else {
+            message.buckets.iter().map(|v| v.lower_bound..v.upper_bound).collect()
+        };
+
+        let mut wallet = self.wallet.clone();
 
         let buckets = wallet
             .output_manager_service
             .count_outputs_in_ranges(bucket_ranges.clone())
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
+        if buckets.len() != bucket_ranges.len() {
+            debug!(
+                target: LOG_TARGET,
+                "coin_histogram: Error - The wallet db did not return the requested number of buckets"
+            );
+        }
 
         let mut buckets_response = Vec::with_capacity(buckets.len());
         for bucket in &buckets {
-            buckets_response.push(CoinBucket {
+            buckets_response.push(CoinBucketStats {
                 count: bucket.number_of_outputs,
                 total_amount: bucket.total_value,
                 lower_bound: bucket.range.start,

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1327,7 +1327,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Err(_) => {
                     break Err(TransactionServiceError::Other(format!(
                         "Transaction {tx_id} not found within timeout of {:.2?}",
-                        self.wallet.config.grpc_db_write_timeout
+                        self.wallet.config.grpc_broadcast_confirmation
                     )))
                 },
             };

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -2137,18 +2137,32 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let message = request.into_inner();
         debug!(target: LOG_TARGET, "coin_histogram: {:?}", message);
 
-        let bucket_ranges = if message.buckets.is_empty() {
-            vec![
-                0..1_000u64,                             // 0 - < 1,000 uT
-                1_000..100_000,                          // 1,000 uT - < 100,000 uT
-                100_000..10_000_000,                     // 100,000 uT - < 10 T
-                10_000_000..1_000_000_000,               // 10 T - < 1,000 T
-                1_000_000_000..100_000_000_000,          // 1,000 T - < 100,000 T
-                100_000_000_000..21_000_000_000_000_000, // 100,000 T - < 21,000,000 T (max supply)
-            ]
+        let bucket_ranges: Result<Vec<_>, Status> = if message.buckets.is_empty() {
+            Ok(vec![
+                0..1_000u64,
+                1_000..100_000,
+                100_000..10_000_000,
+                10_000_000..1_000_000_000,
+                1_000_000_000..100_000_000_000,
+                100_000_000_000..21_000_000_000_000_000,
+            ])
         } else {
-            message.buckets.iter().map(|v| v.lower_bound..v.upper_bound).collect()
+            message
+                .buckets
+                .iter()
+                .map(|v| {
+                    if v.lower_bound * v.upper_bound == 0 || v.lower_bound >= v.upper_bound {
+                        Err(Status::invalid_argument(format!(
+                            "Invalid range: lower_bound..upper_bound {}..{}",
+                            v.lower_bound, v.upper_bound
+                        )))
+                    } else {
+                        Ok(v.lower_bound..v.upper_bound)
+                    }
+                })
+                .collect()
         };
+        let bucket_ranges = bucket_ranges?;
 
         let mut wallet = self.wallet.clone();
 

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1191,6 +1191,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         request: Request<RangeLimitedCoinJoinRequest>,
     ) -> Result<Response<TransferResponse>, Status> {
         let message = request.into_inner();
+        debug!(target: LOG_TARGET, "range_limit_coin_join: {:?}", message);
 
         // Simple verification of range and target amount
         let range = message.lower_bound..message.upper_bound;

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1206,7 +1206,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 "maximum_inputs_per_transaction cannot be zero",
             ));
         }
-        if message.target_minimum_amount < message.upper_bound {
+        if message.target_minimum_amount <= message.upper_bound {
             return Err(Status::invalid_argument(format!(
                 "target_minimum_amount must be > than upper_bound {} vs. {}",
                 message.target_minimum_amount, message.upper_bound

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1195,7 +1195,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         // Simple verification of range and target amount
         let range = message.lower_bound..message.upper_bound;
-        if message.lower_bound * message.upper_bound == 0 || message.lower_bound >= message.upper_bound {
+        if message.lower_bound >= message.upper_bound {
             return Err(Status::invalid_argument(format!(
                 "Invalid range range: lower_bound..upper_bound {}..{}",
                 message.lower_bound, message.upper_bound
@@ -2151,7 +2151,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 .buckets
                 .iter()
                 .map(|v| {
-                    if v.lower_bound * v.upper_bound == 0 || v.lower_bound >= v.upper_bound {
+                    if v.lower_bound >= v.upper_bound {
                         Err(Status::invalid_argument(format!(
                             "Invalid range: lower_bound..upper_bound {}..{}",
                             v.lower_bound, v.upper_bound

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1206,10 +1206,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
             "The wallet does not have any funds in the specified range: {}..{}",
             message.lower_bound, message.upper_bound
         )))?;
-        if bucket.total_value < message.target_amount {
+        if bucket.total_value < message.target_minimum_amount {
             return Err(Status::internal(format!(
                 "The wallet does not have sufficient funds in the specified range: {} uT < {} uT",
-                bucket.total_value, message.target_amount
+                bucket.total_value, message.target_minimum_amount
             )));
         }
 
@@ -1261,7 +1261,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         range_limit: Some(RangeLimit {
                             range: message.lower_bound..message.upper_bound,
                             transaction_input_limit: message.maximum_inputs_per_transaction,
-                            target_minimum_amount: message.target_amount,
+                            target_minimum_amount: message.target_minimum_amount,
                         }),
                         ..Default::default()
                     },
@@ -1316,6 +1316,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
                                     continue;
                                 },
                             }
+                        } else {
+                            sleep(Duration::from_millis(10)).await;
                         }
                     }
                 },
@@ -1327,7 +1329,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Err(_) => {
                     break Err(TransactionServiceError::Other(format!(
                         "Transaction {tx_id} not found within timeout of {:.2?}",
-                        self.wallet.config.grpc_broadcast_confirmation
+                        Duration::from_millis(self.wallet.config.grpc_broadcast_confirmation)
                     )))
                 },
             };

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -38,6 +38,7 @@ use log::*;
 use minotari_app_grpc::tari_rpc::{
     self,
     payment_recipient::PaymentType,
+    range_limited_coin_join_request::FeeType as GrpcFeeType,
     wallet_server,
     BroadcastSignedOneSidedTransactionRequest,
     BroadcastSignedOneSidedTransactionResponse,
@@ -46,6 +47,9 @@ use minotari_app_grpc::tari_rpc::{
     ClaimHtlcRefundResponse,
     ClaimShaAtomicSwapRequest,
     ClaimShaAtomicSwapResponse,
+    CoinBucket,
+    CoinHistogramRequest,
+    CoinHistogramResponse,
     CoinSplitRequest,
     CoinSplitResponse,
     CreateBurnTransactionRequest,
@@ -94,6 +98,7 @@ use minotari_app_grpc::tari_rpc::{
     PrepareOneSidedTransactionForSigningResponse,
     PrepareWithdrawMultisigTransactionRequest,
     PrepareWithdrawMultisigTransactionResponse,
+    RangeLimitedCoinJoinRequest,
     RegisterValidatorNodeRequest,
     RegisterValidatorNodeResponse,
     ReplaceByFeeRequest,
@@ -128,7 +133,12 @@ use minotari_wallet::{
     connectivity_service::{OnlineStatus, WalletConnectivityInterface, UNKNOWN_LATENCY_MS},
     error::WalletStorageError,
     legacy_transaction_protocol::recipient::RecipientState,
-    output_manager_service::{handle::OutputManagerHandle, UtxoSelectionCriteria},
+    output_manager_service::{
+        error::OutputManagerError,
+        handle::OutputManagerHandle,
+        RangeLimit,
+        UtxoSelectionCriteria,
+    },
     transaction_service::{
         error::TransactionServiceError,
         handle::TransactionServiceHandle,
@@ -150,6 +160,7 @@ use tari_common_types::{
         PrivateKey,
         SignatureWithDomain,
     },
+    wallet_types::FeeType,
 };
 use tari_comms::{connectivity::ConnectivityStatus, types::CommsPublicKey};
 use tari_hashing::WalletMessageSigningDomain;
@@ -1175,6 +1186,143 @@ impl wallet_server::Wallet for WalletGrpcServer {
         Ok(Response::new(TransferResponse { results }))
     }
 
+    #[allow(clippy::too_many_lines)]
+    async fn range_limited_coin_join(
+        &self,
+        request: Request<RangeLimitedCoinJoinRequest>,
+    ) -> Result<Response<TransferResponse>, Status> {
+        let message = request.into_inner();
+
+        // Simple verification of range and target amount
+        let range = message.lower_bound..message.upper_bound;
+        let mut wallet = self.wallet.clone();
+        let mut results = Vec::new();
+        let buckets = wallet
+            .output_manager_service
+            .count_outputs_in_ranges(vec![range])
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        let bucket = buckets.first().ok_or(Status::internal(format!(
+            "The wallet does not have any funds in the specified range: {}..{}",
+            message.lower_bound, message.upper_bound
+        )))?;
+        if bucket.total_value < message.target_amount {
+            return Err(Status::internal(format!(
+                "The wallet does not have sufficient funds in the specified range: {} < {}",
+                bucket.total_value, message.target_amount
+            )));
+        }
+
+        // Extract fee, payment id, and wallet address
+        let fee = match GrpcFeeType::try_from(message.fee_type).unwrap_or(GrpcFeeType::TotalFee) {
+            GrpcFeeType::TotalFee => FeeType::TotalFee(message.total_fee_or_fee_per_gram.max(1)),
+            GrpcFeeType::FeePerGram => FeeType::FeePerGram(message.total_fee_or_fee_per_gram.max(1)),
+        };
+        let payment_id = if let Some(user_pay_id) = message.user_payment_id {
+            let bytes = match (
+                user_pay_id.u256.is_empty(),
+                user_pay_id.utf8_string.is_empty(),
+                user_pay_id.user_bytes.is_empty(),
+            ) {
+                (false, true, true) => user_pay_id.u256,
+                (true, false, true) => user_pay_id.utf8_string.as_bytes().to_vec(),
+                (true, true, false) => user_pay_id.user_bytes,
+                _ => {
+                    return Err(Status::invalid_argument(
+                        "user_payment_id must be one of u256, utf8_string or user_bytes".to_string(),
+                    ))
+                },
+            };
+            MemoField::new_open(bytes, TxType::PaymentToSelf).map_err(|e| {
+                error!(target: LOG_TARGET, "range_limit_coin_join: {}", e);
+                Status::invalid_argument(format!("range_limit_coin_join: {}", e))
+            })?
+        } else {
+            MemoField::new_empty()
+        };
+        let wallet_address = self
+            .wallet
+            .get_wallet_one_sided_address()
+            .await
+            .map_err(|e| Status::internal(format!("{e:?}")))?;
+
+        // Start sending coin join transactions until we exhaust the range or reach the target amount
+        // Note:
+        //   This is done synchronously to ensure each transaction can be successfully processed and submitted to a base
+        //   node before the next is created.
+        let mut transaction_service = self.get_transaction_service();
+        let batch_result = loop {
+            let tx_result = transaction_service
+                .send_range_limited_coin_join_transaction(
+                    UtxoSelectionCriteria {
+                        range_limit: Some(RangeLimit {
+                            range: message.lower_bound..message.upper_bound,
+                            transaction_input_limit: message.maximum_inputs_per_transaction,
+                            target_minimum_amount: message.target_amount,
+                        }),
+                        ..Default::default()
+                    },
+                    OutputFeatures::default(),
+                    fee,
+                    payment_id.clone(),
+                )
+                .await;
+            let tx_id = match tx_result {
+                Ok(val) => val,
+                Err(err) => {
+                    if let TransactionServiceError::OutputManagerError(OutputManagerError::RangeLimitError {
+                        range_exhausted,
+                        ..
+                    }) = err
+                    {
+                        if range_exhausted && !results.is_empty() {
+                            break Ok(());
+                        }
+                    }
+                    break Err(err);
+                },
+            };
+
+            let wallet_tx = timeout(Duration::from_millis(self.wallet.config.grpc_db_write_timeout), async {
+                loop {
+                    let tx = self.get_transaction_service().get_any_transaction(tx_id).await;
+
+                    if let Ok(Some(tx)) = tx {
+                        break tx;
+                    }
+                    sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await;
+            let wallet_tx = match wallet_tx {
+                Ok(val) => val,
+                Err(_) => {
+                    break Err(TransactionServiceError::Other(format!(
+                        "Transaction {tx_id} not found within timeout"
+                    )))
+                },
+            };
+
+            let address = wallet_tx.destination_address().expect("cannot fail").to_string();
+            let final_tx = convert_wallet_transaction_into_transaction_info(wallet_tx, &wallet_address);
+            results.push(minotari_app_grpc::tari_rpc::TransferResult {
+                address,
+                transaction_id: tx_id.into(),
+                is_success: true,
+                failure_message: Default::default(),
+                transaction_info: Some(final_tx),
+            });
+        };
+
+        match batch_result {
+            Ok(_) => Ok(Response::new(minotari_app_grpc::tari_rpc::TransferResponse { results })),
+            Err(err) => {
+                error!(target: LOG_TARGET, "range_limit_coin_join: {}", err);
+                Err(Status::internal(format!("range_limit_coin_join: {}", err)))
+            },
+        }
+    }
+
     async fn create_burn_transaction(
         &self,
         request: Request<CreateBurnTransactionRequest>,
@@ -1925,6 +2073,43 @@ impl wallet_server::Wallet for WalletGrpcServer {
             .map_err(|e| Status::internal(format!("{e:?}")))?;
 
         Ok(Response::new(CoinSplitResponse { tx_id: tx_id.into() }))
+    }
+
+    async fn coin_histogram(
+        &self,
+        _request: Request<CoinHistogramRequest>,
+    ) -> Result<Response<CoinHistogramResponse>, Status> {
+        let mut wallet = self.wallet.clone();
+
+        // These ranges are hard-coded for now - easy enough to change later if needed
+        let bucket_ranges = vec![
+            0..1_000u64,                             // 0 - < 1,000 uT
+            1_000..100_000,                          // 1,000 uT - < 100,000 uT
+            100_000..1_000_000,                      // 100,000 uT - < 1 T
+            1_000_000..1_000_000_000,                // 1 T - < 1,000 T
+            1_000_000_000..100_000_000_000,          // 1,000 T - < 100,000 T
+            100_000_000_000..21_000_000_000_000_000, // 100,000 T - < 21,000,000 T (max supply)
+        ];
+
+        let buckets = wallet
+            .output_manager_service
+            .count_outputs_in_ranges(bucket_ranges.clone())
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let mut buckets_response = Vec::with_capacity(buckets.len());
+        for bucket in &buckets {
+            buckets_response.push(CoinBucket {
+                count: bucket.number_of_outputs,
+                total_amount: bucket.total_value,
+                lower_bound: bucket.range.start,
+                upper_bound: bucket.range.end,
+            });
+        }
+
+        Ok(Response::new(CoinHistogramResponse {
+            buckets: buckets_response,
+        }))
     }
 
     async fn import_utxos(

--- a/base_layer/common_types/src/wallet_types.rs
+++ b/base_layer/common_types/src/wallet_types.rs
@@ -97,3 +97,21 @@ impl LedgerWallet {
         }
     }
 }
+
+/// Specifies either a total fee for a transaction or a fee per gram
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum FeeType {
+    /// A total fee for the transaction (in MicroMinotari units)
+    TotalFee(u64),
+    /// A fee per gram for the transaction (in MicroMinotari units)
+    FeePerGram(u64),
+}
+
+impl Display for FeeType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TotalFee(fee) => write!(f, "TotalFee({fee})"),
+            Self::FeePerGram(fee_per_gram) => write!(f, "FeePerGram({fee_per_gram})"),
+        }
+    }
+}

--- a/base_layer/wallet/src/config.rs
+++ b/base_layer/wallet/src/config.rs
@@ -139,6 +139,9 @@ pub struct WalletConfig {
     /// before returning an error to the client. This should be long enough to cover the majority of database writes
     /// but short enough to avoid blocking the grpc server for too long. Default = 100ms
     pub grpc_db_write_timeout: u64,
+    /// gRPC broadcast confirmation timeout in ms. This is how long the grpc server will wait for the mempool to
+    /// respond once the transaction has been submitted, either accepted or rejected. Default = 5000ms
+    pub grpc_broadcast_confirmation: u64,
 }
 
 impl Default for WalletConfig {
@@ -184,6 +187,7 @@ impl Default for WalletConfig {
             fallback_http_server_url,
             scanning_interval: 60,
             grpc_db_write_timeout: 100,
+            grpc_broadcast_confirmation: 5000,
         }
     }
 }

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -61,6 +61,8 @@ pub enum OutputManagerError {
     TransactionError(#[from] TransactionError),
     #[error("DHT outbound error: `{0}`")]
     DhtOutboundError(#[from] DhtOutboundError),
+    #[error("Error processing range limit output selection criteria: {reason}")]
+    RangeLimitError { reason: String, range_exhausted: bool },
     #[error("Conversion error: `{0}`")]
     ConversionError(String),
     #[error("Not all the transaction inputs and outputs are present to be confirmed: {0}")]
@@ -188,6 +190,8 @@ pub enum OutputManagerStorageError {
     ValuesNotFound,
     #[error("Error converting a type: {reason}")]
     ConversionError { reason: String },
+    #[error("Error processing range limit output selection criteria: {reason}")]
+    RangeLimitError { reason: String },
     #[error("Output has already been spent")]
     OutputAlreadySpent,
     #[error("Output is already encumbered")]

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -146,8 +146,10 @@ pub enum OutputManagerError {
     ValidationInProgress,
     #[error("Invalid data: `{0}`")]
     RangeProofError(String),
-    #[error("Transaction is over sized: `{0}`")]
+    #[error("Transaction inputs are over sized: `{0}`")]
     TooManyInputsToFulfillTransaction(String),
+    #[error("Transaction outputs are over sized: `{0}`")]
+    TooManyOutputsToFulfillTransaction(String),
     #[error("Std I/O error: {0}")]
     StdIoError(#[from] std::io::Error),
     #[error("Tari address error: `{0}`")]

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -19,13 +19,14 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use std::{collections::HashMap, fmt, fmt::Formatter, sync::Arc};
+use std::{collections::HashMap, fmt, fmt::Formatter, ops::Range, sync::Arc};
 
 use log::warn;
 use tari_common_types::{
     tari_address::TariAddress,
     transaction::TxId,
     types::{CompressedCommitment, CompressedPublicKey, FixedHash, HashOutput},
+    wallet_types::FeeType,
 };
 use tari_script::{CompressedCheckSigSchnorrSignature, TariScript};
 use tari_service_framework::reply_channel::SenderService;
@@ -53,6 +54,7 @@ use crate::output_manager_service::{
     storage::{
         database::OutputBackendQuery,
         models::{DbWalletOutput, KnownOneSidedPaymentScript, SpendingPriority},
+        sqlite_db::CoinBucket,
     },
     UtxoSelectionCriteria,
 };
@@ -62,6 +64,9 @@ const LOG_TARGET: &str = "wallet::output_manager_service::handle";
 /// API Request enum
 pub enum OutputManagerRequest {
     GetBalance,
+    GetCoinBuckets {
+        ranges: Vec<Range<u64>>,
+    },
     GetBalancePaymentId(Vec<u8>),
     AddOutput((Box<WalletOutput>, Option<SpendingPriority>)),
     AddOutputWithTxId((TxId, Box<WalletOutput>, Option<SpendingPriority>)),
@@ -97,6 +102,14 @@ pub enum OutputManagerRequest {
         selection_criteria: UtxoSelectionCriteria,
         output_features: Box<OutputFeatures>,
         fee_per_gram: MicroMinotari,
+        script: TariScript,
+        covenant: Covenant,
+    },
+    GetTransactionBuilderRangeLimitedCoinJoin {
+        tx_id: TxId,
+        selection_criteria: UtxoSelectionCriteria,
+        output_features: Box<OutputFeatures>,
+        fee: FeeType,
         script: TariScript,
         covenant: Covenant,
     },
@@ -164,6 +177,13 @@ impl fmt::Display for OutputManagerRequest {
         use OutputManagerRequest::*;
         match self {
             GetBalance => write!(f, "GetBalance"),
+            GetCoinBuckets { ranges } => {
+                let buckets = ranges
+                    .iter()
+                    .map(|v| format!("range: {}..{}", v.start, v.end))
+                    .collect::<Vec<_>>();
+                write!(f, "GetCoinBuckets: buckets {:?}", buckets)
+            },
             GetBalancePaymentId(_) => write!(f, "GetBalance for user payment id"),
             AddOutput((v, _)) => write!(f, "AddOutput ({})", v.value()),
             AddOutputWithTxId((t, v, _)) => write!(f, "AddOutputWithTxId ({}: {})", t, v.value()),
@@ -215,7 +235,8 @@ impl fmt::Display for OutputManagerRequest {
             } => {
                 write!(f, "ConfirmPendingTransaction ({tx_id} replace with {:?})", tx_id_update)
             },
-            GetTransactionBuilder { .. } => write!(f, "PrepareToSendTransaction "),
+            GetTransactionBuilder { .. } => write!(f, "GetTransactionBuilder "),
+            GetTransactionBuilderRangeLimitedCoinJoin { .. } => write!(f, "GetTransactionBuilderRangeLimitedCoinJoin "),
             CreatePayToSelfTransaction { .. } => write!(f, "CreatePayToSelfTransaction",),
             CancelTransaction(v) => write!(f, "CancelTransaction ({v})"),
             GetSpentOutputs => write!(f, "GetSpentOutputs"),
@@ -283,6 +304,8 @@ impl fmt::Display for OutputManagerRequest {
 #[derive(Debug, Clone)]
 pub enum OutputManagerResponse<KM> {
     Balance(Balance),
+    GetCoinBuckets(Vec<CoinBucket>),
+    GetRangeLimitedOutputs(Vec<DbWalletOutput>),
     OutputAdded,
     ConvertedToTransactionOutput(Box<TransactionOutput>),
     OutputMetadataSignatureUpdated,
@@ -514,6 +537,23 @@ where KM: TransactionKeyManagerInterface
         }
     }
 
+    pub async fn count_outputs_in_ranges(
+        &mut self,
+        ranges: Vec<Range<u64>>,
+    ) -> Result<Vec<CoinBucket>, OutputManagerError> {
+        match self
+            .handle
+            .call(OutputManagerRequest::GetCoinBuckets { ranges })
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetCoinBuckets({e})"))??
+        {
+            OutputManagerResponse::GetCoinBuckets(b) => Ok(b),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetCoinBuckets".to_string(),
+            )),
+        }
+    }
+
     pub async fn get_balance_for_payment_id(&mut self, payment_id: Vec<u8>) -> Result<Balance, OutputManagerError> {
         match self
             .handle
@@ -560,6 +600,35 @@ where KM: TransactionKeyManagerInterface
                 selection_criteria: utxo_selection,
                 output_features: Box::new(output_features),
                 fee_per_gram,
+                script,
+                covenant,
+            })
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "OutputManagerRequest::GetTransactionBuilder({e})"))??
+        {
+            OutputManagerResponse::TransactionBuilderToSend(stp) => Ok(*stp),
+            _ => Err(OutputManagerError::UnexpectedApiResponse(
+                "OutputManagerRequest::GetTransactionBuilder".to_string(),
+            )),
+        }
+    }
+
+    pub async fn prepare_range_limited_coin_join_transaction_to_send(
+        &mut self,
+        tx_id: TxId,
+        utxo_selection: UtxoSelectionCriteria,
+        output_features: OutputFeatures,
+        fee: FeeType,
+        script: TariScript,
+        covenant: Covenant,
+    ) -> Result<TransactionBuilder<KM>, OutputManagerError> {
+        match self
+            .handle
+            .call(OutputManagerRequest::GetTransactionBuilderRangeLimitedCoinJoin {
+                tx_id,
+                selection_criteria: utxo_selection,
+                output_features: Box::new(output_features),
+                fee,
                 script,
                 covenant,
             })

--- a/base_layer/wallet/src/output_manager_service/input_selection.rs
+++ b/base_layer/wallet/src/output_manager_service/input_selection.rs
@@ -23,6 +23,7 @@
 use std::{
     fmt,
     fmt::{Display, Formatter},
+    ops::Range,
 };
 
 use tari_common_types::types::CompressedCommitment;
@@ -43,6 +44,18 @@ pub struct UtxoSelectionCriteria {
     pub min_dust: u64,
     pub excluding_onesided: bool,
     pub excluding_multisig: bool,
+    pub range_limit: Option<RangeLimit>,
+}
+
+/// Select outputs within the specified amount ranges
+#[derive(Debug, Clone, Default)]
+pub struct RangeLimit {
+    /// The range of amounts to select from
+    pub range: Range<u64>,
+    /// The maximum number of inputs to select
+    pub transaction_input_limit: u64,
+    /// The target minimum amount to select
+    pub target_minimum_amount: u64,
 }
 
 impl UtxoSelectionCriteria {

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -25,7 +25,7 @@ pub mod error;
 pub mod handle;
 
 mod input_selection;
-pub use input_selection::{UtxoSelectionCriteria, UtxoSelectionFilter, UtxoSelectionOrdering};
+pub use input_selection::{RangeLimit, UtxoSelectionCriteria, UtxoSelectionFilter, UtxoSelectionOrdering};
 
 mod recovery;
 pub mod resources;

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -67,6 +67,9 @@ use crate::{
 /// The maximum number of transaction inputs that can be created in a single transaction, slightly less than the maximum
 /// that a single comms message can hold.
 pub const TRANSACTION_INPUTS_LIMIT: u32 = 4000;
+/// The maximum number of transaction outputs that can be created in a single transaction, which must be comfortably
+/// less than what can fit into one block.
+pub const TRANSACTION_OUTPUTS_LIMIT: usize = 500;
 const LOG_TARGET: &str = "wallet::output_manager_service::initializer";
 
 pub struct OutputManagerServiceInitializer<T, TKeyManagerInterface, THttpClientFactory>

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1959,8 +1959,8 @@ where
                     1,
                     usize::try_from(range_limit_criteria.transaction_input_limit)
                         .unwrap_or(TRANSACTION_INPUTS_LIMIT as usize),
-                    1,
-                    total_output_features_and_scripts_byte_size,
+                    10, // Assume 10 outputs for estimation
+                    total_output_features_and_scripts_byte_size * 10,
                 )
             },
         }
@@ -1987,6 +1987,11 @@ where
             });
         }
 
+        let number_of_outputs =
+            usize::try_from((total_value.as_u64() - fee_estimate) / range_limit_criteria.target_minimum_amount)
+                .map_err(|_e| OutputManagerError::ConversionError("number_of_outputs".to_string()))?
+                .max(1);
+
         let fee_without_change = match fee {
             FeeType::TotalFee(fee) => MicroMinotari(fee),
             FeeType::FeePerGram(fee_per_gram) => {
@@ -1995,15 +2000,15 @@ where
                     MicroMinotari(fee_per_gram),
                     1,
                     utxos.len(),
-                    1,
-                    total_output_features_and_scripts_byte_size,
+                    number_of_outputs,
+                    total_output_features_and_scripts_byte_size * number_of_outputs,
                 )
             },
         };
         trace!(
             target: LOG_TARGET,
-            "select_utxos_for_range_limited_coin_join profile - get_range_limited_outputs_for_spending: {} outputs, {} \
-            ms (at {} ms)",
+            "select_utxos_for_range_limited_coin_join profile - get_range_limited_outputs_for_spending: inputs: {}, \
+            outputs: {}, ms (at {} ms)",
             utxos.len(),
             start_new.elapsed().as_millis(),
             start.elapsed().as_millis(),

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1049,7 +1049,7 @@ where
         }
         debug!(
             target: LOG_TARGET,
-            "TxId: {}, input(s) value: {}, amount: {}, fee {}, fee per gram: {}, num inputs: {}.",
+            "TxId: {}, input(s) value: {}, amount: {}, fee {}, final fee: {}, num inputs: {}.",
             tx_id,
             input_selection.total_value(),
             input_selection.total_value() - input_selection.as_final_fee(),
@@ -2021,11 +2021,12 @@ where
             });
         }
 
-        if fee_without_change > total_value {
+        if total_value - fee_without_change < MicroMinotari(range_limit_criteria.target_minimum_amount) {
             return Err(OutputManagerError::RangeLimitError {
                 reason: format!(
-                    "Fee exceeds total value in range: {} vs. {}",
-                    fee_without_change, total_value
+                    "Total available in range less fee exceeds target value: {} vs. {}",
+                    total_value - fee_without_change,
+                    MicroMinotari(range_limit_criteria.target_minimum_amount)
                 ),
                 range_exhausted: false,
             });

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -115,6 +115,7 @@ use crate::{
         tasks::TxoValidationTask,
         RangeLimit,
         TRANSACTION_INPUTS_LIMIT,
+        TRANSACTION_OUTPUTS_LIMIT,
     },
     utxo_scanner_service::handle::{UtxoScannerEvent, UtxoScannerHandle},
 };
@@ -1854,7 +1855,7 @@ where
             utxos_total_value += o.wallet_output.value();
 
             trace!(target: LOG_TARGET, "-- utxos_total_value = {utxos_total_value}");
-            utxos.push(o.clone());
+            utxos.push(o);
             // The assumption here is that the only output will be the payment output and change if required
             fee_without_change = fee_calc.calculate(
                 fee_per_gram,
@@ -1962,14 +1963,35 @@ where
         let fee_estimate = match fee {
             FeeType::TotalFee(fee) => MicroMinotari(fee),
             FeeType::FeePerGram(fee_per_gram) => {
+                #[allow(clippy::single_range_in_vec_init)]
+                let ranges = vec![range_limit_criteria.range.start..range_limit_criteria.range.end];
+                let number_of_outputs =
+                    if let Some(bucket) = self.resources.db.count_outputs_in_ranges(ranges, None)?.first() {
+                        // 'range_limit_criteria.target_minimum_amount' cannot be zero here as checked above
+                        usize::try_from(bucket.total_value / range_limit_criteria.target_minimum_amount)
+                            .unwrap_or(usize::MAX)
+                    } else {
+                        return Err(OutputManagerError::RangeLimitError {
+                            reason: format!(
+                                "No outputs could be selected for the specified range: {:?}",
+                                range_limit_criteria
+                            ),
+                            range_exhausted: true,
+                        });
+                    };
+                if number_of_outputs > TRANSACTION_OUTPUTS_LIMIT {
+                    return Err(OutputManagerError::TooManyOutputsToFulfillTransaction(format!(
+                        "{number_of_outputs} > {TRANSACTION_OUTPUTS_LIMIT}"
+                    )));
+                }
                 let fee_calc = self.get_fee_calc();
                 fee_calc.calculate(
                     MicroMinotari(fee_per_gram),
                     1,
                     usize::try_from(range_limit_criteria.transaction_input_limit)
                         .unwrap_or(TRANSACTION_INPUTS_LIMIT as usize),
-                    10, // Assume 10 outputs for estimation
-                    total_output_features_and_scripts_byte_size * 10,
+                    number_of_outputs,
+                    total_output_features_and_scripts_byte_size * number_of_outputs,
                 )
             },
         }
@@ -2010,6 +2032,12 @@ where
         )
         .map_err(|_e| OutputManagerError::ConversionError("number_of_outputs".to_string()))?
         .max(1);
+
+        if number_of_outputs > TRANSACTION_OUTPUTS_LIMIT {
+            return Err(OutputManagerError::TooManyOutputsToFulfillTransaction(format!(
+                "{number_of_outputs} > {TRANSACTION_OUTPUTS_LIMIT}"
+            )));
+        }
 
         let fee_without_change = match fee {
             FeeType::TotalFee(fee) => MicroMinotari(fee),

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -19,7 +19,7 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{collections::HashMap, fmt, ops::Range, sync::Arc};
 
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use futures::{pin_mut, StreamExt};
@@ -41,6 +41,7 @@ use tari_common_types::{
         UncompressedCommitment,
         UncompressedPublicKey,
     },
+    wallet_types::FeeType,
 };
 use tari_comms::types::CommsDHKE;
 use tari_crypto::commitment::HomomorphicCommitmentFactory;
@@ -107,6 +108,7 @@ use crate::{
         storage::{
             database::{OutputBackendQuery, OutputManagerBackend, OutputManagerDatabase},
             models::{DbWalletOutput, KnownOneSidedPaymentScript, SpendingPriority},
+            sqlite_db::CoinBucket,
             OutputSource,
             OutputStatus,
         },
@@ -115,6 +117,7 @@ use crate::{
     },
     utxo_scanner_service::handle::{UtxoScannerEvent, UtxoScannerHandle},
 };
+
 const LOG_TARGET: &str = "wallet::output_manager_service";
 
 /// This service will manage a wallet's available outputs and the key manager that produces the keys for these outputs.
@@ -328,6 +331,11 @@ where
                 self.get_balance(current_tip_for_time_lock_calculation)
                     .map(OutputManagerResponse::Balance)
             },
+            OutputManagerRequest::GetCoinBuckets { ranges } => {
+                let current_tip_for_time_lock_calculation = self.resources.db.get_last_scanned_height()?;
+                self.count_outputs_in_ranges(ranges, current_tip_for_time_lock_calculation)
+                    .map(OutputManagerResponse::GetCoinBuckets)
+            },
             OutputManagerRequest::GetBalancePaymentId(payment_id) => {
                 let current_tip_for_time_lock_calculation = self.resources.db.get_last_scanned_height()?;
                 self.get_balance_payment_id(current_tip_for_time_lock_calculation, payment_id)
@@ -347,6 +355,24 @@ where
                     amount,
                     selection_criteria,
                     fee_per_gram,
+                    *output_features,
+                    script,
+                    covenant,
+                )
+                .await
+                .map(|tx_builder| OutputManagerResponse::TransactionBuilderToSend(Box::new(tx_builder))),
+            OutputManagerRequest::GetTransactionBuilderRangeLimitedCoinJoin {
+                tx_id,
+                selection_criteria,
+                output_features,
+                fee,
+                script,
+                covenant,
+            } => self
+                .prepare_range_limited_coin_join_transaction_to_send(
+                    tx_id,
+                    selection_criteria,
+                    fee,
                     *output_features,
                     script,
                     covenant,
@@ -783,6 +809,24 @@ where
         Ok(balance)
     }
 
+    fn count_outputs_in_ranges(
+        &self,
+        ranges: Vec<Range<u64>>,
+        tip_height: Option<u64>,
+    ) -> Result<Vec<CoinBucket>, OutputManagerError> {
+        let coin_buckets = self.resources.db.count_outputs_in_ranges(ranges, tip_height)?;
+        trace!(target: LOG_TARGET, "Coin buckets: {:?}", coin_buckets
+            .iter()
+            .map(|v| {
+                format!(
+                    "count: {}, value: {}, range: {}..{}",
+                    v.number_of_outputs, v.total_value, v.range.start, v.range.end
+                )
+            })
+            .collect::<Vec<_>>());
+        Ok(coin_buckets)
+    }
+
     fn get_balance_payment_id(
         &self,
         current_tip_for_time_lock_calculation: Option<u64>,
@@ -945,49 +989,50 @@ where
         Ok(builder)
     }
 
-    pub async fn create_transaction_with_outputs_internal(
+    /// Prepare a Sender Transaction Protocol for a range limited coin-join and fee_per_gram specified. No change output
+    /// will be produced.
+    pub async fn prepare_range_limited_coin_join_transaction_to_send(
         &mut self,
-        outputs: Vec<WalletOutputBuilder>,
+        tx_id: TxId,
         selection_criteria: UtxoSelectionCriteria,
-        fee_per_gram: MicroMinotari,
-        payment_id: MemoField,
-    ) -> Result<(TxId, Transaction), OutputManagerError> {
-        let total_value = outputs.iter().map(|o| o.value()).sum();
-
-        let nop_script = script![Nop]?;
-        let weighting = self.resources.consensus_constants.transaction_weight_params();
-        let mut features_and_scripts_byte_size = 0;
-
-        for output in &outputs {
-            let (features, covenant, script) = (
-                output
-                    .features()
+        fee: FeeType,
+        recipient_output_features: OutputFeatures,
+        recipient_script: TariScript,
+        recipient_covenant: Covenant,
+    ) -> Result<TransactionBuilder<TKeyManagerInterface>, OutputManagerError> {
+        let target_minimum_amount = selection_criteria
+            .clone()
+            .range_limit
+            .ok_or_else(|| OutputManagerError::RangeLimitError {
+                reason: "Range limit must be specified for range limited coin-join UTXO selection".to_string(),
+                range_exhausted: false,
+            })?
+            .target_minimum_amount;
+        debug!(
+            target: LOG_TARGET,
+            "Preparing to send range limited coin join transaction - TxId: {tx_id}, target_minimum_amount: \
+            {target_minimum_amount}, fee: {fee}, selection: {selection_criteria}"
+        );
+        let features_and_scripts_byte_size = self
+            .resources
+            .consensus_constants
+            .transaction_weight_params()
+            .round_up_features_and_scripts_size(
+                recipient_output_features
                     .get_serialized_size()
-                    .map_err(|e| OutputManagerError::ServiceError(e.to_string()))?,
-                output
-                    .covenant()
-                    .get_serialized_size()
-                    .map_err(|e| OutputManagerError::ServiceError(e.to_string()))?,
-                output
-                    .script()
-                    .unwrap_or(&nop_script)
-                    .get_serialized_size()
-                    .map_err(|e| OutputManagerError::ServiceError(e.to_string()))?,
+                    .map_err(|e| OutputManagerError::ConversionError(e.to_string()))? +
+                    recipient_script
+                        .get_serialized_size()
+                        .map_err(|e| OutputManagerError::ConversionError(e.to_string()))? +
+                    recipient_covenant
+                        .get_serialized_size()
+                        .map_err(|e| OutputManagerError::ConversionError(e.to_string()))?,
             );
-            features_and_scripts_byte_size += weighting.round_up_features_and_scripts_size(features + covenant + script)
-        }
 
         let input_selection = self
-            .select_utxos(
-                total_value,
-                selection_criteria,
-                fee_per_gram,
-                outputs.len(),
-                features_and_scripts_byte_size,
-            )
+            .select_utxos_for_range_limited_coin_join(selection_criteria, fee, features_and_scripts_byte_size)
             .await?;
 
-        // Create builder with no recipients (other than ourselves)
         let mut builder = TransactionBuilder::new(
             self.resources.consensus_constants.clone(),
             self.resources.key_manager.clone(),
@@ -995,57 +1040,30 @@ where
         )
         .await?;
         builder
-            .with_lock_height(0)
-            .with_fee_per_gram(fee_per_gram)
-            .with_prevent_fee_gt_amount(false)
-            .with_kernel_features(KernelFeatures::empty())
-            .with_memo(payment_id);
+            .with_fee(input_selection.as_final_fee())
+            .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount);
 
         for uo in input_selection.iter() {
             builder.with_input(uo.wallet_output.clone()).await?;
         }
-
-        let mut db_outputs = vec![];
-
-        for mut wallet_output in outputs {
-            let sender_offset_key = self
-                .resources
-                .key_manager
-                .get_next_key(TransactionKeyManagerBranch::SenderOffset.get_branch_key())
-                .await?;
-            wallet_output = wallet_output
-                .sign_as_sender_and_receiver(&mut self.resources.key_manager, &sender_offset_key.key_id)
-                .await?;
-            let ub = wallet_output.try_build(&self.resources.key_manager).await?;
-
-            builder
-                .with_output(ub.clone(), sender_offset_key.key_id.clone(), None)
-                .await
-                .map_err(|e| OutputManagerError::BuildError(e.to_string()))?;
-            db_outputs.push(DbWalletOutput::from_wallet_output(
-                ub,
-                None,
-                OutputSource::default(),
-                None,
-                None,
-            ));
-        }
-
-        let finalized = builder.build().await?;
-        if let Some(wallet_output) = finalized.change {
-            db_outputs.push(DbWalletOutput::from_wallet_output(
-                wallet_output.clone(),
-                None,
-                OutputSource::default(),
-                Some(finalized.tx_id),
-                None,
-            ));
-        }
+        debug!(
+            target: LOG_TARGET,
+            "TxId: {}, input(s) value: {}, amount: {}, fee {}, fee per gram: {}, num inputs: {}.",
+            tx_id,
+            input_selection.total_value(),
+            input_selection.total_value() - input_selection.as_final_fee(),
+            fee,
+            input_selection.as_final_fee(),
+            input_selection.num_selected(),
+        );
 
         self.resources
             .db
-            .encumber_outputs(finalized.tx_id, input_selection.into_selected(), db_outputs)?;
-        Ok((finalized.tx_id, finalized.transaction))
+            .encumber_outputs(tx_id, input_selection.into_selected(), vec![])?;
+
+        debug!(target: LOG_TARGET, "Prepared transaction (TxId: {tx_id}) to send");
+
+        Ok(builder)
     }
 
     async fn pre_mine_script_key_from_payment_id(
@@ -1616,6 +1634,12 @@ where
         payment_id: MemoField,
         minimum_value_promise: MicroMinotari,
     ) -> Result<(MicroMinotari, Transaction, TxId), OutputManagerError> {
+        if selection_criteria.range_limit.is_some() {
+            return Err(OutputManagerError::RangeLimitError {
+                reason: "Range limit coin-join cannot be set for create_pay_to_self_transaction".to_string(),
+                range_exhausted: false,
+            });
+        }
         let covenant = Covenant::default();
 
         let features_and_scripts_byte_size = self
@@ -1829,7 +1853,7 @@ where
             utxos_total_value += o.wallet_output.value();
 
             trace!(target: LOG_TARGET, "-- utxos_total_value = {utxos_total_value}");
-            utxos.push(o);
+            utxos.push(o.clone());
             // The assumption here is that the only output will be the payment output and change if required
             fee_without_change = fee_calc.calculate(
                 fee_per_gram,
@@ -1889,6 +1913,100 @@ where
             total_value: utxos_total_value,
             fee_without_change,
             fee_with_change,
+        })
+    }
+
+    /// Select which unspent transaction outputs to use to send a range limited coin join transaction. Use the specified
+    /// selection strategy to choose the outputs. No change output will be produced.
+    #[allow(clippy::too_many_lines)]
+    async fn select_utxos_for_range_limited_coin_join(
+        &mut self,
+        selection_criteria: UtxoSelectionCriteria,
+        fee: FeeType,
+        total_output_features_and_scripts_byte_size: usize,
+    ) -> Result<UtxoSelection, OutputManagerError> {
+        let start = Instant::now();
+        let range_limit_criteria =
+            selection_criteria
+                .clone()
+                .range_limit
+                .ok_or_else(|| OutputManagerError::RangeLimitError {
+                    reason: "Range limit must be specified for range limited coin-join UTXO selection".to_string(),
+                    range_exhausted: false,
+                })?;
+        debug!(
+            target: LOG_TARGET,
+            "select_utxos_for_range_limited_coin_join target_minimum_amount: {}, fee: {fee}, \
+            output_features_and_scripts_byte_size:  {total_output_features_and_scripts_byte_size}, \
+            selection_criteria: {selection_criteria:?}",
+            range_limit_criteria.target_minimum_amount
+        );
+
+        // Attempt to get the chain tip height
+        let tip_height = self.resources.db.get_last_scanned_height()?;
+
+        let start_new = Instant::now();
+        let (utxos, total_value) = self
+            .resources
+            .db
+            .get_range_limited_outputs_for_spending(&selection_criteria, tip_height)?;
+        trace!(
+            target: LOG_TARGET,
+            "select_utxos_for_range_limited_coin_join profile - get_range_limited_outputs_for_spending: {} outputs, {} \
+            ms (at {} ms)",
+            utxos.len(),
+            start_new.elapsed().as_millis(),
+            start.elapsed().as_millis(),
+        );
+        if utxos.is_empty() {
+            return Err(OutputManagerError::RangeLimitError {
+                reason: format!(
+                    "No outputs could be selected for the specified range: {:?}",
+                    range_limit_criteria
+                ),
+                range_exhausted: true,
+            });
+        } else {
+            trace!(target: LOG_TARGET, "We found {} UTXOs that match the range limit criteria", utxos.len());
+        }
+
+        // For non-standard queries, we want to ensure that the intended UTXOs are selected
+        if !selection_criteria.filter.is_standard() && utxos.is_empty() {
+            return Err(OutputManagerError::NoUtxosSelected {
+                criteria: selection_criteria,
+            });
+        }
+
+        let fee_without_change = match fee {
+            FeeType::TotalFee(fee) => MicroMinotari(fee),
+            FeeType::FeePerGram(fee_per_gram) => {
+                let fee_calc = self.get_fee_calc();
+                fee_calc.calculate(
+                    MicroMinotari(fee_per_gram),
+                    1,
+                    utxos.len(),
+                    1,
+                    total_output_features_and_scripts_byte_size,
+                )
+            },
+        };
+
+        if fee_without_change > total_value {
+            return Err(OutputManagerError::RangeLimitError {
+                reason: format!(
+                    "Fee exceeds total value in range: {} vs. {}",
+                    fee_without_change, total_value
+                ),
+                range_exhausted: false,
+            });
+        }
+
+        Ok(UtxoSelection {
+            utxos,
+            requires_change_output: false,
+            total_value,
+            fee_without_change,
+            fee_with_change: fee_without_change,
         })
     }
 

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -1943,6 +1943,15 @@ where
             selection_criteria: {selection_criteria:?}",
             range_limit_criteria.target_minimum_amount
         );
+        if range_limit_criteria.target_minimum_amount <= range_limit_criteria.range.end {
+            return Err(OutputManagerError::RangeLimitError {
+                reason: format!(
+                    "Target minimum amount {} cannot be less or equal than range end {}",
+                    range_limit_criteria.target_minimum_amount, range_limit_criteria.range.end
+                ),
+                range_exhausted: false,
+            });
+        }
 
         // Attempt to get the chain tip height
         let tip_height = self.resources.db.get_last_scanned_height()?;
@@ -1965,6 +1974,15 @@ where
             },
         }
         .as_u64();
+        if range_limit_criteria.target_minimum_amount < fee_estimate {
+            return Err(OutputManagerError::RangeLimitError {
+                reason: format!(
+                    "Target minimum amount {} is less than the estimated fee {}",
+                    range_limit_criteria.target_minimum_amount, fee_estimate
+                ),
+                range_exhausted: false,
+            });
+        }
 
         let selection_criteria = UtxoSelectionCriteria {
             range_limit: Some(RangeLimit {
@@ -1987,10 +2005,11 @@ where
             });
         }
 
-        let number_of_outputs =
-            usize::try_from((total_value.as_u64() - fee_estimate) / range_limit_criteria.target_minimum_amount)
-                .map_err(|_e| OutputManagerError::ConversionError("number_of_outputs".to_string()))?
-                .max(1);
+        let number_of_outputs = usize::try_from(
+            total_value.as_u64().saturating_sub(fee_estimate) / range_limit_criteria.target_minimum_amount,
+        )
+        .map_err(|_e| OutputManagerError::ConversionError("number_of_outputs".to_string()))?
+        .max(1);
 
         let fee_without_change = match fee {
             FeeType::TotalFee(fee) => MicroMinotari(fee),

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -113,6 +113,7 @@ use crate::{
             OutputStatus,
         },
         tasks::TxoValidationTask,
+        RangeLimit,
         TRANSACTION_INPUTS_LIMIT,
     },
     utxo_scanner_service::handle::{UtxoScannerEvent, UtxoScannerHandle},
@@ -1917,7 +1918,8 @@ where
     }
 
     /// Select which unspent transaction outputs to use to send a range limited coin join transaction. Use the specified
-    /// selection strategy to choose the outputs. No change output will be produced.
+    /// selection strategy to choose the outputs. No change output will be produced, and the total value selected will
+    /// be >= the target amount plus fee.
     #[allow(clippy::too_many_lines)]
     async fn select_utxos_for_range_limited_coin_join(
         &mut self,
@@ -1946,18 +1948,35 @@ where
         let tip_height = self.resources.db.get_last_scanned_height()?;
 
         let start_new = Instant::now();
+
+        // Find the UTXOs that satisfy the range limit criteria and actual fee
+        let fee_estimate = match fee {
+            FeeType::TotalFee(fee) => MicroMinotari(fee),
+            FeeType::FeePerGram(fee_per_gram) => {
+                let fee_calc = self.get_fee_calc();
+                fee_calc.calculate(
+                    MicroMinotari(fee_per_gram),
+                    1,
+                    usize::try_from(range_limit_criteria.transaction_input_limit)
+                        .unwrap_or(TRANSACTION_INPUTS_LIMIT as usize),
+                    1,
+                    total_output_features_and_scripts_byte_size,
+                )
+            },
+        }
+        .as_u64();
+
+        let selection_criteria = UtxoSelectionCriteria {
+            range_limit: Some(RangeLimit {
+                target_minimum_amount: range_limit_criteria.target_minimum_amount + fee_estimate,
+                ..range_limit_criteria.clone()
+            }),
+            ..selection_criteria
+        };
         let (utxos, total_value) = self
             .resources
             .db
             .get_range_limited_outputs_for_spending(&selection_criteria, tip_height)?;
-        trace!(
-            target: LOG_TARGET,
-            "select_utxos_for_range_limited_coin_join profile - get_range_limited_outputs_for_spending: {} outputs, {} \
-            ms (at {} ms)",
-            utxos.len(),
-            start_new.elapsed().as_millis(),
-            start.elapsed().as_millis(),
-        );
         if utxos.is_empty() {
             return Err(OutputManagerError::RangeLimitError {
                 reason: format!(
@@ -1965,15 +1984,6 @@ where
                     range_limit_criteria
                 ),
                 range_exhausted: true,
-            });
-        } else {
-            trace!(target: LOG_TARGET, "We found {} UTXOs that match the range limit criteria", utxos.len());
-        }
-
-        // For non-standard queries, we want to ensure that the intended UTXOs are selected
-        if !selection_criteria.filter.is_standard() && utxos.is_empty() {
-            return Err(OutputManagerError::NoUtxosSelected {
-                criteria: selection_criteria,
             });
         }
 
@@ -1990,6 +2000,21 @@ where
                 )
             },
         };
+        trace!(
+            target: LOG_TARGET,
+            "select_utxos_for_range_limited_coin_join profile - get_range_limited_outputs_for_spending: {} outputs, {} \
+            ms (at {} ms)",
+            utxos.len(),
+            start_new.elapsed().as_millis(),
+            start.elapsed().as_millis(),
+        );
+
+        // For non-standard queries, we want to ensure that the intended UTXOs are selected
+        if !selection_criteria.filter.is_standard() && utxos.is_empty() {
+            return Err(OutputManagerError::NoUtxosSelected {
+                criteria: selection_criteria,
+            });
+        }
 
         if fee_without_change > total_value {
             return Err(OutputManagerError::RangeLimitError {

--- a/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
@@ -1,11 +1,16 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::ops::Range;
+
 use tari_common_types::{
     transaction::TxId,
     types::{CompressedCommitment, FixedHash},
 };
-use tari_transaction_components::transaction_components::{OutputType, TransactionOutput};
+use tari_transaction_components::{
+    transaction_components::{OutputType, TransactionOutput},
+    MicroMinotari,
+};
 
 use crate::output_manager_service::{
     error::OutputManagerStorageError,
@@ -14,7 +19,7 @@ use crate::output_manager_service::{
     storage::{
         database::{DbKey, DbValue, OutputBackendQuery, WriteOperation},
         models::DbWalletOutput,
-        sqlite_db::{ReceivedOutputInfoForBatch, SpentOutputInfoForBatch},
+        sqlite_db::{CoinBucket, ReceivedOutputInfoForBatch, SpentOutputInfoForBatch},
     },
 };
 
@@ -99,6 +104,12 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
     fn reinstate_cancelled_inbound_output(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError>;
     /// Return the available, time locked, pending incoming and pending outgoing balance
     fn get_balance(&self, tip: Option<u64>) -> Result<Balance, OutputManagerStorageError>;
+    /// Count outputs in the specified ranges
+    fn count_outputs_in_ranges(
+        &self,
+        ranges: Vec<Range<u64>>,
+        tip_height: Option<u64>,
+    ) -> Result<Vec<CoinBucket>, OutputManagerStorageError>;
     /// Return the available, time locked, pending incoming and pending outgoing balance only matching the payment id
     fn get_balance_payment_id(
         &self,
@@ -107,6 +118,12 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
     ) -> Result<Balance, OutputManagerStorageError>;
     /// Import unvalidated output
     fn add_unvalidated_output(&self, output: DbWalletOutput, tx_id: TxId) -> Result<(), OutputManagerStorageError>;
+    /// Retrieves UTXOs within a specified limited range with minimum target amount for spending
+    fn get_range_limited_outputs_for_spending(
+        &self,
+        selection_criteria: &UtxoSelectionCriteria,
+        tip_height: Option<u64>,
+    ) -> Result<(Vec<DbWalletOutput>, MicroMinotari), OutputManagerStorageError>;
     fn fetch_unspent_outputs_for_spending(
         &self,
         selection_criteria: &UtxoSelectionCriteria,

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -23,6 +23,7 @@
 mod backend;
 use std::{
     fmt::{Debug, Display, Error, Formatter},
+    ops::Range,
     sync::Arc,
 };
 
@@ -44,7 +45,7 @@ use crate::output_manager_service::{
     service::Balance,
     storage::{
         models::{DbWalletOutput, KnownOneSidedPaymentScript},
-        sqlite_db::{ReceivedOutputInfoForBatch, SpentOutputInfoForBatch},
+        sqlite_db::{CoinBucket, ReceivedOutputInfoForBatch, SpentOutputInfoForBatch},
         OutputStatus,
     },
 };
@@ -188,6 +189,14 @@ where T: OutputManagerBackend + 'static
         self.db.get_balance(current_tip_for_time_lock_calculation)
     }
 
+    pub fn count_outputs_in_ranges(
+        &self,
+        ranges: Vec<Range<u64>>,
+        tip_height: Option<u64>,
+    ) -> Result<Vec<CoinBucket>, OutputManagerStorageError> {
+        self.db.count_outputs_in_ranges(ranges, tip_height)
+    }
+
     pub fn get_balance_payment_id(
         &self,
         current_tip_for_time_lock_calculation: Option<u64>,
@@ -255,6 +264,18 @@ where T: OutputManagerBackend + 'static
 
     pub fn fetch_with_features(&self, feature: OutputType) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError> {
         self.db.fetch_with_features(feature)
+    }
+
+    /// Retrieves UTXOs within a specified limited range with minimum target amount for spending
+    pub fn get_range_limited_outputs_for_spending(
+        &self,
+        selection_criteria: &UtxoSelectionCriteria,
+        tip_height: Option<u64>,
+    ) -> Result<(Vec<DbWalletOutput>, MicroMinotari), OutputManagerStorageError> {
+        let utxos = self
+            .db
+            .get_range_limited_outputs_for_spending(selection_criteria, tip_height)?;
+        Ok(utxos)
     }
 
     /// Retrieves UTXOs than can be spent, sorted by priority, then value from smallest to largest.

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryFrom, str::FromStr};
+use std::{convert::TryFrom, ops::Range, str::FromStr};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use derivative::Derivative;
@@ -38,6 +38,7 @@ use tari_script::{ExecutionStack, TariScript};
 use tari_transaction_components::{
     key_manager::TariKeyId,
     transaction_components::{OutputType, TransactionOutput},
+    MicroMinotari,
 };
 use tokio::time::Instant;
 
@@ -1029,6 +1030,29 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         result
     }
 
+    fn count_outputs_in_ranges(
+        &self,
+        ranges: Vec<Range<u64>>,
+        tip_height: Option<u64>,
+    ) -> Result<Vec<CoinBucket>, OutputManagerStorageError> {
+        let start = Instant::now();
+        let mut conn = self.database_connection.get_pooled_connection()?;
+        let acquire_lock = start.elapsed();
+
+        let result =
+            OutputSql::count_outputs_in_ranges(&UtxoSelectionCriteria::default(), &ranges, tip_height, &mut conn);
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - count_outputs_in_ranges: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
+        result
+    }
+
     fn get_balance_payment_id(
         &self,
         current_tip_for_time_lock_calculation: Option<u64>,
@@ -1234,6 +1258,35 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             );
         }
         Ok(())
+    }
+
+    /// Retrieves UTXOs within a specified limited range with minimum target amount for spending
+    fn get_range_limited_outputs_for_spending(
+        &self,
+        selection_criteria: &UtxoSelectionCriteria,
+        tip_height: Option<u64>,
+    ) -> Result<(Vec<DbWalletOutput>, MicroMinotari), OutputManagerStorageError> {
+        let start = Instant::now();
+        let mut conn = self.database_connection.get_pooled_connection()?;
+        let acquire_lock = start.elapsed();
+
+        let (outputs, total) =
+            OutputSql::get_range_limited_outputs_for_spending(selection_criteria, tip_height, &mut conn)?;
+
+        trace!(
+            target: LOG_TARGET,
+            "sqlite profile - get_range_limited_outputs_for_spending: lock {} + db_op {} = {} ms",
+            acquire_lock.as_millis(),
+            (start.elapsed() - acquire_lock).as_millis(),
+            start.elapsed().as_millis()
+        );
+        Ok((
+            outputs
+                .iter()
+                .map(|o| o.clone().to_db_wallet_output())
+                .collect::<Result<Vec<_>, _>>()?,
+            total,
+        ))
     }
 
     /// Retrieves UTXOs than can be spent, sorted by priority, then value from smallest to largest.
@@ -1541,6 +1594,17 @@ impl KnownOneSidedPaymentScriptSql {
 
         Ok(payment_script)
     }
+}
+
+/// A summary of coins in a particular range
+#[derive(Clone, Debug)]
+pub struct CoinBucket {
+    /// The number of outputs in this range
+    pub number_of_outputs: u64,
+    /// The total value of outputs in this range
+    pub total_value: u64,
+    /// The range that this bucket covers
+    pub range: Range<u64>,
 }
 
 #[cfg(test)]

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -22,13 +22,19 @@
 
 use std::{
     convert::{TryFrom, TryInto},
+    ops::Range,
     str::FromStr,
 };
 
 use borsh::BorshDeserialize;
 use chrono::NaiveDateTime;
 use derivative::Derivative;
-use diesel::{prelude::*, sql_query};
+use diesel::{
+    dsl::{count_star, sql},
+    prelude::*,
+    sql_query,
+    sql_types::{BigInt, Nullable},
+};
 use log::*;
 use tari_common_sqlite::util::diesel_ext::ExpectedRowsExtension;
 use tari_common_types::{
@@ -67,7 +73,7 @@ use crate::{
         storage::{
             database::{OutputBackendQuery, SortDirection},
             models::{DbWalletOutput, SpendingPriority},
-            sqlite_db::{UpdateOutput, UpdateOutputSql},
+            sqlite_db::{CoinBucket, UpdateOutput, UpdateOutputSql},
             OutputSource,
             OutputStatus,
         },
@@ -77,6 +83,7 @@ use crate::{
     },
     schema::outputs,
 };
+
 const LOG_TARGET: &str = "wallet::output_manager_service::database::wallet";
 
 #[derive(Clone, Derivative, Debug, Queryable, Identifiable, PartialEq, QueryableByName)]
@@ -290,6 +297,132 @@ impl OutputSql {
         };
 
         Ok(query.limit(i64::from(TRANSACTION_INPUTS_LIMIT)).load(conn)?)
+    }
+
+    /// Retrieves UTXOs within a specified limited range with minimum target amount for spending. If not enough UTXOs
+    /// can be found, an empty vector is returned.
+    pub fn get_range_limited_outputs_for_spending(
+        selection_criteria: &UtxoSelectionCriteria,
+        tip_height: Option<u64>,
+        conn: &mut SqliteConnection,
+    ) -> Result<(Vec<OutputSql>, MicroMinotari), OutputManagerStorageError> {
+        let range_limit =
+            selection_criteria
+                .range_limit
+                .as_ref()
+                .ok_or_else(|| OutputManagerStorageError::RangeLimitError {
+                    reason: "Range limit must be specified".to_string(),
+                })?;
+        let amounts_from = i64::try_from(range_limit.range.start).unwrap_or(i64::MAX);
+        let amounts_to = i64::try_from(range_limit.range.end).unwrap_or(i64::MAX);
+
+        let mut query = outputs::table
+            .into_boxed()
+            .filter(outputs::status.eq(OutputStatus::Unspent as i32))
+            .filter(outputs::value.ge(amounts_from))
+            .filter(outputs::value.lt(amounts_to));
+
+        // NOTE: Safe mode presets `script_lock_height` and `maturity` filters for all queries
+        let i64_tip_height = tip_height.and_then(|h| i64::try_from(h).ok()).unwrap_or(i64::MAX);
+        if selection_criteria.mode == UtxoSelectionMode::Safe {
+            query = query
+                .filter(outputs::script_lock_height.le(i64_tip_height))
+                .filter(outputs::maturity.le(i64_tip_height));
+        };
+
+        for exclude in &selection_criteria.excluding {
+            query = query.filter(outputs::commitment.ne(exclude.as_bytes()));
+        }
+
+        query = query.then_order_by(outputs::value.asc());
+
+        let transaction_input_limit = u32::try_from(range_limit.transaction_input_limit)
+            .unwrap_or(u32::MAX)
+            .min(TRANSACTION_INPUTS_LIMIT);
+        let outputs: Vec<OutputSql> = query.limit(i64::from(transaction_input_limit)).load(conn)?;
+
+        // Post processing in Rust vs. all in raw SQL.
+        //
+        // The current version:
+        // - does a single backend query;
+        // - loads at most transaction_input_limit rows;
+        // - runs a cheap O(n) scan.
+        // The raw SQL alternative would conceptually:
+        // - order outputs and compute a running sum;
+        // - give each row a row number in that order;
+        // - find the smallest row number whose running_sum >= target_minimum_amount;
+        // - return all rows with row_number <= that row_number.
+        // The raw SQL alternative:
+        // - is more complex;
+        // - is less type-safe;
+        // - is harder to maintain/debug.
+
+        // If all the outputs together don't reach target, we cannot continue
+        let total_sum: u64 = outputs.iter().fold(0u64, |acc, o| acc.saturating_add(o.value as u64));
+        if total_sum < range_limit.target_minimum_amount {
+            debug!(
+                target: LOG_TARGET,
+                "Total unspent outputs' value in the specified range was less than the target_minimum_amount: {} < {}",
+                total_sum, range_limit.target_minimum_amount
+            );
+            return Ok((Vec::new(), MicroMinotari::zero()));
+        }
+
+        // Pick the smallest prefix that reaches the target
+        let mut selected = Vec::new();
+        let mut total = 0u64;
+        for output in outputs {
+            total = total.saturating_add(output.value as u64);
+            selected.push(output);
+            if total >= range_limit.target_minimum_amount {
+                break;
+            }
+        }
+
+        Ok((selected, MicroMinotari::from(total)))
+    }
+
+    /// Retrieves UTXO counts grouped by the provided ranges
+    pub fn count_outputs_in_ranges(
+        selection_criteria: &UtxoSelectionCriteria,
+        ranges: &[Range<u64>],
+        tip_height: Option<u64>,
+        conn: &mut SqliteConnection,
+    ) -> Result<Vec<CoinBucket>, OutputManagerStorageError> {
+        let mut result = Vec::with_capacity(ranges.len());
+        let i64_tip_height = tip_height.and_then(|h| i64::try_from(h).ok()).unwrap_or(i64::MAX);
+
+        for range in ranges {
+            let amounts_from = i64::try_from(range.start).unwrap_or(i64::MAX);
+            let amounts_to = i64::try_from(range.end).unwrap_or(i64::MAX);
+
+            let mut query = outputs::table
+                .into_boxed()
+                .filter(outputs::status.eq(OutputStatus::Unspent as i32))
+                .filter(outputs::value.ge(amounts_from))
+                .filter(outputs::value.lt(amounts_to));
+
+            if selection_criteria.mode == UtxoSelectionMode::Safe {
+                query = query
+                    .filter(outputs::script_lock_height.le(i64_tip_height))
+                    .filter(outputs::maturity.le(i64_tip_height));
+            }
+
+            // Rust
+            let (count_res, sum_res) = query
+                .select((count_star(), sql::<Nullable<BigInt>>("SUM(value)")))
+                .first::<(i64, Option<i64>)>(conn)
+                .optional()?
+                .unwrap_or_default();
+
+            result.push(CoinBucket {
+                number_of_outputs: count_res as u64,
+                total_value: sum_res.unwrap_or(0) as u64,
+                range: range.clone(),
+            });
+        }
+
+        Ok(result)
     }
 
     fn handle_must_include_filter(

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -341,22 +341,6 @@ impl OutputSql {
             .min(TRANSACTION_INPUTS_LIMIT);
         let outputs: Vec<OutputSql> = query.limit(i64::from(transaction_input_limit)).load(conn)?;
 
-        // Post processing in Rust vs. all in raw SQL.
-        //
-        // The current version:
-        // - does a single backend query;
-        // - loads at most transaction_input_limit rows;
-        // - runs a cheap O(n) scan.
-        // The raw SQL alternative would conceptually:
-        // - order outputs and compute a running sum;
-        // - give each row a row number in that order;
-        // - find the smallest row number whose running_sum >= target_minimum_amount;
-        // - return all rows with row_number <= that row_number.
-        // The raw SQL alternative:
-        // - is more complex;
-        // - is less type-safe;
-        // - is harder to maintain/debug.
-
         // If all the outputs together don't reach target, we cannot continue
         let total_sum: u64 = outputs.iter().fold(0u64, |acc, o| acc.saturating_add(o.value as u64));
         if total_sum < range_limit.target_minimum_amount {
@@ -368,18 +352,7 @@ impl OutputSql {
             return Ok((Vec::new(), MicroMinotari::zero()));
         }
 
-        // Pick the smallest prefix that reaches the target
-        let mut selected = Vec::new();
-        let mut total = 0u64;
-        for output in outputs {
-            total = total.saturating_add(output.value as u64);
-            selected.push(output);
-            if total >= range_limit.target_minimum_amount {
-                break;
-            }
-        }
-
-        Ok((selected, MicroMinotari::from(total)))
+        Ok((outputs, MicroMinotari::from(total_sum)))
     }
 
     /// Retrieves UTXO counts grouped by the provided ranges

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -107,10 +107,6 @@ pub enum TransactionServiceError {
     BaseNodeChanged { task_name: &'static str },
     #[error("Error sending data to Protocol via registered channels")]
     ProtocolChannelError,
-    #[error("Transaction detected as rejected by mempool")]
-    MempoolRejection,
-    #[error("Mempool response key does not match on that is expected")]
-    UnexpectedMempoolResponse,
     #[error("Base Node response key does not match on that is expected")]
     UnexpectedBaseNodeResponse,
     #[error("The current transaction has been cancelled")]
@@ -149,12 +145,20 @@ pub enum TransactionServiceError {
     Shutdown,
     #[error("Transaction detected as rejected by mempool due to containing time-locked input")]
     MempoolRejectionTimeLocked,
-    #[error("Transaction detected as rejected by mempool due to containing  orphan input")]
+    #[error("Transaction detected as rejected by mempool due to containing orphan input")]
     MempoolRejectionOrphan,
     #[error("Transaction detected as rejected by mempool due to containing double spend")]
     MempoolRejectionDoubleSpend,
     #[error("Transaction detected as rejected by mempool due to invalid transaction")]
     MempoolRejectionInvalidTransaction,
+    #[error("Transaction detected as rejected by mempool due to fee too low")]
+    MempoolRejectionFeeTooLow,
+    #[error("Transaction detected as rejected by mempool due to already mined")]
+    MempoolRejectionAlreadyMined,
+    #[error("Transaction detected as rejected by mempool")]
+    MempoolRejection { reason: String },
+    #[error("Mempool response key does not match on that is expected")]
+    UnexpectedMempoolResponse,
     #[error("Transaction is malformed")]
     InvalidTransaction,
     #[error("RpcError: `{0}`")]

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -88,6 +88,8 @@ pub enum TransactionServiceError {
     InvalidSourcePublicKey,
     #[error("The transaction does not contain the receivers output")]
     ReceiverOutputNotFound,
+    #[error("Error processing range limit output selection criteria: {reason}")]
+    RangeLimitError { reason: String },
     #[error("Outbound Service send failed")]
     OutboundSendFailure,
     #[error(

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -35,6 +35,7 @@ use tari_common_types::{
     tari_address::TariAddress,
     transaction::{LegacyImportStatus, TransactionDirection, TxId},
     types::{CompressedCommitment, CompressedPublicKey, CompressedSignature, FixedHash, HashOutput, PrivateKey},
+    wallet_types::FeeType,
 };
 use tari_comms::types::CommsPublicKey;
 use tari_max_size::MaxSizeString;
@@ -220,6 +221,12 @@ pub enum TransactionServiceRequest {
         selection_criteria: UtxoSelectionCriteria,
         output_features: Box<OutputFeatures>,
         fee_per_gram: MicroMinotari,
+    },
+    SendRangeLimitedCoinJoinTransaction {
+        selection_criteria: UtxoSelectionCriteria,
+        output_features: Box<OutputFeatures>,
+        fee: FeeType,
+        payment_id: MemoField,
     },
     SendOneSidedToStealthAddressTransaction {
         destination: TariAddress,
@@ -453,6 +460,20 @@ impl fmt::Display for TransactionServiceRequest {
                 payment_id,
                 ..
             } => write!(f, "SendOneSidedTransaction (to {destination}, {amount}, {payment_id})"),
+            Self::SendRangeLimitedCoinJoinTransaction {
+                selection_criteria,
+                payment_id,
+                ..
+            } => write!(
+                f,
+                "SendRangeLimitedCoinJoinTransaction ({}, {})",
+                selection_criteria
+                    .range_limit
+                    .clone()
+                    .unwrap_or_default()
+                    .target_minimum_amount,
+                payment_id,
+            ),
             Self::SendOneSidedToStealthAddressTransaction {
                 destination,
                 amount,
@@ -1267,6 +1288,32 @@ impl TransactionServiceHandle {
             TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
             _ => Err(TransactionServiceError::UnexpectedApiResponse(
                 "TransactionServiceRequest::FinalizeSentAggregateTransaction".to_string(),
+            )),
+        }
+    }
+
+    pub async fn send_range_limited_coin_join_transaction(
+        &mut self,
+        selection_criteria: UtxoSelectionCriteria,
+        output_features: OutputFeatures,
+        fee: FeeType,
+        payment_id: MemoField,
+    ) -> Result<TxId, TransactionServiceError> {
+        match self
+            .handle
+            .call(TransactionServiceRequest::SendRangeLimitedCoinJoinTransaction {
+                selection_criteria,
+                output_features: Box::new(output_features),
+                fee,
+                payment_id,
+            })
+            .await
+            .inspect_err(
+                |e| warn!(target: LOG_TARGET, "TransactionServiceRequest:SendRangeLimitedCoinJoinTransaction:({e})"),
+            )?? {
+            TransactionServiceResponse::TransactionSent(tx_id) => Ok(tx_id),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::SendRangeLimitedCoinJoinTransaction".to_string(),
             )),
         }
     }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -220,9 +220,13 @@ where
                     TransactionServiceError::MempoolRejectionTimeLocked,
                     TxCancellationReason::TimeLocked,
                 ),
-                _ => (
-                    TransactionServiceError::UnexpectedBaseNodeResponse,
-                    TxCancellationReason::Unknown,
+                TxSubmissionRejectionReason::FeeTooLow => (
+                    TransactionServiceError::MempoolRejectionFeeTooLow,
+                    TxCancellationReason::FeeTooLow,
+                ),
+                TxSubmissionRejectionReason::AlreadyMined => (
+                    TransactionServiceError::MempoolRejectionAlreadyMined,
+                    TxCancellationReason::AlreadyMined,
                 ),
             };
 
@@ -317,11 +321,10 @@ where
                 self.last_rejection = Some(Instant::now());
                 Ok(false)
             } else {
-                error!(
-                    target: LOG_TARGET,
-                    "Transaction (TxId: {}) has been rejected by the mempool after second submission attempt, \
-                     cancelling transaction",
-                    self.tx_id
+                let reason = "rejected by the mempool after second submission attempt".to_string();
+                error!(target: LOG_TARGET,
+                    "Transaction (TxId: {}) has been {}, cancelling transaction",
+                    self.tx_id, reason,
                 );
                 self.cancel_transaction(TxCancellationReason::InvalidTransaction).await;
 
@@ -340,7 +343,7 @@ where
                     });
                 Err(TransactionServiceProtocolError::new(
                     self.tx_id,
-                    TransactionServiceError::MempoolRejection,
+                    TransactionServiceError::MempoolRejection { reason },
                 ))
             }
         } else {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2462,7 +2462,7 @@ where
             )
             .await?;
         let fee_estimate = tx_builder.get_fee_estimate_without_change()?;
-        let amount_without_fee = tx_builder.get_total_input_value()? - fee_estimate;
+        let amount_without_fee = tx_builder.get_total_input_value()?.saturating_sub(fee_estimate);
         let dest_address = self.resources.one_sided_tari_address.clone();
         debug!(
             target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2436,6 +2436,14 @@ where
         >,
         payment_id: MemoField,
     ) -> Result<TxId, TransactionServiceError> {
+        let range_limit_criteria =
+            selection_criteria
+                .clone()
+                .range_limit
+                .ok_or_else(|| OutputManagerError::RangeLimitError {
+                    reason: "Range limit must be specified for range limited coin-join UTXO selection".to_string(),
+                    range_exhausted: false,
+                })?;
         let temp_tx_id = TxId::new_random();
 
         // Prepare sender part of the transaction
@@ -2473,14 +2481,21 @@ where
         trace!(target: LOG_TARGET, "Finalized payment_id: {payment_id}");
         self.verify_send(&dest_address, TariAddressFeatures::create_one_sided_only())?;
 
-        let _output = tx_builder
-            .add_stealth_recipient(
-                dest_address.clone(),
-                amount_without_fee,
-                output_features.clone(),
-                payment_id.clone(),
-            )
-            .await?;
+        let number_of_outputs =
+            usize::try_from(amount_without_fee.as_u64() / range_limit_criteria.target_minimum_amount)
+                .map_err(|_e| OutputManagerError::ConversionError("number_of_outputs".to_string()))?
+                .max(1);
+        let mut values = vec![MicroMinotari(range_limit_criteria.target_minimum_amount); number_of_outputs];
+        let residual = amount_without_fee
+            .as_u64()
+            .saturating_sub(range_limit_criteria.target_minimum_amount * number_of_outputs as u64);
+        values.get_mut(0).expect("index exists").0 += residual;
+
+        for value in values {
+            let _output = tx_builder
+                .add_stealth_recipient(dest_address.clone(), value, output_features.clone(), payment_id.clone())
+                .await?;
+        }
         tx_builder.with_memo(payment_id.clone());
 
         // Finalize

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1681,9 +1681,15 @@ where
         // If the individual handlers did not already send the API response then do it here.
         if let Some(rp) = reply_channel {
             let _result = rp
-                .send(response.inspect_err(|e1| warn!(target: LOG_TARGET, "{}", e1)))
+                .send(response.inspect_err(|e1| {
+                    let mut msg = format!("{}", e1);
+                    msg.truncate(100);
+                    warn!(target: LOG_TARGET, "{}", msg);
+                }))
                 .inspect_err(|e2| {
-                    warn!(target: LOG_TARGET, "Failed to send reply: {:?}", e2);
+                    let mut msg = format!("{:?}", e2);
+                    msg.truncate(100);
+                    warn!(target: LOG_TARGET, "Failed to send reply: {}", msg);
                 });
         }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -420,7 +420,7 @@ where
                 async {
                     if selection_criteria.range_limit.is_some() {
                         return Err(TransactionServiceError::RangeLimitError {
-                            reason: "Range limit coin-join cannot be set for ons sided signing transactions"
+                            reason: "Range limit coin-join cannot be set for ons-sided signing transactions"
                                 .to_string(),
                         });
                     }
@@ -2475,17 +2475,20 @@ where
                 self.resources.one_sided_tari_address.clone(),
                 true,
                 fee_estimate,
-                Some(TxType::PaymentToSelf),
+                Some(TxType::CoinJoin),
             )
             .map_err(TransactionServiceError::InvalidPaymentId)?;
         trace!(target: LOG_TARGET, "Finalized payment_id: {payment_id}");
         self.verify_send(&dest_address, TariAddressFeatures::create_one_sided_only())?;
 
+        // Note: Division by zero is checked during 'prepare_range_limited_coin_join_transaction_to_send'
         let number_of_outputs =
             usize::try_from(amount_without_fee.as_u64() / range_limit_criteria.target_minimum_amount)
                 .map_err(|_e| OutputManagerError::ConversionError("number_of_outputs".to_string()))?
                 .max(1);
         let mut values = vec![MicroMinotari(range_limit_criteria.target_minimum_amount); number_of_outputs];
+        // Note: 'amount_without_fee >= target_minimum_amount' is checked during
+        //       'prepare_range_limited_coin_join_transaction_to_send'
         let residual = amount_without_fee
             .as_u64()
             .saturating_sub(range_limit_criteria.target_minimum_amount * number_of_outputs as u64);
@@ -2496,7 +2499,7 @@ where
                 .add_stealth_recipient(dest_address.clone(), value, output_features.clone(), payment_id.clone())
                 .await?;
         }
-        tx_builder.with_memo(payment_id.clone());
+        tx_builder.with_memo(payment_id.clone()).with_tx_type(TxType::CoinJoin);
 
         // Finalize
         let finalized = tx_builder.build().await?;

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -53,7 +53,7 @@ use tari_common_types::{
         PrivateKey,
         UncompressedPublicKey,
     },
-    wallet_types::WalletType,
+    wallet_types::{FeeType, WalletType},
 };
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
 use tari_crypto::{
@@ -418,6 +418,12 @@ where
                 mut payment_id,
             } => {
                 async {
+                    if selection_criteria.range_limit.is_some() {
+                        return Err(TransactionServiceError::RangeLimitError {
+                            reason: "Range limit coin-join cannot be set for ons sided signing transactions"
+                                .to_string(),
+                        });
+                    }
                     self.verify_send(&destination, TariAddressFeatures::create_one_sided_only())?;
                     debug!(target: LOG_TARGET, "Locking one sided transaction to {destination} with {amount}");
                     let temp_tx_id = TxId::new_random();
@@ -833,6 +839,27 @@ where
                 async {
                     let res = self
                         .scrape_wallet(destination, fee_per_gram, transaction_broadcast_join_handles)
+                        .await?;
+                    Ok(TransactionServiceResponse::TransactionSent(res))
+                }
+                .await
+            },
+
+            TransactionServiceRequest::SendRangeLimitedCoinJoinTransaction {
+                selection_criteria,
+                output_features,
+                fee,
+                payment_id,
+            } => {
+                async {
+                    let res = self
+                        .send_range_limited_coin_join(
+                            selection_criteria,
+                            *output_features,
+                            fee,
+                            transaction_broadcast_join_handles,
+                            payment_id,
+                        )
                         .await?;
                     Ok(TransactionServiceResponse::TransactionSent(res))
                 }
@@ -2069,6 +2096,11 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<Box<(TxId, CompressedPublicKey, TransactionOutput)>, TransactionServiceError> {
+        if selection_criteria.range_limit.is_some() {
+            return Err(TransactionServiceError::RangeLimitError {
+                reason: "Range limit coin-join cannot be set for send_sha_atomic_swap_transaction".to_string(),
+            });
+        }
         let temp_tx_id = TxId::new_random();
         self.verify_send(&destination, TariAddressFeatures::create_one_sided_only())?;
         // this can be anything, so lets generate a random private key
@@ -2269,6 +2301,11 @@ where
         mut payment_id: MemoField,
     ) -> Result<TxId, TransactionServiceError> {
         debug!(target: LOG_TARGET, "Sending one sided transaction to {dest_address} with amount {amount}");
+        if selection_criteria.range_limit.is_some() {
+            return Err(TransactionServiceError::RangeLimitError {
+                reason: "Range limit coin-join cannot be set for send_one_sided_or_stealth".to_string(),
+            });
+        }
         let temp_tx_id = TxId::new_random();
         // let override the payment_id if the address says we should
         if dest_address.features().contains(TariAddressFeatures::PAYMENT_ID) {
@@ -2365,6 +2402,138 @@ where
                 dest_address.clone(),
                 amount,
                 fee,
+                tx.clone(),
+                LegacyTransactionStatus::Completed,
+                Utc::now(),
+                TransactionDirection::Outbound,
+                None,
+                None,
+                payment_id,
+                sent_hashes,
+                vec![],
+                change_hashes,
+            )?,
+        )
+        .await?;
+
+        Ok(finalized.tx_id)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn send_range_limited_coin_join(
+        &mut self,
+        selection_criteria: UtxoSelectionCriteria,
+        output_features: OutputFeatures,
+        fee: FeeType,
+        transaction_broadcast_join_handles: &mut FuturesUnordered<
+            JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
+        >,
+        payment_id: MemoField,
+    ) -> Result<TxId, TransactionServiceError> {
+        let temp_tx_id = TxId::new_random();
+
+        // Prepare sender part of the transaction
+        let script = push_pubkey_script(&Default::default());
+        let covenant = Covenant::default();
+        let mut tx_builder = self
+            .resources
+            .output_manager_service
+            .prepare_range_limited_coin_join_transaction_to_send(
+                temp_tx_id,
+                selection_criteria,
+                output_features.clone(),
+                fee,
+                script,
+                covenant,
+            )
+            .await?;
+        let fee_estimate = tx_builder.get_fee_estimate_without_change()?;
+        let amount_without_fee = tx_builder.get_total_input_value()? - fee_estimate;
+        let dest_address = self.resources.one_sided_tari_address.clone();
+        debug!(
+            target: LOG_TARGET,
+            "Sending range_limit_coin_join transaction to {} with amount {amount_without_fee} fee {fee_estimate} total {}",
+            dest_address.to_hex(), tx_builder.get_total_input_value()?
+        );
+
+        let payment_id = payment_id
+            .add_sender_address(
+                self.resources.one_sided_tari_address.clone(),
+                true,
+                fee_estimate,
+                Some(TxType::PaymentToSelf),
+            )
+            .map_err(TransactionServiceError::InvalidPaymentId)?;
+        trace!(target: LOG_TARGET, "Finalized payment_id: {payment_id}");
+        self.verify_send(&dest_address, TariAddressFeatures::create_one_sided_only())?;
+
+        let _output = tx_builder
+            .add_stealth_recipient(
+                dest_address.clone(),
+                amount_without_fee,
+                output_features.clone(),
+                payment_id.clone(),
+            )
+            .await?;
+        tx_builder.with_memo(payment_id.clone());
+
+        // Finalize
+        let finalized = tx_builder.build().await?;
+        if let Some(change) = finalized.change {
+            let msg = format!(
+                "One sided range_limit_coin_join transaction cannot have a change output: {}",
+                change.value()
+            );
+            error!(target: LOG_TARGET, "{}", msg);
+            return Err(TransactionServiceError::RangeLimitError { reason: msg });
+        }
+        if amount_without_fee != finalized.amount {
+            let msg = format!(
+                "One sided range_limit_coin_join transaction amount mismatch: expected {}, got {}",
+                amount_without_fee, finalized.amount
+            );
+            error!(target: LOG_TARGET, "{}", msg);
+            return Err(TransactionServiceError::RangeLimitError { reason: msg });
+        }
+        if fee_estimate != finalized.fee {
+            let msg = format!(
+                "One sided range_limit_coin_join transaction fee mismatch: expected {}, got {}",
+                fee_estimate, finalized.fee
+            );
+            error!(target: LOG_TARGET, "{}", msg);
+            return Err(TransactionServiceError::RangeLimitError { reason: msg });
+        }
+
+        info!(target: LOG_TARGET, "Finalized one-side transaction TxId: {}", finalized.tx_id);
+
+        // This event being sent is important, but not critical to the protocol being successful. Send only fails if
+        // there are no subscribers.
+        let _result = self
+            .event_publisher
+            .send(Arc::new(TransactionEvent::TransactionCompletedImmediately(
+                finalized.tx_id,
+            )));
+
+        // Broadcast one-sided transaction
+
+        let tx = finalized.transaction.clone();
+        let final_fee = finalized.fee;
+        let change = finalized.change.clone().map(|change| vec![change]);
+        self.resources
+            .output_manager_service
+            .confirm_pending_transaction(temp_tx_id, Some(finalized.tx_id), change)
+            .await
+            .map_err(|e| TransactionServiceProtocolError::new(finalized.tx_id, e.into()))?;
+        let sent_hashes = finalized.sent_output_hashes.clone();
+        let change_hashes = finalized.change_output_hashes.clone();
+        self.submit_transaction(
+            transaction_broadcast_join_handles,
+            CompletedTransaction::new_with_output_hashes(
+                finalized.tx_id,
+                self.resources.one_sided_tari_address.clone(),
+                dest_address.clone(),
+                amount_without_fee,
+                final_fee,
                 tx.clone(),
                 LegacyTransactionStatus::Completed,
                 Utc::now(),
@@ -2611,6 +2780,11 @@ where
                 TransactionBuilderError::NoRecipients,
             ));
         }
+        if selection_criteria.range_limit.is_some() {
+            return Err(TransactionServiceError::RangeLimitError {
+                reason: "Range limit coin-join cannot be set for send_many_one_sided_transactions".to_string(),
+            });
+        }
         let temp_tx_id = TxId::new_random();
         // let override the payment_id if the address says we should
         let mut total_send = MicroMinotari::zero();
@@ -2791,6 +2965,11 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<(TxId, Option<BurnClaimProof>), TransactionServiceError> {
+        if selection_criteria.range_limit.is_some() {
+            return Err(TransactionServiceError::RangeLimitError {
+                reason: "Range limit coin-join cannot be set for burn_tari".to_string(),
+            });
+        }
         let temp_tx_id = TxId::new_random();
 
         if claim_public_key.is_none() && sidechain_deployment_key.is_some() {

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -617,6 +617,26 @@ impl WalletTransaction {
             WalletTransaction::Completed(tx) => tx.status,
         }
     }
+
+    pub fn cancelled_reason(&self) -> Option<TxCancellationReason> {
+        match self {
+            WalletTransaction::PendingInbound(tx) => {
+                if tx.cancelled {
+                    Some(TxCancellationReason::Unknown)
+                } else {
+                    None
+                }
+            },
+            WalletTransaction::PendingOutbound(tx) => {
+                if tx.cancelled {
+                    Some(TxCancellationReason::Unknown)
+                } else {
+                    None
+                }
+            },
+            WalletTransaction::Completed(tx) => tx.cancelled,
+        }
+    }
 }
 
 impl From<WalletTransaction> for CompletedTransaction {
@@ -639,6 +659,8 @@ pub enum TxCancellationReason {
     TimeLocked,         // 5
     InvalidTransaction, // 6
     Oversized,          // 7
+    FeeTooLow,          // 8
+    AlreadyMined,       // 9
 }
 
 impl TryFrom<u32> for TxCancellationReason {
@@ -672,6 +694,8 @@ impl Display for TxCancellationReason {
             TimeLocked => "TimeLocked",
             InvalidTransaction => "Invalid Transaction",
             Oversized => "Oversized",
+            FeeTooLow => "Fee Too Low",
+            AlreadyMined => "Already Mined",
         };
         fmt.write_str(response)
     }

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -460,28 +460,6 @@ pub async fn test_range_limited_outputs_for_spending() {
     }
     db.mark_outputs_as_unspent(unspent).unwrap();
 
-    // We have [50, 100, 200] in the range 50..250, but target_minimum_amount cannot be met
-    // Selection:
-    //  - It fetches all 3x outputs
-    //  - Compares 50 >= 500, do not meet target
-    //  - Compares 50 + 100 >= 500, do not meet target
-    //  - Compares 50 + 100 + 200 >= 500, do not meet target
-    let (selected, total) = db
-        .get_range_limited_outputs_for_spending(
-            &UtxoSelectionCriteria {
-                range_limit: Some(RangeLimit {
-                    range: 50u64..250,
-                    transaction_input_limit: all_outputs,
-                    target_minimum_amount: 500,
-                }),
-                ..Default::default()
-            },
-            None,
-        )
-        .unwrap();
-    assert_eq!(selected.len(), 0);
-    assert_eq!(total, MicroMinotari(0));
-
     // We have [50, 100, 200] in the range 50..250, but restrain transaction input limit
     // Selection:
     //  - It fetches only 50
@@ -501,50 +479,6 @@ pub async fn test_range_limited_outputs_for_spending() {
         .unwrap();
     assert_eq!(selected.len(), 0);
     assert_eq!(total, MicroMinotari(0));
-
-    // We have [50, 100, 200] in the range 50..250, no restrains.
-    // Selection:
-    //  - It fetches all 3x outputs
-    //  - Compares 50 >= 50, meet target
-    let (selected, total) = db
-        .get_range_limited_outputs_for_spending(
-            &UtxoSelectionCriteria {
-                range_limit: Some(RangeLimit {
-                    range: 50u64..250,
-                    transaction_input_limit: all_outputs,
-                    target_minimum_amount: 50,
-                }),
-                ..Default::default()
-            },
-            None,
-        )
-        .unwrap();
-    assert_eq!(selected.len(), 1);
-    assert_eq!(total, MicroMinotari(50));
-    assert_eq!(selected[0].wallet_output.value().0, 50);
-
-    // We have [50, 100, 200] in the range 50..250, no restrains.
-    // Selection:
-    //  - It fetches all 3x outputs
-    //  - Compares 50 >= 100, do not meet target
-    //  - Compares 50 + 100 >= 100, meet target
-    let (selected, total) = db
-        .get_range_limited_outputs_for_spending(
-            &UtxoSelectionCriteria {
-                range_limit: Some(RangeLimit {
-                    range: 50u64..250,
-                    transaction_input_limit: all_outputs,
-                    target_minimum_amount: 100,
-                }),
-                ..Default::default()
-            },
-            None,
-        )
-        .unwrap();
-    assert_eq!(selected.len(), 2);
-    assert_eq!(total, MicroMinotari(150));
-    assert_eq!(selected[0].wallet_output.value().0, 50);
-    assert_eq!(selected[1].wallet_output.value().0, 100);
 
     // We have [50, 100, 200] in the range 50..250, no restrains.
     // Selection:
@@ -570,6 +504,26 @@ pub async fn test_range_limited_outputs_for_spending() {
     assert_eq!(selected[0].wallet_output.value().0, 50);
     assert_eq!(selected[1].wallet_output.value().0, 100);
     assert_eq!(selected[2].wallet_output.value().0, 200);
+
+    // We have [50, 100, 200] in the range 50..250, but target_minimum_amount cannot be met
+    // Selection:
+    //  - It fetches all 3x outputs
+    //  - Compares 50 + 100 + 200 >= 500, do not meet target
+    let (selected, total) = db
+        .get_range_limited_outputs_for_spending(
+            &UtxoSelectionCriteria {
+                range_limit: Some(RangeLimit {
+                    range: 50u64..250,
+                    transaction_input_limit: all_outputs,
+                    target_minimum_amount: 500,
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    assert_eq!(selected.len(), 0);
+    assert_eq!(total, MicroMinotari(0));
 }
 
 #[tokio::test]

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -33,6 +33,7 @@ use minotari_wallet::output_manager_service::{
         OutputSource,
         OutputStatus,
     },
+    RangeLimit,
     UtxoSelectionCriteria,
 };
 use rand::{rngs::OsRng, RngCore};
@@ -368,6 +369,207 @@ pub async fn test_output_manager_sqlite_db() {
     let (connection, _tempdir) = get_temp_sqlite_database_connection();
 
     test_db_backend(OutputManagerSqliteDatabase::new(connection)).await;
+}
+
+#[tokio::test]
+pub async fn test_count_outputs_in_ranges() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection);
+    let db = OutputManagerDatabase::new(backend);
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
+
+    // Create test outputs with specific values
+    let mut outputs = Vec::new();
+    let mut unspent = Vec::new();
+    let values = vec![300, 400, 100, 500, 200];
+
+    for value in values {
+        let uo = make_input(
+            &mut OsRng,
+            MicroMinotari::from(value),
+            &OutputFeatures::default(),
+            &mut key_manager,
+        )
+        .await;
+        let output = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
+        db.add_unspent_output(output.clone()).unwrap();
+        unspent.push((output.hash, true));
+        outputs.push(output);
+    }
+    db.mark_outputs_as_unspent(unspent).unwrap();
+
+    // Define ranges
+    let ranges = vec![
+        50..250,  // Should match 100, 200
+        200..400, // Should match 200, 300
+        400..600, // Should match 400, 500
+        600..700, // Should match none
+    ];
+
+    // Call the function
+    let result = db.count_outputs_in_ranges(ranges.clone(), None).unwrap();
+
+    // Assert expected counts
+    let bucket = &result[0];
+    assert_eq!(bucket.number_of_outputs, 2);
+    assert_eq!(bucket.total_value, 300);
+    assert_eq!(bucket.range, 50..250);
+
+    let bucket = &result[1];
+    assert_eq!(bucket.number_of_outputs, 2);
+    assert_eq!(bucket.total_value, 500);
+    assert_eq!(bucket.range, 200..400);
+
+    let bucket = &result[2];
+    assert_eq!(bucket.number_of_outputs, 2);
+    assert_eq!(bucket.total_value, 900);
+    assert_eq!(bucket.range, 400..600);
+
+    let bucket = &result[3];
+    assert_eq!(bucket.number_of_outputs, 0);
+    assert_eq!(bucket.total_value, 0);
+    assert_eq!(bucket.range, 600..700);
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+pub async fn test_range_limited_outputs_for_spending() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection);
+    let db = OutputManagerDatabase::new(backend);
+    let mut key_manager = create_memory_db_key_manager().await.unwrap();
+
+    // Create test outputs with specific values
+    let mut outputs = Vec::new();
+    let mut unspent = Vec::new();
+    let values = vec![10, 300, 20, 400, 30, 100, 40, 500, 50, 200];
+    let all_outputs = values.len() as u64;
+
+    for value in values {
+        let uo = make_input(
+            &mut OsRng,
+            MicroMinotari::from(value),
+            &OutputFeatures::default(),
+            &mut key_manager,
+        )
+        .await;
+        let output = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
+        db.add_unspent_output(output.clone()).unwrap();
+        unspent.push((output.hash, true));
+        outputs.push(output);
+    }
+    db.mark_outputs_as_unspent(unspent).unwrap();
+
+    // We have [50, 100, 200] in the range 50..250, but target_minimum_amount cannot be met
+    // Selection:
+    //  - It fetches all 3x outputs
+    //  - Compares 50 >= 500, do not meet target
+    //  - Compares 50 + 100 >= 500, do not meet target
+    //  - Compares 50 + 100 + 200 >= 500, do not meet target
+    let (selected, total) = db
+        .get_range_limited_outputs_for_spending(
+            &UtxoSelectionCriteria {
+                range_limit: Some(RangeLimit {
+                    range: 50u64..250,
+                    transaction_input_limit: all_outputs,
+                    target_minimum_amount: 500,
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    assert_eq!(selected.len(), 0);
+    assert_eq!(total, MicroMinotari(0));
+
+    // We have [50, 100, 200] in the range 50..250, but restrain transaction input limit
+    // Selection:
+    //  - It fetches only 50
+    //  - Compares 50 >= 100, do not meet target
+    let (selected, total) = db
+        .get_range_limited_outputs_for_spending(
+            &UtxoSelectionCriteria {
+                range_limit: Some(RangeLimit {
+                    range: 50u64..250,
+                    transaction_input_limit: 1,
+                    target_minimum_amount: 100,
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    assert_eq!(selected.len(), 0);
+    assert_eq!(total, MicroMinotari(0));
+
+    // We have [50, 100, 200] in the range 50..250, no restrains.
+    // Selection:
+    //  - It fetches all 3x outputs
+    //  - Compares 50 >= 50, meet target
+    let (selected, total) = db
+        .get_range_limited_outputs_for_spending(
+            &UtxoSelectionCriteria {
+                range_limit: Some(RangeLimit {
+                    range: 50u64..250,
+                    transaction_input_limit: all_outputs,
+                    target_minimum_amount: 50,
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    assert_eq!(selected.len(), 1);
+    assert_eq!(total, MicroMinotari(50));
+    assert_eq!(selected[0].wallet_output.value().0, 50);
+
+    // We have [50, 100, 200] in the range 50..250, no restrains.
+    // Selection:
+    //  - It fetches all 3x outputs
+    //  - Compares 50 >= 100, do not meet target
+    //  - Compares 50 + 100 >= 100, meet target
+    let (selected, total) = db
+        .get_range_limited_outputs_for_spending(
+            &UtxoSelectionCriteria {
+                range_limit: Some(RangeLimit {
+                    range: 50u64..250,
+                    transaction_input_limit: all_outputs,
+                    target_minimum_amount: 100,
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    assert_eq!(selected.len(), 2);
+    assert_eq!(total, MicroMinotari(150));
+    assert_eq!(selected[0].wallet_output.value().0, 50);
+    assert_eq!(selected[1].wallet_output.value().0, 100);
+
+    // We have [50, 100, 200] in the range 50..250, no restrains.
+    // Selection:
+    //  - It fetches all 3x outputs
+    //  - Compares 50 >= 201, do not meet target
+    //  - Compares 50 + 100 >= 201, do not meet target
+    //  - Compares 50 + 100 + 200 >= 201, meet target
+    let (selected, total) = db
+        .get_range_limited_outputs_for_spending(
+            &UtxoSelectionCriteria {
+                range_limit: Some(RangeLimit {
+                    range: 50u64..250,
+                    transaction_input_limit: all_outputs,
+                    target_minimum_amount: 201,
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    assert_eq!(selected.len(), 3);
+    assert_eq!(total, MicroMinotari(350));
+    assert_eq!(selected[0].wallet_output.value().0, 50);
+    assert_eq!(selected[1].wallet_output.value().0, 100);
+    assert_eq!(selected[2].wallet_output.value().0, 200);
 }
 
 #[tokio::test]

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -102,6 +102,9 @@
 #before returning an error to the client. This should be long enough to cover the majority of database writes
 #but short enough to avoid blocking the grpc server for too long.
 #grpc_db_write_timeout = 100
+# gRPC broadcast confirmation timeout in ms. This is how long the grpc server will wait for the mempool to
+# respond once the transaction has been submitted, either accepted or rejected. Default = 5000ms
+#pub grpc_broadcast_confirmation = 5000
 # The URL of the HTTP client to use for base node service requests
 #http_server_url="http://127.0.0.1:9000"
 # The fallback url address to use if the base node at http_server_url does not respond

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -104,7 +104,7 @@
 #grpc_db_write_timeout = 100
 # gRPC broadcast confirmation timeout in ms. This is how long the grpc server will wait for the mempool to
 # respond once the transaction has been submitted, either accepted or rejected. Default = 5000ms
-#pub grpc_broadcast_confirmation = 5000
+#grpc_broadcast_confirmation = 5000
 # The URL of the HTTP client to use for base node service requests
 #http_server_url="http://127.0.0.1:9000"
 # The fallback url address to use if the base node at http_server_url does not respond


### PR DESCRIPTION
Description
---

Add range limit coin-join:
- Added an unspent output coin distribution gRPC method ('CoinHistogramRequest'), whereby the wallet will return the amount and value of coins in a pre-set range of buckets.
- Added a range limit coin-join gRPC method ('RangeLimitCoinJoin') to the wallet, whereby the user can specify the minimum target amount, maximum number of inputs, dust lower bound (inclusive), dust upper bound (exclusive) and fee. Transaction size will be limited to the specified maximum number of inputs, and multiple outputs will be created according to the minimum target amount. All the inputs in the range will be spent, unless the total available amount does not meet the minimum target amount. 

Closes #7582.

Motivation and Context
---
See #7582.

How Has This Been Tested?
---
System-level testing

gRPC **CoinHistogram** method
```
{
  "buckets": [
    {
      "count": "0",
      "total_amount": "0",
      "lower_bound": "0",
      "upper_bound": "1000"
    },
    {
      "count": "0",
      "total_amount": "0",
      "lower_bound": "1000",
      "upper_bound": "100000"
    },
    {
      "count": "2",
      "total_amount": "1165548",
      "lower_bound": "100000",
      "upper_bound": "1000000"
    },
    {
      "count": "158",
      "total_amount": "1455989209",
      "lower_bound": "1000000",
      "upper_bound": "1000000000"
    },
    {
      "count": "0",
      "total_amount": "0",
      "lower_bound": "1000000000",
      "upper_bound": "100000000000"
    },
    {
      "count": "0",
      "total_amount": "0",
      "lower_bound": "100000000000",
      "upper_bound": "21000000000000000"
    }
  ]
}
```

gRPC **RangeLimitCoinJoin** method

In this example, two transactions were created, bounded by the 350 input size limit. gRPC client view:

<img width="897" height="396" alt="image" src="https://github.com/user-attachments/assets/6c5ae857-8a01-4c90-9c55-1eee2fbdc035" />

Console wallet coin-join transactions:

<img width="1132" height="191" alt="image" src="https://github.com/user-attachments/assets/b860a4cd-381d-4a01-8dea-6d27c45e0ba0" />

<img width="1134" height="189" alt="image" src="https://github.com/user-attachments/assets/cc708985-e33c-4a40-813c-b292f8edfb21" />

Example of some newly created coin-joined scanned inputs:

<img width="1126" height="189" alt="image" src="https://github.com/user-attachments/assets/19e187b6-d5dc-422d-96a7-b15f9dfef9fc" />

<img width="1135" height="185" alt="image" src="https://github.com/user-attachments/assets/fddc3b02-8240-44f1-a18f-31e2bbf651e0" />


What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Range-limited coin-join: combine UTXOs within specified value ranges with per-transaction input limits, target minimums, fee choice, and optional payment IDs.
  * Coin histogram: view UTXO distribution across configurable value buckets.
  * Fee options: specify either a total fee or a fee-per-gram.

* **Improvements**
  * More detailed mempool rejection feedback (fee-too-low, already-mined).
  * gRPC broadcast confirmation timeout added (configurable, default 5000 ms).

* **Tests**
  * Added tests for range-based counting and range-limited spending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->