### PR TITLE
fix: potential cache issues

### DIFF
--- a/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
+++ b/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::{fmt::Display, sync::Arc};
+use std::{cmp, fmt::Display, sync::Arc};
 
 use axum::{
     Extension,
@@ -91,6 +91,7 @@ pub async fn handle<B: BlockchainBackend + 'static>(
     let tip_info = query_service.get_tip_info().await.map_err(error_handler_with_message)?;
     let tip_height = tip_info.metadata.map(|m| m.best_block_height()).unwrap_or(0);
     let height;
+    let exclude_spent = request.exclude_spent;
     let mut response = match request.version {
         0 => {
             let response = query_service
@@ -111,7 +112,14 @@ pub async fn handle<B: BlockchainBackend + 'static>(
             body.into_response()
         },
     };
-    let last_height = height.unwrap_or(0);
+    let last_height = if let true = exclude_spent {
+        // if we're excluding spent outputs we cannot cache for longer than a day, so we force the "height" so that the
+        // caching will only be a max of 1 day. Wallets will sent full without excluding spends the last 1000 blocks so
+        // this leaves a margin for wallets to get data if it changed.
+        cmp::min(height.unwrap_or(0), tip_height.saturating_add(2500))
+    } else {
+        height.unwrap_or(0)
+    };
 
     apply_cache_control(
         response.headers_mut(),

--- a/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
+++ b/applications/minotari_node/src/http/handler/sync_utxos_by_block.rs
@@ -112,7 +112,7 @@ pub async fn handle<B: BlockchainBackend + 'static>(
             body.into_response()
         },
     };
-    let last_height = if let true = exclude_spent {
+    let last_height = if exclude_spent {
         // if we're excluding spent outputs we cannot cache for longer than a day, so we force the "height" so that the
         // caching will only be a max of 1 day. Wallets will sent full without excluding spends the last 1000 blocks so
         // this leaves a margin for wallets to get data if it changed.


### PR DESCRIPTION
Description
---
Excluding spends, can cause an issue with spends as those older blocks are cached for long periods, where as the ouputs can be spent any block. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTXO synchronization caching logic to adapt based on sync parameters, enhancing consistency in block processing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->