### PR TITLE
feat: network silence mode

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -624,6 +624,8 @@ message GetNetworkStateResponse {
   bool initial_sync_achieved = 2;
   //current state of the base node
   BaseNodeState base_node_state = 3;
+  // true when node is in Listening state and network silence has been detected
+  bool network_silence = 13;
   // do we have failed checkpoints
   bool failed_checkpoints = 4;
   // The block reward of the next tip

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -567,7 +567,12 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         let failed_checkpoints = *self.tari_pulse.get_failed_checkpoints_notifier();
         let status_watch = self.state_machine_handle.get_status_info_watch();
-        let state: tari_rpc::BaseNodeState = (&status_watch.borrow().state_info).into();
+        let (state, network_silence, initial_sync_achieved) = {
+            let status = status_watch.borrow();
+            let state: tari_rpc::BaseNodeState = (&status.state_info).into();
+            let network_silence = matches!(&status.state_info, StateInfo::Listening(info) if info.is_network_silence());
+            (state, network_silence, status.bootstrapped)
+        };
 
         let mut connectivity = self.comms.connectivity();
         let connected_peers = connectivity
@@ -603,8 +608,9 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         );
         let response = tari_rpc::GetNetworkStateResponse {
             metadata: Some(metadata.into()),
-            initial_sync_achieved: status_watch.borrow().bootstrapped,
+            initial_sync_achieved,
             base_node_state: state.into(),
+            network_silence,
             failed_checkpoints,
             reward,
             sha3x_estimated_hash_rate,

--- a/applications/minotari_node/src/grpc/readiness_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/readiness_grpc_server.rs
@@ -142,6 +142,7 @@ impl tari_rpc::base_node_server::BaseNode for ReadinessGrpcServer {
             metadata: None,
             initial_sync_achieved: false,
             base_node_state: tari_rpc::BaseNodeState::StartUp.into(),
+            network_silence: false,
             failed_checkpoints: false,
             reward: 0,
             sha3x_estimated_hash_rate: 0,

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -191,21 +191,32 @@ pub struct ListeningInfo {
     pub initial_delay_connected_count: u64,
     pub initial_sync_peer_wait_count: u64,
     pub bootstrap_phase: Option<BootstrapPhaseInfo>,
+    pub network_silence: bool,
 }
 impl Display for ListeningInfo {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        fmt.write_str("Node in listening state\n")
+        if self.network_silence {
+            fmt.write_str("Node in listening state (Network Silence)\n")
+        } else {
+            fmt.write_str("Node in listening state\n")
+        }
     }
 }
 
 impl ListeningInfo {
     /// Creates a new ListeningInfo
-    pub const fn new(is_synced: bool, initial_delay_connected_count: u64, initial_sync_peer_wait_count: u64) -> Self {
+    pub const fn new(
+        is_synced: bool,
+        initial_delay_connected_count: u64,
+        initial_sync_peer_wait_count: u64,
+        network_silence: bool,
+    ) -> Self {
         Self {
             synced: is_synced,
             initial_delay_connected_count,
             initial_sync_peer_wait_count,
             bootstrap_phase: None,
+            network_silence,
         }
     }
 
@@ -223,6 +234,10 @@ impl ListeningInfo {
 
     pub fn initial_sync_peer_wait_count(&self) -> u64 {
         self.initial_sync_peer_wait_count
+    }
+
+    pub fn is_network_silence(&self) -> bool {
+        self.network_silence
     }
 }
 
@@ -265,7 +280,11 @@ impl StateInfo {
                         bootstrap_info.current_round, bootstrap_info.total_rounds
                     )
                 } else if info.is_synced() {
-                    "Listening".to_string()
+                    if info.is_network_silence() {
+                        "Listening (Network Silence)".to_string()
+                    } else {
+                        "Listening".to_string()
+                    }
                 } else {
                     format!(
                         "Waiting for peer data: {}/{}",

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -117,6 +117,7 @@ impl ListeningInfo {
 pub struct Listening {
     is_synced: bool,
     initial_delay_count: u64,
+    network_silence: bool,
 }
 
 impl Listening {
@@ -128,12 +129,17 @@ impl Listening {
         if !self.is_synced {
             self.is_synced = true;
             self.initial_delay_count = 0;
-            shared.set_state_info(StateInfo::Listening(events_and_states::ListeningInfo::new(
-                true,
-                0,
-                shared.config.initial_sync_peer_count,
-            )));
+            self.publish_status_info(shared);
         }
+    }
+
+    fn publish_status_info<B: BlockchainBackend + 'static>(&self, shared: &mut BaseNodeStateMachine<B>) {
+        shared.set_state_info(StateInfo::Listening(events_and_states::ListeningInfo::new(
+            self.is_synced,
+            self.initial_delay_count,
+            shared.config.initial_sync_peer_count,
+            self.network_silence,
+        )));
     }
 
     #[allow(clippy::too_many_lines)]
@@ -144,6 +150,8 @@ impl Listening {
     ) -> StateEvent {
         info!(target: LOG_TARGET, "Listening for chain metadata updates");
 
+        self.network_silence = network_silence;
+
         if network_silence {
             self.set_synced_response(shared);
             warn!(
@@ -152,11 +160,7 @@ impl Listening {
                 network in general is slow to respond to pings"
             );
         } else {
-            shared.set_state_info(StateInfo::Listening(events_and_states::ListeningInfo::new(
-                self.is_synced,
-                self.initial_delay_count,
-                shared.config.initial_sync_peer_count,
-            )));
+            self.publish_status_info(shared);
         }
 
         let mut time_since_better_block = None;
@@ -167,18 +171,21 @@ impl Listening {
             let metadata_event = shared.metadata_event_stream.recv().await;
             match metadata_event.as_ref().map(|v| v.deref()) {
                 Ok(ChainMetadataEvent::NetworkSilence) => {
+                    self.network_silence = true;
                     self.set_synced_response(shared);
                     debug!("NetworkSilence event received");
                 },
                 Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata)) => {
+                    // We received a valid metadata update, so the network is not silent.
+                    if self.network_silence {
+                        self.network_silence = false;
+                        self.publish_status_info(shared);
+                    }
+
                     // if we are not yet synced, we wait for the initial delay of ping/pongs, so let's propagate the
                     // updated info
                     if !self.is_synced {
-                        shared.set_state_info(StateInfo::Listening(events_and_states::ListeningInfo::new(
-                            self.is_synced,
-                            self.initial_delay_count,
-                            shared.config.initial_sync_peer_count,
-                        )));
+                        self.publish_status_info(shared);
                     }
                     // We already ban the peer based on some previous logic, but this message was already in the
                     // pipeline before the ban went into effect.
@@ -349,6 +356,7 @@ impl From<Waiting> for Listening {
         Self {
             is_synced: false,
             initial_delay_count: 0,
+            network_silence: false,
         }
     }
 }
@@ -358,6 +366,7 @@ impl From<HeaderSyncState> for Listening {
         Self {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
+            network_silence: false,
         }
     }
 }
@@ -367,6 +376,7 @@ impl From<BlockSync> for Listening {
         Self {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
+            network_silence: false,
         }
     }
 }
@@ -376,6 +386,7 @@ impl From<DecideNextSync> for Listening {
         Self {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
+            network_silence: false,
         }
     }
 }

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -1037,19 +1037,19 @@ async fn receive_and_propagate_transaction() {
 
     alice_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     bob_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     carol_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
@@ -1685,7 +1685,7 @@ async fn block_event_and_reorg_event_handling() {
 
     alice.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });

--- a/base_layer/core/tests/tests/node_service.rs
+++ b/base_layer/core/tests/tests/node_service.rs
@@ -143,25 +143,25 @@ async fn propagate_and_forward_many_valid_blocks() {
     wait_until_online(&[&alice_node, &bob_node, &carol_node, &dan_node]).await;
     alice_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     bob_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     carol_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     dan_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
@@ -281,19 +281,19 @@ async fn propagate_and_forward_invalid_block_hash() {
     wait_until_online(&[&alice_node, &bob_node, &carol_node]).await;
     alice_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     bob_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     carol_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
@@ -435,25 +435,25 @@ async fn propagate_and_forward_invalid_block() {
 
     alice_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     bob_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     carol_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });
     dan_node.mock_base_node_state_machine.publish_status(StatusInfo {
         bootstrapped: true,
-        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0)),
+        state_info: StateInfo::Listening(ListeningInfo::new(true, 0, 0, false)),
         randomx_vm_cnt: 0,
         randomx_vm_flags: RandomXFlag::FLAG_DEFAULT,
     });

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -168,6 +168,12 @@ impl DhtConnectivity {
                     if let Err(err) = self.handle_connectivity_event(event).await {
                         error!(target: LOG_TARGET, "Error handling connectivity event: {err:?}");
                     }
+                    if self.connection_handles.is_empty() {
+                        debug!(target: LOG_TARGET, "No active peer connections detected. Triggering aggressive peer pool refresh.");
+                        if let Err(err) = self.refresh_peer_pools(true).await {
+                             error!(target: LOG_TARGET, "Error during aggressive peer pool refresh: {err:?}");
+                        }
+                    }
                },
 
                Ok(event) = self.dht_events.recv() => {

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -28,7 +28,6 @@ use tari_comms::{
     connectivity::ConnectivityEvent,
     peer_manager::{Peer, PeerFeatures, STALE_PEER_THRESHOLD_DURATION},
     test_utils::{
-        count_string_occurrences,
         mocks::{create_connectivity_mock, create_dummy_peer_connection, ConnectivityManagerMockState},
         node_identity::ordered_node_identities_by_distance,
     },
@@ -184,8 +183,9 @@ async fn added_neighbours() {
         interval = Duration::from_millis(10),
     );
 
-    let calls = connectivity.take_calls().await;
-    assert_eq!(count_string_occurrences(&calls, &["DialPeer"]), 5);
+    let _calls = connectivity.take_calls().await;
+    // Check that we requested 5 dials (either via 5 DialPeer calls or 1 DialManyPeers with 5 items)
+    assert_eq!(connectivity.get_dialed_peers().await.len(), 5);
 
     let (conn, _) = create_dummy_peer_connection(closer_peer.node_id().clone());
     connectivity.publish_event(ConnectivityEvent::PeerConnected(conn.clone().into()));
@@ -259,8 +259,10 @@ async fn replace_peer_when_peer_goes_offline() {
 
     // Check that the next closer neighbour was added to the pool
     let dialed = connectivity.take_dialed_peers().await;
-    assert_eq!(dialed.len(), 1);
-    assert_eq!(dialed[0], *node_identities[5].node_id());
+    // With aggressive reconnection, we might also redial the disconnected peer (index 4) because we have 0 connections
+    // and are in "desperate mode". So we might see index 4 and index 5 dialed.
+    // We only strictly care that we attempted to contact the new neighbour (index 5).
+    assert!(dialed.contains(node_identities[5].node_id()));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Description
---

This PR addresses issues where nodes could become isolated without user feedback and were slow to recover.

Updates `ListeningInfo` and `Listening` state to track and display a "Network Silence" flag. The node status will now report "Listening (Network Silence)" instead of just "Listening" when no liveness metadata is being received, distinguishing between a synced node and an isolated one.

Modifies the `DhtConnectivity` to trigger an immediate peer pool refresh  whenever the active connection count drops to zero. This bypasses the standard ticker (default 2 mins), allowing the node to attempt reconnection immediately upon isolation.

Updates response of `GetNetworkState` GRPC method with "network_silence" field.

<img width="1477" height="857" alt="network_silence_grpc" src="https://github.com/user-attachments/assets/d1046063-2152-4dcf-8da0-e8c7661005d5" />



<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
