### PR TITLE
feat: add more detail to grpc payment reference information

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1590,16 +1590,10 @@ service Wallet {
   // - **user_payment_id** (bytes): User-visible payment ID, if applicable.
   // - **mined_in_block_height** (uint64): Block height where the transaction was mined. Zero if not mined.
   // - **input_commitments** (repeated bytes): Commitments for transaction inputs.
-  // - **output_commitments** (repeated bytes): Commitments for transaction outputs. *(deprecated)*
-  // - **payment_references_sent** (repeated bytes): Metadata references associated with sent outputs. *(deprecated)*
-  // - **payment_references_received** (repeated bytes): Metadata references associated with received outputs. *(deprecated)*
-  // - **payment_references_change** (repeated bytes): Metadata references associated with change outputs. *(deprecated)*
-  // - **output_commitments_info** (repeated CommitmentInfo):
-  //     Contains details for each output commitment (excluding change) in the transaction.
-  //     Each CommitmentInfo includes:
-  //       - `commitment` (bytes): The cryptographic commitment representing the output.
-  //       - `payment_reference` (bytes): The associated payment reference for the output.
-  //       - `category` (enum): The category of the output (`Sent`, `Received`, `Change`).
+  // - **output_commitments** (repeated bytes): Commitments for transaction outputs.
+  // - **payment_references_sent** (repeated bytes): Metadata references associated with sent outputs.
+  // - **payment_references_received** (repeated bytes): Metadata references associated with received outputs.
+  // - **payment_references_change** (repeated bytes): Metadata references associated with change outputs.
   //
   // ### Example JavaScript gRPC client usage:
   // ```javascript
@@ -1643,19 +1637,7 @@ service Wallet {
   //     "output_commitments": ["0x...", "0x..."],
   //     "payment_references_sent": ["0x...", "0x..."],
   //     "payment_references_received": [],
-  //     "payment_references_change": [],
-  //     "output_commitments_info": [
-  //       {
-  //         "commitment": "0xabcdef...",
-  //         "payment_reference": "0x123456...",
-  //         "category": "Sent"
-  //       },
-  //       {
-  //         "commitment": "0xghijkl...",
-  //         "payment_reference": "0x789abc...",
-  //         "category": "Change"
-  //       }
-  //     ]
+  //     "payment_references_change": []
   //   }
   // }
   // ```
@@ -2148,23 +2130,10 @@ message TransactionInfo {
   uint64 mined_in_block_height = 13;
   bytes user_payment_id = 14;
   repeated bytes input_commitments = 15;
-  repeated bytes output_commitments = 16 [deprecated = true];
-  repeated bytes payment_references_sent = 17 [deprecated = true];
-  repeated bytes payment_references_received = 18 [deprecated = true];
-  repeated bytes payment_references_change = 19 [deprecated = true];
-  repeated CommitmentInfo output_commitments_info = 20;
-}
-
-message CommitmentInfo {
-  bytes commitment = 1;
-  bytes payment_reference = 2;
-  OutputCategory category = 3;
-}
-
-enum OutputCategory {
-  OUTPUT_CATEGORY_SENT = 0;
-  OUTPUT_CATEGORY_RECEIVED = 1;
-  OUTPUT_CATEGORY_CHANGE = 2;
+  repeated bytes output_commitments = 16;
+  repeated bytes payment_references_sent = 17;
+  repeated bytes payment_references_received = 18;
+  repeated bytes payment_references_change = 19;
 }
 
 enum TransactionDirection {

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1597,7 +1597,6 @@ service Wallet {
   // - **output_commitments_info** (repeated CommitmentInfo):
   //     Contains details for each output commitment (excluding change) in the transaction.
   //     Each CommitmentInfo includes:
-  //       - `hash` (bytes): The hash representing the output.
   //       - `commitment` (bytes): The cryptographic commitment representing the output.
   //       - `payment_reference` (bytes): The associated payment reference for the output.
   //       - `category` (enum): The category of the output (`Sent`, `Received`, `Change`).
@@ -1647,13 +1646,11 @@ service Wallet {
   //     "payment_references_change": [],
   //     "output_commitments_info": [
   //       {
-  //         "hash": "0xa1b2c3...",
   //         "commitment": "0xabcdef...",
   //         "payment_reference": "0x123456...",
   //         "category": "Sent"
   //       },
   //       {
-    //       "hash": "0xf4e3d2c1...",
   //         "commitment": "0xghijkl...",
   //         "payment_reference": "0x789abc...",
   //         "category": "Change"
@@ -2159,10 +2156,9 @@ message TransactionInfo {
 }
 
 message CommitmentInfo {
-  bytes hash = 1;
-  bytes commitment = 2;
-  bytes payment_reference = 3;
-  OutputCategory category = 4;
+  bytes commitment = 1;
+  bytes payment_reference = 2;
+  OutputCategory category = 3;
 }
 
 enum OutputCategory {

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1595,7 +1595,7 @@ service Wallet {
   // - **payment_references_received** (repeated bytes): Metadata references associated with received outputs. *(deprecated)*
   // - **payment_references_change** (repeated bytes): Metadata references associated with change outputs. *(deprecated)*
   // - **output_commitments_info** (repeated CommitmentInfo):
-  //     Contains details for each output commitment in the transaction.
+  //     Contains details for each output commitment (excluding change) in the transaction.
   //     Each CommitmentInfo includes:
   //       - `hash` (bytes): The hash representing the output.
   //       - `commitment` (bytes): The cryptographic commitment representing the output.

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -883,6 +883,16 @@ service Wallet {
   //     - Must be a valid transaction ID that exists in the wallet.
   //     - If the transaction ID is invalid or not found, an error will be returned.
   //
+  // ### Response:
+  // - **payment_references** (repeated bytes): Metadata references associated with change outputs. *(deprecated)*
+  // - **output_commitments_info** (repeated CommitmentInfo):
+  //     Contains details for each output commitment in the transaction.
+  //     Each CommitmentInfo includes:
+  //       - `hash` (bytes): The hash representing the output.
+  //       - `commitment` (bytes): The cryptographic commitment representing the output.
+  //       - `payment_reference` (bytes): The associated payment reference for the output.
+  //       - `category` (enum): The category of the output (`Sent`, `Received`, `Change`).
+  //
   // ### Example JavaScript gRPC client usage:
   //
   // ```javascript
@@ -2462,9 +2472,23 @@ message GetTransactionPayRefsRequest {
 // Response message for GetTransactionPayRefs RPC.
 message GetTransactionPayRefsResponse {
   // List of PayRefs (32-byte payment references) for the transaction.
-  repeated bytes payment_references = 1;
+  repeated bytes payment_references = 1 [deprecated = true];
+  // List of input commitment info for the transaction - hash, commitment, payment reference, output category.
+  repeated CommitmentInfo output_commitments_info = 2;
 }
 
+message CommitmentInfo {
+  bytes hash = 1;
+  bytes commitment = 2;
+  bytes payment_reference = 3;
+  OutputCategory category = 4;
+}
+
+enum OutputCategory {
+  OUTPUT_CATEGORY_SENT = 0;
+  OUTPUT_CATEGORY_RECEIVED = 1;
+  OUTPUT_CATEGORY_CHANGE = 2;
+}
 
 // Response message for GetTransactionsWithPayRefs RPC.
 message GetTransactionsWithPayRefsResponse {

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1590,10 +1590,16 @@ service Wallet {
   // - **user_payment_id** (bytes): User-visible payment ID, if applicable.
   // - **mined_in_block_height** (uint64): Block height where the transaction was mined. Zero if not mined.
   // - **input_commitments** (repeated bytes): Commitments for transaction inputs.
-  // - **output_commitments** (repeated bytes): Commitments for transaction outputs.
-  // - **payment_references_sent** (repeated bytes): Metadata references associated with sent outputs.
-  // - **payment_references_received** (repeated bytes): Metadata references associated with received outputs.
-  // - **payment_references_change** (repeated bytes): Metadata references associated with change outputs.
+  // - **output_commitments** (repeated bytes): Commitments for transaction outputs. *(deprecated)*
+  // - **payment_references_sent** (repeated bytes): Metadata references associated with sent outputs. *(deprecated)*
+  // - **payment_references_received** (repeated bytes): Metadata references associated with received outputs. *(deprecated)*
+  // - **payment_references_change** (repeated bytes): Metadata references associated with change outputs. *(deprecated)*
+  // - **output_commitments_info** (repeated CommitmentInfo):
+  //     Contains details for each output commitment (excluding change) in the transaction.
+  //     Each CommitmentInfo includes:
+  //       - `commitment` (bytes): The cryptographic commitment representing the output.
+  //       - `payment_reference` (bytes): The associated payment reference for the output.
+  //       - `category` (enum): The category of the output (`Sent`, `Received`, `Change`).
   //
   // ### Example JavaScript gRPC client usage:
   // ```javascript
@@ -1637,7 +1643,19 @@ service Wallet {
   //     "output_commitments": ["0x...", "0x..."],
   //     "payment_references_sent": ["0x...", "0x..."],
   //     "payment_references_received": [],
-  //     "payment_references_change": []
+  //     "payment_references_change": [],
+  //     "output_commitments_info": [
+  //       {
+  //         "commitment": "0xabcdef...",
+  //         "payment_reference": "0x123456...",
+  //         "category": "Sent"
+  //       },
+  //       {
+  //         "commitment": "0xghijkl...",
+  //         "payment_reference": "0x789abc...",
+  //         "category": "Change"
+  //       }
+  //     ]
   //   }
   // }
   // ```
@@ -2130,10 +2148,23 @@ message TransactionInfo {
   uint64 mined_in_block_height = 13;
   bytes user_payment_id = 14;
   repeated bytes input_commitments = 15;
-  repeated bytes output_commitments = 16;
-  repeated bytes payment_references_sent = 17;
-  repeated bytes payment_references_received = 18;
-  repeated bytes payment_references_change = 19;
+  repeated bytes output_commitments = 16 [deprecated = true];
+  repeated bytes payment_references_sent = 17 [deprecated = true];
+  repeated bytes payment_references_received = 18 [deprecated = true];
+  repeated bytes payment_references_change = 19 [deprecated = true];
+  repeated CommitmentInfo output_commitments_info = 20;
+}
+
+message CommitmentInfo {
+  bytes commitment = 1;
+  bytes payment_reference = 2;
+  OutputCategory category = 3;
+}
+
+enum OutputCategory {
+  OUTPUT_CATEGORY_SENT = 0;
+  OUTPUT_CATEGORY_RECEIVED = 1;
+  OUTPUT_CATEGORY_CHANGE = 2;
 }
 
 enum TransactionDirection {

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1597,6 +1597,7 @@ service Wallet {
   // - **output_commitments_info** (repeated CommitmentInfo):
   //     Contains details for each output commitment (excluding change) in the transaction.
   //     Each CommitmentInfo includes:
+  //       - `hash` (bytes): The hash representing the output.
   //       - `commitment` (bytes): The cryptographic commitment representing the output.
   //       - `payment_reference` (bytes): The associated payment reference for the output.
   //       - `category` (enum): The category of the output (`Sent`, `Received`, `Change`).
@@ -1646,11 +1647,13 @@ service Wallet {
   //     "payment_references_change": [],
   //     "output_commitments_info": [
   //       {
+  //         "hash": "0xa1b2c3...",
   //         "commitment": "0xabcdef...",
   //         "payment_reference": "0x123456...",
   //         "category": "Sent"
   //       },
   //       {
+    //       "hash": "0xf4e3d2c1...",
   //         "commitment": "0xghijkl...",
   //         "payment_reference": "0x789abc...",
   //         "category": "Change"
@@ -2156,9 +2159,10 @@ message TransactionInfo {
 }
 
 message CommitmentInfo {
-  bytes commitment = 1;
-  bytes payment_reference = 2;
-  OutputCategory category = 3;
+  bytes hash = 1;
+  bytes commitment = 2;
+  bytes payment_reference = 3;
+  OutputCategory category = 4;
 }
 
 enum OutputCategory {

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1595,7 +1595,7 @@ service Wallet {
   // - **payment_references_received** (repeated bytes): Metadata references associated with received outputs. *(deprecated)*
   // - **payment_references_change** (repeated bytes): Metadata references associated with change outputs. *(deprecated)*
   // - **output_commitments_info** (repeated CommitmentInfo):
-  //     Contains details for each output commitment (excluding change) in the transaction.
+  //     Contains details for each output commitment in the transaction.
   //     Each CommitmentInfo includes:
   //       - `hash` (bytes): The hash representing the output.
   //       - `commitment` (bytes): The cryptographic commitment representing the output.

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -340,7 +340,6 @@ impl WalletGrpcServer {
     }
 }
 
-#[allow(clippy::too_many_lines)]
 #[tonic::async_trait]
 impl wallet_server::Wallet for WalletGrpcServer {
     type GetAllCompletedTransactionsStreamStream = mpsc::Receiver<Result<GetCompletedTransactionsResponse, Status>>;
@@ -3233,7 +3232,7 @@ fn convert_wallet_transaction_into_transaction_info(
 }
 
 struct CommitmentInfo {
-    commitment: Option<CompressedCommitment>,
+    commitment: CompressedCommitment,
     hash: FixedHash,
 }
 
@@ -3244,12 +3243,10 @@ fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<ta
         .inputs()
         .iter()
         .map(|o| CommitmentInfo {
-            commitment: if let Ok(commitment) = o.commitment().cloned() {
-                Some(commitment)
-            } else {
-                warn!(target: LOG_TARGET, "Expected to find a commitment for output '{}'", o.output_hash());
-                None
-            },
+            commitment: o
+                .commitment()
+                .expect("wallet db contains full set of input/output data")
+                .clone(),
             hash: o.output_hash(),
         })
         .collect::<Vec<_>>();
@@ -3259,7 +3256,7 @@ fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<ta
         .outputs()
         .iter()
         .map(|o| CommitmentInfo {
-            commitment: Some(o.commitment.clone()),
+            commitment: o.commitment.clone(),
             hash: o.hash(),
         })
         .collect::<Vec<_>>();
@@ -3298,11 +3295,7 @@ fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<ta
 
 fn get_commitment(all_artefacts: &[CommitmentInfo], hash: &FixedHash) -> Vec<u8> {
     if let Some(output) = all_artefacts.iter().find(|&val| &val.hash == hash) {
-        if let Some(commitment) = &output.commitment {
-            commitment.as_bytes().to_vec()
-        } else {
-            vec![]
-        }
+        output.commitment.as_bytes().to_vec()
     } else {
         vec![]
     }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -141,7 +141,7 @@ use minotari_wallet::{
     transaction_service::{
         error::TransactionServiceError,
         handle::TransactionServiceHandle,
-        storage::models::{self, WalletTransaction},
+        storage::models::{self, CompletedTransaction, WalletTransaction},
     },
     WalletKeyManager,
     WalletSqlite,
@@ -156,6 +156,7 @@ use tari_common_types::{
         CompressedCommitment,
         CompressedPublicKey,
         CompressedSignature,
+        FixedHash,
         PrivateKey,
         SignatureWithDomain,
     },
@@ -181,8 +182,7 @@ use tokio::{
     time::{sleep, timeout},
 };
 use tonic::{Request, Response, Status};
-use minotari_wallet::transaction_service::storage::models::CompletedTransaction;
-use tari_common_types::types::FixedHash;
+
 use crate::{
     grpc::{convert_to_transaction_event, wallet_debouncer::WalletDebouncer, TransactionWrapper},
     notifier::{CANCELLED, CONFIRMATION, MINED, QUEUED, RECEIVED, SENT},

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -141,7 +141,7 @@ use minotari_wallet::{
     transaction_service::{
         error::TransactionServiceError,
         handle::TransactionServiceHandle,
-        storage::models::{self, WalletTransaction},
+        storage::models::{self, CompletedTransaction, WalletTransaction},
     },
     WalletKeyManager,
     WalletSqlite,
@@ -1540,7 +1540,6 @@ impl wallet_server::Wallet for WalletGrpcServer {
         Ok(Response::new(receiver))
     }
 
-    #[allow(clippy::too_many_lines)]
     async fn get_completed_transactions(
         &self,
         request: Request<GetCompletedTransactionsRequest>,
@@ -1635,23 +1634,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         raw_payment_id: txn.payment_id.to_bytes(),
                         user_payment_id: txn.payment_id.payment_id_as_bytes(),
                         mined_in_block_height: txn.mined_height.unwrap_or(0),
+                        #[allow(deprecated)]
                         output_commitments,
                         input_commitments,
+                        #[allow(deprecated)]
                         payment_references_sent: txn
                             .calculate_sent_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
+                        #[allow(deprecated)]
                         payment_references_received: txn
                             .calculate_received_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
+                        #[allow(deprecated)]
                         payment_references_change: txn
                             .calculate_change_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
+                        output_commitments_info: get_transaction_output_commitments_info(txn),
                     }),
                 };
                 match sender.send(Ok(response)).await {
@@ -1773,23 +1777,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     raw_payment_id: txn.payment_id.to_bytes(),
                     user_payment_id: txn.payment_id.payment_id_as_bytes(),
                     mined_in_block_height: txn.mined_height.unwrap_or(0),
+                    #[allow(deprecated)]
                     output_commitments,
                     input_commitments,
+                    #[allow(deprecated)]
                     payment_references_sent: txn
                         .calculate_sent_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
+                    #[allow(deprecated)]
                     payment_references_received: txn
                         .calculate_received_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
+                    #[allow(deprecated)]
                     payment_references_change: txn
                         .calculate_change_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
+                    output_commitments_info: get_transaction_output_commitments_info(&txn),
                 });
             }
 
@@ -1934,23 +1943,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         raw_payment_id: txn.payment_id.to_bytes(),
                         user_payment_id: txn.payment_id.payment_id_as_bytes(),
                         mined_in_block_height: txn.mined_height.unwrap_or(0),
+                        #[allow(deprecated)]
                         output_commitments,
                         input_commitments,
+                        #[allow(deprecated)]
                         payment_references_sent: txn
                             .calculate_sent_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
+                        #[allow(deprecated)]
                         payment_references_received: txn
                             .calculate_received_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
+                        #[allow(deprecated)]
                         payment_references_change: txn
                             .calculate_change_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
+                        output_commitments_info: get_transaction_output_commitments_info(&txn),
                     };
 
                     let response = GetCompletedTransactionsResponse {
@@ -2076,23 +2090,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 raw_payment_id: txn.payment_id.to_bytes(),
                 user_payment_id: txn.payment_id.payment_id_as_bytes(),
                 mined_in_block_height: txn.mined_height.unwrap_or(0),
+                #[allow(deprecated)]
                 output_commitments,
                 input_commitments,
+                #[allow(deprecated)]
                 payment_references_sent: txn
                     .calculate_sent_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
+                #[allow(deprecated)]
                 payment_references_received: txn
                     .calculate_received_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
+                #[allow(deprecated)]
                 payment_references_change: txn
                     .calculate_change_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
+                output_commitments_info: get_transaction_output_commitments_info(txn),
             });
         }
 
@@ -2612,23 +2631,28 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     raw_payment_id: txn.payment_id.to_bytes(),
                     user_payment_id: txn.payment_id.payment_id_as_bytes(),
                     mined_in_block_height: txn.mined_height.unwrap_or(0),
+                    #[allow(deprecated)]
                     output_commitments,
                     input_commitments,
+                    #[allow(deprecated)]
                     payment_references_sent: txn
                         .calculate_sent_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
+                    #[allow(deprecated)]
                     payment_references_received: txn
                         .calculate_received_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
+                    #[allow(deprecated)]
                     payment_references_change: txn
                         .calculate_change_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
+                    output_commitments_info: get_transaction_output_commitments_info(&txn),
                 };
                 Ok(Response::new(GetPaymentByReferenceResponse {
                     transaction: Some(transaction_info),
@@ -3086,11 +3110,16 @@ fn convert_wallet_transaction_into_transaction_info(
                 raw_payment_id: tx.payment_id.to_bytes(),
                 user_payment_id: tx.payment_id.payment_id_as_bytes(),
                 mined_in_block_height: 0,
+                #[allow(deprecated)]
                 output_commitments,
                 input_commitments: vec![],
+                #[allow(deprecated)]
                 payment_references_sent: vec![],
+                #[allow(deprecated)]
                 payment_references_received: vec![],
+                #[allow(deprecated)]
                 payment_references_change: vec![],
+                output_commitments_info: vec![],
             }
         },
         PendingOutbound(tx) => {
@@ -3108,6 +3137,7 @@ fn convert_wallet_transaction_into_transaction_info(
                     vec![]
                 },
             };
+
             TransactionInfo {
                 tx_id: tx.tx_id.into(),
                 source_address: wallet_address.to_vec(),
@@ -3122,11 +3152,16 @@ fn convert_wallet_transaction_into_transaction_info(
                 raw_payment_id: tx.payment_id.to_bytes(),
                 user_payment_id: tx.payment_id.payment_id_as_bytes(),
                 mined_in_block_height: 0,
+                #[allow(deprecated)]
                 output_commitments,
                 input_commitments,
+                #[allow(deprecated)]
                 payment_references_sent: vec![],
+                #[allow(deprecated)]
                 payment_references_received: vec![],
+                #[allow(deprecated)]
                 payment_references_change: vec![],
+                output_commitments_info: vec![],
             }
         },
         Completed(tx) => {
@@ -3168,24 +3203,56 @@ fn convert_wallet_transaction_into_transaction_info(
                 raw_payment_id: tx.payment_id.to_bytes(),
                 user_payment_id: tx.payment_id.payment_id_as_bytes(),
                 mined_in_block_height: tx.mined_height.unwrap_or(0),
+                #[allow(deprecated)]
                 output_commitments: output_commitments.clone(),
                 input_commitments,
+                #[allow(deprecated)]
                 payment_references_sent: tx
                     .calculate_sent_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
+                #[allow(deprecated)]
                 payment_references_received: tx
                     .calculate_received_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
+                #[allow(deprecated)]
                 payment_references_change: tx
                     .calculate_change_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
+                output_commitments_info: get_transaction_output_commitments_info(&tx),
             }
         },
     }
+}
+
+fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<tari_rpc::CommitmentInfo> {
+    let mut output_commitments_info = Vec::with_capacity(txn.transaction.body.outputs().len());
+    for output in txn.transaction.body.outputs() {
+        output_commitments_info.push(tari_rpc::CommitmentInfo {
+            commitment: output.commitment().to_vec(),
+            payment_reference: if txn.status.is_confirmed() {
+                {
+                    txn.mined_in_block
+                        .as_ref()
+                        .map(|block_hash| generate_payment_reference(block_hash, &output.hash()).to_vec())
+                        .unwrap_or_default()
+                }
+            } else {
+                Default::default()
+            },
+            category: if txn.change_output_hashes.contains(&output.hash()) {
+                tari_rpc::OutputCategory::Change as i32
+            } else if txn.direction == tari_common_types::transaction::TransactionDirection::Inbound {
+                tari_rpc::OutputCategory::Received as i32
+            } else {
+                tari_rpc::OutputCategory::Sent as i32
+            },
+        });
+    }
+    output_commitments_info
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -156,7 +156,6 @@ use tari_common_types::{
         CompressedCommitment,
         CompressedPublicKey,
         CompressedSignature,
-        FixedHash,
         PrivateKey,
         SignatureWithDomain,
     },
@@ -3231,85 +3230,29 @@ fn convert_wallet_transaction_into_transaction_info(
     }
 }
 
-struct CommitmentInfo {
-    commitment: CompressedCommitment,
-    hash: FixedHash,
-}
-
 fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<tari_rpc::CommitmentInfo> {
-    let input_artefacts = txn
-        .transaction
-        .body
-        .inputs()
-        .iter()
-        .map(|o| CommitmentInfo {
-            commitment: o
-                .commitment()
-                .expect("wallet db contains full set of input/output data")
-                .clone(),
-            hash: o.output_hash(),
-        })
-        .collect::<Vec<_>>();
-    let output_artefacts = txn
-        .transaction
-        .body
-        .outputs()
-        .iter()
-        .map(|o| CommitmentInfo {
-            commitment: o.commitment.clone(),
-            hash: o.hash(),
-        })
-        .collect::<Vec<_>>();
-    let all_artefacts = input_artefacts.into_iter().chain(output_artefacts).collect::<Vec<_>>();
-
-    let mut output_commitments_info = Vec::with_capacity(
-        txn.sent_output_hashes.len() + txn.received_output_hashes.len() + txn.change_output_hashes.len(),
-    );
-    for hash in &txn.sent_output_hashes {
+    let mut output_commitments_info = Vec::with_capacity(txn.transaction.body.outputs().len());
+    for output in txn.transaction.body.outputs() {
         output_commitments_info.push(tari_rpc::CommitmentInfo {
-            hash: hash.to_vec(),
-            commitment: get_commitment(&all_artefacts, hash),
-            payment_reference: get_payment_reference(txn, hash),
-            category: tari_rpc::OutputCategory::Sent as i32,
+            commitment: output.commitment().to_vec(),
+            payment_reference: if txn.status.is_confirmed() {
+                {
+                    txn.mined_in_block
+                        .as_ref()
+                        .map(|block_hash| generate_payment_reference(block_hash, &output.hash()).to_vec())
+                        .unwrap_or_default()
+                }
+            } else {
+                Default::default()
+            },
+            category: if txn.change_output_hashes.contains(&output.hash()) {
+                tari_rpc::OutputCategory::Change as i32
+            } else if txn.direction == tari_common_types::transaction::TransactionDirection::Inbound {
+                tari_rpc::OutputCategory::Received as i32
+            } else {
+                tari_rpc::OutputCategory::Sent as i32
+            },
         });
     }
-    for hash in &txn.received_output_hashes {
-        output_commitments_info.push(tari_rpc::CommitmentInfo {
-            hash: hash.to_vec(),
-            commitment: get_commitment(&all_artefacts, hash),
-            payment_reference: get_payment_reference(txn, hash),
-            category: tari_rpc::OutputCategory::Received as i32,
-        });
-    }
-    for hash in &txn.change_output_hashes {
-        output_commitments_info.push(tari_rpc::CommitmentInfo {
-            hash: hash.to_vec(),
-            commitment: get_commitment(&all_artefacts, hash),
-            payment_reference: get_payment_reference(txn, hash),
-            category: tari_rpc::OutputCategory::Change as i32,
-        });
-    }
-
     output_commitments_info
-}
-
-fn get_commitment(all_artefacts: &[CommitmentInfo], hash: &FixedHash) -> Vec<u8> {
-    if let Some(output) = all_artefacts.iter().find(|&val| &val.hash == hash) {
-        output.commitment.as_bytes().to_vec()
-    } else {
-        vec![]
-    }
-}
-
-fn get_payment_reference(txn: &CompletedTransaction, hash: &FixedHash) -> Vec<u8> {
-    if txn.status.is_confirmed() {
-        {
-            txn.mined_in_block
-                .as_ref()
-                .map(|block_hash| generate_payment_reference(block_hash, hash).to_vec())
-                .unwrap_or_default()
-        }
-    } else {
-        Default::default()
-    }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -156,6 +156,7 @@ use tari_common_types::{
         CompressedCommitment,
         CompressedPublicKey,
         CompressedSignature,
+        FixedHash,
         PrivateKey,
         SignatureWithDomain,
     },
@@ -3230,29 +3231,85 @@ fn convert_wallet_transaction_into_transaction_info(
     }
 }
 
+struct CommitmentInfo {
+    commitment: CompressedCommitment,
+    hash: FixedHash,
+}
+
 fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<tari_rpc::CommitmentInfo> {
-    let mut output_commitments_info = Vec::with_capacity(txn.transaction.body.outputs().len());
-    for output in txn.transaction.body.outputs() {
+    let input_artefacts = txn
+        .transaction
+        .body
+        .inputs()
+        .iter()
+        .map(|o| CommitmentInfo {
+            commitment: o
+                .commitment()
+                .expect("wallet db contains full set of input/output data")
+                .clone(),
+            hash: o.output_hash(),
+        })
+        .collect::<Vec<_>>();
+    let output_artefacts = txn
+        .transaction
+        .body
+        .outputs()
+        .iter()
+        .map(|o| CommitmentInfo {
+            commitment: o.commitment.clone(),
+            hash: o.hash(),
+        })
+        .collect::<Vec<_>>();
+    let all_artefacts = input_artefacts.into_iter().chain(output_artefacts).collect::<Vec<_>>();
+
+    let mut output_commitments_info = Vec::with_capacity(
+        txn.sent_output_hashes.len() + txn.received_output_hashes.len() + txn.change_output_hashes.len(),
+    );
+    for hash in &txn.sent_output_hashes {
         output_commitments_info.push(tari_rpc::CommitmentInfo {
-            commitment: output.commitment().to_vec(),
-            payment_reference: if txn.status.is_confirmed() {
-                {
-                    txn.mined_in_block
-                        .as_ref()
-                        .map(|block_hash| generate_payment_reference(block_hash, &output.hash()).to_vec())
-                        .unwrap_or_default()
-                }
-            } else {
-                Default::default()
-            },
-            category: if txn.change_output_hashes.contains(&output.hash()) {
-                tari_rpc::OutputCategory::Change as i32
-            } else if txn.direction == tari_common_types::transaction::TransactionDirection::Inbound {
-                tari_rpc::OutputCategory::Received as i32
-            } else {
-                tari_rpc::OutputCategory::Sent as i32
-            },
+            hash: hash.to_vec(),
+            commitment: get_commitment(&all_artefacts, hash),
+            payment_reference: get_payment_reference(txn, hash),
+            category: tari_rpc::OutputCategory::Sent as i32,
         });
     }
+    for hash in &txn.received_output_hashes {
+        output_commitments_info.push(tari_rpc::CommitmentInfo {
+            hash: hash.to_vec(),
+            commitment: get_commitment(&all_artefacts, hash),
+            payment_reference: get_payment_reference(txn, hash),
+            category: tari_rpc::OutputCategory::Received as i32,
+        });
+    }
+    for hash in &txn.change_output_hashes {
+        output_commitments_info.push(tari_rpc::CommitmentInfo {
+            hash: hash.to_vec(),
+            commitment: get_commitment(&all_artefacts, hash),
+            payment_reference: get_payment_reference(txn, hash),
+            category: tari_rpc::OutputCategory::Change as i32,
+        });
+    }
+
     output_commitments_info
+}
+
+fn get_commitment(all_artefacts: &[CommitmentInfo], hash: &FixedHash) -> Vec<u8> {
+    if let Some(output) = all_artefacts.iter().find(|&val| &val.hash == hash) {
+        output.commitment.as_bytes().to_vec()
+    } else {
+        vec![]
+    }
+}
+
+fn get_payment_reference(txn: &CompletedTransaction, hash: &FixedHash) -> Vec<u8> {
+    if txn.status.is_confirmed() {
+        {
+            txn.mined_in_block
+                .as_ref()
+                .map(|block_hash| generate_payment_reference(block_hash, hash).to_vec())
+                .unwrap_or_default()
+        }
+    } else {
+        Default::default()
+    }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -340,6 +340,7 @@ impl WalletGrpcServer {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 #[tonic::async_trait]
 impl wallet_server::Wallet for WalletGrpcServer {
     type GetAllCompletedTransactionsStreamStream = mpsc::Receiver<Result<GetCompletedTransactionsResponse, Status>>;
@@ -3232,7 +3233,7 @@ fn convert_wallet_transaction_into_transaction_info(
 }
 
 struct CommitmentInfo {
-    commitment: CompressedCommitment,
+    commitment: Option<CompressedCommitment>,
     hash: FixedHash,
 }
 
@@ -3243,10 +3244,12 @@ fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<ta
         .inputs()
         .iter()
         .map(|o| CommitmentInfo {
-            commitment: o
-                .commitment()
-                .expect("wallet db contains full set of input/output data")
-                .clone(),
+            commitment: if let Ok(commitment) = o.commitment().cloned() {
+                Some(commitment)
+            } else {
+                warn!(target: LOG_TARGET, "Expected to find a commitment for output '{}'", o.output_hash());
+                None
+            },
             hash: o.output_hash(),
         })
         .collect::<Vec<_>>();
@@ -3256,7 +3259,7 @@ fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<ta
         .outputs()
         .iter()
         .map(|o| CommitmentInfo {
-            commitment: o.commitment.clone(),
+            commitment: Some(o.commitment.clone()),
             hash: o.hash(),
         })
         .collect::<Vec<_>>();
@@ -3295,7 +3298,11 @@ fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<ta
 
 fn get_commitment(all_artefacts: &[CommitmentInfo], hash: &FixedHash) -> Vec<u8> {
     if let Some(output) = all_artefacts.iter().find(|&val| &val.hash == hash) {
-        output.commitment.as_bytes().to_vec()
+        if let Some(commitment) = &output.commitment {
+            commitment.as_bytes().to_vec()
+        } else {
+            vec![]
+        }
     } else {
         vec![]
     }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -181,7 +181,8 @@ use tokio::{
     time::{sleep, timeout},
 };
 use tonic::{Request, Response, Status};
-
+use minotari_wallet::transaction_service::storage::models::CompletedTransaction;
+use tari_common_types::types::FixedHash;
 use crate::{
     grpc::{convert_to_transaction_event, wallet_debouncer::WalletDebouncer, TransactionWrapper},
     notifier::{CANCELLED, CONFIRMATION, MINED, QUEUED, RECEIVED, SENT},
@@ -2659,50 +2660,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let mut transaction_service = self.get_transaction_service();
         let tx_id = TxId::from(req.transaction_id);
-
-        match transaction_service.get_completed_transaction(tx_id).await {
-            Ok(completed_tx) => {
-                // Only return PayRefs if transaction is mined and has block hash
-                if let Some(block_hash) = &completed_tx.mined_in_block {
-                    let mut payment_references = Vec::new();
-
-                    // Generate PayRefs from sent output hashes
-                    for output_hash in &completed_tx.sent_output_hashes {
-                        let payref = generate_payment_reference(block_hash, output_hash);
-                        payment_references.push(payref.to_vec());
-                    }
-
-                    // Generate PayRefs from received output hashes
-                    for output_hash in &completed_tx.received_output_hashes {
-                        let payref = generate_payment_reference(block_hash, output_hash);
-                        payment_references.push(payref.to_vec());
-                    }
-
-                    // Generate PayRefs from change output hashes (per-output approach)
-                    for output_hash in &completed_tx.change_output_hashes {
-                        let payref = generate_payment_reference(block_hash, output_hash);
-                        payment_references.push(payref.to_vec());
-                    }
-
-                    debug!(
-                        target: LOG_TARGET,
-                        "get_transaction_pay_refs: Generated {} PayRefs for transaction {} (including change outputs)",
-                        payment_references.len(),
-                        req.transaction_id
-                    );
-
-                    Ok(Response::new(GetTransactionPayRefsResponse { payment_references }))
-                } else {
-                    debug!(
-                        target: LOG_TARGET,
-                        "get_transaction_pay_refs: Transaction {} is not mined yet",
-                        req.transaction_id
-                    );
-                    Ok(Response::new(GetTransactionPayRefsResponse {
-                        payment_references: vec![],
-                    }))
-                }
-            },
+        let completed_tx = match transaction_service.get_completed_transaction(tx_id).await {
+            Ok(completed_tx) => completed_tx,
             Err(e) => {
                 warn!(
                     target: LOG_TARGET,
@@ -2710,12 +2669,59 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     req.transaction_id,
                     e
                 );
-                Err(Status::not_found(format!(
+                return Err(Status::not_found(format!(
                     "Transaction {} not found",
                     req.transaction_id
-                )))
+                )));
             },
-        }
+        };
+
+        let payment_references = {
+            // Only return PayRefs if transaction is mined and has block hash
+            if let Some(block_hash) = &completed_tx.mined_in_block {
+                let mut payment_references = Vec::new();
+
+                // Generate PayRefs from sent output hashes
+                for output_hash in &completed_tx.sent_output_hashes {
+                    let payref = generate_payment_reference(block_hash, output_hash);
+                    payment_references.push(payref.to_vec());
+                }
+
+                // Generate PayRefs from received output hashes
+                for output_hash in &completed_tx.received_output_hashes {
+                    let payref = generate_payment_reference(block_hash, output_hash);
+                    payment_references.push(payref.to_vec());
+                }
+
+                // Generate PayRefs from change output hashes (per-output approach)
+                for output_hash in &completed_tx.change_output_hashes {
+                    let payref = generate_payment_reference(block_hash, output_hash);
+                    payment_references.push(payref.to_vec());
+                }
+
+                debug!(
+                    target: LOG_TARGET,
+                    "get_transaction_pay_refs: Generated {} PayRefs for transaction {} (including change outputs)",
+                    payment_references.len(),
+                    req.transaction_id
+                );
+
+                payment_references
+            } else {
+                debug!(
+                    target: LOG_TARGET,
+                    "get_transaction_pay_refs: Transaction {} is not mined yet",
+                    req.transaction_id
+                );
+                vec![]
+            }
+        };
+
+        Ok(Response::new(GetTransactionPayRefsResponse {
+            #[allow(deprecated)]
+            payment_references,
+            output_commitments_info: get_transaction_output_commitments_info(&completed_tx),
+        }))
     }
 
     async fn get_fee_estimate(
@@ -3187,5 +3193,94 @@ fn convert_wallet_transaction_into_transaction_info(
                     .collect(),
             }
         },
+    }
+}
+
+struct CommitmentInfo {
+    commitment: Option<CompressedCommitment>,
+    hash: FixedHash,
+}
+
+fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<tari_rpc::CommitmentInfo> {
+    let input_artefacts = txn
+        .transaction
+        .body
+        .inputs()
+        .iter()
+        .map(|o| CommitmentInfo {
+            commitment: if let Ok(commitment) = o.commitment().cloned() {
+                Some(commitment)
+            } else {
+                warn!(target: LOG_TARGET, "Expected to find a commitment for output '{}'", o.output_hash());
+                None
+            },
+            hash: o.output_hash(),
+        })
+        .collect::<Vec<_>>();
+    let output_artefacts = txn
+        .transaction
+        .body
+        .outputs()
+        .iter()
+        .map(|o| CommitmentInfo {
+            commitment: Some(o.commitment.clone()),
+            hash: o.hash(),
+        })
+        .collect::<Vec<_>>();
+    let all_artefacts = input_artefacts.into_iter().chain(output_artefacts).collect::<Vec<_>>();
+
+    let mut output_commitments_info = Vec::with_capacity(
+        txn.sent_output_hashes.len() + txn.received_output_hashes.len() + txn.change_output_hashes.len(),
+    );
+    for hash in &txn.sent_output_hashes {
+        output_commitments_info.push(tari_rpc::CommitmentInfo {
+            hash: hash.to_vec(),
+            commitment: get_commitment(&all_artefacts, hash),
+            payment_reference: get_payment_reference(txn, hash),
+            category: tari_rpc::OutputCategory::Sent as i32,
+        });
+    }
+    for hash in &txn.received_output_hashes {
+        output_commitments_info.push(tari_rpc::CommitmentInfo {
+            hash: hash.to_vec(),
+            commitment: get_commitment(&all_artefacts, hash),
+            payment_reference: get_payment_reference(txn, hash),
+            category: tari_rpc::OutputCategory::Received as i32,
+        });
+    }
+    for hash in &txn.change_output_hashes {
+        output_commitments_info.push(tari_rpc::CommitmentInfo {
+            hash: hash.to_vec(),
+            commitment: get_commitment(&all_artefacts, hash),
+            payment_reference: get_payment_reference(txn, hash),
+            category: tari_rpc::OutputCategory::Change as i32,
+        });
+    }
+
+    output_commitments_info
+}
+
+fn get_commitment(all_artefacts: &[CommitmentInfo], hash: &FixedHash) -> Vec<u8> {
+    if let Some(output) = all_artefacts.iter().find(|&val| &val.hash == hash) {
+        if let Some(commitment) = &output.commitment {
+            commitment.as_bytes().to_vec()
+        } else {
+            vec![]
+        }
+    } else {
+        vec![]
+    }
+}
+
+fn get_payment_reference(txn: &CompletedTransaction, hash: &FixedHash) -> Vec<u8> {
+    if txn.status.is_confirmed() {
+        {
+            txn.mined_in_block
+                .as_ref()
+                .map(|block_hash| generate_payment_reference(block_hash, hash).to_vec())
+                .unwrap_or_default()
+        }
+    } else {
+        Default::default()
     }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -141,7 +141,7 @@ use minotari_wallet::{
     transaction_service::{
         error::TransactionServiceError,
         handle::TransactionServiceHandle,
-        storage::models::{self, CompletedTransaction, WalletTransaction},
+        storage::models::{self, WalletTransaction},
     },
     WalletKeyManager,
     WalletSqlite,
@@ -1540,6 +1540,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
         Ok(Response::new(receiver))
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn get_completed_transactions(
         &self,
         request: Request<GetCompletedTransactionsRequest>,
@@ -1634,28 +1635,23 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         raw_payment_id: txn.payment_id.to_bytes(),
                         user_payment_id: txn.payment_id.payment_id_as_bytes(),
                         mined_in_block_height: txn.mined_height.unwrap_or(0),
-                        #[allow(deprecated)]
                         output_commitments,
                         input_commitments,
-                        #[allow(deprecated)]
                         payment_references_sent: txn
                             .calculate_sent_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
-                        #[allow(deprecated)]
                         payment_references_received: txn
                             .calculate_received_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
-                        #[allow(deprecated)]
                         payment_references_change: txn
                             .calculate_change_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
-                        output_commitments_info: get_transaction_output_commitments_info(txn),
                     }),
                 };
                 match sender.send(Ok(response)).await {
@@ -1777,28 +1773,23 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     raw_payment_id: txn.payment_id.to_bytes(),
                     user_payment_id: txn.payment_id.payment_id_as_bytes(),
                     mined_in_block_height: txn.mined_height.unwrap_or(0),
-                    #[allow(deprecated)]
                     output_commitments,
                     input_commitments,
-                    #[allow(deprecated)]
                     payment_references_sent: txn
                         .calculate_sent_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
-                    #[allow(deprecated)]
                     payment_references_received: txn
                         .calculate_received_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
-                    #[allow(deprecated)]
                     payment_references_change: txn
                         .calculate_change_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
-                    output_commitments_info: get_transaction_output_commitments_info(&txn),
                 });
             }
 
@@ -1943,28 +1934,23 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         raw_payment_id: txn.payment_id.to_bytes(),
                         user_payment_id: txn.payment_id.payment_id_as_bytes(),
                         mined_in_block_height: txn.mined_height.unwrap_or(0),
-                        #[allow(deprecated)]
                         output_commitments,
                         input_commitments,
-                        #[allow(deprecated)]
                         payment_references_sent: txn
                             .calculate_sent_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
-                        #[allow(deprecated)]
                         payment_references_received: txn
                             .calculate_received_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
-                        #[allow(deprecated)]
                         payment_references_change: txn
                             .calculate_change_payment_references()
                             .into_iter()
                             .map(|pr| pr.to_vec())
                             .collect(),
-                        output_commitments_info: get_transaction_output_commitments_info(&txn),
                     };
 
                     let response = GetCompletedTransactionsResponse {
@@ -2090,28 +2076,23 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 raw_payment_id: txn.payment_id.to_bytes(),
                 user_payment_id: txn.payment_id.payment_id_as_bytes(),
                 mined_in_block_height: txn.mined_height.unwrap_or(0),
-                #[allow(deprecated)]
                 output_commitments,
                 input_commitments,
-                #[allow(deprecated)]
                 payment_references_sent: txn
                     .calculate_sent_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
-                #[allow(deprecated)]
                 payment_references_received: txn
                     .calculate_received_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
-                #[allow(deprecated)]
                 payment_references_change: txn
                     .calculate_change_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
-                output_commitments_info: get_transaction_output_commitments_info(txn),
             });
         }
 
@@ -2631,28 +2612,23 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     raw_payment_id: txn.payment_id.to_bytes(),
                     user_payment_id: txn.payment_id.payment_id_as_bytes(),
                     mined_in_block_height: txn.mined_height.unwrap_or(0),
-                    #[allow(deprecated)]
                     output_commitments,
                     input_commitments,
-                    #[allow(deprecated)]
                     payment_references_sent: txn
                         .calculate_sent_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
-                    #[allow(deprecated)]
                     payment_references_received: txn
                         .calculate_received_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
-                    #[allow(deprecated)]
                     payment_references_change: txn
                         .calculate_change_payment_references()
                         .into_iter()
                         .map(|pr| pr.to_vec())
                         .collect(),
-                    output_commitments_info: get_transaction_output_commitments_info(&txn),
                 };
                 Ok(Response::new(GetPaymentByReferenceResponse {
                     transaction: Some(transaction_info),
@@ -3110,16 +3086,11 @@ fn convert_wallet_transaction_into_transaction_info(
                 raw_payment_id: tx.payment_id.to_bytes(),
                 user_payment_id: tx.payment_id.payment_id_as_bytes(),
                 mined_in_block_height: 0,
-                #[allow(deprecated)]
                 output_commitments,
                 input_commitments: vec![],
-                #[allow(deprecated)]
                 payment_references_sent: vec![],
-                #[allow(deprecated)]
                 payment_references_received: vec![],
-                #[allow(deprecated)]
                 payment_references_change: vec![],
-                output_commitments_info: vec![],
             }
         },
         PendingOutbound(tx) => {
@@ -3137,7 +3108,6 @@ fn convert_wallet_transaction_into_transaction_info(
                     vec![]
                 },
             };
-
             TransactionInfo {
                 tx_id: tx.tx_id.into(),
                 source_address: wallet_address.to_vec(),
@@ -3152,16 +3122,11 @@ fn convert_wallet_transaction_into_transaction_info(
                 raw_payment_id: tx.payment_id.to_bytes(),
                 user_payment_id: tx.payment_id.payment_id_as_bytes(),
                 mined_in_block_height: 0,
-                #[allow(deprecated)]
                 output_commitments,
                 input_commitments,
-                #[allow(deprecated)]
                 payment_references_sent: vec![],
-                #[allow(deprecated)]
                 payment_references_received: vec![],
-                #[allow(deprecated)]
                 payment_references_change: vec![],
-                output_commitments_info: vec![],
             }
         },
         Completed(tx) => {
@@ -3203,56 +3168,24 @@ fn convert_wallet_transaction_into_transaction_info(
                 raw_payment_id: tx.payment_id.to_bytes(),
                 user_payment_id: tx.payment_id.payment_id_as_bytes(),
                 mined_in_block_height: tx.mined_height.unwrap_or(0),
-                #[allow(deprecated)]
                 output_commitments: output_commitments.clone(),
                 input_commitments,
-                #[allow(deprecated)]
                 payment_references_sent: tx
                     .calculate_sent_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
-                #[allow(deprecated)]
                 payment_references_received: tx
                     .calculate_received_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
-                #[allow(deprecated)]
                 payment_references_change: tx
                     .calculate_change_payment_references()
                     .into_iter()
                     .map(|pr| pr.to_vec())
                     .collect(),
-                output_commitments_info: get_transaction_output_commitments_info(&tx),
             }
         },
     }
-}
-
-fn get_transaction_output_commitments_info(txn: &CompletedTransaction) -> Vec<tari_rpc::CommitmentInfo> {
-    let mut output_commitments_info = Vec::with_capacity(txn.transaction.body.outputs().len());
-    for output in txn.transaction.body.outputs() {
-        output_commitments_info.push(tari_rpc::CommitmentInfo {
-            commitment: output.commitment().to_vec(),
-            payment_reference: if txn.status.is_confirmed() {
-                {
-                    txn.mined_in_block
-                        .as_ref()
-                        .map(|block_hash| generate_payment_reference(block_hash, &output.hash()).to_vec())
-                        .unwrap_or_default()
-                }
-            } else {
-                Default::default()
-            },
-            category: if txn.change_output_hashes.contains(&output.hash()) {
-                tari_rpc::OutputCategory::Change as i32
-            } else if txn.direction == tari_common_types::transaction::TransactionDirection::Inbound {
-                tari_rpc::OutputCategory::Received as i32
-            } else {
-                tari_rpc::OutputCategory::Sent as i32
-            },
-        });
-    }
-    output_commitments_info
 }


### PR DESCRIPTION
Description
---
Added more detail to the gRPC methods that return payment reference information. Commitments are now aligned with payment references, and the output is categorised as sent, received or change.

Fixes #7561.

Motivation and Context
---
See #7561.

How Has This Been Tested?
---
System-level testing

What process can a PR reviewer use to test or verify this change?
---
- Code review.
- System-level testing

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-output structured details added: commitment, payment reference, and output category (sent/received/change).

* **Improvements**
  * Transaction metadata now returns per-output commitment and payment-reference entries for clearer tracking and display.

* **Deprecation Notice**
  * Legacy aggregated payment-reference field deprecated; migrate to the new per-output structured format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->