### PR TITLE
chore: remove redundant readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,18 +205,6 @@ on your system:
     cargo install --path=applications/minotari_mcp_wallet --force
     cargo install --path=applications/minotari_mcp_node --force
 
----
-
-Alternatively, `cargo` can build and install the executable into `%USERPROFILE%\.cargo\bin`, so it will be executable from
-anywhere on your system:
-
-    cargo install --path=applications/minotari_node --force
-    cargo install --path=applications/minotari_console_wallet --force
-    cargo install --path=applications/minotari_merge_mining_proxy --force
-    cargo install --path=applications/minotari_miner --force
-    cargo install --path=applications/minotari_mcp_wallet --force
-    cargo install --path=applications/minotari_mcp_node --force
-
 ### Run
 
 The executables will either be inside your `~/tari/target/release` (on Linux) or `%USERPROFILE%\Code\tari\target\release`


### PR DESCRIPTION
Description
---
Consecutive README sections stating basically the same exact thing.

Motivation and Context
---
I'd like to eventually update the README to reflect a more current Ubuntu version and clarify build deps/package names.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
