### PR TITLE
feat: add option to manually try import of blockchain outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ dependencies = [
 name = "minotari_console_wallet"
 version = "5.2.0-pre.6"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap 3.2.25",
  "config",
@@ -4267,6 +4268,7 @@ dependencies = [
  "minotari_app_utilities",
  "minotari_ledger_wallet_common",
  "minotari_ledger_wallet_comms",
+ "minotari_node_wallet_client",
  "minotari_wallet",
  "qrcode",
  "rand 0.8.5",

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -1916,6 +1916,7 @@ service Wallet {
   rpc SubmitValidatorNodeExit(SubmitValidatorNodeExitRequest) returns (SubmitValidatorNodeExitResponse);
   rpc GetBurnClaimProof(GetBurnClaimProofRequest) returns (GetBurnClaimProofResponse);
   rpc RescanWallet(RescanWalletRequest) returns (RescanWalletResponse);
+  rpc ScanAndImportUtxos(ScanAndImportUtxosRequest) returns (ScanAndImportUtxosResponse);
 }
 
 
@@ -2650,4 +2651,18 @@ message RescanWalletRequest {
 }
 
 message RescanWalletResponse {
+}
+
+message ScanAndImportUtxosRequest{
+  repeated bytes output_hashes = 1;
+}
+message ScanAndImportUtxosResponse{
+  repeated ScanFeedback feedback = 1;
+}
+
+message ScanFeedback{
+  bytes output_hash = 1;
+  bool is_found = 2;
+  uint64 tx_id = 3;
+  repeated string debug_info = 4;
 }

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -2654,14 +2654,14 @@ message RescanWalletResponse {
 }
 
 message ScanAndImportUtxosRequest{
-  repeated bytes output_hashes = 1;
+  repeated string output_hashes = 1;
 }
 message ScanAndImportUtxosResponse{
   repeated ScanFeedback feedback = 1;
 }
 
 message ScanFeedback{
-  bytes output_hash = 1;
+  string output_hash = 1;
   bool is_found = 2;
   uint64 tx_id = 3;
   repeated string debug_info = 4;

--- a/applications/minotari_console_wallet/Cargo.toml
+++ b/applications/minotari_console_wallet/Cargo.toml
@@ -25,6 +25,7 @@ tari_shutdown = { workspace = true }
 tari_transaction_key_manager = { workspace = true }
 tari_utilities = { workspace = true }
 minotari_wallet = { workspace = true, features = ["bundled_sqlite"] }
+minotari_node_wallet_client = { workspace = true }
 tari_hashing = { workspace = true }
 
 # Uncomment for tokio tracing via tokio-console (needs "tracing" featurs)
@@ -32,7 +33,7 @@ console-subscriber = "0.4"
 #tokio = { workspace = true, features = ["signal", "tracing"] }
 # Uncomment for normal use (non tokio-console tracing)
 tokio = { workspace = true, features = ["signal"] }
-
+anyhow = { workspace = true }
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3.2", features = ["derive", "env"] }
 config = "0.14.0"

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -3080,10 +3080,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 &output.sender_offset_public_key,
             ) {
                 Ok(Some((commitment_mask, value, memo))) => {
-                    debug_info.push(format!(
-                        "Successfully recovered keys for UTXO with hash {}",
-                        hex
-                    ));
+                    debug_info.push(format!("Successfully recovered keys for UTXO with hash {}", hex));
                     (commitment_mask, value, memo)
                 },
                 Ok(None) => {
@@ -3100,11 +3097,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     continue;
                 },
                 Err(e) => {
-                    debug_info.push(format!(
-                        "Error recovering keys for UTXO with hash {}: {}",
-                        hex,
-                        e
-                    ));
+                    debug_info.push(format!("Error recovering keys for UTXO with hash {}: {}", hex, e));
                     results.push(ScanFeedback {
                         output_hash: hex,
                         is_found: false,
@@ -3130,11 +3123,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     wo
                 },
                 Err(e) => {
-                    debug_info.push(format!(
-                        "Error creating WalletOutput for UTXO with hash {}: {}",
-                        hex,
-                        e
-                    ));
+                    debug_info.push(format!("Error creating WalletOutput for UTXO with hash {}: {}", hex, e));
                     results.push(ScanFeedback {
                         output_hash: hex,
                         is_found: false,
@@ -3149,8 +3138,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Err(e) => {
                     debug_info.push(format!(
                         "Error converting WalletOutput to TransactionOutput for UTXO with hash {}: {}",
-                        hex,
-                        e
+                        hex, e
                     ));
                     results.push(ScanFeedback {
                         output_hash: hex,
@@ -3166,10 +3154,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 .await
                 .map_err(|e| Status::internal(format!("Failed to get output from Output Manager: {}", e)))?;
             if !db_result.is_empty() {
-                debug_info.push(format!(
-                    "UTXO with hash {} already exists in Output Manager",
-                    hex
-                ));
+                debug_info.push(format!("UTXO with hash {} already exists in Output Manager", hex));
                 let tx = db_result
                     .first()
                     .expect("Should not be empty, this is checked")

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -3025,14 +3025,26 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let mut results = Vec::new();
         let mut oms = self.wallet.output_manager_service.clone();
         let mut tms = self.wallet.transaction_service.clone();
-        for utxo in message.output_hashes {
+        for hex in message.output_hashes {
+            let utxo = match FixedHash::from_hex(&hex) {
+                Ok(h) => h,
+                Err(e) => {
+                    results.push(ScanFeedback {
+                        output_hash: hex,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info: vec![format!("Invalid output hash format: {}", e)],
+                    });
+                    continue;
+                },
+            };
             let mut debug_info = Vec::new();
             let output = match self
                 .wallet
                 .wallet_connectivity
                 .obtain_base_node_wallet_rpc_client()
                 .await
-                .fetch_utxo(utxo.clone())
+                .fetch_utxo(utxo.to_vec())
                 .await
                 .map_err(|e| OutputManagerError::BaseNodeClientError(e.to_string()))
             {
@@ -3043,7 +3055,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Ok(None) => {
                     debug_info.push(format!("UTXO with hash {} not found on base node", utxo.to_hex()));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: false,
                         tx_id: 0,
                         debug_info,
@@ -3053,7 +3065,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Err(e) => {
                     debug_info.push(format!("Error fetching UTXO with hash {}: {}", utxo.to_hex(), e));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: false,
                         tx_id: 0,
                         debug_info,
@@ -3061,7 +3073,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     continue;
                 },
             };
-            // we have the output, net lets try and recover this
+            // we have the output, now lets try and recover this
             let (commitment_mask, value, memo) = match self.wallet.key_manager_service.try_output_key_recovery(
                 &output.commitment,
                 &output.encrypted_data,
@@ -3070,17 +3082,17 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Ok(Some((commitment_mask, value, memo))) => {
                     debug_info.push(format!(
                         "Successfully recovered keys for UTXO with hash {}",
-                        utxo.to_hex()
+                        hex
                     ));
                     (commitment_mask, value, memo)
                 },
                 Ok(None) => {
                     debug_info.push(format!(
                         "Failed to recover keys for UTXO with hash {}, UTXO does not belong to this wallet",
-                        utxo.to_hex()
+                        hex
                     ));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: false,
                         tx_id: 0,
                         debug_info,
@@ -3090,11 +3102,11 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Err(e) => {
                     debug_info.push(format!(
                         "Error recovering keys for UTXO with hash {}: {}",
-                        utxo.to_hex(),
+                        hex,
                         e
                     ));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: false,
                         tx_id: 0,
                         debug_info,
@@ -3120,11 +3132,11 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Err(e) => {
                     debug_info.push(format!(
                         "Error creating WalletOutput for UTXO with hash {}: {}",
-                        utxo.to_hex(),
+                        hex,
                         e
                     ));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: false,
                         tx_id: 0,
                         debug_info,
@@ -3137,11 +3149,11 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 Err(e) => {
                     debug_info.push(format!(
                         "Error converting WalletOutput to TransactionOutput for UTXO with hash {}: {}",
-                        utxo.to_hex(),
+                        hex,
                         e
                     ));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: false,
                         tx_id: 0,
                         debug_info,
@@ -3150,14 +3162,13 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 },
             };
             let db_result = oms
-                .get_many_outputs(vec![FixedHash::try_from(utxo.clone())
-                    .map_err(|e| Status::internal(format!("Failed to convert hash: {}", e)))?])
+                .get_many_outputs(vec![utxo])
                 .await
                 .map_err(|e| Status::internal(format!("Failed to get output from Output Manager: {}", e)))?;
             if !db_result.is_empty() {
                 debug_info.push(format!(
                     "UTXO with hash {} already exists in Output Manager",
-                    utxo.to_hex()
+                    hex
                 ));
                 let tx = db_result
                     .first()
@@ -3166,7 +3177,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                     .received_in_tx_id
                     .unwrap_or_default();
                 results.push(ScanFeedback {
-                    output_hash: utxo,
+                    output_hash: hex,
                     is_found: true,
                     tx_id: tx.as_u64(),
                     debug_info,
@@ -3189,7 +3200,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         e
                     ));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: false,
                         tx_id: 0,
                         debug_info,
@@ -3233,7 +3244,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         id
                     ));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: true,
                         tx_id: id.as_u64(),
                         debug_info,
@@ -3246,12 +3257,17 @@ impl wallet_server::Wallet for WalletGrpcServer {
                         e
                     ));
                     results.push(ScanFeedback {
-                        output_hash: utxo,
+                        output_hash: hex,
                         is_found: false,
                         tx_id: 0,
                         debug_info,
                     });
                 },
+            }
+        }
+        for feedback in &results {
+            for info in &feedback.debug_info {
+                debug!(target: LOG_TARGET, "scan_and_import_utxos: {}", info);
             }
         }
         Ok(Response::new(ScanAndImportUtxosResponse { feedback: results }))

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -29,6 +29,7 @@ use std::{
     time::Duration,
 };
 
+use anyhow::anyhow;
 use futures::{
     channel::mpsc::{self, Sender},
     future,
@@ -106,6 +107,9 @@ use minotari_app_grpc::tari_rpc::{
     RescanWalletResponse,
     RevalidateRequest,
     RevalidateResponse,
+    ScanAndImportUtxosRequest,
+    ScanAndImportUtxosResponse,
+    ScanFeedback,
     SendShaAtomicSwapRequest,
     SendShaAtomicSwapResponse,
     SignMessageRequest,
@@ -128,6 +132,7 @@ use minotari_app_grpc::tari_rpc::{
     ValidateRequest,
     ValidateResponse,
 };
+use minotari_node_wallet_client::BaseNodeWalletClient;
 use minotari_wallet::{
     connectivity_service::{OnlineStatus, WalletConnectivityInterface, UNKNOWN_LATENCY_MS},
     error::WalletStorageError,
@@ -150,7 +155,7 @@ use rand::rngs::OsRng;
 use tari_common_types::{
     payment_reference::generate_payment_reference,
     tari_address::TariAddress,
-    transaction::{LegacyTransactionStatus, TxId},
+    transaction::{LegacyImportStatus, LegacyTransactionStatus, TxId},
     types::{
         BlockHash,
         CompressedCommitment,
@@ -166,15 +171,18 @@ use tari_hashing::WalletMessageSigningDomain;
 use tari_script::CompressedCheckSigSchnorrSignature;
 use tari_transaction_components::{
     consensus::{ConsensusConstants, ConsensusManager},
+    key_manager::TransactionKeyManagerInterface,
     offline_signing::models::SignedOneSidedTransactionResult,
     transaction_components::{
         memo_field::{MemoField, TxType},
         OutputFeatures,
+        TransactionOutput,
         UnblindedOutput,
+        WalletOutput,
     },
     MicroMinotari,
 };
-use tari_transaction_key_manager::legacy_key_manager::wallet_types::FeeType;
+use tari_transaction_key_manager::legacy_key_manager::{wallet_types::FeeType, LegacyTransactionKeyManagerInterface};
 use tari_utilities::{hex::Hex, message_format::MessageFormat, ByteArray};
 use tokio::{
     sync::{broadcast, Mutex},
@@ -2973,8 +2981,8 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 leaf_index: p.leaf_index,
             }),
             kernel: Some(proof.kernel.into()),
-            encrypted_data: output.encrypted_data().to_byte_vec(),
-            value: output.value().as_u64(),
+            encrypted_data: output.1.encrypted_data().to_byte_vec(),
+            value: output.1.value().as_u64(),
         }))
     }
 
@@ -3002,6 +3010,251 @@ impl wallet_server::Wallet for WalletGrpcServer {
         }
 
         Ok(Response::new(RescanWalletResponse {}))
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn scan_and_import_utxos(
+        &self,
+        request: Request<ScanAndImportUtxosRequest>,
+    ) -> Result<Response<ScanAndImportUtxosResponse>, Status> {
+        let message = request.into_inner();
+        debug!(
+            target: LOG_TARGET,
+            "scan_and_import_utxos: Incoming GRPC request to manually scan and import UTXOs",
+        );
+        let mut results = Vec::new();
+        let mut oms = self.wallet.output_manager_service.clone();
+        let mut tms = self.wallet.transaction_service.clone();
+        for utxo in message.output_hashes {
+            let mut debug_info = Vec::new();
+            let output = match self
+                .wallet
+                .wallet_connectivity
+                .obtain_base_node_wallet_rpc_client()
+                .await
+                .fetch_utxo(utxo.clone())
+                .await
+                .map_err(|e| OutputManagerError::BaseNodeClientError(e.to_string()))
+            {
+                Ok(Some(output)) => {
+                    debug_info.push(format!("Fetched UTXO with hash {} from base node", utxo.to_hex()));
+                    output
+                },
+                Ok(None) => {
+                    debug_info.push(format!("UTXO with hash {} not found on base node", utxo.to_hex()));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info,
+                    });
+                    continue;
+                },
+                Err(e) => {
+                    debug_info.push(format!("Error fetching UTXO with hash {}: {}", utxo.to_hex(), e));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info,
+                    });
+                    continue;
+                },
+            };
+            // we have the output, net lets try and recover this
+            let (commitment_mask, value, memo) = match self.wallet.key_manager_service.try_output_key_recovery(
+                &output.commitment,
+                &output.encrypted_data,
+                &output.sender_offset_public_key,
+            ) {
+                Ok(Some((commitment_mask, value, memo))) => {
+                    debug_info.push(format!(
+                        "Successfully recovered keys for UTXO with hash {}",
+                        utxo.to_hex()
+                    ));
+                    (commitment_mask, value, memo)
+                },
+                Ok(None) => {
+                    debug_info.push(format!(
+                        "Failed to recover keys for UTXO with hash {}, UTXO does not belong to this wallet",
+                        utxo.to_hex()
+                    ));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info,
+                    });
+                    continue;
+                },
+                Err(e) => {
+                    debug_info.push(format!(
+                        "Error recovering keys for UTXO with hash {}: {}",
+                        utxo.to_hex(),
+                        e
+                    ));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info,
+                    });
+                    continue;
+                },
+            };
+            // this is our output, lets try and recover the final pieces
+            let wallet_output = match WalletOutput::new_imported(
+                value,
+                commitment_mask,
+                memo,
+                output.clone(),
+                self.wallet.key_manager_service.key_manager(),
+            ) {
+                Ok(wo) => {
+                    debug_info.push(format!(
+                        "Successfully created WalletOutput for UTXO with hash {}",
+                        utxo.to_hex()
+                    ));
+                    wo
+                },
+                Err(e) => {
+                    debug_info.push(format!(
+                        "Error creating WalletOutput for UTXO with hash {}: {}",
+                        utxo.to_hex(),
+                        e
+                    ));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info,
+                    });
+                    continue;
+                },
+            };
+            let txo = match wallet_output.to_transaction_output() {
+                Ok(txo) => txo,
+                Err(e) => {
+                    debug_info.push(format!(
+                        "Error converting WalletOutput to TransactionOutput for UTXO with hash {}: {}",
+                        utxo.to_hex(),
+                        e
+                    ));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info,
+                    });
+                    continue;
+                },
+            };
+            let db_result = oms
+                .get_many_outputs(vec![FixedHash::try_from(utxo.clone())
+                    .map_err(|e| Status::internal(format!("Failed to convert hash: {}", e)))?])
+                .await
+                .map_err(|e| Status::internal(format!("Failed to get output from Output Manager: {}", e)))?;
+            if !db_result.is_empty() {
+                debug_info.push(format!(
+                    "UTXO with hash {} already exists in Output Manager",
+                    utxo.to_hex()
+                ));
+                let tx = db_result
+                    .first()
+                    .expect("Should not be empty, this is checked")
+                    .0
+                    .received_in_tx_id
+                    .unwrap_or_default();
+                results.push(ScanFeedback {
+                    output_hash: utxo,
+                    is_found: true,
+                    tx_id: tx.as_u64(),
+                    debug_info,
+                });
+                continue;
+            }
+            let status = match import_output_to_oms(&mut oms, txo).await {
+                Ok(status) => {
+                    debug_info.push(format!(
+                        "Successfully imported UTXO with hash {} into Output Manager with status {:?}",
+                        utxo.to_hex(),
+                        status
+                    ));
+                    status
+                },
+                Err(e) => {
+                    debug_info.push(format!(
+                        "Error importing UTXO with hash {} into Output Manager: {}",
+                        utxo.to_hex(),
+                        e
+                    ));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info,
+                    });
+                    continue;
+                },
+            };
+
+            // output is imported, lets import tx
+            let source_address = if wallet_output.is_coinbase() {
+                // It's a coinbase, so we know we mined it (we do mining with cold wallets).
+                self.wallet
+                    .get_wallet_one_sided_address()
+                    .map_err(|e| Status::internal(format!("Failed to get wallet address: {e}")))?
+            } else if let Some(address) = wallet_output.payment_id().get_sender_address() {
+                address
+            } else if wallet_output.payment_id().is_transaction_info() {
+                self.wallet
+                    .get_wallet_one_sided_address()
+                    .map_err(|e| Status::internal(format!("Failed to get wallet address: {e}")))?
+            } else {
+                TariAddress::default()
+            };
+            match tms
+                .import_utxo_with_status(
+                    wallet_output.value(),
+                    source_address,
+                    status,
+                    None,
+                    None,
+                    output,
+                    wallet_output.payment_id().clone(),
+                )
+                .await
+            {
+                Ok(id) => {
+                    debug_info.push(format!(
+                        "Successfully imported transaction for UTXO with hash {} into Transaction Service with tx_id \
+                         {}",
+                        utxo.to_hex(),
+                        id
+                    ));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: true,
+                        tx_id: id.as_u64(),
+                        debug_info,
+                    });
+                },
+                Err(e) => {
+                    debug_info.push(format!(
+                        "Error importing transaction for UTXO with hash {} into Transaction Service: {}",
+                        utxo.to_hex(),
+                        e
+                    ));
+                    results.push(ScanFeedback {
+                        output_hash: utxo,
+                        is_found: false,
+                        tx_id: 0,
+                        debug_info,
+                    });
+                },
+            }
+        }
+        Ok(Response::new(ScanAndImportUtxosResponse { feedback: results }))
     }
 }
 
