### PR TITLE
fix: store completed transactions with corresponding sent_output_hash

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2829,7 +2829,7 @@ where
             let sent_hash = finalized
                 .sent_output_hashes
                 .get(i)
-                .cloned()
+                .copied()
                 .ok_or(TransactionServiceError::Other(
                     "sent_output_hashes index out of bounds".to_string(),
                 ))?;

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -93,7 +93,6 @@ use tari_transaction_components::{
         TransactionError,
         TransactionOutput,
         ValidatorNodeSignature,
-        WalletOutput,
         WalletOutputBuilder,
     },
     tx_outputs_to_tx_id,
@@ -2801,69 +2800,46 @@ where
         // Broadcast one-sided transaction
 
         let tx = finalized.transaction.clone();
-
         let change = finalized.change.clone().map(|change| vec![change]);
         self.resources
             .output_manager_service
             .confirm_pending_transaction(temp_tx_id, Some(finalized.tx_id), change)
             .await
             .map_err(|e| TransactionServiceProtocolError::new(finalized.tx_id, e.into()))?;
-        let sent_hashes = finalized.sent_output_hashes.clone();
         let change_hashes = finalized.change_output_hashes.clone();
 
-        let mut outputs = finalized
-            .sent_outputs
-            .iter()
-            .map(|o| o.output.clone())
-            .collect::<Vec<WalletOutput>>();
-
         check_transaction_size(&tx, finalized.tx_id)?;
-        let (first_address, first_amount, first_memo) = destinations.remove(0);
-        self.submit_transaction(
-            transaction_broadcast_join_handles,
-            CompletedTransaction::new_with_output_hashes(
-                finalized.tx_id,
-                self.resources.one_sided_tari_address.clone(),
-                first_address,
-                first_amount,
-                finalized.fee,
-                tx.clone(),
-                LegacyTransactionStatus::Completed,
-                Utc::now(),
-                TransactionDirection::Outbound,
-                None,
-                None,
-                first_memo,
-                sent_hashes.clone(),
-                vec![],
-                change_hashes.clone(),
-            )?,
-        )
-        .await?;
-        if let Some(pos) = outputs.iter().position(|o| o.value() == first_amount) {
-            outputs.swap_remove(pos);
-        }
 
-        // Save the other transactions with zero fee and random tx_id to the database
-        let mut tx_ids = vec![finalized.tx_id];
+        let mut tx_ids = Vec::new();
+        let mut completed_txs = Vec::new();
         let view_key = self.resources.transaction_key_manager_service.get_view_key().pub_key;
-        for (address, amount, memo) in destinations {
-            let new_tx_id = if let Some(pos) = outputs.iter().position(|o| o.value() == amount) {
-                let tx_id = outputs
-                    .get(pos)
-                    .expect("pos exists")
-                    .calculate_tx_id(view_key.as_bytes());
-                outputs.swap_remove(pos);
-                tx_id
+
+        for (i, (address, amount, memo)) in destinations.into_iter().enumerate() {
+            let tx_id = if i == 0 {
+                finalized.tx_id
             } else {
-                TxId::new_random()
+                finalized
+                    .sent_outputs
+                    .get(i)
+                    .expect("recipient index must exist")
+                    .output
+                    .calculate_tx_id(view_key.as_bytes())
             };
 
-            tx_ids.push(new_tx_id);
+            let sent_hash = finalized
+                .sent_output_hashes
+                .get(i)
+                .cloned()
+                .ok_or(TransactionServiceError::Other(
+                    "sent_output_hashes index out of bounds".to_string(),
+                ))?;
+
+            tx_ids.push(tx_id);
+
             let completed_tx = CompletedTransaction::new_with_output_hashes(
-                new_tx_id,
+                tx_id,
                 self.resources.one_sided_tari_address.clone(),
-                address.clone(),
+                address,
                 amount,
                 finalized.fee,
                 tx.clone(),
@@ -2873,11 +2849,20 @@ where
                 None,
                 None,
                 memo,
-                sent_hashes.clone(),
+                vec![sent_hash],
                 vec![],
                 change_hashes.clone(),
             )?;
-            self.db.insert_completed_transaction(new_tx_id, completed_tx.clone())?;
+            completed_txs.push(completed_tx);
+        }
+
+        let first_completed_tx = completed_txs.remove(0);
+        self.submit_transaction(transaction_broadcast_join_handles, first_completed_tx)
+            .await?;
+
+        for completed_tx in completed_txs {
+            self.db
+                .insert_completed_transaction(completed_tx.tx_id, completed_tx.clone())?;
             trace!(
                 target: LOG_TARGET,
                 "Created transaction for ({}).", finalized.tx_id

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2821,7 +2821,9 @@ where
                 finalized
                     .sent_outputs
                     .get(i)
-                    .expect("recipient index must exist")
+                    .ok_or(TransactionServiceError::Other(
+                        "sent_outputs index out of bounds".to_string(),
+                    ))?
                     .output
                     .calculate_tx_id(view_key.as_bytes())
             };
@@ -2861,8 +2863,7 @@ where
             .await?;
 
         for completed_tx in completed_txs {
-            self.db
-                .insert_completed_transaction(completed_tx.tx_id, completed_tx.clone())?;
+            self.db.insert_completed_transaction(completed_tx.tx_id, completed_tx)?;
             trace!(
                 target: LOG_TARGET,
                 "Created transaction for ({}).", finalized.tx_id


### PR DESCRIPTION
Description
---

Updates `send_many_one_sided_transactions` so that completed transactions, which are stored for each recipient, have a single corresponding output hash.

This fix simplifies the code, as well as fixes a possible bug of how corresponding outputs where found. They were looked up by `value`, which would yield incorrect results, if multiple payments with the same value would be sent using this function.

I inspected the **Transaction Builder**, its `add_stealth_recipient()` and `build()`.
The order of `sent_output_hashes` and `sent_outputs` is exactly the same as they were originally added in transaction builder.

Motivation and Context
---

GRPC `transfer` call has a feature (enabled by setting `single_tx=true`) to send a single transaction to multiple recipients.
But when the resulting transaction is queried for each recipient, it returned all `sent_output_hashes` instead of the one, which belongs to that particular recipient.

This change makes a fix, so that `sent_output_hashes` will always contain a single entry with corresponding output hash.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved multi-recipient one-sided sending: preserves the first recipient’s transaction ID, assigns distinct per-recipient IDs for subsequent recipients, and switches to submitting the primary transaction before storing additional per-recipient records to improve ordering and reliability. Return behavior for the send-many path is unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->