### PR TITLE
fix: grpc re-validation trigger

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -2344,8 +2344,18 @@ message CancelTransactionResponse {
 }
 
 message RevalidateRequest{
-  bool only_rejected = 1;
-  bool revalidate_outputs = 2;
+  TransactionValidationMode transaction_mode =1;
+  OutputValidationMode output_mode = 2;
+}
+
+enum TransactionValidationMode {
+    RevalidateAll = 0;
+    RejectedOnly = 1;
+}
+
+enum OutputValidationMode {
+    Ignore = 0;
+    Revalidate = 1;
 }
 
 message RevalidateResponse{}

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -2343,7 +2343,9 @@ message CancelTransactionResponse {
   string failure_message = 2;
 }
 
-message RevalidateRequest{}
+message RevalidateRequest{
+  bool only_rejected = 1;
+}
 
 message RevalidateResponse{}
 

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -2345,6 +2345,7 @@ message CancelTransactionResponse {
 
 message RevalidateRequest{
   bool only_rejected = 1;
+  bool revalidate_outputs = 2;
 }
 
 message RevalidateResponse{}

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -566,14 +566,21 @@ impl wallet_server::Wallet for WalletGrpcServer {
         request: Request<RevalidateRequest>,
     ) -> Result<Response<RevalidateResponse>, Status> {
         let mut tms = self.wallet.transaction_service.clone();
-        if request.into_inner().only_rejected {
+        let message = request.into_inner();
+        if message.only_rejected {
             tms.revalidate_rejected_transactions().await.map_err(|e| {
-                Status::internal(format!("Failed to revalidate rejected transactions: {}", e.to_string()))
+                Status::internal(format!("Failed to revalidate rejected transactions: {}", e))
             })?;
         } else {
             tms.revalidate_all_transactions()
                 .await
-                .map_err(|e| Status::internal(format!("Failed to revalidate all transactions: {}", e.to_string())))?;
+                .map_err(|e| Status::internal(format!("Failed to revalidate all transactions: {}", e)))?;
+        }
+        if message.revalidate_outputs{
+            let mut oms = self.wallet.output_manager_service.clone();
+            oms.revalidate_all_outputs()
+                .await
+                .map_err(|e| Status::internal(format!("Failed to revalidate outputs: {}", e)))?;
         }
 
         Ok(Response::new(RevalidateResponse {}))

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -563,8 +563,19 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
     async fn revalidate_all_transactions(
         &self,
-        _request: Request<RevalidateRequest>,
+        request: Request<RevalidateRequest>,
     ) -> Result<Response<RevalidateResponse>, Status> {
+        let mut tms = self.wallet.transaction_service.clone();
+        if request.into_inner().only_rejected {
+            tms.revalidate_rejected_transactions().await.map_err(|e| {
+                Status::internal(format!("Failed to revalidate rejected transactions: {}", e.to_string()))
+            })?;
+        } else {
+            tms.revalidate_all_transactions()
+                .await
+                .map_err(|e| Status::internal(format!("Failed to revalidate all transactions: {}", e.to_string())))?;
+        }
+
         Ok(Response::new(RevalidateResponse {}))
     }
 

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -568,15 +568,15 @@ impl wallet_server::Wallet for WalletGrpcServer {
         let mut tms = self.wallet.transaction_service.clone();
         let message = request.into_inner();
         if message.only_rejected {
-            tms.revalidate_rejected_transactions().await.map_err(|e| {
-                Status::internal(format!("Failed to revalidate rejected transactions: {}", e))
-            })?;
+            tms.revalidate_rejected_transactions()
+                .await
+                .map_err(|e| Status::internal(format!("Failed to revalidate rejected transactions: {}", e)))?;
         } else {
             tms.revalidate_all_transactions()
                 .await
                 .map_err(|e| Status::internal(format!("Failed to revalidate all transactions: {}", e)))?;
         }
-        if message.revalidate_outputs{
+        if message.revalidate_outputs {
             let mut oms = self.wallet.output_manager_service.clone();
             oms.revalidate_all_outputs()
                 .await

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -131,6 +131,8 @@ use minotari_app_grpc::tari_rpc::{
     UserPayForFeeResponse,
     ValidateRequest,
     ValidateResponse,
+    TransactionValidationMode,
+    OutputValidationMode,
 };
 use minotari_node_wallet_client::BaseNodeWalletClient;
 use minotari_wallet::{
@@ -567,7 +569,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
     ) -> Result<Response<RevalidateResponse>, Status> {
         let mut tms = self.wallet.transaction_service.clone();
         let message = request.into_inner();
-        if message.only_rejected {
+        if message.transaction_mode == TransactionValidationMode::RejectedOnly as i32 {
             tms.revalidate_rejected_transactions()
                 .await
                 .map_err(|e| Status::internal(format!("Failed to revalidate rejected transactions: {}", e)))?;
@@ -576,7 +578,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 .await
                 .map_err(|e| Status::internal(format!("Failed to revalidate all transactions: {}", e)))?;
         }
-        if message.revalidate_outputs {
+        if message.output_mode == OutputValidationMode::Revalidate as i32 {
             let mut oms = self.wallet.output_manager_service.clone();
             oms.revalidate_all_outputs()
                 .await

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -92,6 +92,7 @@ use minotari_app_grpc::tari_rpc::{
     ImportTransactionsResponse,
     ImportUtxosRequest,
     ImportUtxosResponse,
+    OutputValidationMode,
     PrepareDepositMultisigTransactionRequest,
     PrepareDepositMultisigTransactionResponse,
     PrepareOneSidedTransactionForSigningRequest,
@@ -124,6 +125,7 @@ use minotari_app_grpc::tari_rpc::{
     TransactionEventResponse,
     TransactionInfo,
     TransactionStatus,
+    TransactionValidationMode,
     TransferRequest,
     TransferResponse,
     TransferResult,
@@ -131,8 +133,6 @@ use minotari_app_grpc::tari_rpc::{
     UserPayForFeeResponse,
     ValidateRequest,
     ValidateResponse,
-    TransactionValidationMode,
-    OutputValidationMode,
 };
 use minotari_node_wallet_client::BaseNodeWalletClient;
 use minotari_wallet::{

--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -310,7 +310,7 @@ where B: BlockchainBackend + 'static
         let wallet_http_server = create_base_node_wallet_http_server(
             wallet_query_service_config.port,
             wallet_query_service_config
-                .local_ip
+                .listen_ip
                 .unwrap_or("0.0.0.0".parse().expect("should not fail")),
             db.clone(),
             handles.expect_handle::<StateMachineHandle>(),

--- a/applications/minotari_node/src/config.rs
+++ b/applications/minotari_node/src/config.rs
@@ -170,7 +170,7 @@ pub struct WalletHttpServiceConfig {
     /// Port that the local wallet query service will listen on.
     pub port: u16,
     #[serde(default)]
-    pub local_ip: Option<IpAddr>,
+    pub listen_ip: Option<IpAddr>,
     /// The external address of the wallet query service.
     /// This must be accessible (if set) from the internet to let other peers connect to that.
     /// Also this address will be sent to peers when requesting for the query service URL (via RPC call).
@@ -185,7 +185,7 @@ impl Default for WalletHttpServiceConfig {
         let port = wallet_http_service_default_port(Network::get_current());
         Self {
             port,
-            local_ip: None,
+            listen_ip: None,
             external_address: Some(
                 Url::parse(format!("http://127.0.0.1:{port}").as_str()).expect("This should be a valid URL"),
             ),

--- a/applications/minotari_node/src/http/mod.rs
+++ b/applications/minotari_node/src/http/mod.rs
@@ -21,7 +21,7 @@ pub use cache_config::HttpCacheConfig;
 
 pub fn create_base_node_wallet_http_server<B: BlockchainBackend + 'static>(
     port: u16,
-    local_ip: IpAddr,
+    listen_ip: IpAddr,
     db: AsyncBlockchainDb<B>,
     state_machine: StateMachineHandle,
     mempool: MempoolHandle,
@@ -30,7 +30,7 @@ pub fn create_base_node_wallet_http_server<B: BlockchainBackend + 'static>(
 ) -> server::Server<impl BaseNodeWalletQueryService> {
     server::Server::new(
         port,
-        local_ip,
+        listen_ip,
         query_service::Service::new(db, state_machine, mempool.clone()),
         mempool,
         shutdown_signal,

--- a/applications/minotari_node/src/http/server.rs
+++ b/applications/minotari_node/src/http/server.rs
@@ -53,7 +53,7 @@ pub struct ApiDoc;
 pub struct Server<S> {
     port: u16,
     query_service: Arc<S>,
-    local_ip: IpAddr,
+    listen_ip: IpAddr,
     mempool_handle: MempoolHandle,
     shutdown_signal: ShutdownSignal,
     cache_cfg: HttpCacheConfig,
@@ -62,7 +62,7 @@ pub struct Server<S> {
 impl<S: BaseNodeWalletQueryService> Server<S> {
     pub fn new(
         port: u16,
-        local_ip: IpAddr,
+        listen_ip: IpAddr,
         query_service: S,
         mempool: MempoolHandle,
         shutdown_signal: ShutdownSignal,
@@ -70,7 +70,7 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
     ) -> Self {
         Self {
             port,
-            local_ip,
+            listen_ip,
             query_service: Arc::new(query_service),
             mempool_handle: mempool,
             shutdown_signal,
@@ -118,14 +118,14 @@ impl<S: BaseNodeWalletQueryService> Server<S> {
             .layer(Extension(self.query_service.clone()))
             .layer(Extension(self.mempool_handle.clone()))
             .layer(Extension(Arc::new(self.cache_cfg.clone())));
-        let local_ip = self.local_ip;
-        let address = SocketAddr::new(local_ip, port);
+        let listen_ip = self.listen_ip;
+        let address = SocketAddr::new(listen_ip, port);
 
         let listener = TcpListener::bind(address).await?;
 
         // spawn server
         tokio::spawn(async move {
-            info!(target: LOG_TARGET, "Wallet query HTTP server listening at {local_ip}:{port}");
+            info!(target: LOG_TARGET, "Wallet query HTTP server listening at {listen_ip}:{port}");
             if let Err(error) = axum::serve(listener, router)
                 .with_graceful_shutdown(shutdown_signal)
                 .await

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -266,6 +266,7 @@ pub enum TransactionServiceRequest {
     SetNumConfirmationsRequired(u64),
     ValidateTransactions,
     ReValidateRejectedTransactions,
+    ReValidateTransactions,
     ReplaceByFee {
         tx_id: TxId,
         fee_increase: MicroMinotari,
@@ -515,6 +516,7 @@ impl fmt::Display for TransactionServiceRequest {
             Self::GetAnyTransaction(t) => write!(f, "GetAnyTransaction({t})"),
             Self::ValidateTransactions => write!(f, "ValidateTransactions"),
             Self::ReValidateRejectedTransactions => write!(f, "ReValidateRejectedTransactions"),
+            Self::ReValidateTransactions => write!(f, "ReValidateTransactions"),
             Self::ReplaceByFee { tx_id, fee_increase } => {
                 write!(f, "ReplaceByFee(tx_id: {tx_id}, fee_increase: {fee_increase})")
             },
@@ -1647,6 +1649,20 @@ impl TransactionServiceHandle {
             TransactionServiceResponse::LowPowerModeSet => Ok(()),
             _ => Err(TransactionServiceError::UnexpectedApiResponse(
                 "TransactionServiceRequest::SetLowPowerMode".to_string(),
+            )),
+        }
+    }
+
+    pub async fn revalidate_all_transactions(&mut self) -> Result<(), TransactionServiceError> {
+        match self
+            .handle
+            .call(TransactionServiceRequest::ReValidateTransactions)
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "TransactionServiceRequest::ReValidateTransactions({e})"))??
+        {
+            TransactionServiceResponse::ValidationStarted(_) => Ok(()),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse(
+                "TransactionServiceRequest::ReValidateTransactions".to_string(),
             )),
         }
     }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1410,7 +1410,6 @@ where
                 }
                 .await
             },
-
             TransactionServiceRequest::ReValidateRejectedTransactions => {
                 async {
                     let res = self
@@ -1420,7 +1419,15 @@ where
                 }
                 .await
             },
-
+            TransactionServiceRequest::ReValidateTransactions => {
+                async {
+                    let res = self
+                        .start_transaction_revalidation(transaction_validation_join_handles)
+                        .await?;
+                    Ok(TransactionServiceResponse::ValidationStarted(res))
+                }
+                .await
+            },
             TransactionServiceRequest::ReplaceByFee { tx_id, fee_increase } => {
                 async {
                     let res = self
@@ -3702,6 +3709,16 @@ where
         >,
     ) -> Result<OperationId, TransactionServiceError> {
         self.resources.db.mark_all_rejected_transactions_as_unvalidated()?;
+        self.start_transaction_validation_protocol(join_handles).await
+    }
+
+    async fn start_transaction_revalidation(
+        &mut self,
+        join_handles: &mut FuturesUnordered<
+            JoinHandle<Result<OperationId, TransactionServiceProtocolError<OperationId>>>,
+        >,
+    ) -> Result<OperationId, TransactionServiceError> {
+        self.resources.db.mark_all_non_coinbases_transactions_as_unvalidated()?;
         self.start_transaction_validation_protocol(join_handles).await
     }
 

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -374,7 +374,7 @@ excluded_dial_addresses = []
 # This address must be accessible by the wallet (on a global scale over the internet).
 [base_node.http_wallet_query_service]
 #port = 9000
-#local_ip = "0.0.0.0"
+#listen_ip = "0.0.0.0"
 #external_address = "http://127.0.0.1:9000"
 
 # If not enabled (false), no Cache-Control header is set anywhere. [Default: true]

--- a/docs/src/09_adding_tari_to_your_exchange.md
+++ b/docs/src/09_adding_tari_to_your_exchange.md
@@ -348,7 +348,7 @@ This is the private base node:
 # This address must be accessible by the wallet (on a global scale over the internet).
 [base_node.http_wallet_query_service]
 #port = 9000
-#local_ip = "0.0.0.0"
+#listen_ip = "0.0.0.0"
 #external_address = "http://127.0.0.1:9000"
 ```
 


### PR DESCRIPTION
Description
---
Fixes the ability to trigger re-validation via grpc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revalidation request now accepts transaction and output modes to control behavior.
  * Option to revalidate only previously rejected transactions or revalidate all.
  * Optional revalidation of outputs alongside transaction revalidation.

* **Configuration**
  * Wallet HTTP bind option renamed from local_ip to listen_ip (defaults/examples updated).

* **Documentation**
  * Config examples and docs updated to use listen_ip.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->