@@ -3064,6 +3317,65 @@ fn simple_event(event: &str) -> TransactionEvent {
         raw_payment_id: vec![],
         user_payment_id: vec![],
     }
+}
+
+async fn import_output_to_oms<KM: LegacyTransactionKeyManagerInterface>(
+    oms: &mut OutputManagerHandle<KM>,
+    output: TransactionOutput,
+) -> Result<LegacyImportStatus, anyhow::Error> {
+    let mut found_outputs = Vec::new();
+
+    found_outputs.append(
+        &mut oms
+            .scan_outputs_for_one_sided_payments(vec![output.clone()])
+            .await?
+            .into_iter()
+            .map(|ro| -> Result<_, anyhow::Error> {
+                let status = if ro.output.is_coinbase() {
+                    LegacyImportStatus::CoinbaseUnconfirmed
+                } else {
+                    LegacyImportStatus::OneSidedUnconfirmed
+                };
+                Ok((ro.output, status, output.clone()))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+    );
+
+    found_outputs.append(
+        &mut oms
+            .scan_outputs_for_multisig(vec![output.clone()])
+            .await?
+            .into_iter()
+            .map(|ro| -> Result<_, anyhow::Error> {
+                let status = LegacyImportStatus::Imported;
+                Ok((ro.output, status, output.clone()))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+    );
+
+    found_outputs.append(
+        &mut oms
+            .scan_for_recoverable_outputs(vec![output.clone()])
+            .await?
+            .into_iter()
+            .map(|ro| -> Result<_, anyhow::Error> {
+                let status = if ro.output.is_coinbase() {
+                    LegacyImportStatus::CoinbaseUnconfirmed
+                } else {
+                    LegacyImportStatus::Imported
+                };
+                Ok((ro.output, status, output.clone()))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+    );
+    if found_outputs.is_empty() {
+        return Err(anyhow!("No outputs were found during import."));
+    }
+    if found_outputs.len() > 1 {
+        return Err(anyhow!("Too many outputs were found during import."));
+    }
+
+    Ok(found_outputs.first().expect("already checked for empty").1.clone())
 }
 
 #[allow(clippy::too_many_lines)]

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -328,7 +328,7 @@ pub enum OutputManagerResponse<KM> {
     TransactionCancelled,
     SpentOutputs(Vec<DbWalletOutput>),
     UnspentOutputs(Vec<DbWalletOutput>),
-    Outputs(Vec<WalletOutput>),
+    Outputs(Vec<(DbWalletOutput, WalletOutput)>),
     InvalidOutputs(Vec<WalletOutput>),
     BaseNodePublicKeySet,
     TxoValidationStarted(u64),
@@ -725,7 +725,10 @@ where KM: LegacyTransactionKeyManagerInterface
         }
     }
 
-    pub async fn get_many_outputs(&mut self, outputs: Vec<FixedHash>) -> Result<Vec<WalletOutput>, OutputManagerError> {
+    pub async fn get_many_outputs(
+        &mut self,
+        outputs: Vec<FixedHash>,
+    ) -> Result<Vec<(DbWalletOutput, WalletOutput)>, OutputManagerError> {
         match self
             .handle
             .call(OutputManagerRequest::GetManyOutputs { outputs })

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -434,7 +434,7 @@ where
                 let outputs = self
                     .fetch_many_outputs(&outputs)?
                     .into_iter()
-                    .map(|v| v.into())
+                    .map(|v| (v.clone(), v.into()))
                     .collect();
                 Ok(OutputManagerResponse::Outputs(outputs))
             },

--- a/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
@@ -72,16 +72,16 @@ where
     }
 
     for output in outputs {
-        if !output.features().output_type.is_burn() {
+        if !output.1.features().output_type.is_burn() {
             warn!(
                 target: LOG_TARGET,
                 "NEVER HAPPEN: Output with key id {} is not a burn output, skipping",
-                output.commitment_mask_key_id()
+                output.1.commitment_mask_key_id()
             );
             continue;
         }
 
-        let output_hash = output.output_hash();
+        let output_hash = output.1.output_hash();
         let Some(burn) = db.fetch_burn_proof(&output_hash)? else {
             // OK - UTXO not burnt with claim key, so no burn proof
             debug!(


### PR DESCRIPTION
Description
---
This will allow the user to try and import blockchain outputs manually and give feedback what happend 

example run:
GRPC request:
```
{
    "output_hashes": [
        "85a9cae3141b7aa27ad1a5a8e04a20bbc9dafd3c27148687cc4658dfefa83745",
        "9a844d5d2f5c8fedb60e03d4f2ef81bef76afe321b9e81eb36780c1e9527b97f",
        "3bbe1b425e6d2f715a8a3b5cee71fc65324d47dc2e3860abd1b6ac4ec970391a"
    ]
}
```
results:
```
{
    "feedback": [
        {
            "debug_info": [
                "Fetched UTXO with hash 85a9cae3141b7aa27ad1a5a8e04a20bbc9dafd3c27148687cc4658dfefa83745 from base node",
                "Failed to recover keys for UTXO with hash 85a9cae3141b7aa27ad1a5a8e04a20bbc9dafd3c27148687cc4658dfefa83745, UTXO does not belong to this wallet"
            ],
            "output_hash": "85a9cae3141b7aa27ad1a5a8e04a20bbc9dafd3c27148687cc4658dfefa83745",
            "is_found": false,
            "tx_id": "0"
        },
        {
            "debug_info": [
                "Fetched UTXO with hash 9a844d5d2f5c8fedb60e03d4f2ef81bef76afe321b9e81eb36780c1e9527b97f from base node",
                "Successfully recovered keys for UTXO with hash 9a844d5d2f5c8fedb60e03d4f2ef81bef76afe321b9e81eb36780c1e9527b97f",
                "Successfully created WalletOutput for UTXO with hash 9a844d5d2f5c8fedb60e03d4f2ef81bef76afe321b9e81eb36780c1e9527b97f",
                "UTXO with hash 9a844d5d2f5c8fedb60e03d4f2ef81bef76afe321b9e81eb36780c1e9527b97f already exists in Output Manager"
            ],
            "output_hash": "9a844d5d2f5c8fedb60e03d4f2ef81bef76afe321b9e81eb36780c1e9527b97f",
            "is_found": true,
            "tx_id": "1532309787288631793"
        },
        {
            "debug_info": [
                "Fetched UTXO with hash 3bbe1b425e6d2f715a8a3b5cee71fc65324d47dc2e3860abd1b6ac4ec970391a from base node",
                "Failed to recover keys for UTXO with hash 3bbe1b425e6d2f715a8a3b5cee71fc65324d47dc2e3860abd1b6ac4ec970391a, UTXO does not belong to this wallet"
            ],
            "output_hash": "3bbe1b425e6d2f715a8a3b5cee71fc65324d47dc2e3860abd1b6ac4ec970391a",
            "is_found": false,
            "tx_id": "0"
        }
    ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual UTXO scan-and-import endpoint added with per-output feedback and transaction import reporting.

* **Chores**
  * Public API expanded with new request/response/feedback types for scanning/import.
  * Output responses now include associated database metadata alongside each wallet output (returned as pairs), affecting the shape of output payloads.

* **Compatibility**
  * Adjusted public response shapes and handlers to reflect the new output pairing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

