### PR TITLE
fix: wrong XMR blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4276,6 +4276,7 @@ dependencies = [
  "config",
  "crossterm 0.28.1",
  "dhat",
+ "futures 0.3.31",
  "hex",
  "http-body 1.0.1",
  "http-body-util",

--- a/applications/minotari_merge_mining_proxy/Cargo.toml
+++ b/applications/minotari_merge_mining_proxy/Cargo.toml
@@ -40,6 +40,7 @@ clap = { version = "3.2", features = ["derive", "env"] }
 config = { version = "0.14.0" }
 crossterm = { version = "0.28" }
 dhat = "0.3.3"
+futures = "0.3"
 hex = "0.4.2"
 hyper = { version = "1.6.0", features = ["full"] }
 hyper-util = "0.1"

--- a/applications/minotari_merge_mining_proxy/docs/Architecture.md
+++ b/applications/minotari_merge_mining_proxy/docs/Architecture.md
@@ -1,0 +1,68 @@
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Miner as XMRig (Miner)
+    box rgb(40, 40, 60) Minotari Proxy
+    participant Proxy as MM Proxy Service
+    participant Repo as BlockTemplateRepository
+    end
+    participant Monerod as Monerod (Node)
+    participant Tari as Tari Base Node (gRPC)
+
+    %% ----------------------------------------------------
+    rect rgb(20, 50, 20)
+    note right of Miner: WORKFLOW 1: Requesting Work (getblocktemplate)
+    
+    Miner->>Proxy: POST /json_rpc (getblocktemplate)
+    
+    note over Proxy: Intercept request.<br/>If extra_nonce exists, pad with 70 zeroes (35 bytes). Else add 35 to reserve_size.<br/>Remove Content-Length.
+    
+    Proxy->>Monerod: Forward modified getblocktemplate
+    Monerod-->>Proxy: Returns Template (Reward properly penalized for weight)
+    
+    Proxy->>Tari: gRPC: get_new_block
+    Tari-->>Proxy: Returns Tari Block Data
+    
+    note over Proxy: Stitch Tari data into Monero block.<br/>Update reserved_offset += 35.
+    
+    Proxy->>Repo: Save complete Block Data (for later lookup)
+    
+    Proxy-->>Miner: Return modified Monero Template
+    end
+
+    %% ----------------------------------------------------
+    rect rgb(50, 20, 20)
+    note right of Miner: WORKFLOW 2: Submitting a Solution (submit_block)
+    
+    Miner->>Proxy: POST /json_rpc (submit_block)
+    
+    note over Proxy: Extract Tari Hash from solved block.
+    
+    Proxy->>Repo: Lookup original Block Data using Tari Hash
+    Repo-->>Proxy: Return complete Block Data
+    
+    note over Proxy: Check if Tari difficulty is met.
+    
+    opt If Tari difficulty met
+        Proxy->>Tari: gRPC: submit_block (Tari Block)
+        Tari-->>Proxy: Success
+    end
+    
+    Proxy->>Monerod: Forward submit_block (Monero Block)
+    note over Monerod: Validates block.<br/>Weight matches reward perfectly!
+    Monerod-->>Proxy: Success
+    
+    Proxy-->>Miner: Success (Status: OK)
+    end
+
+    %% ----------------------------------------------------
+    rect rgb(20, 30, 50)
+    note right of Miner: WORKFLOW 3: Memory Management
+    
+    loop Every 10 Minutes
+        note over Proxy: Background tokio task
+        Proxy->>Repo: remove_outdated()
+        note over Repo: Drops requested templates<br/>older than 20 mins.
+    end
+    end
+```

--- a/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
@@ -789,7 +789,10 @@ impl InnerService {
             .map(|s| s.to_string())
         {
             // XMRig sent `extra_nonce`. Append hex zeroes to force weight calculation.
-            let padding = "0".repeat((TARI_MERGE_MINING_DATA_SIZE * 2) as usize);
+            let padding = "0".repeat(
+                usize::try_from(TARI_MERGE_MINING_DATA_SIZE * 2)
+                    .map_err(|err| MmProxyError::ConversionError(err.to_string()))?,
+            );
             let new_extra_nonce = format!("{}{}", extra_nonce, padding);
             params.insert("extra_nonce".to_string(), serde_json::json!(new_extra_nonce));
             params.remove("reserve_size");
@@ -822,11 +825,9 @@ impl InnerService {
 
         // Intercept the getblocktemplate request and ask Monerod to reserve an extra 35 bytes.
         // This forces Monerod to correctly calculate the block weight penalty
-        if monerod_method == MonerodMethod::GetBlockTemplate {
-            if self.modify_monero_template_request(&mut json)? {
-                let json_bytes = serde_json::to_vec(&json).map_err(|e| MmProxyError::ConversionError(e.to_string()))?;
-                body = Bytes::from(json_bytes);
-            }
+        if monerod_method == MonerodMethod::GetBlockTemplate && self.modify_monero_template_request(&mut json)? {
+            let json_bytes = serde_json::to_vec(&json).map_err(|e| MmProxyError::ConversionError(e.to_string()))?;
+            body = Bytes::from(json_bytes);
         }
 
         let start = Instant::now();

--- a/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
@@ -68,6 +68,7 @@ const LOG_TARGET: &str = "minotari_mm_proxy::proxy::inner";
 /// The identifier used to identify the tari aux chain data
 const TARI_CHAIN_ID: &str = "xtr";
 const BUSY_QUALIFYING: &str = "BusyQualifyingMonerodUrl";
+const TARI_MERGE_MINING_DATA_SIZE: u64 = 35;
 
 #[derive(Debug, Clone)]
 pub struct InnerService {
@@ -315,7 +316,6 @@ impl InnerService {
                     },
                 }
             };
-            self.block_templates.remove_outdated().await;
         }
 
         debug!(
@@ -429,6 +429,12 @@ impl InnerService {
         monerod_resp["result"]["blocktemplate_blob"] = final_block_template_data.blocktemplate_blob.clone().into();
         monerod_resp["result"]["blockhashing_blob"] = final_block_template_data.blockhashing_blob.clone().into();
         monerod_resp["result"]["difficulty"] = final_block_template_data.target_difficulty.as_u64().into();
+
+        // We must shift the reserved_offset so the miner writes its nonce in the correct place,
+        // preventing coinbase corruption.
+        if let Some(offset) = monerod_resp["result"]["reserved_offset"].as_u64() {
+            monerod_resp["result"]["reserved_offset"] = (offset + TARI_MERGE_MINING_DATA_SIZE).into();
+        }
 
         let tari_difficulty = final_block_template_data.template.tari_difficulty;
         let tari_height = final_block_template_data
@@ -758,6 +764,46 @@ impl InnerService {
         Err(MmProxyError::ServersUnavailable(format!("{}", self.config.monerod_url)))
     }
 
+    // Modifies the Monero `getblocktemplate` request to reserve space for the Minotari merge mining tag.
+    /// This function intercepts the JSON-RPC parameters and ensures that Monerod accounts for the
+    /// extra space (35 bytes) required for the Minotari tag in the coinbase transaction. This is
+    /// crucial for correct block weight and hashing blob calculation.
+    ///
+    /// # Logic
+    /// * If `extra_nonce` is present (common with XMRig), it appends 35 bytes of padding (70 hex zeros) to it.
+    /// * Otherwise, it increments the `reserve_size` parameter by 35 bytes.
+    ///
+    /// # Returns
+    /// * `Ok(true)` if the JSON was modified (the caller must re-serialize the body).
+    /// * `Ok(false)` if no modification was made (e.g. parameters were missing).
+    /// * `Err(_)` if an error occurred during processing.
+    fn modify_monero_template_request(&self, json: &mut serde_json::Value) -> Result<bool, MmProxyError> {
+        let params = match json.get_mut("params").and_then(|p| p.as_object_mut()) {
+            Some(p) => p,
+            None => return Ok(false),
+        };
+
+        if let Some(extra_nonce) = params
+            .get("extra_nonce")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+        {
+            // XMRig sent `extra_nonce`. Append hex zeroes to force weight calculation.
+            let padding = "0".repeat((TARI_MERGE_MINING_DATA_SIZE * 2) as usize);
+            let new_extra_nonce = format!("{}{}", extra_nonce, padding);
+            params.insert("extra_nonce".to_string(), serde_json::json!(new_extra_nonce));
+            params.remove("reserve_size");
+        } else {
+            let current_reserve = params.get("reserve_size").and_then(|v| v.as_u64()).unwrap_or(0);
+            params.insert(
+                "reserve_size".to_string(),
+                serde_json::json!(current_reserve + TARI_MERGE_MINING_DATA_SIZE),
+            );
+        }
+
+        Ok(true)
+    }
+
     /// Proxy a request received by this server to Monerod
     #[allow(clippy::too_many_lines)]
     async fn proxy_request_to_monerod(
@@ -769,14 +815,27 @@ impl InnerService {
         trace!(target: LOG_TARGET, "proxy_request_to_monerod: '{}' (trace_id: {})", monerod_method, trace_id);
 
         // This is a cheap clone of the request body
-        let body: Bytes = request.body().clone();
-        let json = json::from_slice::<json::Value>(&body[..]).unwrap_or_default();
+        let mut body: Bytes = request.body().clone();
+        let mut json = json::from_slice::<json::Value>(&body[..]).unwrap_or_default();
         let request_id = json["id"].as_i64();
         let self_select_response = monerod_method == MonerodMethod::SubmitBlock && !self.config.submit_to_origin;
+
+        // Intercept the getblocktemplate request and ask Monerod to reserve an extra 35 bytes.
+        // This forces Monerod to correctly calculate the block weight penalty
+        if monerod_method == MonerodMethod::GetBlockTemplate {
+            if self.modify_monero_template_request(&mut json)? {
+                let json_bytes = serde_json::to_vec(&json).map_err(|e| MmProxyError::ConversionError(e.to_string()))?;
+                body = Bytes::from(json_bytes);
+            }
+        }
 
         let start = Instant::now();
         let json_response = if let Some(monerod_url) = self.get_monerod_url(request.uri()).await? {
             let mut headers = request.headers().clone();
+
+            // We changed the body, let's remove the content length, so that "reqwest" recalculates it
+            headers.remove(hyper::header::CONTENT_LENGTH);
+
             // Some public monerod setups (e.g. those that are reverse proxied by nginx) require the Host header.
             // The mmproxy is the direct client of monerod and so is responsible for setting this header.
             if let Some(host) = monerod_url.host_str() {

--- a/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
+++ b/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use futures::FutureExt;
 use hyper::server::conn::http1;
 use hyper_util::rt::TokioIo;
 use log::*;
@@ -115,7 +116,12 @@ pub async fn start_merge_miner(cli: Cli) -> Result<(), anyhow::Error> {
         let mut interval = tokio::time::interval(Duration::from_secs(BLOCK_TEMPLATE_CLEANUP_INTERVAL));
         loop {
             interval.tick().await;
-            cleanup_repo.remove_outdated().await;
+            if let Err(e) = std::panic::AssertUnwindSafe(cleanup_repo.remove_outdated())
+                .catch_unwind()
+                .await
+            {
+                error!(target: LOG_TARGET, "Block template cleanup task panicked: {:?}", e);
+            }
         }
     });
 

--- a/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
+++ b/applications/minotari_merge_mining_proxy/src/run_merge_miner.rs
@@ -49,6 +49,7 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "minotari_mm_proxy::proxy";
+const BLOCK_TEMPLATE_CLEANUP_INTERVAL: u64 = 10 * 60; // 10 minutes
 
 #[allow(clippy::too_many_lines)]
 pub async fn start_merge_miner(cli: Cli) -> Result<(), anyhow::Error> {
@@ -106,12 +107,24 @@ pub async fn start_merge_miner(cli: Cli) -> Result<(), anyhow::Error> {
 
     let listen_addr = multiaddr_to_socketaddr(&config.listener_address)?;
     let randomx_factory = RandomXFactory::new(config.max_randomx_vms);
+    let block_templates = BlockTemplateRepository::new();
+
+    // Run clean up old templates every 10 minutes
+    let cleanup_repo = block_templates.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(BLOCK_TEMPLATE_CLEANUP_INTERVAL));
+        loop {
+            interval.tick().await;
+            cleanup_repo.remove_outdated().await;
+        }
+    });
+
     let randomx_service = MergeMiningProxyService::try_create(
         config,
         client,
         base_node_client,
         p2pool_client,
-        BlockTemplateRepository::new(),
+        block_templates,
         randomx_factory,
         wallet_payment_address,
     )?;


### PR DESCRIPTION
Description
---

This PR addresses the sporadic Monero block rejections ("spend too much money" and "incorrect miner transaction") and resolves a memory leak in the merge mining proxy. 

1. Intercepts block template requests from the miner and forces the upstream Monero node to pre-allocate the exact byte size required for the Tari merge mining data. This ensures the Monero node correctly calculates any block weight penalties and adjusts the block reward *before* the template is sent to the proxy.

2. Shifts the reserved space offset reported back to the miner by the exact size of the injected Tari data. This prevents the miner's software from overwriting the Tari payload or corrupting the coinbase transaction.

3. Detaches the block template memory cleanup process from the block submission workflow. Stale templates are now pruned via an independent background interval, preventing memory leaks when miners request templates but fail to submit solutions.

Closes #7045

Motivation and Context
---

When the proxy facilitates merge mining, it injects 35 bytes of Tari-specific data into the Monero block's coinbase `tx_extra` field. 

Historically, this injection happened *after* `monerod` generated the template. As a result, the final mined block was physically heavier than `monerod` originally predicted. If the Monero network was under load and the block was near the median weight limit, this hidden extra weight would trigger Monero's native weight penalty. Because the block was claiming the original, un-penalized reward, the Monero network would reject it for spending too much money. By tricking the Monero node into pre-reserving this space, the node handles the complex penalty math natively.

Additionally, because the proxy prepended the Tari data into the coinbase, the empty space reserved for the miner's nonce was physically shifted. Failing to report this shift to the miner resulted in corrupted miner transactions.

Finally, the proxy previously only cleared its internal memory of old block templates when a miner successfully submitted a block. If miners disconnected or simply couldn't find a solution, the stored templates would accumulate indefinitely, leading to a slow memory leak. Moving this to an automated background lifecycle ensures stable, long-term operation of the proxy.

How Has This Been Tested?
---

### Run `monerod` (regtest mode)

```sh
$ ./monerod --regtest --fixed-difficulty 1 --offline --rpc-bind-port 28081
2026-02-27 10:04:24.566 I Monero 'Fluorine Fermi' (v0.18.4.5-release)
2026-02-27 10:04:24.566 I Initializing cryptonote protocol...
2026-02-27 10:04:24.566 I Cryptonote protocol initialized OK
2026-02-27 10:04:24.566 I Initializing core...
2026-02-27 10:04:24.566 I Loading blockchain from folder /Users/martinserts/.bitmonero/fake/lmdb ...
2026-02-27 10:04:24.616 I Loading checkpoints
2026-02-27 10:04:24.616 I Core initialized OK
2026-02-27 10:04:24.616 I Initializing p2p server...
2026-02-27 10:04:24.617 I p2p server initialized OK
2026-02-27 10:04:24.617 I Initializing core RPC server...
2026-02-27 10:04:24.617 I Binding on 127.0.0.1 (IPv4):28081
2026-02-27 10:04:24.636 I core RPC server initialized OK on port: 28081
2026-02-27 10:04:24.636 I Starting core RPC server...
2026-02-27 10:04:24.636 I core RPC server started ok
2026-02-27 10:04:24.637 I Starting p2p net loop...
2026-02-27 10:04:25.638 I
2026-02-27 10:04:25.638 I **********************************************************************
2026-02-27 10:04:25.638 I The daemon is running offline and will not attempt to sync to the Monero network.
2026-02-27 10:04:25.639 I
2026-02-27 10:04:25.639 I You can set the level of process detailization through "set_log <level|categories>" command,
2026-02-27 10:04:25.639 I where <level> is between 0 (no details) and 4 (very verbose), or custom category based levels (eg, *:WARNING).
2026-02-27 10:04:25.639 I
2026-02-27 10:04:25.639 I Use the "help" command to see the list of available commands.
2026-02-27 10:04:25.639 I Use "help <command>" to see a command's documentation.
2026-02-27 10:04:25.639 I **********************************************************************
```

### Run `minotari_merge_mining_proxy`

```sh
$ cargo run --bin minotari_merge_mining_proxy
14:31 INFO  Starting Minotari Merge Mining Proxy version: 5.3.0-pre.1-baa3f950cc89a4540aab858c196151a22bdb88a8-debug
14:31 INFO  Configuration file loaded.
14:31 INFO  Configuration: MergeMiningProxyConfig { override_from: Some("esmeralda"), use_dynamic_fail_data: true, monero_fail_url: "https://monero.fail/?chain=monero&network=mainnet&all=true", monerod_url: ConfigList(["http://127.0.0.1:28081"]), monerod_username: "", monerod_password: "", monerod_use_auth: false, base_node_grpc_address: Some("http://127.0.0.1:18142"), p2pool_node_grpc_address: None, base_node_grpc_authentication: None, base_node_grpc_tls_domain_name: None, base_node_grpc_ca_cert_filename: "node_ca.pem", listener_address: "/ip4/127.0.0.1/tcp/18081", submit_to_origin: true, wait_for_initial_sync_at_startup: true, check_tari_difficulty_before_submit: true, max_randomx_vms: 5, coinbase_extra: "tari_merge_mining_proxy", network: Esmeralda, config_dir: "/Users/martinserts/.tari/esmeralda/config/merge_mining_proxy", wallet_payment_address: "f411111111111111111111111111111111111111111111111111111111111111114K", range_proof_type: RevealedValue, p2pool_enabled: false, monerod_connection_timeout: 2s }

Please enter 'wallet-payment-address' ('quit' or 'exit' to quit) : f411111111111111111111111111111111111111111111111111111111111111114K
14:32 INFO  👛 Connecting to base node at http://127.0.0.1:18142
14:32 INFO  Listening on 127
```

### Run `xmrig`

```sh
[2026-02-27 12:04:55.740]  net      use daemon 127.0.0.1:18081  127.0.0.1
[2026-02-27 12:04:55.740]  net      new job from 127.0.0.1:18081 diff 1 algo rx/0 height 1 (1 tx)
[2026-02-27 12:04:55.740]  cpu      use argon2 implementation default
[2026-02-27 12:04:55.741]  randomx  init dataset algo rx/0 (10 threads) seed 418015bb9ae982a1...
[2026-02-27 12:04:55.741]  randomx  allocated 2336 MB (2080+256) huge pages 0% 0/1168 +JIT (0 ms)
[2026-02-27 12:04:57.033]  net      new job from 127.0.0.1:18081 diff 1 algo rx/0 height 1 (1 tx)
[2026-02-27 12:04:57.982]  net      new job from 127.0.0.1:18081 diff 1 algo rx/0 height 1 (1 tx)
[2026-02-27 12:05:00.086]  randomx  dataset ready (4346 ms)
[2026-02-27 12:05:00.086]  cpu      use profile  rx  (1 thread) scratchpad 2048 KB
[2026-02-27 12:05:00.086]  cpu      READY threads 1/1 (1) huge pages 0% 0/1 memory 2048 KB (0 ms)
[2026-02-27 12:05:03.271]  cpu      accepted (1/0) diff 1 (3098 ms)
[2026-02-27 12:05:03.271]  net      no active pools, stop mining
[2026-02-27 12:05:03.478]  cpu      accepted (2/0) diff 1 (2724 ms)
[2026-02-27 12:05:03.646]  cpu      accepted (3/0) diff 1 (3323 ms)
[2026-02-27 12:05:03.672]  cpu      accepted (4/0) diff 1 (2908 ms)

...

[2026-02-27 12:05:16.173]  cpu      accepted (82/0) diff 1 (1548 ms)
[2026-02-27 12:05:16.218]  cpu      accepted (83/0) diff 1 (1625 ms)
[2026-02-27 12:05:16.264]  cpu      accepted (84/0) diff 1 (1681 ms)
[2026-02-27 12:05:16.308]  cpu      accepted (85/0) diff 1 (1702 ms)
[2026-02-27 12:05:16.353]  cpu      accepted (86/0) diff 1 (1776 ms)
[2026-02-27 12:05:16.398]  cpu      accepted (87/0) diff 1 (1818 ms)
[2026-02-27 12:05:16.443]  cpu      accepted (88/0) diff 1 (1835 ms)
[2026-02-27 12:05:16.489]  cpu      accepted (89/0) diff 1 (1878 ms)
[2026-02-27 12:05:16.534]  cpu      accepted (90/0) diff 1 (1938 ms)
[2026-02-27 12:05:16.580]  cpu      accepted (91/0) diff 1 (1993 ms)
[2026-02-27 12:05:16.626]  cpu      accepted (92/0) diff 1 (2024 ms)
...
```

### No errors in `monerod`

```
2026-02-27 10:05:00.359 I ----- BLOCK ADDED AS ALTERNATIVE ON HEIGHT 1
2026-02-27 10:05:00.359 I id:   <50cf9302a87f2a0074a780af3875b2611ff548beb8849a702c53878a4fac3234>
2026-02-27 10:05:00.359 I PoW:  <b3c8263ae59892f1cb740ffdf0ae2fc947007800fd50ad448763ca8b4494d57a>
2026-02-27 10:05:00.359 I difficulty:   1
2026-02-27 10:05:03.314 I ----- BLOCK ADDED AS ALTERNATIVE ON HEIGHT 1
2026-02-27 10:05:03.314 I id:   <281b4663d5bf3c16042fd0356a72678071dadce973d69eda6962f0e7cfc91040>
2026-02-27 10:05:03.315 I PoW:  <0834449bc6d011dac3d62f90f1baade7bbb7f6e6f6b0f53ba995dad99b9db2b4>
2026-02-27 10:05:03.315 I difficulty:   1
2026-02-27 10:05:03.349 I ----- BLOCK ADDED AS ALTERNATIVE ON HEIGHT 1
2026-02-27 10:05:03.349 I id:   <0a3d1631a302b0498d5e79c3de271354b7f541fabb2b6f766aa3ab875df30f96>
2026-02-27 10:05:03.349 I PoW:  <9e014de75ca8af944165514665c3cd046fbef9c859d4b943ff0f0537470bfb5a>
2026-02-27 10:05:03.349 I difficulty:   1

...

2026-02-27 10:05:22.053 I ----- BLOCK ADDED AS ALTERNATIVE ON HEIGHT 2
2026-02-27 10:05:22.054 I id:   <ed3eee9892b6a23be6003789073bdd6105d24476dc0aab8fea9a4350c36d0008>
2026-02-27 10:05:22.054 I PoW:  <12cf2f1d8b67df85332d8756e0b210117e82f08ace1ec0f80d4fa3957958e35b>
2026-02-27 10:05:22.054 I difficulty:   1
2026-02-27 10:05:22.086 I ----- BLOCK ADDED AS ALTERNATIVE ON HEIGHT 2
2026-02-27 10:05:22.086 I id:   <c1a0f4ca5738c3e2a0d05277a1ed85a1741335d7728b416dc54d91aef6d2a0c8>
2026-02-27 10:05:22.086 I PoW:  <573c7cf393bc759f7aea4f8455c61932f97c5214840c69813ad3d8e6219d108c>
2026-02-27 10:05:22.086 I difficulty:   1
2026-02-27 10:05:22.120 I ----- BLOCK ADDED AS ALTERNATIVE ON HEIGHT 2
2026-02-27 10:05:22.120 I id:   <fa689b0bd028218f6715cdf89d910b0bd4484c31b2aa82ca86ea67b2ed314152>
2026-02-27 10:05:22.120 I PoW:  <d1d228e773e131fe6ff013cbba9bc23929f59d4b2b2cad0946d548f97b73bf64>
2026-02-27 10:05:22.120 I difficulty:   1
```

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
