### PR TITLE
fix: http server request size

### DIFF
--- a/applications/minotari_node/src/http/server.rs
+++ b/applications/minotari_node/src/http/server.rs
@@ -105,7 +105,9 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
                 "/generate_kernel_merkle_proof",
                 get(handler::generate_kernel_merkle_proof::handle::<B>),
             )
-            .layer(RequestBodyLimitLayer::new(4 * 1024 * 1024))
+            // A large transaction with 2_316 inputs, 154 outputs and byte size 2_109_809 translated to 4_853_330 JSON
+            // object bytes, ~ 2.3 times larger. So we set the limit here to 2.5 times 4 MB.
+            .layer(RequestBodyLimitLayer::new(25 * 4 * 1024 * 1024 / 10))
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))
             .layer(Extension(self.query_service.clone()))
             .layer(Extension(self.mempool_handle.clone()))

--- a/clients/rust/base_node_wallet_client/src/client/http.rs
+++ b/clients/rust/base_node_wallet_client/src/client/http.rs
@@ -45,10 +45,15 @@ pub struct Client {
 
 impl Client {
     pub fn new(local_api_address: Url, default_seed_address: Url) -> Self {
+        let http_client_builder = reqwest::Client::builder();
+        let http_client = http_client_builder
+            .http2_initial_stream_window_size(4 * 1024 * 1024)
+            .build()
+            .expect("http2 init");
         Self {
             local_api_address,
             default_seed_address,
-            http_client: reqwest::Client::new(),
+            http_client,
             last_latency: RwLock::new(None),
             use_local_api_address: RwLock::new(None),
         }
@@ -455,6 +460,14 @@ impl BaseNodeWalletClient for Client {
                 "transaction": transaction,
             }
         });
+
+        let body_bytes = serde_json::to_vec(&request_body)?;
+        let len = body_bytes.len();
+        debug!(
+            target: LOG_TARGET,
+            "submit_transaction JSON body size: {}, bytes: ~{:.2} MiB, inputs: {}, outputs: {}",
+            len, len as f64 / (1024.0 * 1024.0), transaction.body.inputs().len(), transaction.body.outputs().len()
+        );
 
         let res = self.http_client.post(target_url).json(&request_body).send().await?;
         if res.status().is_client_error() || res.status().is_server_error() {


### PR DESCRIPTION
Description
---
Fixed http server request size. When byte size request is converted to JSON, it expands ~2.3 times. This PR increase the http server size by 2.5 times 4MiB.

This is not strictly a breaking change as the server will not reject previously accepted transactions; it will now accept previously rejected trnsactions.

Motivation and Context
---
Transactions of 2MiB size could not be submitted to the base node, as they were rejected with 
```
[wallet::transaction_service::protocols] DEBUG Transaction '12820213401082185863' size ok, can be broadcast (got: 2109809, limit: 4184064).
```
```
 [tari::wallet::client::http] [Thread:4504] WARN  Received error response from Base Node wallet service: 413 Payload Too Large. length limit exceeded
 ```

How Has This Been Tested?
---
System-level testing.

This transaction was previously in the Completed state forever, now mined.

<img width="1136" height="209" alt="image" src="https://github.com/user-attachments/assets/65705020-6536-4dc9-869d-d4ee627b2533" />


What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
