### PR TITLE
fix: console wallet address display overrun

### DIFF
--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -151,7 +151,6 @@ pub(crate) const SPEND_STEP_2_SELF: &str = "step_2_for_self";
 pub(crate) const SPEND_STEP_3_SELF: &str = "step_3_for_self";
 pub(crate) const SPEND_STEP_3_PARTIES: &str = "step_3_for_parties";
 pub(crate) const SPEND_STEP_4_LEADER: &str = "step_4_for_leader_from_";
-// 182pdTyFugJYu7vDc1z7bU1t6KvoqzvKxwbfw1AcYK7X63xduDvSHsezfNgKY5xjEX4EYnC5zoqLVTv2xfzhFYgpVBMxnMyuS
 
 #[derive(Debug)]
 pub struct SentTransaction {}

--- a/applications/minotari_console_wallet/src/automation/commands.rs
+++ b/applications/minotari_console_wallet/src/automation/commands.rs
@@ -151,6 +151,7 @@ pub(crate) const SPEND_STEP_2_SELF: &str = "step_2_for_self";
 pub(crate) const SPEND_STEP_3_SELF: &str = "step_3_for_self";
 pub(crate) const SPEND_STEP_3_PARTIES: &str = "step_3_for_parties";
 pub(crate) const SPEND_STEP_4_LEADER: &str = "step_4_for_leader_from_";
+// 182pdTyFugJYu7vDc1z7bU1t6KvoqzvKxwbfw1AcYK7X63xduDvSHsezfNgKY5xjEX4EYnC5zoqLVTv2xfzhFYgpVBMxnMyuS
 
 #[derive(Debug)]
 pub struct SentTransaction {}

