### PR TITLE
fix: utxo retrieval for wallet

### DIFF
--- a/base_layer/core/src/base_node/rpc/mod.rs
+++ b/base_layer/core/src/base_node/rpc/mod.rs
@@ -16,7 +16,10 @@ use tari_comms::{
     types::CompressedSignature,
 };
 use tari_comms_rpc_macros::tari_rpc;
-use tari_transaction_components::rpc::{models, models::GenerateKernelMerkleProofResponse};
+use tari_transaction_components::{
+    rpc::{models, models::GenerateKernelMerkleProofResponse},
+    transaction_components::TransactionOutput,
+};
 use url::Url;
 
 use crate::{
@@ -86,7 +89,7 @@ pub trait BaseNodeWalletQueryService: Send + Sync + 'static {
         excess_sig: CompressedSignature,
     ) -> Result<GenerateKernelMerkleProofResponse, Self::Error>;
 
-    async fn get_utxo(&self, request: models::GetUtxoRequest) -> Result<models::GetUtxoResponse, Self::Error>;
+    async fn get_utxo(&self, request: models::GetUtxoRequest) -> Result<Option<TransactionOutput>, Self::Error>;
 }
 
 #[tari_rpc(protocol_name = b"t/bnwallet/1", server_struct = BaseNodeWalletRpcServer, client_struct = BaseNodeWalletRpcClient)]

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -568,14 +568,14 @@ impl<B: BlockchainBackend + 'static> BaseNodeWalletQueryService for Service<B> {
         })
     }
 
-    async fn get_utxo(&self, request: models::GetUtxoRequest) -> Result<models::GetUtxoResponse, Self::Error> {
+    async fn get_utxo(&self, request: models::GetUtxoRequest) -> Result<Option<TransactionOutput>, Self::Error> {
         let hash: FixedHash = request.output_hash.try_into().map_err(Error::general)?;
         let outputs = self.db().fetch_outputs_with_spend_status_at_tip(vec![hash]).await?;
         let output = match outputs.first() {
             Some(Some((output, _spent))) => Some(output.clone()),
             _ => return Err(Error::OutputNotFound),
         };
-        Ok(models::GetUtxoResponse { output })
+        Ok(output)
     }
 }
 


### PR DESCRIPTION
Description
---
Fixes the retrieval of the utxo for the wallet from the base node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the UTXO query response structure by removing unnecessary wrapper layers, returning the transaction output directly. This streamlines the API interface for developers integrating with the base node's RPC service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->