### PR TITLE
fix(mm_proxy): update reserved_offset after inserting merge mining tag

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
@@ -67,6 +67,11 @@ const LOG_TARGET: &str = "minotari_mm_proxy::proxy::inner";
 /// The identifier used to identify the tari aux chain data
 const TARI_CHAIN_ID: &str = "xtr";
 const BUSY_QUALIFYING: &str = "BusyQualifyingMonerodUrl";
+/// Size in bytes of the merge mining tag that is inserted into the Monero coinbase transaction's
+/// extra field. When this tag is inserted at the beginning of the extra field, all subsequent
+/// data (including the pool nonce reserved area) is shifted by this amount, so the `reserved_offset`
+/// must be adjusted accordingly.
+const MERGE_MINING_TAG_SIZE: u64 = 35;
 
 #[derive(Debug, Clone)]
 pub struct InnerService {
@@ -425,6 +430,12 @@ impl InnerService {
         monerod_resp["result"]["blocktemplate_blob"] = final_block_template_data.blocktemplate_blob.clone().into();
         monerod_resp["result"]["blockhashing_blob"] = final_block_template_data.blockhashing_blob.clone().into();
         monerod_resp["result"]["difficulty"] = final_block_template_data.target_difficulty.as_u64().into();
+        // Update reserved_offset to account for the merge mining tag inserted at the beginning
+        // of the coinbase extra field, which shifts all subsequent data including the nonce area.
+        if let Some(original_offset) = monerod_resp["result"]["reserved_offset"].as_u64() {
+            monerod_resp["result"]["reserved_offset"] =
+                (original_offset + MERGE_MINING_TAG_SIZE).into();
+        }
 
         let tari_difficulty = final_block_template_data.template.tari_difficulty;
         let tari_height = final_block_template_data


### PR DESCRIPTION
Description
---
The merge mining proxy inserts a merge mining tag at the beginning of the Monero coinbase transaction's extra field, which shifts all subsequent data by 35 bytes. However, the `reserved_offset` field in the response was not being updated to reflect this shift.

This caused mining pools to have to calculate the correct nonce position themselves instead of using the provided `reserved_offset` value.

This fix adjusts `reserved_offset` by adding the merge mining tag size (35 bytes) after modifying the block template.

Motivation and Context
---
Mining pools that use the `reserved_offset` value from the proxy response were receiving an incorrect offset (e.g., 131) when the actual position in the modified blob was different (e.g., 166). This forced pools to calculate the correct position themselves by searching for the nonce pattern in the blob.


How Has This Been Tested?
---
Empirical testing the offset mismatch: daemon reported 131, actual position was 166, difference = 35 bytes.

What process can a PR reviewer use to test or verify this change?
---
1. Start the merge mining proxy
2. Request a block template via getblocktemplate RPC
3. Verify that reserved_offset in the response equals the original monerod reserved_offset + 35

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
