### PR TITLE
feat: reduce scanning size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,7 +4199,7 @@ name = "minotari_app_grpc"
 version = "5.2.0-pre.6"
 dependencies = [
  "argon2 0.4.1",
- "base64 0.13.1",
+ "base64 0.22.1",
  "borsh",
  "log",
  "prost 0.13.4",
@@ -4381,7 +4381,7 @@ dependencies = [
 name = "minotari_miner"
 version = "5.2.0-pre.6"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "borsh",
  "bufstream",
  "chrono",
@@ -7601,7 +7601,7 @@ name = "tari_common_types"
 version = "5.2.0-pre.6"
 dependencies = [
  "argon2 0.4.1",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "blake2",
  "borsh",
@@ -8108,6 +8108,7 @@ version = "5.2.0-pre.6"
 dependencies = [
  "anyhow",
  "argon2 0.4.1",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "blake2",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ borsh = { version = "1.5.7" }
 tokio = { version = "1.47" }
 log = { version = "0.4" }
 log4rs = { version = "1.4", default-features = false}
-
+base64 = "0.22"
 [profile.release]
 # By default, Rust will wrap an integer in release mode instead of throwing the overflow error
 # seen in debug mode. Panicking at this time is better than silently using the wrong value.

--- a/applications/minotari_app_grpc/Cargo.toml
+++ b/applications/minotari_app_grpc/Cargo.toml
@@ -26,7 +26,7 @@ tari_utilities = { workspace = true }
 tari_transaction_components = { workspace = true }
 
 argon2 = { version = "0.4.1", features = ["std", "password-hash"] }
-base64 = "0.13.0"
+base64 = { workspace = true }
 borsh = { workspace = true }
 log = { workspace = true }
 prost = "0.13.3"

--- a/applications/minotari_app_grpc/src/authentication/basic_auth.rs
+++ b/applications/minotari_app_grpc/src/authentication/basic_auth.rs
@@ -100,7 +100,8 @@ impl BasicAuthCredentials {
         }
 
         // Decode the credentials using base64
-        let decoded = base64::decode(encoded_credentials)?;
+        use base64::{prelude::BASE64_STANDARD, Engine};
+        let decoded = BASE64_STANDARD.decode(encoded_credentials)?;
         let as_utf8 = Zeroizing::new(String::from_utf8(decoded)?);
 
         // Parse the username and password, which must be separated by a colon
@@ -166,9 +167,10 @@ impl BasicAuthCredentials {
 
     /// Generates a `Basic` HTTP Authorization header value from the given username and password.
     pub fn generate_header(username: &str, password: &[u8]) -> Result<MetadataValue<Ascii>, BasicAuthError> {
+        use base64::{prelude::BASE64_STANDARD, Engine};
         let password_str = String::from_utf8_lossy(password);
         let token_str = Zeroizing::new(format!("{username}:{password_str}"));
-        let mut token = base64::encode(token_str.deref());
+        let mut token = BASE64_STANDARD.encode(token_str.deref());
         let header = format!("Basic {token}");
         token.zeroize();
         match password_str {

--- a/applications/minotari_miner/Cargo.toml
+++ b/applications/minotari_miner/Cargo.toml
@@ -21,7 +21,7 @@ minotari_app_utilities = { path = "../minotari_app_utilities", features = [
 minotari_app_grpc = { path = "../minotari_app_grpc" }
 tari_utilities = { version = "0.8" }
 
-base64 = "0.13.0"
+base64 = { workspace = true }
 borsh = { workspace = true }
 bufstream = "0.1"
 chrono = { version = "0.4", default-features = false }

--- a/applications/minotari_miner/src/stratum/controller.rs
+++ b/applications/minotari_miner/src/stratum/controller.rs
@@ -194,8 +194,10 @@ impl Controller {
     }
 
     fn send_miner_job(&mut self, job: types::job_params::JobParams) -> Result<(), Error> {
-        let blob_bytes =
-            base64::decode(&job.blob).map_err(|_| Error::General("Invalid base64 byte string received".to_string()))?;
+        use base64::{prelude::BASE64_STANDARD, Engine};
+        let blob_bytes = BASE64_STANDARD
+            .decode(&job.blob)
+            .map_err(|_| Error::General("Invalid base64 byte string received".to_string()))?;
         let miner_message = types::miner_message::MinerMessage::ReceivedJob(
             job.height,
             job.job_id.parse::<u64>()?,

--- a/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
+++ b/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
@@ -17,7 +17,11 @@ use tari_core::{
     base_node::rpc::{query_service, BaseNodeWalletQueryService},
     chain_storage::BlockchainBackend,
 };
-use tari_transaction_components::rpc::models::{SyncUtxosByBlockRequest, SyncUtxosByBlockResponse};
+use tari_transaction_components::rpc::models::{
+    SyncUtxosByBlockRequest,
+    SyncUtxosByBlockResponseV0,
+    SyncUtxosByBlockResponseV1,
+};
 use tari_utilities::hex::Hex;
 use tonic::service::AxumBody;
 
@@ -45,6 +49,8 @@ pub struct SyncUtxosByBlockQueryParams {
     #[serde(default)]
     #[param(value_type = bool, example = false)]
     pub exclude_spent: bool,
+    #[serde(default)]
+    pub version: u8,
 }
 
 impl From<SyncUtxosByBlockQueryParams> for SyncUtxosByBlockRequest {
@@ -54,6 +60,7 @@ impl From<SyncUtxosByBlockQueryParams> for SyncUtxosByBlockRequest {
             limit: params.limit,
             page: params.page,
             exclude_spent: params.exclude_spent,
+            version: params.version,
         }
     }
 }
@@ -64,7 +71,8 @@ impl From<SyncUtxosByBlockQueryParams> for SyncUtxosByBlockRequest {
     params(SyncUtxosByBlockQueryParams),
     path = "/sync_utxos_by_block",
     responses(
-        (status = 200, description = "UTXOs returned successfully in the given headers' hash range", body = SyncUtxosByBlockResponse),
+        (status = 200, description = "UTXOs returned successfully in the given headers' hash range", body = SyncUtxosByBlockResponseV0),
+        (status = 200, description = "UTXOs returned successfully in the given headers' hash range", body = SyncUtxosByBlockResponseV1),
         (status = NOT_FOUND, description = "Header not found", body = ErrorResponse, example = json!({"error": "Header not found at height: 10"})),
         (status = INTERNAL_SERVER_ERROR, description = "Start/end header hash not found or header height mismatch", body = ErrorResponse),
     ),
@@ -75,17 +83,32 @@ pub async fn handle<B: BlockchainBackend + 'static>(
     Extension(cache_cfg): Extension<Arc<HttpCacheConfig>>,
 ) -> Result<Response<AxumBody>, (StatusCode, Json<ErrorResponse>)> {
     debug!(target: LOG_TARGET, "Received sync_utxos_by_block request: {params}");
-    let request = params.into();
+    let request: SyncUtxosByBlockRequest = params.into();
     let tip_info = query_service.get_tip_info().await.map_err(error_handler_with_message)?;
     let tip_height = tip_info.metadata.map(|m| m.best_block_height()).unwrap_or(0);
-    let response = query_service
-        .sync_utxos_by_block(request)
-        .await
-        .map_err(error_handler_with_message)?;
-    let last_height = response.blocks.last().map(|b| b.height).unwrap_or(0);
+    let height;
+    let mut response = match request.version {
+        0 => {
+            let response = query_service
+                .sync_utxos_by_block_v0(request)
+                .await
+                .map_err(error_handler_with_message)?;
+            height = response.blocks.last().map(|b| b.height);
+            let body = Json(response);
+            body.into_response()
+        },
+        _ => {
+            let response = query_service
+                .sync_utxos_by_block_v1(request)
+                .await
+                .map_err(error_handler_with_message)?;
+            height = response.blocks.last().map(|b| b.height);
+            let body = Json(response);
+            body.into_response()
+        },
+    };
+    let last_height = height.unwrap_or(0);
 
-    let body = Json(response);
-    let mut response = body.into_response();
     apply_cache_control(
         response.headers_mut(),
         &cache_cfg,

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -21,7 +21,7 @@ tari_utilities = { workspace = true }
 
 
 argon2 = { version = "0.4.1", features = ["std", "alloc"] }
-base64 = "0.21.0"
+base64 = { workspace = true }
 blake2 = "0.10"
 bitflags = { version = "2.4", features = ["serde"] }
 bs58 = "0.5.1"

--- a/base_layer/core/src/base_node/rpc/mod.rs
+++ b/base_layer/core/src/base_node/rpc/mod.rs
@@ -74,10 +74,15 @@ pub trait BaseNodeWalletQueryService: Send + Sync + 'static {
 
     async fn transaction_query(&self, signature: models::Signature) -> Result<models::TxQueryResponse, Self::Error>;
 
-    async fn sync_utxos_by_block(
+    async fn sync_utxos_by_block_v0(
         &self,
         request: models::SyncUtxosByBlockRequest,
-    ) -> Result<models::SyncUtxosByBlockResponse, Self::Error>;
+    ) -> Result<models::SyncUtxosByBlockResponseV0, Self::Error>;
+
+    async fn sync_utxos_by_block_v1(
+        &self,
+        request: models::SyncUtxosByBlockRequest,
+    ) -> Result<models::SyncUtxosByBlockResponseV1, Self::Error>;
 
     async fn get_utxos_deleted_info(
         &self,

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -626,6 +626,7 @@ mod tests {
             limit: 4,
             page: 0,
             exclude_spent: false,
+            version: 0,
         };
         let err = service.fetch_utxos(req).await.unwrap_err();
         match err {

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -19,7 +19,8 @@ use tari_transaction_components::{
             GetUtxosByBlockResponse,
             MinimalUtxoSyncInfo,
             SyncUtxosByBlockRequest,
-            SyncUtxosByBlockResponse,
+            SyncUtxosByBlockResponseV0,
+            SyncUtxosByBlockResponseV1,
             TipInfoResponse,
             TxLocation,
             TxQueryResponse,
@@ -177,7 +178,7 @@ impl<B: BlockchainBackend + 'static> Service<B> {
     }
 
     #[allow(clippy::too_many_lines)]
-    async fn fetch_utxos(&self, request: SyncUtxosByBlockRequest) -> Result<SyncUtxosByBlockResponse, Error> {
+    async fn fetch_utxos(&self, request: SyncUtxosByBlockRequest) -> Result<SyncUtxosByBlockResponseV0, Error> {
         // validate and fetch inputs
         request.validate()?;
 
@@ -347,7 +348,7 @@ impl<B: BlockchainBackend + 'static> Service<B> {
             }
         }
 
-        Ok(SyncUtxosByBlockResponse {
+        Ok(SyncUtxosByBlockResponseV0 {
             blocks: utxos,
             has_next_page,
             next_header_to_scan: next_header_to_request,
@@ -458,11 +459,19 @@ impl<B: BlockchainBackend + 'static> BaseNodeWalletQueryService for Service<B> {
         Ok(response)
     }
 
-    async fn sync_utxos_by_block(
+    async fn sync_utxos_by_block_v0(
         &self,
         request: SyncUtxosByBlockRequest,
-    ) -> Result<SyncUtxosByBlockResponse, Self::Error> {
+    ) -> Result<SyncUtxosByBlockResponseV0, Self::Error> {
         self.fetch_utxos(request).await
+    }
+
+    async fn sync_utxos_by_block_v1(
+        &self,
+        request: SyncUtxosByBlockRequest,
+    ) -> Result<SyncUtxosByBlockResponseV1, Self::Error> {
+        let v1 = self.fetch_utxos(request).await?;
+        Ok(v1.into())
     }
 
     async fn get_utxos_by_block(
@@ -602,7 +611,7 @@ mod tests {
     }
 
     async fn make_service() -> Service<crate::test_helpers::blockchain::TempDatabase> {
-        let db = create_new_blockchain_with_network(Network::default());
+        let db = create_new_blockchain_with_network(Network::MainNet);
         let adb = AsyncBlockchainDb::from(db);
         let state_machine = make_state_machine_handle();
         let mempool = make_mempool_handle();
@@ -635,6 +644,7 @@ mod tests {
             limit: 1,
             page: 1,
             exclude_spent: false,
+            version: 0,
         };
         let err = service.fetch_utxos(req).await.unwrap_err();
         match err {

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -611,7 +611,7 @@ mod tests {
     }
 
     async fn make_service() -> Service<crate::test_helpers::blockchain::TempDatabase> {
-        let db = create_new_blockchain_with_network(Network::MainNet);
+        let db = create_new_blockchain_with_network(Network::LocalNet);
         let adb = AsyncBlockchainDb::from(db);
         let state_machine = make_state_machine_handle();
         let mempool = make_mempool_handle();

--- a/base_layer/transaction_components/Cargo.toml
+++ b/base_layer/transaction_components/Cargo.toml
@@ -24,6 +24,7 @@ tari_utilities = { workspace = true }
 minotari_ledger_wallet_common = { workspace = true }
 
 anyhow = { workspace = true }
+base64 = { workspace = true }
 bitflags = { version = "2.4", features = ["serde"] }
 borsh = { workspace = true, features = ["derive"] }
 

--- a/base_layer/transaction_components/src/rpc/models/sync_utxos_by_block.rs
+++ b/base_layer/transaction_components/src/rpc/models/sync_utxos_by_block.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 use serde::{Deserialize, Serialize};
 use serde_valid::Validate;
+use tari_utilities::hex::Hex;
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Validate, Debug)]
@@ -58,7 +59,7 @@ impl From<SyncUtxosByBlockResponseV1> for SyncUtxosByBlockResponseV0 {
         Self {
             blocks,
             has_next_page: value.has_next_page,
-            next_header_to_scan: value.next_header_to_scan,
+            next_header_to_scan: Vec::<u8>::from_hex(&value.next_header_to_scan).unwrap_or_default(),
         }
     }
 }
@@ -67,7 +68,7 @@ impl From<SyncUtxosByBlockResponseV1> for SyncUtxosByBlockResponseV0 {
 pub struct SyncUtxosByBlockResponseV1 {
     pub blocks: Vec<BlockUtxoInfoBase64>,
     pub has_next_page: bool,
-    pub next_header_to_scan: Vec<u8>,
+    pub next_header_to_scan: String,
 }
 
 impl From<SyncUtxosByBlockResponseV0> for SyncUtxosByBlockResponseV1 {
@@ -101,7 +102,7 @@ impl From<SyncUtxosByBlockResponseV0> for SyncUtxosByBlockResponseV1 {
         Self {
             blocks,
             has_next_page: value.has_next_page,
-            next_header_to_scan: value.next_header_to_scan,
+            next_header_to_scan: value.next_header_to_scan.to_hex(),
         }
     }
 }

--- a/base_layer/transaction_components/src/rpc/models/sync_utxos_by_block.rs
+++ b/base_layer/transaction_components/src/rpc/models/sync_utxos_by_block.rs
@@ -14,13 +14,96 @@ pub struct SyncUtxosByBlockRequest {
     pub page: u64,
     #[serde(default)]
     pub exclude_spent: bool,
+    #[serde(default)]
+    pub version: u8,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug)]
-pub struct SyncUtxosByBlockResponse {
+pub struct SyncUtxosByBlockResponseV0 {
     pub blocks: Vec<BlockUtxoInfo>,
     pub has_next_page: bool,
     pub next_header_to_scan: Vec<u8>,
+}
+
+impl From<SyncUtxosByBlockResponseV1> for SyncUtxosByBlockResponseV0 {
+    fn from(value: SyncUtxosByBlockResponseV1) -> Self {
+        use base64::{prelude::BASE64_STANDARD, Engine};
+        let blocks = value
+            .blocks
+            .into_iter()
+            .map(|block| BlockUtxoInfo {
+                header_hash: BASE64_STANDARD.decode(block.header_hash).unwrap_or_default(),
+                height: block.height,
+                outputs: block
+                    .outputs
+                    .into_iter()
+                    .map(|utxo| MinimalUtxoSyncInfo {
+                        output_hash: BASE64_STANDARD.decode(utxo.output_hash).unwrap_or_default(),
+                        commitment: BASE64_STANDARD.decode(utxo.commitment).unwrap_or_default(),
+                        encrypted_data: BASE64_STANDARD.decode(utxo.encrypted_data).unwrap_or_default(),
+                        sender_offset_public_key: BASE64_STANDARD
+                            .decode(utxo.sender_offset_public_key)
+                            .unwrap_or_default(),
+                    })
+                    .collect(),
+                inputs: block
+                    .inputs
+                    .into_iter()
+                    .map(|input| BASE64_STANDARD.decode(input).unwrap_or_default())
+                    .collect(),
+                mined_timestamp: block.mined_timestamp,
+            })
+            .collect();
+
+        Self {
+            blocks,
+            has_next_page: value.has_next_page,
+            next_header_to_scan: value.next_header_to_scan,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, ToSchema, Debug)]
+pub struct SyncUtxosByBlockResponseV1 {
+    pub blocks: Vec<BlockUtxoInfoBase64>,
+    pub has_next_page: bool,
+    pub next_header_to_scan: Vec<u8>,
+}
+
+impl From<SyncUtxosByBlockResponseV0> for SyncUtxosByBlockResponseV1 {
+    fn from(value: SyncUtxosByBlockResponseV0) -> Self {
+        use base64::{prelude::BASE64_STANDARD, Engine};
+        let blocks = value
+            .blocks
+            .into_iter()
+            .map(|block| BlockUtxoInfoBase64 {
+                header_hash: BASE64_STANDARD.encode(block.header_hash),
+                height: block.height,
+                outputs: block
+                    .outputs
+                    .into_iter()
+                    .map(|utxo| MinimalUtxoSyncInfoBase64 {
+                        output_hash: BASE64_STANDARD.encode(utxo.output_hash),
+                        commitment: BASE64_STANDARD.encode(utxo.commitment),
+                        encrypted_data: BASE64_STANDARD.encode(utxo.encrypted_data),
+                        sender_offset_public_key: BASE64_STANDARD.encode(utxo.sender_offset_public_key),
+                    })
+                    .collect(),
+                inputs: block
+                    .inputs
+                    .into_iter()
+                    .map(|input| BASE64_STANDARD.encode(input))
+                    .collect(),
+                mined_timestamp: block.mined_timestamp,
+            })
+            .collect();
+
+        Self {
+            blocks,
+            has_next_page: value.has_next_page,
+            next_header_to_scan: value.next_header_to_scan,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone)]
@@ -30,6 +113,23 @@ pub struct BlockUtxoInfo {
     pub outputs: Vec<MinimalUtxoSyncInfo>,
     pub inputs: Vec<Vec<u8>>,
     pub mined_timestamp: u64,
+}
+
+#[derive(Serialize, Deserialize, ToSchema, Debug, Clone)]
+pub struct BlockUtxoInfoBase64 {
+    pub header_hash: String,
+    pub height: u64,
+    pub outputs: Vec<MinimalUtxoSyncInfoBase64>,
+    pub inputs: Vec<String>,
+    pub mined_timestamp: u64,
+}
+
+#[derive(Serialize, Deserialize, ToSchema, Debug, Clone)]
+pub struct MinimalUtxoSyncInfoBase64 {
+    pub output_hash: String,
+    pub commitment: String,
+    pub encrypted_data: String,
+    pub sender_offset_public_key: String,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone)]

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -37,7 +37,6 @@ use tari_transaction_components::{
         GenerateKernelMerkleProofResponse,
         GetUtxosDeletedInfoResponse,
         GetUtxosMinedInfoResponse,
-        SyncUtxosByBlockResponse,
         TxSubmissionResponse,
     },
     transaction_components::{Transaction, TransactionOutput},
@@ -45,7 +44,7 @@ use tari_transaction_components::{
 use tari_utilities::ByteArray;
 use tokio::sync::{mpsc, RwLock};
 use url::Url;
-
+use tari_transaction_components::rpc::models::{SyncUtxosByBlockResponseV0};
 use crate::support::comms_rpc::UtxosByBlock;
 
 #[derive(Default)]
@@ -250,7 +249,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
         &self,
         start_header_hash: Vec<u8>,
         shutdown: ShutdownSignal,
-    ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponse, Error>>, Error> {
+    ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponseV0, Error>>, Error> {
         let (tx, rx) = mpsc::channel(100);
         let state2 = self.state.read().await;
 
@@ -296,7 +295,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
                 }
                 if blocks.len() >= page_size || height == end_height {
                     let has_next_page = height < end_height;
-                    let response = SyncUtxosByBlockResponse {
+                    let response = SyncUtxosByBlockResponseV0 {
                         blocks: blocks.clone(),
                         has_next_page,
                         next_header_to_scan: vec![],

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -37,6 +37,7 @@ use tari_transaction_components::{
         GenerateKernelMerkleProofResponse,
         GetUtxosDeletedInfoResponse,
         GetUtxosMinedInfoResponse,
+        SyncUtxosByBlockResponseV0,
         TxSubmissionResponse,
     },
     transaction_components::{Transaction, TransactionOutput},
@@ -44,7 +45,7 @@ use tari_transaction_components::{
 use tari_utilities::ByteArray;
 use tokio::sync::{mpsc, RwLock};
 use url::Url;
-use tari_transaction_components::rpc::models::{SyncUtxosByBlockResponseV0};
+
 use crate::support::comms_rpc::UtxosByBlock;
 
 #[derive(Default)]

--- a/clients/rust/base_node_wallet_client/src/client/http.rs
+++ b/clients/rust/base_node_wallet_client/src/client/http.rs
@@ -17,7 +17,8 @@ use tari_transaction_components::{
             GenerateKernelMerkleProofResponse,
             GetUtxosDeletedInfoResponse,
             GetUtxosMinedInfoResponse,
-            SyncUtxosByBlockResponse,
+            SyncUtxosByBlockResponseV0,
+            SyncUtxosByBlockResponseV1,
             TipInfoResponse,
             TxQueryResponse,
             TxSubmissionResponse,
@@ -289,7 +290,7 @@ impl BaseNodeWalletClient for Client {
         &self,
         start_header_hash: Vec<u8>,
         shutdown: ShutdownSignal,
-    ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponse, anyhow::Error>>, anyhow::Error> {
+    ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponseV0, anyhow::Error>>, anyhow::Error> {
         debug!(
             target: LOG_TARGET,
             "Starting UTXO sync from {}",
@@ -314,11 +315,11 @@ impl BaseNodeWalletClient for Client {
                 ));
                 debug!(target: LOG_TARGET, "Requesting UTXOs by block from Base Node wallet service at {target_url}");
                 match client.get(target_url.clone()).send().await {
-                    Ok(response) => match response.json::<SyncUtxosByBlockResponse>().await {
+                    Ok(response) => match response.json::<SyncUtxosByBlockResponseV1>().await {
                         Ok(response) => {
                             has_next_page = response.has_next_page;
                             debug!(target: LOG_TARGET, "Received UTXOs for page {page}");
-                            if let Err(send_error) = resp_tx.send(Ok(response)).await {
+                            if let Err(send_error) = resp_tx.send(Ok(response.into())).await {
                                 error!(target: LOG_TARGET, "Error sending utxo response: {send_error:?}");
                             }
                         },

--- a/clients/rust/base_node_wallet_client/src/client/mod.rs
+++ b/clients/rust/base_node_wallet_client/src/client/mod.rs
@@ -13,7 +13,7 @@ use tari_transaction_components::{
         GenerateKernelMerkleProofResponse,
         GetUtxosDeletedInfoResponse,
         GetUtxosMinedInfoResponse,
-        SyncUtxosByBlockResponse,
+        SyncUtxosByBlockResponseV0,
     },
     transaction_components::{Transaction, TransactionOutput},
 };
@@ -40,7 +40,7 @@ pub trait BaseNodeWalletClient: Send + Sync + Clone + 'static {
         &self,
         start_header_hash: Vec<u8>,
         shutdown: ShutdownSignal,
-    ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponse, Error>>, Error>;
+    ) -> Result<mpsc::Receiver<Result<SyncUtxosByBlockResponseV0, Error>>, Error>;
 
     async fn get_last_request_latency(&self) -> Option<std::time::Duration>;
 


### PR DESCRIPTION
Description
---
Reduces the scanning download size that a wallet has to scan by roughly half. 
The screenshot compares the current version to new version downloading the scanning data for the first 10 blocks. 
 
Size: 528Kb vs 240 Kb

<img width="2698" height="364" alt="screenshot download size" src="https://github.com/user-attachments/assets/d7164fd0-e716-46ea-a38f-88bc69273aff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned UTXO-by-block API (v0 and v1) with a request version field and automatic V0↔V1 conversions.
  * V1 supports Base64-encoded block and UTXO payloads; responses returned per requested version.

* **Chores**
  * Aligned base64 dependency to workspace-managed configuration across crates.
  * Updated client and service APIs and mocks to use and forward the new versioned response types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->