### PR TITLE
fix(wallet): fix fetching kernel merkle proof

### DIFF
--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -3217,7 +3217,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
             if !db_result.is_empty() {
                 add_to_oms = false;
                 is_found = true;
-                let db_output = &db_result.first().expect("Should not be empty, this is checked").0;
+                let db_output = db_result.first().expect("Should not be empty, this is checked");
                 debug_info.push(format!(
                     "UTXO with hash {} already exists in Output Manager with status: {}",
                     hex, db_output.status

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -330,7 +330,7 @@ pub enum OutputManagerResponse<KM> {
     TransactionCancelled,
     SpentOutputs(Vec<DbWalletOutput>),
     UnspentOutputs(Vec<DbWalletOutput>),
-    Outputs(Vec<(DbWalletOutput, WalletOutput)>),
+    Outputs(Vec<DbWalletOutput>),
     InvalidOutputs(Vec<WalletOutput>),
     BaseNodePublicKeySet,
     TxoValidationStarted(u64),
@@ -744,7 +744,7 @@ where KM: LegacyTransactionKeyManagerInterface
     pub async fn get_many_outputs(
         &mut self,
         outputs: Vec<FixedHash>,
-    ) -> Result<Vec<(DbWalletOutput, WalletOutput)>, OutputManagerError> {
+    ) -> Result<Vec<DbWalletOutput>, OutputManagerError> {
         match self
             .handle
             .call(OutputManagerRequest::GetManyOutputs { outputs })

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -434,7 +434,7 @@ where
                 Ok(OutputManagerResponse::InvalidOutputs(outputs))
             },
             OutputManagerRequest::GetManyOutputs { outputs } => {
-                let outputs = self.fetch_many_outputs(&outputs)?.into_iter().collect();
+                let outputs = self.fetch_many_outputs(&outputs)?;
                 Ok(OutputManagerResponse::Outputs(outputs))
             },
             OutputManagerRequest::PreviewCoinJoin((commitments, fee_per_gram)) => {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -434,11 +434,7 @@ where
                 Ok(OutputManagerResponse::InvalidOutputs(outputs))
             },
             OutputManagerRequest::GetManyOutputs { outputs } => {
-                let outputs = self
-                    .fetch_many_outputs(&outputs)?
-                    .into_iter()
-                    .map(|v| (v.clone(), v.into()))
-                    .collect();
+                let outputs = self.fetch_many_outputs(&outputs)?.into_iter().collect();
                 Ok(OutputManagerResponse::Outputs(outputs))
             },
             OutputManagerRequest::PreviewCoinJoin((commitments, fee_per_gram)) => {

--- a/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::time::Duration;
+
 use log::*;
 use minotari_node_wallet_client::BaseNodeWalletClient;
 use tari_common_types::{burn_proof::EncodedMerkleProof, types::FixedHash};
@@ -10,7 +12,8 @@ use crate::{
     connectivity_service::WalletConnectivityInterface,
     transaction_service::storage::database::{TransactionBackend, TransactionDatabase},
 };
-
+const RETRY_DELAY: Duration = Duration::from_secs(10);
+const MAX_ATTEMPTS: usize = 10;
 const LOG_TARGET: &str = "wallet::transaction_service::protocols::sync_claim_burn_merkle_proofs";
 
 pub async fn execute<TBackend, TConnectivity>(
@@ -31,9 +34,9 @@ pub async fn execute<TBackend, TConnectivity>(
         if let Err(err) = execute_inner(&db, &connectivity, &confirmed_burns).await {
             // TODO: not very robust, some burnt outputs may never be updated (save it for the rewrite ;).
             error!(target: LOG_TARGET, "Error in sync_claim_burn_merkle_proofs: {}", err);
-            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            tokio::time::sleep(RETRY_DELAY).await;
             attempt += 1;
-            if attempt > 10 {
+            if attempt > MAX_ATTEMPTS {
                 error!(
                     target: LOG_TARGET,
                     "sync_claim_burn_merkle_proofs failed after {} attempts, giving up",

--- a/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
@@ -4,25 +4,21 @@
 use log::*;
 use minotari_node_wallet_client::BaseNodeWalletClient;
 use tari_common_types::{burn_proof::EncodedMerkleProof, types::FixedHash};
-use tari_transaction_key_manager::legacy_key_manager::LegacyTransactionKeyManagerInterface;
 use tari_utilities::ByteArray;
 
 use crate::{
     connectivity_service::WalletConnectivityInterface,
-    output_manager_service::handle::OutputManagerHandle,
     transaction_service::storage::database::{TransactionBackend, TransactionDatabase},
 };
 
 const LOG_TARGET: &str = "wallet::transaction_service::protocols::sync_claim_burn_merkle_proofs";
 
-pub async fn execute<TBackend, KM, TConnectivity>(
+pub async fn execute<TBackend, TConnectivity>(
     db: TransactionDatabase<TBackend>,
-    output_manager: OutputManagerHandle<KM>,
     connectivity: TConnectivity,
     confirmed_burns: Vec<FixedHash>,
 ) where
     TBackend: TransactionBackend + 'static,
-    KM: LegacyTransactionKeyManagerInterface,
     TConnectivity: WalletConnectivityInterface,
 {
     debug!(
@@ -30,21 +26,34 @@ pub async fn execute<TBackend, KM, TConnectivity>(
         "Starting sync_claim_burn_merkle_proofs with {} confirmed burns",
         confirmed_burns.len()
     );
-    if let Err(err) = execute_inner(db, output_manager, connectivity, confirmed_burns).await {
-        // TODO: not very robust, some burnt outputs may never be updated (save it for the rewrite ;).
-        error!(target: LOG_TARGET, "Error in sync_claim_burn_merkle_proofs: {}", err);
+    let mut attempt = 0usize;
+    loop {
+        if let Err(err) = execute_inner(&db, &connectivity, &confirmed_burns).await {
+            // TODO: not very robust, some burnt outputs may never be updated (save it for the rewrite ;).
+            error!(target: LOG_TARGET, "Error in sync_claim_burn_merkle_proofs: {}", err);
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            attempt += 1;
+            if attempt > 10 {
+                error!(
+                    target: LOG_TARGET,
+                    "sync_claim_burn_merkle_proofs failed after {} attempts, giving up",
+                    attempt
+                );
+                break;
+            }
+            continue;
+        }
+        break;
     }
 }
 
-async fn execute_inner<TBackend, KM, TConnectivity>(
-    db: TransactionDatabase<TBackend>,
-    mut output_manager: OutputManagerHandle<KM>,
-    connectivity: TConnectivity,
-    confirmed_burns: Vec<FixedHash>,
+async fn execute_inner<TBackend, TConnectivity>(
+    db: &TransactionDatabase<TBackend>,
+    connectivity: &TConnectivity,
+    confirmed_burns: &Vec<FixedHash>,
 ) -> anyhow::Result<()>
 where
     TBackend: TransactionBackend + 'static,
-    KM: LegacyTransactionKeyManagerInterface,
     TConnectivity: WalletConnectivityInterface,
 {
     let timer = std::time::Instant::now();
@@ -60,37 +69,16 @@ where
         timer.elapsed()
     );
 
-    let num_expected = confirmed_burns.len();
-    let outputs = output_manager.get_many_outputs(confirmed_burns).await?;
-    if outputs.len() != num_expected {
-        warn!(
-            target: LOG_TARGET,
-            "Some requested outputs were not found. Requested {}, but only found {} in the database",
-            num_expected,
-            outputs.len()
-        );
-    }
-
-    for output in outputs {
-        if !output.1.features().output_type.is_burn() {
+    for output_hash in confirmed_burns {
+        let Some(burn) = db.fetch_burn_proof(output_hash)? else {
             warn!(
                 target: LOG_TARGET,
-                "NEVER HAPPEN: Output with key id {} is not a burn output, skipping",
-                output.1.commitment_mask_key_id()
-            );
-            continue;
-        }
-
-        let output_hash = output.1.output_hash();
-        let Some(burn) = db.fetch_burn_proof(&output_hash)? else {
-            // OK - UTXO not burnt with claim key, so no burn proof
-            debug!(
-                target: LOG_TARGET,
-                "Burn output {} not found in database, skipping",
+                "No burn proof found in database for output {}, skipping",
                 output_hash
             );
             continue;
         };
+
         if burn.kernel_merkle_proof.is_some() {
             // If we're getting the same output again, there could be a reorg so just to be safe we'll refetch.
             warn!(
@@ -123,7 +111,7 @@ where
 
                 // We trust our base node right? ;-) So just store it without validating.
 
-                db.update_burn_proof_set_merkle_proof(&output_hash, &EncodedMerkleProof {
+                db.update_burn_proof_set_merkle_proof(output_hash, &EncodedMerkleProof {
                     block_hash: resp.block_hash,
                     encoded_merkle_proof: resp.encoded_merkle_proof,
                     leaf_index: resp.leaf_index,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -109,7 +109,6 @@ where
         if !confirmed_burnt.is_empty() {
             tokio::spawn(fetch_claim_burn_merkle_proofs::execute(
                 self.db.clone(),
-                self.output_manager.clone(),
                 self.connectivity.clone(),
                 confirmed_burnt,
             ));


### PR DESCRIPTION
Description
---
fix(wallet): fix fetching kernel merkle proof

Motivation and Context
---
A burnt output is not contained in the output database. Burnt outputs are kept in a separate table however the merkle proof fetching task was fetching from the output table. 

This PR removes the unnecessary query for the output manager in the `sync_claim_burn_merkle_proofs` task and makes it more robust by adding a simple retry.

How Has This Been Tested?
---
Claiming a burn successfully using Ootle swarm

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
