### PR TITLE
fix: grpc methods user_pay_for_fee and replace_by_fee

### DIFF
--- a/base_layer/common_types/src/transaction.rs
+++ b/base_layer/common_types/src/transaction.rs
@@ -66,6 +66,10 @@ impl LegacyTransactionStatus {
         )
     }
 
+    pub fn is_broadcast(&self) -> bool {
+        matches!(self, LegacyTransactionStatus::Broadcast)
+    }
+
     pub fn is_confirmed(&self) -> bool {
         matches!(
             self,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -3986,15 +3986,11 @@ where
             return Err(TransactionServiceError::ZeroFeeIncrease);
         }
 
-        let original_transaction = self.resources.db.get_transaction_to_be_broadcast(tx_id).map_err(|_| {
-            TransactionServiceError::TransactionStorageError(TransactionStorageError::ValueNotFound(
-                DbKey::CompletedTransaction(tx_id),
-            ))
-        })?;
-
-        if original_transaction.status.is_mined() {
-            return Err(TransactionServiceError::TransactionAlreadyMined(tx_id.to_string()));
-        }
+        let original_transaction = self
+            .resources
+            .db
+            .get_broadcasted_not_cancelled_transaction(tx_id)
+            .inspect_err(|e| warn!(target: LOG_TARGET, "replace_by_fee error: {}", e))?;
 
         let destination = original_transaction.destination_address.clone();
         let original_amount = original_transaction.amount;
@@ -4049,11 +4045,6 @@ where
     ///
     /// # Returns
     /// Returns the new transaction ID of the fee payment transaction, or an error if the operation fails.
-    ///
-    /// # Errors
-    /// * `TransactionStorageError` - If the original transaction cannot be found
-    /// * `TransactionAlreadyMined` - If the original transaction has already been mined
-    /// * `KeyManagerServiceError` - If there are issues accessing cryptographic keys
     #[allow(clippy::too_many_lines)]
     async fn user_pay_for_fee(
         &mut self,
@@ -4064,14 +4055,11 @@ where
             JoinHandle<Result<TxId, TransactionServiceProtocolError<TxId>>>,
         >,
     ) -> Result<TxId, TransactionServiceError> {
-        let original_transaction = self.resources.db.get_transaction_to_be_broadcast(tx_id).map_err(|_| {
-            TransactionServiceError::TransactionStorageError(TransactionStorageError::ValueNotFound(
-                DbKey::CompletedTransaction(tx_id),
-            ))
-        })?;
-        if original_transaction.status.is_mined() {
-            return Err(TransactionServiceError::TransactionAlreadyMined(tx_id.to_string()));
-        }
+        let original_transaction = self
+            .resources
+            .db
+            .get_broadcasted_not_cancelled_transaction(tx_id)
+            .inspect_err(|e| warn!(target: LOG_TARGET, "user_pay_for_fee error: {}", e))?;
 
         let all_outputs = original_transaction
             .transaction

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -71,7 +71,14 @@ pub trait TransactionBackend: Send + Sync + Clone {
     /// Light weight method to retrieve pertinent unconfirmed transactions info from completed transactions
     fn fetch_unconfirmed_transactions_info(&self) -> Result<Vec<UnconfirmedTransactionInfo>, TransactionStorageError>;
 
+    /// This method returns all completed transactions that must be broadcast
     fn get_transactions_to_be_broadcast(&self) -> Result<Vec<CompletedTransaction>, TransactionStorageError>;
+
+    /// Get the broadcasted not-cancelled transaction with the given TxId
+    fn get_broadcasted_not_cancelled_transaction(
+        &self,
+        tx_id: TxId,
+    ) -> Result<CompletedTransaction, TransactionStorageError>;
 
     /// Check for presence of any form of cancelled transaction with this TxId
     fn fetch_any_cancelled_transaction(
@@ -559,24 +566,12 @@ where T: TransactionBackend + 'static
         self.db.get_transactions_to_be_broadcast()
     }
 
-    pub fn get_transaction_to_be_broadcast(
+    /// This method returns all completed transactions that must be broadcast
+    pub(crate) fn get_broadcasted_not_cancelled_transaction(
         &self,
         tx_id: TxId,
     ) -> Result<CompletedTransaction, TransactionStorageError> {
-        let key = DbKey::CompletedTransaction(tx_id);
-        let t = match self.db.fetch(&DbKey::CompletedTransaction(tx_id)) {
-            Ok(None) => Err(TransactionStorageError::ValueNotFound(key)),
-            Ok(Some(DbValue::CompletedTransaction(pt))) => {
-                if pt.status == LegacyTransactionStatus::Completed && pt.status == LegacyTransactionStatus::Broadcast {
-                    Ok(pt)
-                } else {
-                    Err(TransactionStorageError::ValueNotFound(key))
-                }
-            },
-            Ok(Some(other)) => unexpected_result(key, other),
-            Err(e) => log_error(key, e),
-        }?;
-        Ok(*t)
+        self.db.get_broadcasted_not_cancelled_transaction(tx_id)
     }
 
     pub fn get_completed_transaction_cancelled_or_not(

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -566,7 +566,7 @@ where T: TransactionBackend + 'static
         self.db.get_transactions_to_be_broadcast()
     }
 
-    /// This method returns all completed transactions that must be broadcast
+    /// This method returns the broadcasted not-cancelled transaction with the given TxId
     pub(crate) fn get_broadcasted_not_cancelled_transaction(
         &self,
         tx_id: TxId,

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -964,6 +964,55 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         Ok(result)
     }
 
+    fn get_broadcasted_not_cancelled_transaction(
+        &self,
+        tx_id: TxId,
+    ) -> Result<CompletedTransaction, TransactionStorageError> {
+        let start = Instant::now();
+        let mut conn = self.database_connection.get_pooled_connection()?;
+        let acquire_lock = start.elapsed();
+
+        let txs = completed_transactions::table
+            .filter(completed_transactions::tx_id.eq(tx_id.as_u64() as i64))
+            .load::<CompletedTransactionSql>(&mut conn)?;
+
+        let tx = txs.first().ok_or(TransactionStorageError::UnexpectedResult(format!(
+            "TxId:{} not found",
+            tx_id
+        )))?;
+        let tx = CompletedTransaction::try_from(tx.clone(), &self.cipher).map_err(|e| {
+            TransactionStorageError::UnexpectedResult(format!(
+                "Transaction TxId:{} could not be converted: {}",
+                tx_id, e
+            ))
+        })?;
+
+        if !tx.status.is_broadcast() {
+            return Err(TransactionStorageError::UnexpectedResult(format!(
+                "Transaction TxId:{} is not in broadcasted state, current status: {:?}",
+                tx_id, tx.status
+            )));
+        }
+        if let Some(cancelled) = tx.cancelled {
+            return Err(TransactionStorageError::UnexpectedResult(format!(
+                "Transaction TxId:{} is cancelled with reason: {:?}",
+                tx_id, cancelled
+            )));
+        }
+
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - get_broadcasted_transaction: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
+
+        Ok(tx)
+    }
+
     // Exclude coinbases as they are validated from the OMS service, and we use these fields to know which tx to
     // extract, thus we should not wipe it out. Coinbases can also not be mined in a different height so the data will
     // never be wrong.


### PR DESCRIPTION

Description
---
Fixed gRPC methods UserPayForFee and ReplaceByFee as the existing methods could not successfully fetch the broadcasted transaction by its tx_id.

Fixes #7602 and #7610.

Motivation and Context
---
See #7602 and #7610.

How Has This Been Tested?
---
System-level testing.

### 1. ReplaceByFee 

<img width="722" height="223" alt="image" src="https://github.com/user-attachments/assets/285838b0-16ee-4241-abda-56c95334613d" />

<img width="959" height="401" alt="image" src="https://github.com/user-attachments/assets/e8c70d07-7ca2-4d45-8e9c-ee8562559aad" />

<img width="910" height="395" alt="image" src="https://github.com/user-attachments/assets/7a6a90d2-6db6-49a4-bb71-bd2f48ac9e8c" />

### 2. UserPayForFee 

<img width="905" height="609" alt="image" src="https://github.com/user-attachments/assets/7b7224ce-e301-4dc0-934e-526d4ae82628" />

<img width="1067" height="398" alt="image" src="https://github.com/user-attachments/assets/782bd8ea-4df8-45ab-838d-bb635c21d801" />

What process can a PR reviewer use to test or verify this change?
---
Code review.
System-level testing.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable handling for fee replacement and fee payment flows, reducing attempts on non-broadcasted, mined, or cancelled transactions and improving transaction state checks.
  * Added runtime diagnostics to surface retrieval issues for broadcasted transactions.

* **Documentation**
  * Cleared and streamlined doc comments for fee-related operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->