### PR TITLE
feat: change logic in node pool management

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1724,7 +1724,7 @@ where
 
         let query_base_node_fut = async move {
             let mut res = vec![];
-            let mut client = connectivity.obtain_base_node_wallet_rpc_client().await;
+            let client = connectivity.obtain_base_node_wallet_rpc_client().await;
             for hash in hashes {
                 match client
                     .fetch_utxo(hash.to_vec())

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -290,6 +290,9 @@ database_url = "data/base_node/dht.db"
 #connectivity.update_interval = 120 # 2 * 60
 # The interval to change the random pool peers. Default = 30 mins
 #connectivity.random_pool_refresh_interval = 1_800 # 30 * 60
+# This is the percentage of nodes that we want to churn per refresh cycle
+# This percentage of nodes will be randomly chosen and disconnected, and then replaced by new nodes
+# connectivity.churn_rate = 10
 # Length of cooldown when high connection failure rates are encountered. Default: 45s
 #connectivity.high_failure_rate_cooldown = 45
 # The minimum desired ratio of TCPv4 to Tor connections. TCPv4 addresses have some significant cost to create,

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -286,10 +286,10 @@ database_url = "data/base_node/dht.db"
 # change happens again after this period, another join will be sent. Default: 10 minutes
 #join_cooldown_interval = 120 # 10 * 60
 
-# The interval to update the neighbouring and random pools, if necessary. Default: 2 minutes
+# The interval to update the neighbouring and random pools, if necessary.
 #connectivity.update_interval = 120 # 2 * 60
-# The interval to change the random pool peers. Default = 2 hours
-#connectivity.random_pool_refresh_interval = 7_200 # 2 * 60 * 60
+# The interval to change the random pool peers. Default = 30 mins
+#connectivity.random_pool_refresh_interval = 1_800 # 30 * 60
 # Length of cooldown when high connection failure rates are encountered. Default: 45s
 #connectivity.high_failure_rate_cooldown = 45
 # The minimum desired ratio of TCPv4 to Tor connections. TCPv4 addresses have some significant cost to create,

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -330,8 +330,6 @@ minimize_connections = true
 
 # The interval to update the neighbouring and random pools, if necessary. Default: 2 minutes
 connectivity.update_interval = 300 # 2 * 60
-# The interval to change the random pool peers. Default = 2 hours
-#connectivity.random_pool_refresh_interval = 7_200 # 2 * 60 * 60
 # Length of cooldown when high connection failure rates are encountered. Default: 45s
 #connectivity.high_failure_rate_cooldown = 45
 # The minimum desired ratio of TCPv4 to Tor connections. TCPv4 addresses have some significant cost to create,

--- a/comms/core/src/multiplexing/yamux.rs
+++ b/comms/core/src/multiplexing/yamux.rs
@@ -317,7 +317,8 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                             match err {
                                 ConnectionError::Io(ref io_err) if
                                     io_err.kind() == io::ErrorKind::ConnectionReset ||
-                                    io_err.kind() == io::ErrorKind::ConnectionAborted =>
+                                    io_err.kind() == io::ErrorKind::ConnectionAborted ||
+                                    io_err.kind() == io::ErrorKind::BrokenPipe =>
                                 {
                                     debug!(
                                         target: LOG_TARGET,
@@ -330,7 +331,8 @@ where TSocket: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 
                                 ConnectionError::Decode(FrameDecodeError::Io(ref io_err)) if
                                     io_err.kind() == io::ErrorKind::ConnectionReset ||
                                     io_err.kind() == io::ErrorKind::ConnectionAborted ||
-                                    io_err.kind() == io::ErrorKind::UnexpectedEof =>
+                                    io_err.kind() == io::ErrorKind::UnexpectedEof ||
+                                    io_err.kind() == io::ErrorKind::BrokenPipe =>
                                 {
                                     debug!(
                                         target: LOG_TARGET,

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -691,8 +691,8 @@ mod test {
         }
 
         // Test Random
-        let identities1 = peer_manager.random_peers(10, &[], None).await.unwrap();
-        let identities2 = peer_manager.random_peers(10, &[], None).await.unwrap();
+        let identities1 = peer_manager.random_peers(10, &[], None, false).await.unwrap();
+        let identities2 = peer_manager.random_peers(10, &[], None, false).await.unwrap();
         assert_ne!(identities1, identities2);
     }
 
@@ -878,7 +878,7 @@ mod test {
                 let peer_manager = peer_manager.clone();
                 tokio::spawn(async move {
                     tokio::time::sleep(Duration::from_micros(rand::random::<u64>() % 100)).await;
-                    let _random_peers = peer_manager.random_peers(n, &[], None).await.unwrap();
+                    let _random_peers = peer_manager.random_peers(n, &[], None, false).await.unwrap();
                     tokio::time::sleep(Duration::from_micros(rand::random::<u64>() % 100)).await;
                     let _total_peers = peer_manager.count().await;
                     Ok::<_, PeerManagerError>(())
@@ -899,7 +899,7 @@ mod test {
 
         // Do one final read
         tokio::time::sleep(Duration::from_micros(rand::random::<u64>() % 100)).await;
-        let random_peers = peer_manager.random_peers(n, &[], None).await.unwrap();
+        let random_peers = peer_manager.random_peers(n, &[], None, false).await.unwrap();
         let total_peers = peer_manager.count().await;
         assert_eq!(total_peers, num_peers * num_write_tasks);
         assert!(random_peers.len() <= n);

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -233,9 +233,22 @@ impl PeerManager {
         n: usize,
         excluded: &[NodeId],
         flags: Option<PeerFlags>,
+        known_good: bool,
     ) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql
-            .random_peers(n, excluded, flags, &self.transport_protocols)
+        let mut peers =
+            self.peer_storage_sql
+                .random_peers(n, excluded, flags, &self.transport_protocols, known_good)?;
+        if known_good && peers.len() < n {
+            let mut additional = self.peer_storage_sql.random_peers(
+                n.checked_sub(peers.len()).unwrap_or(1),
+                excluded,
+                flags,
+                &self.transport_protocols,
+                false,
+            )?;
+            peers.append(&mut additional);
+        }
+        Ok(peers)
     }
 
     /// Unbans the peer if it is banned. This function is idempotent.

--- a/comms/core/src/peer_manager/peer_storage_sql.rs
+++ b/comms/core/src/peer_manager/peer_storage_sql.rs
@@ -260,10 +260,11 @@ impl PeerStorageSql {
         exclude_peers: &[NodeId],
         flags: Option<PeerFlags>,
         transport_protocols: &[TransportProtocol],
+        known_good: bool,
     ) -> Result<Vec<Peer>, PeerManagerError> {
         Ok(self
             .peer_db
-            .get_n_random_peers(n, exclude_peers, flags, transport_protocols)?)
+            .get_n_random_peers(n, exclude_peers, flags, transport_protocols, known_good)?)
     }
 
     /// Unban the peer

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -161,323 +161,26 @@ impl PeerDatabaseSql {
         })
     }
 
-    // Note: This function is not properly working at the moment, but must be kept here for in its commented out form
-    // for further evaluation.
-    // ==============================================================================================================
-    // /// This function will add peers and their associated multi-addresses in batch mode:
-    // /// - New peers are added with all their information.
-    // /// - Existing peers are not modified.
-    // /// - Only missing multi-addresses are added for existing peers.
-    // ///
-    // ///   Note:
-    // ///   SQLite does not support the DEFAULT keyword in INSERT statements, which Diesel uses for batch inserts.
-    // ///   Diesel's batch insert API is designed for databases like PostgreSQL that support this feature.
-    // #[allow(clippy::too_many_lines)]
-    // pub fn batch_add_peers_with_addresses(
-    //     &self,
-    //     peers_with_addresses: Vec<NewPeerWithAddressesSql>,
-    // ) -> Result<usize, StorageError> {
-    //     let mut conn = self.connection.get_pooled_connection()?;
-    //     conn.immediate_transaction::<_, StorageError, _>(|conn| {
-    //         // Step 1: Insert new peers with ON CONFLICT DO NOTHING
-    //         let values = peers_with_addresses
-    //             .iter()
-    //             .map(|p| {
-    //                 let peer_id = generate_peer_id_as_i64();
-    //                 let public_key = sql_escape(&p.peer.public_key);
-    //                 let node_id = sql_escape(&p.peer.node_id);
-    //                 let distance_to_self = self
-    //                     .this_peer_identity
-    //                     .node_id
-    //                     .distance(&NodeId::from_hex(&p.peer.node_id)?)
-    //                     .to_string();
-    //                 let flags = p.peer.flags;
-    //                 let banned_until = p.peer.banned_until.map_or("NULL".to_string(), |dt| format!("'{}'", dt));
-    //                 let banned_reason = p
-    //                     .peer
-    //                     .banned_reason
-    //                     .clone()
-    //                     .map_or("NULL".to_string(), |reason| format!("'{}'", sql_escape(&reason)));
-    //                 let features = p.peer.features;
-    //                 let supported_protocols = sql_escape(&p.peer.supported_protocols);
-    //                 let added_at = p.peer.added_at;
-    //                 let user_agent = sql_escape(&p.peer.user_agent);
-    //                 let metadata = p
-    //                     .peer
-    //                     .metadata
-    //                     .clone()
-    //                     .map_or("NULL".to_string(), |meta| format!("x'{}'", hex::to_hex(&meta)));
-    //                 let deleted_at = p.peer.deleted_at.map_or("NULL".to_string(), |dt| format!("'{}'", dt));
-    //
-    //                 Ok::<String, StorageError>(format!(
-    //                     "({}, '{}', '{}', '{}', {}, {}, {}, {}, '{}', '{}', '{}', {}, {})",
-    //                     peer_id,
-    //                     public_key,
-    //                     node_id,
-    //                     distance_to_self,
-    //                     flags,
-    //                     banned_until,
-    //                     banned_reason,
-    //                     features,
-    //                     supported_protocols,
-    //                     added_at,
-    //                     user_agent,
-    //                     metadata,
-    //                     deleted_at
-    //                 ))
-    //             })
-    //             .collect::<Result<Vec<String>, _>>()?;
-    //
-    //         let mut peer_query = format!(
-    //             "INSERT INTO peers (peer_id, public_key, node_id, distance_to_self, flags, banned_until, \
-    //              banned_reason, features, supported_protocols, added_at, user_agent, metadata, deleted_at) VALUES
-    // {}",             values.join(", ")
-    //         );
-    //
-    //         peer_query.push_str(" ON CONFLICT (node_id) DO NOTHING");
-    //         conn.batch_execute(&peer_query)?;
-    //
-    //         // Step 2: Collect all multi-addresses into a map
-    //         let mut address_map: HashMap<String, Vec<NewMultiaddrWithStatsSql>> = HashMap::new();
-    //         for item in peers_with_addresses {
-    //             address_map
-    //                 .entry(item.peer.node_id.to_string())
-    //                 .or_default()
-    //                 .extend(item.addresses);
-    //         }
-    //
-    //         // Step 3: Insert missing multi-addresses
-    //         let mut address_query = String::from(
-    //             "INSERT INTO multi_addresses (peer_id, address, last_seen, connection_attempts, \
-    //              avg_initial_dial_time, initial_dial_time_sample_count, avg_latency, latency_sample_count, \
-    //              last_attempted, last_failed_reason, quality_score, source) VALUES ",
-    //         );
-    //
-    //         let mut total_addresses_inserted = 0;
-    //         for (node_id, addresses) in address_map {
-    //             // Retrieve peer_id for the node_id
-    //             let peer_id = peers::table
-    //                 .filter(peers::node_id.eq(node_id))
-    //                 .select(peers::peer_id)
-    //                 .first::<i64>(conn)?;
-    //
-    //             // Filter out existing addresses
-    //             let existing_addresses: Vec<_> = multi_addresses::table
-    //                 .filter(multi_addresses::peer_id.eq(peer_id))
-    //                 .select(multi_addresses::address)
-    //                 .load::<String>(conn)?;
-    //
-    //             let new_addresses: Vec<_> = addresses
-    //                 .into_iter()
-    //                 .filter(|addr| !existing_addresses.contains(&addr.address.to_string()))
-    //                 .collect();
-    //
-    //             if !new_addresses.is_empty() {
-    //                 address_query.push_str(
-    //                     &new_addresses
-    //                         .iter()
-    //                         .map(|addr| {
-    //                             format!(
-    //                                 "({}, '{}', {}, {}, {}, {}, {}, {}, {}, {}, {}, '{}')",
-    //                                 peer_id,
-    //                                 sql_escape(&addr.address),
-    //                                 addr.last_seen.map_or("NULL".to_string(), |dt| format!("'{}'", dt)),
-    //                                 addr.connection_attempts.map_or("NULL".to_string(), |v| v.to_string()),
-    //                                 addr.avg_initial_dial_time.map_or("NULL".to_string(), |v| v.to_string()),
-    //                                 addr.initial_dial_time_sample_count
-    //                                     .map_or("NULL".to_string(), |v| v.to_string()),
-    //                                 addr.avg_latency.map_or("NULL".to_string(), |v| v.to_string()),
-    //                                 addr.latency_sample_count.map_or("NULL".to_string(), |v| v.to_string()),
-    //                                 addr.last_attempted.map_or("NULL".to_string(), |dt| format!("'{}'", dt)),
-    //                                 addr.last_failed_reason
-    //                                     .clone()
-    //                                     .map_or("NULL".to_string(), |reason| format!("'{}'", sql_escape(&reason))),
-    //                                 addr.quality_score.map_or("NULL".to_string(), |v| v.to_string()),
-    //                                 sql_escape(&addr.source),
-    //                             )
-    //                         })
-    //                         .collect::<Vec<String>>()
-    //                         .join(", "),
-    //                 );
-    //
-    //                 total_addresses_inserted += new_addresses.len();
-    //             }
-    //         }
-    //
-    //         if total_addresses_inserted > 0 {
-    //             address_query.push_str(" ON CONFLICT (address) DO NOTHING");
-    //             conn.batch_execute(&address_query)?;
-    //         }
-    //
-    //         Ok(total_addresses_inserted)
-    //     })
-    // }
-    // ==============================================================================================================
-
-    // Note: This function is not properly working at the moment, but must be kept here for in its commented out form
-    // for further evaluation.
-    // ==============================================================================================================
-    // /// This function will update peers and their associated multi-addresses in batch mode.
-    // #[allow(clippy::too_many_lines)]
-    // pub fn batch_update_peers_with_addresses(
-    //     &self,
-    //     peers_with_addresses: Vec<UpdatePeerWithAddressesSql>,
-    // ) -> Result<(), StorageError> {
-    //     let mut conn = self.connection.get_pooled_connection()?;
-    //     conn.immediate_transaction::<_, StorageError, _>(|conn| {
-    //         // Batch update peers
-    //         if !peers_with_addresses.is_empty() {
-    //             let mut peer_query = String::from("UPDATE peers SET ");
-    //             let mut set_clauses = vec![];
-    //             let mut node_ids = vec![];
-    //
-    //             for update in &peers_with_addresses {
-    //                 let peer_update = update.peer.clone();
-    //
-    //                 if let Some(banned_until) = peer_update.banned_until {
-    //                     set_clauses.push(format!(
-    //                         "banned_until = CASE WHEN node_id = '{}' THEN '{}' ELSE banned_until END",
-    //                         peer_update.node_id, banned_until
-    //                     ));
-    //                 }
-    //                 if let Some(banned_reason) = peer_update.banned_reason {
-    //                     set_clauses.push(format!(
-    //                         "banned_reason = CASE WHEN node_id = '{}' THEN '{}' ELSE banned_reason END",
-    //                         peer_update.node_id,
-    //                         sql_escape(&banned_reason)
-    //                     ));
-    //                 }
-    //                 if let Some(supported_protocols) = peer_update.supported_protocols {
-    //                     set_clauses.push(format!(
-    //                         "supported_protocols = CASE WHEN node_id = '{}' THEN '{}' ELSE supported_protocols END",
-    //                         peer_update.node_id,
-    //                         sql_escape(&supported_protocols)
-    //                     ));
-    //                 }
-    //                 if let Some(user_agent) = peer_update.user_agent {
-    //                     set_clauses.push(format!(
-    //                         "user_agent = CASE WHEN node_id = '{}' THEN '{}' ELSE user_agent END",
-    //                         peer_update.node_id,
-    //                         sql_escape(&user_agent)
-    //                     ));
-    //                 }
-    //                 if let Some(metadata) = peer_update.metadata {
-    //                     set_clauses.push(format!(
-    //                         "metadata = CASE WHEN node_id = '{}' THEN x'{}' ELSE metadata END",
-    //                         peer_update.node_id,
-    //                         hex::to_hex(&metadata)
-    //                     ));
-    //                 }
-    //                 if let Some(deleted_at) = peer_update.deleted_at {
-    //                     set_clauses.push(format!(
-    //                         "deleted_at = CASE WHEN node_id = '{}' THEN '{}' ELSE deleted_at END",
-    //                         peer_update.node_id, deleted_at
-    //                     ));
-    //                 }
-    //                 node_ids.push(format!("'{}'", peer_update.node_id.replace('\'', "''")));
-    //             }
-    //
-    //             peer_query.push_str(&set_clauses.join(", "));
-    //             peer_query.push_str(&format!(" WHERE node_id IN ({})", node_ids.join(", ")));
-    //             conn.batch_execute(&peer_query)?;
-    //         }
-    //
-    //         // Batch update multi-addresses
-    //         let mut address_query = String::from("UPDATE multi_addresses SET ");
-    //         let mut set_clauses = vec![];
-    //         let mut addresses = vec![];
-    //
-    //         for update in peers_with_addresses {
-    //             for address_update in update.addresses {
-    //                 if let Some(last_seen) = address_update.last_seen {
-    //                     set_clauses.push(format!(
-    //                         "last_seen = CASE WHEN address = '{}' THEN '{}' ELSE last_seen END",
-    //                         address_update.address, last_seen
-    //                     ));
-    //                 }
-    //                 if let Some(connection_attempts) = address_update.connection_attempts {
-    //                     set_clauses.push(format!(
-    //                         "connection_attempts = CASE WHEN address = '{}' THEN {} ELSE connection_attempts END",
-    //                         address_update.address, connection_attempts
-    //                     ));
-    //                 }
-    //                 if let Some(avg_initial_dial_time) = address_update.avg_initial_dial_time {
-    //                     set_clauses.push(format!(
-    //                         "avg_initial_dial_time = CASE WHEN address = '{}' THEN {} ELSE avg_initial_dial_time
-    // END",                         address_update.address, avg_initial_dial_time
-    //                     ));
-    //                 }
-    //                 if let Some(initial_dial_time_sample_count) = address_update.initial_dial_time_sample_count {
-    //                     set_clauses.push(format!(
-    //                         "initial_dial_time_sample_count = CASE WHEN address = '{}' THEN {} ELSE \
-    //                          initial_dial_time_sample_count END",
-    //                         address_update.address, initial_dial_time_sample_count
-    //                     ));
-    //                 }
-    //                 if let Some(avg_latency) = address_update.avg_latency {
-    //                     set_clauses.push(format!(
-    //                         "avg_latency = CASE WHEN address = '{}' THEN {} ELSE avg_latency END",
-    //                         address_update.address, avg_latency
-    //                     ));
-    //                 }
-    //                 if let Some(latency_sample_count) = address_update.latency_sample_count {
-    //                     set_clauses.push(format!(
-    //                         "latency_sample_count = CASE WHEN address = '{}' THEN {} ELSE latency_sample_count END",
-    //                         address_update.address, latency_sample_count
-    //                     ));
-    //                 }
-    //                 if let Some(last_attempted) = address_update.last_attempted {
-    //                     set_clauses.push(format!(
-    //                         "last_attempted = CASE WHEN address = '{}' THEN '{}' ELSE last_attempted END",
-    //                         address_update.address, last_attempted
-    //                     ));
-    //                 }
-    //                 if let Some(last_failed_reason) = address_update.last_failed_reason {
-    //                     set_clauses.push(format!(
-    //                         "last_failed_reason = CASE WHEN address = '{}' THEN '{}' ELSE last_failed_reason END",
-    //                         address_update.address,
-    //                         sql_escape(&last_failed_reason)
-    //                     ));
-    //                 }
-    //                 if let Some(quality_score) = address_update.quality_score {
-    //                     set_clauses.push(format!(
-    //                         "quality_score = CASE WHEN address = '{}' THEN {} ELSE quality_score END",
-    //                         address_update.address, quality_score
-    //                     ));
-    //                 }
-    //                 if let Some(source) = address_update.source {
-    //                     set_clauses.push(format!(
-    //                         "source = CASE WHEN address = '{}' THEN '{}' ELSE source END",
-    //                         address_update.address,
-    //                         sql_escape(&source)
-    //                     ));
-    //                 }
-    //                 addresses.push(format!("'{}'", address_update.address.replace('\'', "''")));
-    //             }
-    //         }
-    //
-    //         if !set_clauses.is_empty() {
-    //             address_query.push_str(&set_clauses.join(", "));
-    //             address_query.push_str(&format!(" WHERE address IN ({})", addresses.join(", ")));
-    //             conn.batch_execute(&address_query)?;
-    //         }
-    //
-    //         Ok(())
-    //     })
-    // }
-    // ==============================================================================================================
-
     /// Add a new peer or update an existing peer with its associated multi-addresses
     pub fn add_or_update_peer(&self, peer: Peer) -> Result<PeerId, StorageError> {
         let mut conn = self.connection.get_pooled_connection()?;
-
         conn.immediate_transaction::<_, StorageError, _>(|conn| {
             let node_id = peer.node_id.clone();
 
             match self.get_peer_by_node_id_inner(&node_id, conn)? {
                 Some(mut existing_peer) => {
-                    trace!(target: LOG_TARGET, "Replacing peer that has NodeId '{node_id}'");
+                    let mut check_merge = false;
+                    if peer.addresses != existing_peer.addresses {
+                        info!(target: LOG_TARGET, "UPDP add_or_update_peer");
+                        info!(target: LOG_TARGET, "UPDP updating exising peer peer: {}: addresses: {}", peer.node_id, peer.addresses);
+                        info!(target: LOG_TARGET, "UPDP found exising data for peer: {}: addresses: {}", existing_peer.node_id, existing_peer.addresses);
+                        check_merge = true;
+                    }
                     existing_peer.merge(&peer);
+                    if check_merge  && peer.addresses.addresses().len() != existing_peer.addresses.addresses().len() {
+                        info!(target: LOG_TARGET, "UPDP after merger");
+                        info!(target: LOG_TARGET, "UPDP exising data for peer: {}: addresses: {}", existing_peer.node_id, existing_peer.addresses);
+                    }
                     let update_peer_sql = PeerDatabaseSql::update_peer_sql(existing_peer.clone())?;
                     self.update_peer_inner(update_peer_sql, conn)?;
                     Ok(existing_peer.id.unwrap_or_default())
@@ -1501,6 +1204,7 @@ impl PeerDatabaseSql {
         exclude_node_ids: &[NodeId],
         peer_flags: Option<PeerFlags>,
         transport_protocols: &[TransportProtocol],
+        known_good: bool,
     ) -> Result<Vec<Peer>, StorageError> {
         if n == 0 {
             warn!(target: LOG_TARGET, "'0' requested for 'get_n_random_peers'");
@@ -1510,7 +1214,6 @@ impl PeerDatabaseSql {
         let mut conn = self.connection.get_pooled_connection()?;
         let exclude_node_ids = exclude_node_ids.iter().map(|id| id.to_hex()).collect::<Vec<_>>();
         let addr_filter_sql = Self::build_addr_filter_sql(transport_protocols);
-
         conn.transaction::<_, StorageError, _>(|conn| {
             // Step 1: Filtered, random and truncated list of node_ids
             let mut query = peers::table
@@ -1532,6 +1235,9 @@ impl PeerDatabaseSql {
                 .distinct()
                 .into_boxed();
 
+            if known_good {
+                query = query.filter(multi_addresses::last_seen.is_not_null());
+            }
             if let Some(flags) = peer_flags {
                 query = query.filter(peers::flags.eq(flags.to_i32()));
             }

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -169,18 +169,7 @@ impl PeerDatabaseSql {
 
             match self.get_peer_by_node_id_inner(&node_id, conn)? {
                 Some(mut existing_peer) => {
-                    let mut check_merge = false;
-                    if peer.addresses != existing_peer.addresses {
-                        info!(target: LOG_TARGET, "UPDP add_or_update_peer");
-                        info!(target: LOG_TARGET, "UPDP updating exising peer peer: {}: addresses: {}", peer.node_id, peer.addresses);
-                        info!(target: LOG_TARGET, "UPDP found exising data for peer: {}: addresses: {}", existing_peer.node_id, existing_peer.addresses);
-                        check_merge = true;
-                    }
                     existing_peer.merge(&peer);
-                    if check_merge  && peer.addresses.addresses().len() != existing_peer.addresses.addresses().len() {
-                        info!(target: LOG_TARGET, "UPDP after merger");
-                        info!(target: LOG_TARGET, "UPDP exising data for peer: {}: addresses: {}", existing_peer.node_id, existing_peer.addresses);
-                    }
                     let update_peer_sql = PeerDatabaseSql::update_peer_sql(existing_peer.clone())?;
                     self.update_peer_inner(update_peer_sql, conn)?;
                     Ok(existing_peer.id.unwrap_or_default())

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -1838,33 +1838,33 @@ mod tests {
 
         // All peers as random
         let random_peers = peers_db
-            .get_n_random_peers(12, &[], None, &transport_protocols)
+            .get_n_random_peers(12, &[], None, &transport_protocols, false)
             .unwrap();
         assert_eq!(random_peers.len(), 12);
 
         // All seed peers only as random
         let random_peers = peers_db
-            .get_n_random_peers(12, &[], Some(PeerFlags::SEED), &transport_protocols)
+            .get_n_random_peers(12, &[], Some(PeerFlags::SEED), &transport_protocols, false)
             .unwrap();
         assert_eq!(random_peers.len(), 4);
         assert!(random_peers.iter().all(|p| p.flags == PeerFlags::SEED));
 
         // One seed peer as random
         let random_peers = peers_db
-            .get_n_random_peers(1, &[], Some(PeerFlags::SEED), &transport_protocols)
+            .get_n_random_peers(1, &[], Some(PeerFlags::SEED), &transport_protocols, false)
             .unwrap();
         assert_eq!(random_peers[0].flags, PeerFlags::SEED);
 
         // All normal peers only as random
         let random_peers = peers_db
-            .get_n_random_peers(12, &[], Some(PeerFlags::NONE), &transport_protocols)
+            .get_n_random_peers(12, &[], Some(PeerFlags::NONE), &transport_protocols, false)
             .unwrap();
         assert_eq!(random_peers.len(), 8);
         assert!(random_peers.iter().all(|p| p.flags == PeerFlags::NONE));
 
         // One normal peer as random
         let random_peers = peers_db
-            .get_n_random_peers(1, &[], Some(PeerFlags::NONE), &transport_protocols)
+            .get_n_random_peers(1, &[], Some(PeerFlags::NONE), &transport_protocols, false)
             .unwrap();
         assert_eq!(random_peers[0].flags, PeerFlags::NONE);
     }
@@ -2022,7 +2022,7 @@ mod tests {
 
         // Test 'random_peers_sqlite'
         let random_peers = peers_db
-            .get_n_random_peers(5, &[node_peers[0].node_id.clone()], None, &transport_protocols)
+            .get_n_random_peers(5, &[node_peers[0].node_id.clone()], None, &transport_protocols, false)
             .unwrap();
         assert_eq!(random_peers.len(), 5);
         // Verify deleted & banned

--- a/comms/core/src/peer_manager/storage/migrations/2025-09-15-120000_remove_distance_to_self/up.sql
+++ b/comms/core/src/peer_manager/storage/migrations/2025-09-15-120000_remove_distance_to_self/up.sql
@@ -1,4 +1,7 @@
 -- Remove distance_to_self column from peers table (SQLite requires table recreation)
+-- Must disable foreign keys to prevent cascading deletion of multi_addresses
+
+PRAGMA foreign_keys = OFF;
 
 CREATE TABLE peers_new (
     peer_id BIGINT PRIMARY KEY NOT NULL,
@@ -28,3 +31,5 @@ ALTER TABLE peers_new RENAME TO peers;
 CREATE INDEX idx_node_id ON peers (node_id);
 CREATE INDEX idx_banned_until ON peers (banned_until);
 CREATE INDEX idx_deleted_at ON peers (deleted_at);
+
+PRAGMA foreign_keys = ON;

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -600,7 +600,7 @@ impl DhtActor {
                 // Send to a random set of peers of size n that are Communication Nodes
                 (
                     peer_manager
-                        .random_peers(n, &excluded, None)
+                        .random_peers(n, &excluded, None, true)
                         .await?
                         .into_iter()
                         .map(|p| p.node_id)

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -220,7 +220,7 @@ impl Default for DhtConnectivityConfig {
     fn default() -> Self {
         Self {
             update_interval: Duration::from_secs(2 * 60),
-            random_pool_refresh_interval: Duration::from_secs(2 * 60 * 60),
+            random_pool_refresh_interval: Duration::from_secs(10 * 60 * 60),
             high_failure_rate_cooldown: Duration::from_secs(45),
             minimum_desired_tcpv4_node_ratio: 0.1,
         }

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -214,6 +214,9 @@ pub struct DhtConnectivityConfig {
     /// Currently, it only emits a warning if the ratio is below this setting.
     /// Default: 0.1 (10%)
     pub minimum_desired_tcpv4_node_ratio: f32,
+    /// This is the percentage of nodes that we want to churn per refresh cycle
+    /// This percentage of nodes will be randomly chosen and disconnected, and then replaced by new nodes,
+    pub churn_rate: usize,
 }
 
 impl Default for DhtConnectivityConfig {
@@ -223,6 +226,7 @@ impl Default for DhtConnectivityConfig {
             random_pool_refresh_interval: Duration::from_secs(10 * 60 * 60),
             high_failure_rate_cooldown: Duration::from_secs(45),
             minimum_desired_tcpv4_node_ratio: 0.1,
+            churn_rate: 10,
         }
     }
 }

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -425,7 +425,7 @@ impl DhtConnectivity {
             .drain(..)
             .partition::<Vec<_>, _>(|n| disconnected.iter().any(|c| c.peer_node_id() == n));
         // we want add and at most 10% new peers or at least 1 peer
-        let keep_size = max(pool_size / 10, 1);
+        let keep_size = pool_size - max(pool_size * self.config.connectivity.churn_rate / 100, 1);
         while connected.len() > keep_size {
             // we remove a random peer so as not to keep swapping the same peer each time.
             let mut rng = thread_rng();

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -38,23 +38,17 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-
+use std::cmp::max;
 use log::*;
+use rand::{thread_rng, Rng};
 pub use metrics::{MetricsCollector, MetricsCollectorHandle};
-use tari_comms::{
-    Minimized,
-    PeerConnection,
-    PeerManager,
-    connectivity::{
-        ConnectivityError,
-        ConnectivityEvent,
-        ConnectivityEventRx,
-        ConnectivityRequester,
-        ConnectivitySelection,
-    },
-    multiaddr,
-    peer_manager::{NodeId, Peer, PeerManagerError},
-};
+use tari_comms::{Minimized, PeerConnection, PeerManager, connectivity::{
+    ConnectivityError,
+    ConnectivityEvent,
+    ConnectivityEventRx,
+    ConnectivityRequester,
+    ConnectivitySelection,
+}, multiaddr, peer_manager::{NodeId, Peer, PeerManagerError}, PeerConnectionError};
 use tari_shutdown::ShutdownSignal;
 use thiserror::Error;
 use tokio::{sync::broadcast, task, task::JoinHandle, time, time::MissedTickBehavior};
@@ -74,6 +68,8 @@ pub enum DhtConnectivityError {
     SendJoinFailed(#[from] DhtActorError),
     #[error("Metrics error: {0}")]
     MetricError(#[from] MetricsError),
+    #[error("Peer connection error: {0}")]
+    PeerConnectionError(#[from] PeerConnectionError),
 }
 
 /// DHT connectivity actor.
@@ -346,6 +342,8 @@ impl DhtConnectivity {
     }
 
     async fn refresh_entire_pool(&mut self) -> Result<(), DhtConnectivityError> {
+        dbg!("refresh entire pool");
+        dbg!(self.random_pool.len());
         let pool_size = self.config.num_neighbouring_nodes + self.config.num_random_nodes;
         // we have no peers, so we need to get peers, so lets double our chances of dialing twice the number we want, we
         // can close them later on And we only select known healty ones
@@ -365,9 +363,9 @@ impl DhtConnectivity {
             self.insert_random_peer(peer.clone());
         }
         // Make sure we d drop any connection handles that removed from the pool
-        old_peers.iter().for_each(|peer| {
-            self.remove_connection_handle(peer);
-        });
+         for old_peer in &old_peers{
+            self.remove_connection_handle(old_peer).await?;
+        };
         self.dial_multiple_peers(&new_peers).await?;
         self.random_pool_last_refresh = Some(Instant::now());
         Ok(())
@@ -419,10 +417,13 @@ impl DhtConnectivity {
             .random_pool
             .drain(..)
             .partition::<Vec<_>, _>(|n| disconnected.iter().any(|c| c.peer_node_id() == n));
-        // we want add and at most 25% new peers
-        let keep_size = pool_size * 3 / 4;
+        // we want add and at most 10% new peers or at least 1 peer
+        let keep_size = max(pool_size / 10, 1);
         while connected.len() > keep_size {
-            let disconnect_peer = connected.pop().expect("Should exist");
+            // we remove a random peer so as not to keep swapping the same peer each time.
+            let mut rng = thread_rng();
+            let index = rng.gen_range(0..connected.len());
+            let disconnect_peer = connected.swap_remove(index);
             disconnected_peers.push(disconnect_peer);
         }
         new_peers.truncate(pool_size.saturating_sub(connected.len()));
@@ -438,9 +439,9 @@ impl DhtConnectivity {
             self.insert_random_peer(peer.clone());
         }
         // Drop any connection handles that removed from the pool
-        disconnected_peers.iter().for_each(|peer| {
-            self.remove_connection_handle(peer);
-        });
+        for peer_to_disconnect in &disconnected_peers {
+            self.remove_connection_handle(peer_to_disconnect).await?;
+        };
         self.dial_multiple_peers(&new_peers).await?;
 
         self.random_pool_last_refresh = Some(Instant::now());
@@ -473,7 +474,7 @@ impl DhtConnectivity {
                 "Added pool peer '{}' to connection handles",
                 conn.peer_node_id()
             );
-            self.insert_connection_handle(conn);
+            self.insert_connection_handle(conn).await?;
             return Ok(());
         }
 
@@ -485,7 +486,7 @@ impl DhtConnectivity {
                 conn.peer_node_id().short_str()
             );
             self.random_pool.push(conn.peer_node_id().clone());
-            self.insert_connection_handle(conn);
+            self.insert_connection_handle(conn).await?;
         }
 
         Ok(())
@@ -524,24 +525,29 @@ impl DhtConnectivity {
                 threshold
             );
             self.replace_pool_peer(&peer.node_id).await?;
-            self.remove_connection_handle(&peer.node_id);
+            self.remove_connection_handle(&peer.node_id).await?;
         }
 
         Ok(())
     }
 
-    fn insert_connection_handle(&mut self, conn: PeerConnection) {
+    async fn insert_connection_handle(&mut self, conn: PeerConnection) -> Result<(), PeerConnectionError> {
         // Remove any existing connection for this peer
-        self.remove_connection_handle(conn.peer_node_id());
+        self.remove_connection_handle(conn.peer_node_id()).await?;
         trace!(target: LOG_TARGET, "Insert new peer connection {conn}" );
         self.connection_handles.push(conn);
+        Ok(())
     }
 
-    fn remove_connection_handle(&mut self, node_id: &NodeId) {
+    async fn remove_connection_handle(&mut self, node_id: &NodeId) -> Result<(), PeerConnectionError> {
         if let Some(idx) = self.connection_handles.iter().position(|c| c.peer_node_id() == node_id) {
-            let conn = self.connection_handles.swap_remove(idx);
+            let mut conn = self.connection_handles.swap_remove(idx);
+            if conn.is_connected(){
+                conn.disconnect(Minimized::No, "DhtConnectivty").await?;
+            }
             trace!(target: LOG_TARGET, "Removing peer connection {conn}" );
         }
+        Ok(())
     }
 
     async fn handle_connectivity_event(&mut self, event: ConnectivityEvent) -> Result<(), DhtConnectivityError> {
@@ -607,7 +613,7 @@ impl DhtConnectivity {
                     // Remove from managed pool if applicable
                     self.replace_pool_peer(&node_id).await?;
                     // In case the connections was not managed, remove the connection handle
-                    self.remove_connection_handle(&node_id);
+                    self.remove_connection_handle(&node_id).await?;
                     return Ok(());
                 }
                 debug!(target: LOG_TARGET, "Pool peer {node_id} disconnected. Redialling...");
@@ -664,7 +670,7 @@ impl DhtConnectivity {
             }
 
             self.random_pool.retain(|n| n != current_peer);
-            self.remove_connection_handle(current_peer);
+            self.remove_connection_handle(current_peer).await?;
 
             debug!(
                 target: LOG_TARGET,

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -322,14 +322,14 @@ impl DhtConnectivity {
         Ok(())
     }
 
-    async fn refresh_peer_pools(&mut self, try_revive_connections: bool) -> Result<(), DhtConnectivityError> {
+    async fn refresh_peer_pools(&mut self, refresh_entire_pool: bool) -> Result<(), DhtConnectivityError> {
         info!(
             target: LOG_TARGET,
             "Reinitializing peer pool. (size={}, try_revive_connections {try_revive_connections})",
             self.random_pool.len(),
         );
 
-        if try_revive_connections {
+        if refresh_entire_pool {
             let should_refresh = self
                 .random_pool_last_refresh
                 .map(|instant| instant.elapsed() >= self.config.connectivity.random_pool_refresh_interval)
@@ -339,7 +339,7 @@ impl DhtConnectivity {
             } else {
                 debug!(
                     target: LOG_TARGET,
-                    "Attempting to revive existing peer connections before refreshing the entire pool. Last refresh was {:.0?} ago.",
+                    "Attempting to refresh entire pool, but time has not expired yet. Last refresh was {:.0?} ago.",
                     self.random_pool_last_refresh.map(|instant| instant.elapsed()).unwrap_or_default()
                 );
             }

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -325,7 +325,7 @@ impl DhtConnectivity {
     async fn refresh_peer_pools(&mut self, refresh_entire_pool: bool) -> Result<(), DhtConnectivityError> {
         info!(
             target: LOG_TARGET,
-            "Reinitializing peer pool. (size={}, try_revive_connections {try_revive_connections})",
+            "Reinitializing peer pool. (size={}, try_revive_connections {refresh_entire_pool})",
             self.random_pool.len(),
         );
 

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -425,7 +425,7 @@ impl DhtConnectivity {
             .drain(..)
             .partition::<Vec<_>, _>(|n| disconnected.iter().any(|c| c.peer_node_id() == n));
         // we want add and at most 10% new peers or at least 1 peer
-        let keep_size = pool_size - max(pool_size * self.config.connectivity.churn_rate / 100, 1);
+        let keep_size = pool_size - pool_size * self.config.connectivity.churn_rate / 100;
         while connected.len() > keep_size {
             // we remove a random peer so as not to keep swapping the same peer each time.
             let mut rng = thread_rng();

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -35,7 +35,6 @@ mod test;
 
 mod metrics;
 use std::{
-    cmp::max,
     sync::Arc,
     time::{Duration, Instant},
 };

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -517,7 +517,14 @@ impl DhtConnectivity {
                 pool_size
             );
             let mut conn = conn;
-            conn.disconnect(Minimized::Yes, "DhtConnectivity pool full").await?;
+            if let Err(err) = conn.disconnect(Minimized::Yes, "DhtConnectivity pool full").await {
+                debug!(
+                    target: LOG_TARGET,
+                    "Failed to disconnect excess peer '{}': {:?}",
+                    conn.peer_node_id().short_str(),
+                    err
+                );
+            }
         }
 
         Ok(())

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -35,20 +35,29 @@ mod test;
 
 mod metrics;
 use std::{
+    cmp::max,
     sync::Arc,
     time::{Duration, Instant},
 };
-use std::cmp::max;
+
 use log::*;
-use rand::{thread_rng, Rng};
 pub use metrics::{MetricsCollector, MetricsCollectorHandle};
-use tari_comms::{Minimized, PeerConnection, PeerManager, connectivity::{
-    ConnectivityError,
-    ConnectivityEvent,
-    ConnectivityEventRx,
-    ConnectivityRequester,
-    ConnectivitySelection,
-}, multiaddr, peer_manager::{NodeId, Peer, PeerManagerError}, PeerConnectionError};
+use rand::{Rng, thread_rng};
+use tari_comms::{
+    Minimized,
+    PeerConnection,
+    PeerConnectionError,
+    PeerManager,
+    connectivity::{
+        ConnectivityError,
+        ConnectivityEvent,
+        ConnectivityEventRx,
+        ConnectivityRequester,
+        ConnectivitySelection,
+    },
+    multiaddr,
+    peer_manager::{NodeId, Peer, PeerManagerError},
+};
 use tari_shutdown::ShutdownSignal;
 use thiserror::Error;
 use tokio::{sync::broadcast, task, task::JoinHandle, time, time::MissedTickBehavior};
@@ -342,8 +351,6 @@ impl DhtConnectivity {
     }
 
     async fn refresh_entire_pool(&mut self) -> Result<(), DhtConnectivityError> {
-        dbg!("refresh entire pool");
-        dbg!(self.random_pool.len());
         let pool_size = self.config.num_neighbouring_nodes + self.config.num_random_nodes;
         // we have no peers, so we need to get peers, so lets double our chances of dialing twice the number we want, we
         // can close them later on And we only select known healty ones
@@ -362,10 +369,10 @@ impl DhtConnectivity {
         for peer in &new_peers {
             self.insert_random_peer(peer.clone());
         }
-        // Make sure we d drop any connection handles that removed from the pool
-         for old_peer in &old_peers{
+        // Make sure we drop any connection handles that removed from the pool
+        for old_peer in &old_peers {
             self.remove_connection_handle(old_peer).await?;
-        };
+        }
         self.dial_multiple_peers(&new_peers).await?;
         self.random_pool_last_refresh = Some(Instant::now());
         Ok(())
@@ -438,10 +445,25 @@ impl DhtConnectivity {
         for peer in &new_peers {
             self.insert_random_peer(peer.clone());
         }
-        // Drop any connection handles that removed from the pool
+        // Drop any connection handles that were removed from the pool
         for peer_to_disconnect in &disconnected_peers {
             self.remove_connection_handle(peer_to_disconnect).await?;
-        };
+        }
+        // Clean up any connection handles not in the current pool (e.g. accumulated between refresh cycles)
+        let stale_handles: Vec<NodeId> = self
+            .connection_handles
+            .iter()
+            .filter(|c| !self.random_pool.contains(c.peer_node_id()) && c.direction().is_outbound())
+            .map(|c| c.peer_node_id().clone())
+            .collect();
+        for node_id in &stale_handles {
+            debug!(
+                target: LOG_TARGET,
+                "Removing stale connection handle for '{}' (not in current pool)",
+                node_id.short_str()
+            );
+            self.remove_connection_handle(node_id).await?;
+        }
         self.dial_multiple_peers(&new_peers).await?;
 
         self.random_pool_last_refresh = Some(Instant::now());
@@ -487,6 +509,16 @@ impl DhtConnectivity {
             );
             self.random_pool.push(conn.peer_node_id().clone());
             self.insert_connection_handle(conn).await?;
+        } else {
+            debug!(
+                target: LOG_TARGET,
+                "Peer '{}' connected but peer pool is full ({}/{}). Disconnecting.",
+                conn.peer_node_id().short_str(),
+                self.random_pool.len(),
+                pool_size
+            );
+            let mut conn = conn;
+            conn.disconnect(Minimized::Yes, "DhtConnectivity pool full").await?;
         }
 
         Ok(())
@@ -542,7 +574,7 @@ impl DhtConnectivity {
     async fn remove_connection_handle(&mut self, node_id: &NodeId) -> Result<(), PeerConnectionError> {
         if let Some(idx) = self.connection_handles.iter().position(|c| c.peer_node_id() == node_id) {
             let mut conn = self.connection_handles.swap_remove(idx);
-            if conn.is_connected(){
+            if conn.is_connected() {
                 conn.disconnect(Minimized::No, "DhtConnectivty").await?;
             }
             trace!(target: LOG_TARGET, "Removing peer connection {conn}" );
@@ -616,10 +648,8 @@ impl DhtConnectivity {
                     self.remove_connection_handle(&node_id).await?;
                     return Ok(());
                 }
-                debug!(target: LOG_TARGET, "Pool peer {node_id} disconnected. Redialling...");
-                // Attempt to reestablish the lost connection to the pool peer. If reconnection fails,
-                // it is replaced with another peer (replace_pool_peer via PeerConnectFailed)
-                self.dial_multiple_peers(&[node_id]).await?;
+                debug!(target: LOG_TARGET, "Pool peer {node_id} disconnected. Replacing with a new peer.");
+                self.replace_pool_peer(&node_id).await?;
             },
             ConnectivityStateOnline(n) => {
                 self.refresh_peer_pools(false).await?;

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -320,40 +320,56 @@ impl DhtConnectivity {
     async fn refresh_peer_pools(&mut self, try_revive_connections: bool) -> Result<(), DhtConnectivityError> {
         info!(
             target: LOG_TARGET,
-            "Reinitializing peer pool. (size={})",
+            "Reinitializing peer pool. (size={}, try_revive_connections {try_revive_connections})",
             self.random_pool.len(),
         );
 
         if try_revive_connections {
-            self.redial_pool_peers_as_required().await?;
+            let should_refresh = self
+                .random_pool_last_refresh
+                .map(|instant| instant.elapsed() >= self.config.connectivity.random_pool_refresh_interval)
+                .unwrap_or(true);
+            if should_refresh {
+                self.refresh_entire_pool().await?;
+            } else {
+                debug!(
+                    target: LOG_TARGET,
+                    "Attempting to revive existing peer connections before refreshing the entire pool. Last refresh was {:.0?} ago.",
+                    self.random_pool_last_refresh.map(|instant| instant.elapsed()).unwrap_or_default()
+                );
+            }
+        } else {
+            self.refresh_random_pool().await?;
         }
-        self.refresh_random_pool().await?;
 
         Ok(())
     }
 
-    async fn redial_pool_peers_as_required(&mut self) -> Result<(), DhtConnectivityError> {
-        let disconnected = self
-            .connection_handles
-            .iter()
-            .filter(|c| !c.is_connected())
-            .collect::<Vec<_>>();
-        let to_redial = self
-            .random_pool
-            .iter()
-            .filter(|n| disconnected.iter().any(|c| c.peer_node_id() == *n))
-            .cloned()
-            .collect::<Vec<_>>();
-
-        if !to_redial.is_empty() {
-            debug!(
-                target: LOG_TARGET,
-                "Redialling {} disconnected peer(s)",
-                to_redial.len()
-            );
-            self.dial_multiple_peers(&to_redial).await?;
+    async fn refresh_entire_pool(&mut self) -> Result<(), DhtConnectivityError> {
+        let pool_size = self.config.num_neighbouring_nodes + self.config.num_random_nodes;
+        // we have no peers, so we need to get peers, so lets double our chances of dialing twice the number we want, we
+        // can close them later on And we only select known healty ones
+        debug!(
+            target: LOG_TARGET,
+            "We have no connections asking for {} nodes",
+            pool_size * 2,
+        );
+        let new_peers = self.fetch_random_peers(pool_size * 2, &Vec::new(), true).await?;
+        debug!(
+            target: LOG_TARGET,
+            "Refreshing peer pool (#new = {})",
+            new_peers.len(),
+        );
+        let old_peers = self.random_pool.drain(..).collect::<Vec<_>>();
+        for peer in &new_peers {
+            self.insert_random_peer(peer.clone());
         }
-
+        // Make sure we d drop any connection handles that removed from the pool
+        old_peers.iter().for_each(|peer| {
+            self.remove_connection_handle(peer);
+        });
+        self.dial_multiple_peers(&new_peers).await?;
+        self.random_pool_last_refresh = Some(Instant::now());
         Ok(())
     }
 
@@ -385,39 +401,44 @@ impl DhtConnectivity {
         if self.config.minimize_connections {
             exclude.extend(self.previous_random.iter().cloned());
         }
-        let mut new_peers = self.fetch_random_peers(pool_size, &exclude).await?;
-        if new_peers.is_empty() {
-            info!(
-                target: LOG_TARGET,
-                "Unable to refresh peer pool because there are insufficient known peers",
-            );
-            return Ok(());
-        }
+        info!(
+            target: LOG_TARGET,
+            "refreshing random peer list, asking for {pool_size} peers",
+        );
+        let mut new_peers = self.fetch_random_peers(pool_size, &exclude, false).await?;
 
-        let (intersection, difference) = self
+        // let see who is not connected and remove them
+        let disconnected = self
+            .connection_handles
+            .iter()
+            .filter(|c| !c.is_connected())
+            .collect::<Vec<_>>();
+
+        // lets remove disconnected ones
+        let (mut disconnected_peers, mut connected) = self
             .random_pool
             .drain(..)
-            .partition::<Vec<_>, _>(|n| new_peers.contains(n));
-        // Remove the peers that we want to keep from the `new_peers` to be added
-        new_peers.retain(|n| !intersection.contains(n));
-        self.random_pool = intersection;
+            .partition::<Vec<_>, _>(|n| disconnected.iter().any(|c| c.peer_node_id() == n));
+        // we want add and at most 25% new peers
+        let keep_size = pool_size * 3 / 4;
+        while connected.len() > keep_size {
+            let disconnect_peer = connected.pop().expect("Should exist");
+            disconnected_peers.push(disconnect_peer);
+        }
+        new_peers.truncate(pool_size.saturating_sub(connected.len()));
+
+        self.random_pool = connected;
         debug!(
             target: LOG_TARGET,
-            "Adding new peers to peer pool (#new = {}, #keeping = {}, #removing = {})",
+            "Adding new peers to peer pool (#new = {}, #keeping = {})",
             new_peers.len(),
             self.random_pool.len(),
-            difference.len()
-        );
-        trace!(
-            target: LOG_TARGET,
-            "Pool peers: Adding = {new_peers:?}, Removing = {difference:?}"
-
         );
         for peer in &new_peers {
             self.insert_random_peer(peer.clone());
         }
         // Drop any connection handles that removed from the pool
-        difference.iter().for_each(|peer| {
+        disconnected_peers.iter().for_each(|peer| {
             self.remove_connection_handle(peer);
         });
         self.dial_multiple_peers(&new_peers).await?;
@@ -649,7 +670,7 @@ impl DhtConnectivity {
                 target: LOG_TARGET,
                 "Peer '{current_peer}' in peer pool is unavailable. Adding a new peer if possible"
             );
-            match self.fetch_random_peers(1, &exclude).await?.pop() {
+            match self.fetch_random_peers(1, &exclude, false).await?.pop() {
                 Some(new_peer) => {
                     self.insert_random_peer(new_peer.clone());
                     self.dial_multiple_peers(&[new_peer]).await?;
@@ -725,10 +746,15 @@ impl DhtConnectivity {
         self.random_pool.clone()
     }
 
-    async fn fetch_random_peers(&mut self, n: usize, excluded: &[NodeId]) -> Result<Vec<NodeId>, DhtConnectivityError> {
+    async fn fetch_random_peers(
+        &mut self,
+        n: usize,
+        excluded: &[NodeId],
+        known_good: bool,
+    ) -> Result<Vec<NodeId>, DhtConnectivityError> {
         let mut excluded = excluded.to_vec();
         excluded.extend(self.peer_allow_list().await?);
-        let peers = self.peer_manager.random_peers(n, &excluded, None).await?;
+        let peers = self.peer_manager.random_peers(n, &excluded, None, known_good).await?;
         Ok(peers.into_iter().map(|p| p.node_id).collect())
     }
 

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -187,69 +187,6 @@ async fn added_pool_peers() {
     assert!(conn.handle_count() == 2 || conn.handle_count() == 3);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn replace_peer_when_peer_goes_offline() {
-    let node_identity = make_node_identity();
-    let node_identities = build_many_node_identities(7, PeerFeatures::COMMUNICATION_NODE);
-    let peers = node_identities
-        .iter()
-        .map(|ni| create_good_standing_peer(ni))
-        .collect::<Vec<_>>();
-
-    // pool_size = 3+3 = 6, with 7 peers available, 6 will be dialed, 1 stays as a spare
-    let config = DhtConfig {
-        num_neighbouring_nodes: 3,
-        num_random_nodes: 3,
-        ..Default::default()
-    };
-    let (dht_connectivity, _, connectivity, _, _, _shutdown) = setup(config, node_identity, peers).await;
-    dht_connectivity.spawn();
-
-    // Wait for calls to dial peers
-    async_assert!(
-        connectivity.call_count().await >= 6,
-        max_attempts = 20,
-        interval = Duration::from_millis(10),
-    );
-    let _result = connectivity.take_calls().await;
-
-    let dialed = connectivity.take_dialed_peers().await;
-    assert_eq!(dialed.len(), 6);
-
-    // Disconnect the first peer that was dialed
-    let disconnected_peer = dialed[0].clone();
-    connectivity.publish_event(ConnectivityEvent::PeerDisconnected(
-        disconnected_peer.clone(),
-        Minimized::No,
-    ));
-
-    async_assert!(
-        connectivity.call_count().await >= 1,
-        max_attempts = 20,
-        interval = Duration::from_millis(10),
-    );
-
-    let _result = connectivity.take_calls().await;
-    let redialed = connectivity.take_dialed_peers().await;
-    // After a disconnect, the peer should be redialed
-    assert!(!redialed.is_empty(), "Expected at least one redial after disconnect");
-
-    connectivity.publish_event(ConnectivityEvent::PeerConnectFailed(disconnected_peer.clone()));
-
-    async_assert!(
-        connectivity.call_count().await >= 1,
-        max_attempts = 20,
-        interval = Duration::from_millis(10),
-    );
-
-    // After connect failure, either the spare peer or the failed peer itself gets dialed
-    let replacement_dialed = connectivity.take_dialed_peers().await;
-    assert!(
-        !replacement_dialed.is_empty(),
-        "Expected replacement dial after connect failure"
-    );
-}
-
 #[tokio::test]
 async fn insert_into_pool() {
     let node_identity = make_node_identity();

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -25,7 +25,6 @@ use std::{iter::repeat_with, sync::Arc, time::Duration};
 
 use rand::{rngs::OsRng, seq::SliceRandom};
 use tari_comms::{
-    Minimized,
     NodeIdentity,
     PeerManager,
     connectivity::ConnectivityEvent,

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -132,7 +132,7 @@ impl Discovering {
                     conn.peer_node_id(),
                     e
                 );
-                let _ = conn.disconnect(Minimized::Yes, "Discovering RPC connect failed").await;
+                let _unused = conn.disconnect(Minimized::Yes, "Discovering RPC connect failed").await;
                 return Err(e.into());
             },
             Err(_) => {
@@ -143,7 +143,7 @@ impl Discovering {
                     conn.peer_node_id(),
                     rpc_connect_timeout,
                 );
-                let _ = conn.disconnect(Minimized::Yes, "Discovering RPC connect timeout").await;
+                let _unused = conn.disconnect(Minimized::Yes, "Discovering RPC connect timeout").await;
                 return Err(NetworkDiscoveryError::Timeout {
                     operation: "connect_rpc".to_string(),
                     peer: conn.peer_node_id().to_hex(),
@@ -166,7 +166,7 @@ impl Discovering {
         );
         let result = self.request_peers(peer_node_id, client).await;
         self.ban_on_offence(peer_node_id.clone(), result).await?;
-        let _ = conn.disconnect(Minimized::Yes, "Discovering sync complete").await;
+        let _unused = conn.disconnect(Minimized::Yes, "Discovering sync complete").await;
 
         Ok(())
     }

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -25,6 +25,7 @@ use std::{collections::HashSet, convert::TryInto};
 use futures::{Stream, StreamExt, stream::FuturesUnordered};
 use log::*;
 use tari_comms::{
+    Minimized,
     PeerConnection,
     connectivity::ConnectivityError,
     peer_manager::{NodeId, Peer, PeerId},
@@ -122,29 +123,34 @@ impl Discovering {
 
     async fn request_from_peers(&mut self, mut conn: PeerConnection) -> Result<(), NetworkDiscoveryError> {
         let rpc_connect_timeout = self.config().network_discovery.bootstrap_rpc_connect_timeout;
-        let client = tokio::time::timeout(rpc_connect_timeout, conn.connect_rpc::<DhtClient>())
-            .await
-            .map_err(|_| {
-                error!(
-                    target: LOG_TARGET,
-                    "Discovering: RPC connect_rpc to sync peer '{}' timed out after {:?}",
-                    conn.peer_node_id(),
-                    rpc_connect_timeout,
-                );
-                NetworkDiscoveryError::Timeout {
-                    operation: "connect_rpc".to_string(),
-                    peer: conn.peer_node_id().to_hex(),
-                    duration: format!("{rpc_connect_timeout:.2?}"),
-                }
-            })?
-            .inspect_err(|e| {
+        let client = match tokio::time::timeout(rpc_connect_timeout, conn.connect_rpc::<DhtClient>()).await {
+            Ok(Ok(client)) => client,
+            Ok(Err(e)) => {
                 error!(
                     target: LOG_TARGET,
                     "Discovering: Failed to connect RPC client to sync peer {}: {}",
                     conn.peer_node_id(),
                     e
                 );
-            })?;
+                let _ = conn.disconnect(Minimized::Yes, "Discovering RPC connect failed").await;
+                return Err(e.into());
+            },
+            Err(_) => {
+                // the peer most likely is not online or has an old address.
+                debug!(
+                    target: LOG_TARGET,
+                    "Discovering: RPC connect_rpc to sync peer '{}' timed out after {:?}",
+                    conn.peer_node_id(),
+                    rpc_connect_timeout,
+                );
+                let _ = conn.disconnect(Minimized::Yes, "Discovering RPC connect timeout").await;
+                return Err(NetworkDiscoveryError::Timeout {
+                    operation: "connect_rpc".to_string(),
+                    peer: conn.peer_node_id().to_hex(),
+                    duration: format!("{rpc_connect_timeout:.2?}"),
+                });
+            },
+        };
 
         trace!(
             target: LOG_TARGET,
@@ -160,6 +166,7 @@ impl Discovering {
         );
         let result = self.request_peers(peer_node_id, client).await;
         self.ban_on_offence(peer_node_id.clone(), result).await?;
+        let _ = conn.disconnect(Minimized::Yes, "Discovering sync complete").await;
 
         Ok(())
     }

--- a/comms/dht/src/network_discovery/ready.rs
+++ b/comms/dht/src/network_discovery/ready.rs
@@ -56,6 +56,7 @@ async fn select_peers_for_discovery_round(
                 config.network_discovery.max_sync_peers,
                 excluded_peers,
                 Some(PeerFlags::NONE),
+                true,
             )
             .await?
     };


### PR DESCRIPTION
Description
---
Completely redo and change pool logic in the node. 
Node will every 10 min by default change 10% of its pool to make sure that islands dont form. 
Node will refresh entire pool if there are no connections. 
Fixes a bad migration on the sql. 