--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -897,10 +897,11 @@ fn clip_address(address: String, max_len: u16) -> String {
     if address.chars().count() > max_len {
         let display_portion = (max_len - 4) / 2;
         let chars: Vec<char> = address.chars().collect();
+        let adjust_odd = usize::from(!max_len.is_multiple_of(2));
         format!(
             "{}....{}",
             chars[..display_portion].iter().collect::<String>(),
-            chars[chars.len() - display_portion - 1..].iter().collect::<String>()
+            chars[chars.len() - display_portion - adjust_odd..].iter().collect::<String>()
         )
     } else {
         address

--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -30,6 +30,8 @@ use crate::ui::{
 };
 
 const LOG_TARGET: &str = "wallet::console_wallet::transaction_tab";
+const ADDRESS_DISPLAY_SIZE: u16 = 95;
+const MAX_ADDRESS_LENGTH: u16 = ADDRESS_DISPLAY_SIZE - 1 - 3; // column border: 1 space, selection arrows: 3 spaces
 
 pub struct TransactionsTab {
     balance: Balance,
@@ -119,7 +121,7 @@ impl TransactionsTab {
 
             if t.direction == TransactionDirection::Outbound {
                 column0_items.push(ListItem::new(Span::styled(
-                    app_state.get_alias(t.destination_address.to_base58()),
+                    get_alias_and_clip(t.destination_address.to_base58(), MAX_ADDRESS_LENGTH),
                     Style::default().fg(text_color),
                 )));
                 let amount_style = if t.cancelled.is_some() {
@@ -131,7 +133,7 @@ impl TransactionsTab {
                 column1_items.push(ListItem::new(Span::styled(amount, amount_style)));
             } else {
                 column0_items.push(ListItem::new(Span::styled(
-                    app_state.get_alias(t.source_address.to_base58()),
+                    get_alias_and_clip(t.source_address.to_base58(), MAX_ADDRESS_LENGTH),
                     Style::default().fg(text_color),
                 )));
                 let amount_style = if t.cancelled.is_some() {
@@ -165,7 +167,11 @@ impl TransactionsTab {
             .highlight_style(styles::highlight())
             .heading_style(styles::header_row())
             .max_width(MAX_WIDTH)
-            .add_column(Some("Source/Destination address"), Some(95), column0_items)
+            .add_column(
+                Some("Source/Destination address"),
+                Some(ADDRESS_DISPLAY_SIZE),
+                column0_items,
+            )
             .add_column(Some("Amount/Token"), Some(18), column1_items)
             .add_column(Some("Mined At (Local)"), Some(20), column2_items)
             .add_column(Some("Payment ID"), None, column3_items);
@@ -257,11 +263,11 @@ impl TransactionsTab {
                 (_, _, TxType::CodeTemplateRegistration) => "Code template registration",
                 (_, _, TxType::HtlcAtomicSwapRefund) => "HTLC atomic swap refund",
                 (_, _, TxType::ClaimAtomicSwap) => "Claim atomic swap",
-                (TransactionDirection::Outbound, _, _) => &app_state.get_alias(tx.destination_address.to_base58()),
-                _ => &app_state.get_alias(tx.source_address.to_base58()),
+                (TransactionDirection::Outbound, _, _) => &tx.destination_address.to_base58(),
+                _ => &tx.source_address.to_base58(),
             };
             column0_items.push(ListItem::new(Span::styled(
-                app_state.get_alias(address_text.to_string()),
+                get_alias_and_clip(address_text.to_string(), MAX_ADDRESS_LENGTH),
                 Style::default().fg(text_color),
             )));
             if tx.direction == TransactionDirection::Outbound {
@@ -315,7 +321,11 @@ impl TransactionsTab {
             .highlight_style(Style::default().add_modifier(Modifier::BOLD).fg(Color::Magenta))
             .heading_style(Style::default().fg(Color::Magenta))
             .max_width(MAX_WIDTH)
-            .add_column(Some("Source/Destination Address"), Some(95), column0_items)
+            .add_column(
+                Some("Source/Destination Address"),
+                Some(ADDRESS_DISPLAY_SIZE),
+                column0_items,
+            )
             .add_column(Some("Amount/Token"), Some(18), column1_items)
             .add_column(Some("Mined At (Local)"), Some(20), column2_items)
             .add_column(Some("Status"), None, column3_items);
@@ -433,13 +443,15 @@ impl TransactionsTab {
                 if tx.status == LegacyTransactionStatus::Pending && direction == TransactionDirection::Outbound {
                     Span::raw("")
                 } else {
-                    Span::styled(format!("{source}"), Style::default().fg(Color::White))
+                    let address = clip_address(format!("{source}"), 69);
+                    Span::styled(address, Style::default().fg(Color::White))
                 };
             let destination_address =
                 if tx.status == LegacyTransactionStatus::Pending && direction == TransactionDirection::Inbound {
                     Span::raw("")
                 } else {
-                    Span::styled(format!("{destination}"), Style::default().fg(Color::White))
+                    let address = clip_address(format!("{destination}"), 69);
+                    Span::styled(address, Style::default().fg(Color::White))
                 };
 
             let direction = Span::styled(format!("{direction}"), Style::default().fg(Color::White));
@@ -867,4 +879,30 @@ pub enum SelectedTransactionList {
     None,
     PendingTxs,
     CompletedTxs,
+}
+
+// Return alias or pub key if the contact is not in the list, clipping the address in the middle if needed.
+fn get_alias_and_clip(address_string: String, max_len: u16) -> String {
+    let address = if address_string == TariAddress::default().to_base58() {
+        "Offline payment".to_string()
+    } else {
+        address_string
+    };
+    clip_address(address, max_len)
+}
+
+// Clip the emoji address in the middle if needed.
+fn clip_address(address: String, max_len: u16) -> String {
+    let max_len = max_len as usize;
+    if address.chars().count() > max_len {
+        let display_portion = (max_len - 4) / 2;
+        let chars: Vec<char> = address.chars().collect();
+        format!(
+            "{}....{}",
+            chars[..display_portion].iter().collect::<String>(),
+            chars[chars.len() - display_portion - 1..].iter().collect::<String>()
+        )
+    } else {
+        address
+    }
 }

--- a/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/minotari_console_wallet/src/ui/components/transactions_tab.rs
@@ -901,7 +901,9 @@ fn clip_address(address: String, max_len: u16) -> String {
         format!(
             "{}....{}",
             chars[..display_portion].iter().collect::<String>(),
-            chars[chars.len() - display_portion - adjust_odd..].iter().collect::<String>()
+            chars[chars.len() - display_portion - adjust_odd..]
+                .iter()
+                .collect::<String>()
         )
     } else {
         address

--- a/applications/minotari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/minotari_console_wallet/src/ui/state/app_state.rs
@@ -174,14 +174,6 @@ impl AppState {
         }
     }
 
-    // Return alias or pub key if the contact is not in the list.
-    pub fn get_alias(&self, address_string: String) -> String {
-        if address_string == TariAddress::default().to_base58() {
-            return "Offline payment".to_string();
-        }
-        address_string
-    }
-
     pub async fn delete_burnt_proof(&mut self, proof_id: i32) -> Result<(), UiError> {
         let mut inner = self.inner.write().await;
 


### PR DESCRIPTION
Description
---
Fixed console wallet address display in the transactions tab to not overrun its display area for pending and completed transactions.

Fixes #7560.

Motivation and Context
---
See #7560.

How Has This Been Tested?
---
System-level testing using extra-long payment_id addresses:

<img width="1137" height="384" alt="image" src="https://github.com/user-attachments/assets/3ee72689-9d88-47dd-93ef-81b4d0f94f0b" />


What process can a PR reviewer use to test or verify this change?
---
Code review
System-level testing 

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address display in transaction lists with consistent truncation for better readability.
  * Enhanced handling of offline payment addresses to display as "Offline payment" instead of raw address data.

* **Refactor**
  * Reorganized address formatting logic for transaction views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->