### PR TITLE
feat: add outputs to offline signing response

### DIFF
--- a/base_layer/transaction_components/src/offline_signing/mod.rs
+++ b/base_layer/transaction_components/src/offline_signing/mod.rs
@@ -200,6 +200,7 @@ mod test {
         assert_eq!(signed.signed_transaction.transaction.body.inputs().len(), 3);
         assert_eq!(signed.signed_transaction.transaction.body.outputs().len(), 2);
         assert_eq!(signed.signed_transaction.sent_hashes.len(), 1);
+        assert_eq!(signed.signed_transaction.outputs.len(), 1);
         let tx = signed.signed_transaction.transaction.clone();
 
         let factories = CryptoFactories::default();
@@ -335,6 +336,7 @@ mod test {
         assert_eq!(signed.signed_transaction.transaction.body.inputs().len(), 3);
         assert_eq!(signed.signed_transaction.transaction.body.outputs().len(), 3);
         assert_eq!(signed.signed_transaction.sent_hashes.len(), 2);
+        assert_eq!(signed.signed_transaction.outputs.len(), 2);
         let tx = signed.signed_transaction.transaction.clone();
 
         let factories = CryptoFactories::default();
@@ -432,6 +434,7 @@ mod test {
         assert_eq!(signed.signed_transaction.transaction.body.inputs().len(), 1);
         assert_eq!(signed.signed_transaction.transaction.body.outputs().len(), 101);
         assert_eq!(signed.signed_transaction.sent_hashes.len(), 100);
+        assert_eq!(signed.signed_transaction.outputs.len(), 100);
         let tx = signed.signed_transaction.transaction.clone();
 
         let factories = CryptoFactories::default();
@@ -553,6 +556,7 @@ mod test {
         assert_eq!(signed.signed_transaction.transaction.body.inputs().len(), 3);
         assert_eq!(signed.signed_transaction.transaction.body.outputs().len(), 2);
         assert_eq!(signed.signed_transaction.sent_hashes.len(), 1);
+        assert_eq!(signed.signed_transaction.outputs.len(), 1);
         let tx = signed.signed_transaction.transaction.clone();
         let factories = CryptoFactories::default();
         let validator = TransactionInternalConsistencyValidator::new(false, rules, factories);
@@ -752,6 +756,7 @@ mod test {
         assert_eq!(signed.signed_transaction.transaction.body.inputs().len(), 1);
         assert_eq!(signed.signed_transaction.transaction.body.outputs().len(), 1);
         assert_eq!(signed.signed_transaction.sent_hashes.len(), 1);
+        assert_eq!(signed.signed_transaction.outputs.len(), 1);
         let tx = signed.signed_transaction.transaction.clone();
         let factories = CryptoFactories::default();
         let validator = TransactionInternalConsistencyValidator::new(false, rules, factories);

--- a/base_layer/transaction_components/src/offline_signing/models.rs
+++ b/base_layer/transaction_components/src/offline_signing/models.rs
@@ -32,7 +32,7 @@ use crate::{
     MicroMinotari,
 };
 
-const SUPPORTED_VERSION: &str = "3.0.0";
+const SUPPORTED_VERSION: &str = "4.0.0";
 
 pub fn get_supported_versions() -> Vec<Version> {
     vec![Version::parse(SUPPORTED_VERSION).unwrap()]
@@ -196,6 +196,7 @@ impl HasVersion for PrepareWithdrawMultisigTransactionResult {
 pub struct SignedTransaction {
     pub transaction: Transaction,
     pub sent_hashes: Vec<FixedHash>,
+    pub outputs: Vec<WalletOutput>,
     pub change_hashes: Vec<FixedHash>,
     pub change_output: Option<WalletOutput>,
     pub tx_id: TxId,

--- a/base_layer/transaction_components/src/offline_signing/one_sided_signer.rs
+++ b/base_layer/transaction_components/src/offline_signing/one_sided_signer.rs
@@ -95,12 +95,15 @@ pub fn build_and_sign_transaction<KM: TransactionKeyManagerInterface>(
         change_output_hashes,
         change,
         tx_id,
+        sent_outputs,
         ..
     } = finalized_tx;
+    let outputs = sent_outputs.iter().map(|o| o.output.clone()).collect();
 
     Ok(SignedTransaction {
         transaction,
         sent_hashes: sent_output_hashes,
+        outputs,
         change_hashes: change_output_hashes,
         change_output: change,
         tx_id,
@@ -150,12 +153,15 @@ pub fn sign_multisig_transaction<KM: TransactionKeyManagerInterface>(
         change_output_hashes,
         change,
         tx_id,
+        sent_outputs,
         ..
     } = finalized_tx;
+    let outputs = sent_outputs.iter().map(|o| o.output.clone()).collect();
 
     Ok(SignedTransaction {
         transaction,
         sent_hashes: sent_output_hashes,
+        outputs,
         change_hashes: change_output_hashes,
         change_output: change,
         tx_id,
@@ -260,11 +266,15 @@ pub fn sign_multisig_withdraw_transaction<KM: TransactionKeyManagerInterface>(
         change_output_hashes,
         change,
         tx_id,
+        sent_outputs,
         ..
     } = finalized_tx;
+    let outputs = sent_outputs.iter().map(|o| o.output.clone()).collect();
+
     Ok(SignedTransaction {
         transaction,
         sent_hashes: sent_output_hashes,
+        outputs,
         change_hashes: change_output_hashes,
         change_output: change,
         tx_id,


### PR DESCRIPTION
Description
---

Adds `WalletOutput`s to the offline signing result.

Motivation and Context
---

The Payment Processor (specifically for [coinjoin](https://github.com/tari-project/minotari_payment_processor/issues/2) ) requires the `WalletOutput` of the signed transaction to support 0-conf transaction creation.

How Has This Been Tested?
---

Updated unit tests to verify the correct number of outputs are returned.


<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline signing module version updated to 4.0.0
  * SignedTransaction now captures and includes transaction outputs
  * Signing workflows enhanced to preserve output data

* **Tests**
  * Added comprehensive validation checks for transaction outputs across signing scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->