### PR TITLE
fix: seed peer connections kept open

### DIFF
--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -158,6 +158,10 @@ pub struct P2pConfig {
     /// it with a new session. If false, the RPC server will reject the new session and preserve the older session.
     /// (default value = true).
     pub cull_oldest_peer_rpc_connection_on_full: bool,
+    /// The maximum time a seed peer connection is allowed to stay open before being forcibly closed.
+    /// Default: 15 minutes
+    #[serde(with = "serializers::seconds")]
+    pub max_seed_peer_age: Duration,
 }
 
 impl Default for P2pConfig {
@@ -183,6 +187,7 @@ impl Default for P2pConfig {
             rpc_max_simultaneous_sessions: 100,
             rpc_max_sessions_per_peer: 10,
             cull_oldest_peer_rpc_connection_on_full: true,
+            max_seed_peer_age: Duration::from_secs(15 * 60),
         }
     }
 }

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -569,7 +569,8 @@ impl ServiceInitializer for P2pInitializer {
                 network_wire_byte: self.network.as_wire_byte(),
                 user_agent: self.user_agent.clone(),
             })
-            .with_connection_pool_refresh_interval(config.dht.connectivity.random_pool_refresh_interval)
+            .with_connection_pool_refresh_interval(config.dht.connectivity.update_interval)
+            .with_max_seed_peer_age(config.max_seed_peer_age)
             .with_peer_validator_config(config.dht.peer_validator_config.clone())
             .with_minimize_connections(if self.config.dht.minimize_connections {
                 Some(self.config.dht.num_neighbouring_nodes + self.config.dht.num_random_nodes)

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -161,6 +161,11 @@ impl CommsBuilder {
         self
     }
 
+    pub fn with_max_seed_peer_age(mut self, max_age: Duration) -> Self {
+        self.connectivity_config.max_seed_peer_age = max_age;
+        self
+    }
+
     /// Return the node identity for this comms instance.
     pub fn node_identity(&self) -> Option<Arc<NodeIdentity>> {
         self.node_identity.clone()

--- a/comms/core/src/connectivity/config.rs
+++ b/comms/core/src/connectivity/config.rs
@@ -70,6 +70,9 @@ pub struct ConnectivityConfig {
     /// Time to wait before retrying a circuit-broken peer
     /// Default: 2 minutes
     pub circuit_breaker_retry_interval: Duration,
+    /// Maximum seed peer age
+    /// Default: 15 minutes
+    pub max_seed_peer_age: Duration,
 }
 
 impl Default for ConnectivityConfig {
@@ -90,6 +93,7 @@ impl Default for ConnectivityConfig {
             success_rate_tracking_window: Duration::from_secs(5 * 60),
             circuit_breaker_failure_threshold: 3,
             circuit_breaker_retry_interval: Duration::from_secs(2 * 60),
+            max_seed_peer_age: Duration::from_secs(15 * 60),
         }
     }
 }

--- a/comms/core/src/connectivity/connection_pool.rs
+++ b/comms/core/src/connectivity/connection_pool.rs
@@ -169,7 +169,7 @@ impl ConnectionPool {
 
     pub fn get_inactive_outbound_connections_mut(&mut self, min_age: Duration) -> Vec<&mut PeerConnection> {
         self.filter_connections_mut(|conn| {
-            conn.age() > min_age && conn.handle_count() <= 1 && conn.substream_count() > 2
+            conn.age() > min_age && conn.handle_count() <= 1 && conn.substream_count() < 3
         })
     }
 

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -667,10 +667,8 @@ impl ConnectivityManagerActor {
         let mut seeds_to_disconnect = Vec::new();
         for seed_node_id in &self.seeds {
             if let Some(conn) = self.pool.get_connection(seed_node_id) {
-                if conn.is_connected() {
-                    if conn.age() > self.config.max_seed_peer_age {
-                        seeds_to_disconnect.push(conn.clone());
-                    }
+                if conn.is_connected() && conn.age() > self.config.max_seed_peer_age {
+                    seeds_to_disconnect.push(conn.clone());
                 }
             }
         }

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -468,6 +468,8 @@ impl ConnectivityManagerActor {
         );
 
         self.clean_connection_pool();
+        self.disconnect_seed_peers(task_id).await;
+
         if self.config.is_connection_reaping_enabled {
             self.reap_inactive_connections(task_id).await;
         }
@@ -640,6 +642,89 @@ impl ConnectivityManagerActor {
                 len,
                 start.elapsed()
             );
+        }
+    }
+
+    async fn refresh_seeds_list(&mut self) {
+        match self.peer_manager.get_seed_peers().await {
+            Ok(seeds) => {
+                self.seeds = seeds.into_iter().map(|p| p.node_id).collect();
+            },
+            Err(err) => {
+                error!(target: LOG_TARGET, "Failed to fetch seed peers: {}", err);
+            },
+        }
+    }
+
+    async fn disconnect_seed_peers(&mut self, task_id: u64) {
+        self.refresh_seeds_list().await;
+
+        if self.seeds.is_empty() {
+            return;
+        }
+
+        // Identify seeds that are too old
+        let mut seeds_to_disconnect = Vec::new();
+        for seed_node_id in &self.seeds {
+            if let Some(conn) = self.pool.get_connection(seed_node_id) {
+                if conn.is_connected() {
+                    if conn.age() > self.config.max_seed_peer_age {
+                        seeds_to_disconnect.push(conn.clone());
+                    }
+                }
+            }
+        }
+
+        if seeds_to_disconnect.is_empty() {
+            return;
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "({}) Found {} seed peer(s) eligible for cleanup", task_id, seeds_to_disconnect.len()
+        );
+
+        for mut conn in seeds_to_disconnect {
+            if self.pool.count_connected_nodes() <= self.config.min_connectivity {
+                debug!(
+                    target: LOG_TARGET,
+                    "({}) SKIPPING seed disconnect for '{}'. Connected Nodes ({}) <= Min ({})",
+                    task_id,
+                    conn.peer_node_id().short_str(),
+                    self.pool.count_connected_nodes(),
+                    self.config.min_connectivity
+                );
+                break;
+            }
+
+            debug!(
+                target: LOG_TARGET,
+                "({}) Disconnecting seed peer '{}' ...",
+                task_id,
+                conn.peer_node_id().short_str()
+            );
+
+            match disconnect_with_timeout(
+                &mut conn,
+                Minimized::Yes,
+                Some(task_id),
+                "ConnectivityManagerActor disconnect seed",
+            )
+            .await
+            {
+                Ok(_) => {
+                    self.pool.remove(conn.peer_node_id());
+                },
+                Err(err) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Seed peer '{}' already disconnected ({:?}). Error: {:?}",
+                        conn.peer_node_id().short_str(),
+                        task_id,
+                        err
+                    );
+                },
+            }
         }
     }
 
@@ -1204,27 +1289,24 @@ impl ConnectivityManagerActor {
         // Update circuit breaker metrics
         self.update_circuit_breaker_metrics();
 
+        self.refresh_seeds_list().await;
+
+        // Determine if we should exclude seeds.
+        let excluded_peers = if self.pool.count_connected_nodes() < self.config.min_connectivity {
+            debug!(target: LOG_TARGET, "({}) Critical connectivity level ({} < {}). Allowing proactive dialer to retry Seed Nodes.",
+                task_id,
+                self.pool.count_connected_nodes(),
+                self.config.min_connectivity
+            );
+            vec![]
+        } else {
+            self.seeds.clone()
+        };
+
         // Execute proactive dialing logic
-        if self.seeds.is_empty() {
-            self.seeds = self
-                .peer_manager
-                .get_seed_peers()
-                .await
-                .inspect_err(|err| {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Failed to get seed peers from PeerManager, using empty list for proactive dialing, seed peers \
-                        will not be excluded as a first pass. ({})", err
-                    );
-                })
-                .unwrap_or(vec![])
-                .iter()
-                .map(|s| s.node_id.clone())
-                .collect();
-        }
         match self
             .proactive_dialer
-            .execute_proactive_dialing(&self.pool, &self.connection_stats, &self.seeds, task_id)
+            .execute_proactive_dialing(&self.pool, &self.connection_stats, &excluded_peers, task_id)
             .await
         {
             Ok(dialed_count) => {

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -39,7 +39,7 @@ use super::{
 use crate::{
     connection_manager::{ConnectionManagerError, ConnectionManagerEvent},
     connectivity::ConnectivityEventRx,
-    peer_manager::{Peer, PeerFeatures},
+    peer_manager::{Peer, PeerFeatures, PeerFlags},
     test_utils::{
         build_peer_manager,
         mocks::{create_connection_manager_mock, create_peer_connection_mock_pair, ConnectionManagerMockState},
@@ -461,4 +461,72 @@ async fn pool_management() {
     unpack_enum!(ConnectivityEvent::PeerDisconnected(..) = events.remove(0));
     let conns = connectivity.get_active_connections().await.unwrap();
     assert!(conns.is_empty());
+}
+
+#[tokio::test]
+async fn seed_peer_release() {
+    let config = ConnectivityConfig {
+        min_connectivity: 1,
+        connection_pool_refresh_interval: Duration::from_millis(100),
+        max_seed_peer_age: Duration::from_secs(3),
+        ..Default::default()
+    };
+
+    let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
+        setup_connectivity_manager(config);
+
+    let peers = add_test_peers(&peer_manager, 2).await;
+
+    // Peer 0 = SEED
+    let mut seed_peer = peers[0].clone();
+    seed_peer.add_flags(PeerFlags::SEED);
+    peer_manager.add_or_update_peer(seed_peer.clone()).await.unwrap();
+
+    // Peer 1 = NORMAL
+    let normal_peer = peers[1].clone();
+
+    // Connect to both
+    let connections = future::join_all(
+        vec![seed_peer.clone(), normal_peer.clone()]
+            .iter()
+            .cloned()
+            .map(|peer| {
+                let my_id = node_identity.clone();
+                async move { create_peer_connection_mock_pair(peer, my_id.to_peer()).await }
+            }),
+    )
+    .await
+    .into_iter()
+    .map(|(_, _, conn, _)| conn)
+    .collect::<Vec<_>>();
+
+    let seed_conn = &connections[0];
+    let normal_conn = &connections[1];
+
+    let mut events = collect_try_recv!(event_stream, take = 1, timeout = Duration::from_secs(5));
+    unpack_enum!(ConnectivityEvent::ConnectivityStateInitialized = events.remove(0));
+
+    // Simulate connections
+    cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(seed_conn.clone().into()));
+    cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(normal_conn.clone().into()));
+
+    // Wait for events to propagate
+    let conn_events = collect_try_recv!(event_stream, take = 2, timeout = Duration::from_secs(5));
+    assert_eq!(conn_events.len(), 2, "Expected 2 connection events");
+
+    // Verify Initial State (Age < 3s)
+    let conns = connectivity.get_active_connections().await.unwrap();
+    assert_eq!(conns.len(), 2, "Both peers should be connected initially");
+
+    // Sleep 3.5s to cross the 3s threshold + allow refresh cycle
+    tokio::time::sleep(Duration::from_millis(3500)).await;
+
+    // Verify Disconnection
+    let conns = connectivity.get_active_connections().await.unwrap();
+    assert_eq!(conns.len(), 1, "Seed peer should have been disconnected");
+    assert_eq!(
+        conns[0].peer_node_id(),
+        &normal_peer.node_id,
+        "Remaining peer should be the normal peer"
+    );
 }

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -486,15 +486,10 @@ async fn seed_peer_release() {
     let normal_peer = peers[1].clone();
 
     // Connect to both
-    let connections = future::join_all(
-        vec![seed_peer.clone(), normal_peer.clone()]
-            .iter()
-            .cloned()
-            .map(|peer| {
-                let my_id = node_identity.clone();
-                async move { create_peer_connection_mock_pair(peer, my_id.to_peer()).await }
-            }),
-    )
+    let connections = future::join_all([seed_peer.clone(), normal_peer.clone()].into_iter().map(|peer| {
+        let my_id = node_identity.clone();
+        async move { create_peer_connection_mock_pair(peer, my_id.to_peer()).await }
+    }))
     .await
     .into_iter()
     .map(|(_, _, conn, _)| conn)

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -677,8 +677,10 @@ impl PeerDatabaseSql {
     fn update_peer_sql(peer: Peer) -> Result<UpdatePeerWithAddressesSql, StorageError> {
         let update_peer_sql = UpdatePeerSql {
             node_id: Some(peer.node_id.to_hex()),
+            flags: Some(peer.flags.to_i32()),
             banned_until: Some(peer.banned_until),
             banned_reason: Some(peer.banned_reason.clone()),
+            features: Some(peer.features.to_i32()),
             supported_protocols: Some(serialize_protocols(&peer.supported_protocols)),
             user_agent: Some(peer.user_agent.clone()),
             metadata: Some(serialize_metadata(&peer.metadata)?),
@@ -1756,7 +1758,10 @@ impl PeerDatabaseSql {
         // Perform a join query to fetch peers and their addresses
         let results = peers::table
             .inner_join(multi_addresses::table.on(multi_addresses::peer_id.eq(peers::peer_id)))
-            .filter(peers::flags.eq(PeerFlags::SEED.to_i32()))
+            .filter(diesel::dsl::sql::<diesel::sql_types::Bool>(&format!(
+                "flags & {} != 0",
+                PeerFlags::SEED.to_i32()
+            )))
             .load::<(NewPeerSql, NewMultiaddrWithStatsSql)>(&mut conn)?;
 
         PeerDatabaseSql::peers_from_join_query(results)
@@ -1833,8 +1838,10 @@ pub struct NewPeerSql {
 #[diesel(table_name = peers)]
 pub struct UpdatePeerSql {
     pub node_id: Option<String>,
+    pub flags: Option<i32>,
     pub banned_until: Option<Option<NaiveDateTime>>,
     pub banned_reason: Option<String>,
+    pub features: Option<i32>,
     pub supported_protocols: Option<String>,
     pub user_agent: Option<String>,
     pub metadata: Option<Option<Vec<u8>>>,


### PR DESCRIPTION
Description
---

Bugs fixed:
- incorrect identification of idle peers (`substream_count() > 2` -> `substream_count() < 3`)
- `ConnectivityManager` was using `random_pool_refresh_interval` (default 2 hrs) instead of intended `update_interval` (default 2 minutes) to fire cleanup logic
- broken seed detection - `get_seed_peers` checked exact equality (`flags == SEED`). If a peer had multiple flags (`SEED | COMPACT`), it would be ignored.

New features / changes:
- Seed nodes are now forcibly disconnected after a grace period, provided the node has sufficient other connections (`> min_connectivity`)
- Added config entry `max_seed_peer_age` (default 15 minutes)
- `update_peer_sql` will persist `flags` and `features` as well

Closes #7558

Motivation and Context
---

It was noticed, that seed connections where kept open for a long time.

How Has This Been Tested?
---

Added a test.

And tested manually:

```
>> list-connections

Base Nodes
----------

NodeId                     | Public Key                                                       | Address                                                                | Direction | Age     | User Agent                | Seed | Info                                  
-------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------- | --------- | ------- | ------------------------- | ---- | ------------------------------------- 
ace05844c9c9723a8597682be3 | 1e08628960f75b7e324f010b2ee609a9e28097e9101f4d769d474a38b6ee2d76 | /ip4/51.83.102.25/tcp/18189                                            | Outbound  | 12m 33s | tari/basenode/5.3.0-pre.1 | SEED | height: 509627, hnd: 2, ss: 2, rpc: 0 
1918864cd464060b70f5158f3e | 6294d74a49720ce37f847d1da69259ac3153b66d40c319a6d44a0982245db51f | /onion3/jimpqrodmtzize3w4wilju6w6nx77ditwp5677lj5mhxlrd6v67s4qqd:18141 | Outbound  | 6m 27s  | tari/basenode/5.3.0-pre.1 |      | height: 509627, hnd: 3, ss: 2, rpc: 0 
e0e3f3a847fbf71baf30cfc79d | 7a079f2b813ddbf5e59403c80200af4137ddd8b0d3f017e2ec6b8fa2fb4f397e | /onion3/bwagn3fa7any5uig2brzbxbk7uxgf5hp2wfbpkmja2pqz37k2zn252qd:18141 | Outbound  | 12m 29s | tari/basenode/5.1.0       |      | height: 509627, hnd: 3, ss: 2, rpc: 0 
52476d7371e2d3cfdc6aa9fa8e | 6001c31cc69b7a4211bdde8a73b88a467fa6a285b2d69631b35747b2df6c7704 | /onion3/3lklntggyxiwi6b5sjwwiwkvzhsiljqyzripveh2uw5lvqarww6lyyad:18141 | Outbound  | 12m 21s | tari/basenode/5.2.0-pre.0 |      | height: 509627, hnd: 3, ss: 2, rpc: 0 
ab2fad12f448628436bcbe98d1 | 4cdfb70e0b38b60c6a3573b2870e32bc3d846419c606ea379f43650b80f38409 | /ip4/51.83.4.85/tcp/18189                                              | Outbound  | 12m 18s | tari/basenode/5.3.0-pre.1 | SEED | height: 509627, hnd: 3, ss: 2, rpc: 0 
bb8da2644a856e5d5f8a7db05c | 2ca6775cde640eff6f433c2bbdda8846e299b667317434996f388630c3b8ae04 | /onion3/a4civpppxeoryjshkezvpi6j2zj4f3pplxjxj55uzlnxaqqmr6svcsad:18141 | Outbound  | 12m 29s | tari/basenode/5.2.1-pre.2 |      | height: 509627, hnd: 3, ss: 2, rpc: 0 
d4ffef3e484b36bac72c46064a | 4e3cf7e6509d41accbed3a1098c2abf601a6b23098a03ffd992eb047e1566561 | /onion3/ngjw3rcuvpfpyg64qyqhlvjitrzq2y3r6hucrk5yqwk6uhkekqnbhead:18141 | Outbound  | 10m 12s | tari/basenode/5.2.1-pre.2 |      | height: 509627, hnd: 3, ss: 2, rpc: 0 
7 active connection(s)

Wallets
-------
No active wallet connections.
>> 
```

**when 15 minutes elapsed**

```
>> list-connections

Base Nodes
----------

NodeId                     | Public Key                                                       | Address                                                                | Direction | Age     | User Agent                | Seed | Info                                  
-------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------- | --------- | ------- | ------------------------- | ---- | ------------------------------------- 
1918864cd464060b70f5158f3e | 6294d74a49720ce37f847d1da69259ac3153b66d40c319a6d44a0982245db51f | /onion3/jimpqrodmtzize3w4wilju6w6nx77ditwp5677lj5mhxlrd6v67s4qqd:18141 | Outbound  | 11m 41s | tari/basenode/5.3.0-pre.1 |      | height: 509629, hnd: 3, ss: 2, rpc: 0 
bb8da2644a856e5d5f8a7db05c | 2ca6775cde640eff6f433c2bbdda8846e299b667317434996f388630c3b8ae04 | /onion3/a4civpppxeoryjshkezvpi6j2zj4f3pplxjxj55uzlnxaqqmr6svcsad:18141 | Outbound  | 17m 42s | tari/basenode/5.2.1-pre.2 |      | height: 509629, hnd: 3, ss: 2, rpc: 0 
d4ffef3e484b36bac72c46064a | 4e3cf7e6509d41accbed3a1098c2abf601a6b23098a03ffd992eb047e1566561 | /onion3/ngjw3rcuvpfpyg64qyqhlvjitrzq2y3r6hucrk5yqwk6uhkekqnbhead:18141 | Outbound  | 15m 25s | tari/basenode/5.2.1-pre.2 |      | height: 509629, hnd: 3, ss: 2, rpc: 0 
e0e3f3a847fbf71baf30cfc79d | 7a079f2b813ddbf5e59403c80200af4137ddd8b0d3f017e2ec6b8fa2fb4f397e | /onion3/bwagn3fa7any5uig2brzbxbk7uxgf5hp2wfbpkmja2pqz37k2zn252qd:18141 | Outbound  | 17m 42s | tari/basenode/5.1.0       |      | height: 509629, hnd: 3, ss: 2, rpc: 0 
ace05844c9c9723a8597682be3 | 1e08628960f75b7e324f010b2ee609a9e28097e9101f4d769d474a38b6ee2d76 | /ip4/51.83.102.25/tcp/18189                                            | Outbound  | 1m 47s  | tari/basenode/5.3.0-pre.1 | SEED | height: 509629, hnd: 3, ss: 2, rpc: 0 
52476d7371e2d3cfdc6aa9fa8e | 6001c31cc69b7a4211bdde8a73b88a467fa6a285b2d69631b35747b2df6c7704 | /onion3/3lklntggyxiwi6b5sjwwiwkvzhsiljqyzripveh2uw5lvqarww6lyyad:18141 | Outbound  | 17m 34s | tari/basenode/5.2.0-pre.0 |      | height: 509629, hnd: 3, ss: 2, rpc: 0 
ab2fad12f448628436bcbe98d1 | 4cdfb70e0b38b60c6a3573b2870e32bc3d846419c606ea379f43650b80f38409 | /ip4/51.83.4.85/tcp/18189                                              | Outbound  | 1m 47s  | tari/basenode/5.3.0-pre.1 | SEED | height: 509629, hnd: 3, ss: 2, rpc: 0 
7 active connection(s)

Wallets
-------
No active wallet connections.
>> 
```


What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
