### PR TITLE
fix: update git2 to 0.20.4 rustsec-2026-0008

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,9 +2611,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.18.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
@@ -3782,9 +3782,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.2+1.7.2"
+version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 cargo_toml = { version = "0.20.4" }
 config = { version = "0.14.0", default-features = false, features = ["toml"] }
 dirs-next = "1.0.2"
-git2 = { version = "0.18", default-features = false, optional = true }
+git2 = { version = "0.20.4", default-features = false, optional = true }
 log = { workspace = true }
 log4rs = { workspace = true, default-features = false, features = [
     "config_parsing",


### PR DESCRIPTION
Description
---
fix: update git2 to 0.20.4 rustsec-2026-0008

Motivation and Context
---
fixes https://github.com/tari-project/tari/issues/7673
fixes https://github.com/tari-project/tari-ootle/issues/1751
