### PR TITLE
fix: wallet  listen address

### DIFF
--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -21,7 +21,6 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{cmp, str::FromStr, sync::Arc};
-
 use log::*;
 use minotari_app_utilities::{consts, identity_management, identity_management::load_from_json};
 use tari_common::{
@@ -309,6 +308,7 @@ where B: BlockchainBackend + 'static
         // wallet http server
         let wallet_http_server = create_base_node_wallet_http_server(
             wallet_query_service_config.port,
+            wallet_query_service_config.local_ip.clone().unwrap_or("127.0.0.1".parse().expect("should not fail")),
             db.clone(),
             handles.expect_handle::<StateMachineHandle>(),
             handles.expect_handle::<MempoolHandle>(),

--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -311,7 +311,7 @@ where B: BlockchainBackend + 'static
             wallet_query_service_config.port,
             wallet_query_service_config
                 .local_ip
-                .unwrap_or("127.0.0.1".parse().expect("should not fail")),
+                .unwrap_or("0.0.0.0".parse().expect("should not fail")),
             db.clone(),
             handles.expect_handle::<StateMachineHandle>(),
             handles.expect_handle::<MempoolHandle>(),

--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{cmp, str::FromStr, sync::Arc};
+
 use log::*;
 use minotari_app_utilities::{consts, identity_management, identity_management::load_from_json};
 use tari_common::{
@@ -308,7 +309,9 @@ where B: BlockchainBackend + 'static
         // wallet http server
         let wallet_http_server = create_base_node_wallet_http_server(
             wallet_query_service_config.port,
-            wallet_query_service_config.local_ip.clone().unwrap_or("127.0.0.1".parse().expect("should not fail")),
+            wallet_query_service_config
+                .local_ip
+                .unwrap_or("127.0.0.1".parse().expect("should not fail")),
             db.clone(),
             handles.expect_handle::<StateMachineHandle>(),
             handles.expect_handle::<MempoolHandle>(),

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -21,10 +21,11 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{
+    net::IpAddr,
     path::{Path, PathBuf},
     time::Duration,
 };
-use std::net::IpAddr;
+
 use config::Config;
 use serde::{Deserialize, Serialize};
 use tari_common::{

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -24,7 +24,7 @@ use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
-
+use std::net::IpAddr;
 use config::Config;
 use serde::{Deserialize, Serialize};
 use tari_common::{
@@ -168,6 +168,8 @@ pub struct BaseNodeConfig {
 pub struct WalletHttpServiceConfig {
     /// Port that the local wallet query service will listen on.
     pub port: u16,
+    #[serde(default)]
+    pub local_ip: Option<IpAddr>,
     /// The external address of the wallet query service.
     /// This must be accessible (if set) from the internet to let other peers connect to that.
     /// Also this address will be sent to peers when requesting for the query service URL (via RPC call).
@@ -182,6 +184,7 @@ impl Default for WalletHttpServiceConfig {
         let port = wallet_http_service_default_port(Network::get_current());
         Self {
             port,
+            local_ip: None,
             external_address: Some(
                 Url::parse(format!("http://127.0.0.1:{port}").as_str()).expect("This should be a valid URL"),
             ),

--- a/applications/minotari_node/src/http/mod.rs
+++ b/applications/minotari_node/src/http/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::net::IpAddr;
 use tari_core::{
     base_node::{
         rpc::{query_service, BaseNodeWalletQueryService},
@@ -19,6 +20,7 @@ pub use cache_config::HttpCacheConfig;
 
 pub fn create_base_node_wallet_http_server<B: BlockchainBackend + 'static>(
     port: u16,
+    local_ip: IpAddr,
     db: AsyncBlockchainDb<B>,
     state_machine: StateMachineHandle,
     mempool: MempoolHandle,
@@ -27,6 +29,7 @@ pub fn create_base_node_wallet_http_server<B: BlockchainBackend + 'static>(
 ) -> server::Server<impl BaseNodeWalletQueryService> {
     server::Server::new(
         port,
+        local_ip,
         query_service::Service::new(db, state_machine, mempool.clone()),
         mempool,
         shutdown_signal,

--- a/applications/minotari_node/src/http/mod.rs
+++ b/applications/minotari_node/src/http/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use std::net::IpAddr;
+
 use tari_core::{
     base_node::{
         rpc::{query_service, BaseNodeWalletQueryService},

--- a/applications/minotari_node/src/http/server.rs
+++ b/applications/minotari_node/src/http/server.rs
@@ -1,8 +1,10 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 
 use axum::{
     extract::DefaultBodyLimit,

--- a/applications/minotari_node/src/http/server.rs
+++ b/applications/minotari_node/src/http/server.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use axum::{
@@ -50,6 +51,7 @@ pub struct ApiDoc;
 pub struct Server<S> {
     port: u16,
     query_service: Arc<S>,
+    local_ip: IpAddr,
     mempool_handle: MempoolHandle,
     shutdown_signal: ShutdownSignal,
     cache_cfg: HttpCacheConfig,
@@ -58,6 +60,7 @@ pub struct Server<S> {
 impl<S: BaseNodeWalletQueryService> Server<S> {
     pub fn new(
         port: u16,
+        local_ip: IpAddr,
         query_service: S,
         mempool: MempoolHandle,
         shutdown_signal: ShutdownSignal,
@@ -65,6 +68,7 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
     ) -> Self {
         Self {
             port,
+            local_ip,
             query_service: Arc::new(query_service),
             mempool_handle: mempool,
             shutdown_signal,
@@ -112,12 +116,14 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
             .layer(Extension(self.query_service.clone()))
             .layer(Extension(self.mempool_handle.clone()))
             .layer(Extension(Arc::new(self.cache_cfg.clone())));
+        let local_ip = self.local_ip;
+        let address = SocketAddr::new(local_ip, port);
 
-        let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
+        let listener = TcpListener::bind(address).await?;
 
         // spawn server
         tokio::spawn(async move {
-            info!(target: LOG_TARGET, "Wallet query HTTP server listening at 0.0.0.0:{port}");
+            info!(target: LOG_TARGET, "Wallet query HTTP server listening at {local_ip}:{port}");
             if let Err(error) = axum::serve(listener, router)
                 .with_graceful_shutdown(shutdown_signal)
                 .await

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -374,6 +374,7 @@ excluded_dial_addresses = []
 # This address must be accessible by the wallet (on a global scale over the internet).
 [base_node.http_wallet_query_service]
 #port = 9000
+#local_ip = "0.0.0.0"
 #external_address = "http://127.0.0.1:9000"
 
 # If not enabled (false), no Cache-Control header is set anywhere. [Default: true]

--- a/docs/src/09_adding_tari_to_your_exchange.md
+++ b/docs/src/09_adding_tari_to_your_exchange.md
@@ -348,6 +348,7 @@ This is the private base node:
 # This address must be accessible by the wallet (on a global scale over the internet).
 [base_node.http_wallet_query_service]
 #port = 9000
+#local_ip = "0.0.0.0"
 #external_address = "http://127.0.0.1:9000"
 ```
 


### PR DESCRIPTION
Description
---
ensure the wallet listens on the correct address

Fixes: #7455 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet HTTP server can be configured to bind to a specific local IP via config (optional); if unset it falls back to 0.0.0.0 (all interfaces).
  * Server startup logs now show the actual IP address the wallet HTTP server is bound to.

* **Documentation**
  * Configuration docs and presets updated to include the new local_ip setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->