### PR TITLE
feat: convert merge mining cucumber tests to RxT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7669,7 +7669,6 @@ dependencies = [
  "tari_shutdown",
  "tari_transaction_components",
  "tari_utilities",
- "tempfile",
  "thiserror 2.0.17",
  "time",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7647,7 +7647,6 @@ dependencies = [
  "minotari_app_grpc",
  "minotari_app_utilities",
  "minotari_console_wallet",
- "minotari_merge_mining_proxy",
  "minotari_miner",
  "minotari_node",
  "minotari_node_grpc_client",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -51,7 +51,6 @@ log = { workspace = true, features = ["std"] }
 rand = { workspace = true }
 reqwest = "0.12"
 serde_json = { workspace = true }
-tempfile = "3.3.0"
 thiserror = { workspace = true }
 time = "0.3.47"
 tokio = { workspace = true, features = [

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -26,7 +26,6 @@ minotari_console_wallet = { path = "../applications/minotari_console_wallet", fe
     "grpc",
 ] }
 tari_core = { path = "../base_layer/core" }
-minotari_merge_mining_proxy = { path = "../applications/minotari_merge_mining_proxy" }
 minotari_miner = { path = "../applications/minotari_miner" }
 tari_p2p = { path = "../base_layer/p2p" }
 tari_script = { path = "../infrastructure/tari_script" }

--- a/integration_tests/src/base_node_process.rs
+++ b/integration_tests/src/base_node_process.rs
@@ -54,6 +54,7 @@ pub struct BaseNodeProcess {
     pub port: u16,
     pub grpc_port: u16,
     pub http_port: u16,
+    pub xmrig_proxy_port: u16,
     pub identity: NodeIdentity,
     pub temp_dir_path: PathBuf,
     pub is_seed_node: bool,
@@ -99,6 +100,7 @@ pub async fn spawn_base_node_with_config(
     let port: u16;
     let grpc_port: u16;
     let http_port: u16;
+    let xmrig_proxy_port: u16;
     let temp_dir_path: PathBuf;
     let base_node_identity: NodeIdentity;
 
@@ -106,6 +108,7 @@ pub async fn spawn_base_node_with_config(
         port = node_ps.port;
         grpc_port = node_ps.grpc_port;
         http_port = node_ps.http_port;
+        xmrig_proxy_port = node_ps.xmrig_proxy_port;
         temp_dir_path = node_ps.temp_dir_path.clone();
         base_node_config = node_ps.config.clone();
 
@@ -119,6 +122,7 @@ pub async fn spawn_base_node_with_config(
         port = ports.p2p;
         grpc_port = ports.grpc;
         http_port = ports.http;
+        xmrig_proxy_port = ports.xmrig_proxy;
         // Track in world for backwards compatibility
         world.assigned_ports.insert(port, port);
         world.assigned_ports.insert(grpc_port, grpc_port);
@@ -151,9 +155,11 @@ pub async fn spawn_base_node_with_config(
         config: base_node_config.clone(),
         kill_signal: shutdown.clone(),
         http_port,
+        xmrig_proxy_port,
     };
 
     let name_cloned = bn_name.clone();
+    let world_default_payment_address = world.default_payment_address.to_base58();
 
     let peer_addresses = get_peer_addresses(world, &peers).await;
 
@@ -182,6 +188,13 @@ pub async fn spawn_base_node_with_config(
         base_node_config.base_node.http_wallet_query_service.listen_ip = Some("127.0.0.1".to_string().parse().unwrap());
         base_node_config.base_node.http_wallet_query_service.external_address =
             Some(format!("http://127.0.0.1:{http_port}").parse().unwrap());
+
+        // Enable the built-in XMRig proxy for RandomXT mining (used by merge mining tests)
+        base_node_config.base_node.xmrig_proxy_enabled = true;
+        base_node_config.base_node.xmrig_proxy_address =
+            format!("/ip4/127.0.0.1/tcp/{xmrig_proxy_port}").parse().unwrap();
+        base_node_config.base_node.xmrig_proxy_wallet_payment_address =
+            world_default_payment_address.clone();
 
         base_node_config.base_node.data_dir = temp_dir_path.to_path_buf();
         base_node_config.base_node.identity_file = PathBuf::from("base_node_id.json");
@@ -250,7 +263,7 @@ pub async fn spawn_base_node_with_config(
 
         println!(
             "Initializing base node: name={name_cloned}; port={port}; grpc_port={grpc_port}; \
-             is_seed_node={is_seed_node}, http_port={http_port}"
+             is_seed_node={is_seed_node}, http_port={http_port}, xmrig_proxy_port={xmrig_proxy_port}"
         );
 
         let result = run_base_node(shutdown, Arc::new(base_node_identity), Arc::new(base_node_config)).await;
@@ -268,6 +281,7 @@ pub async fn spawn_base_node_with_config(
     wait_for_service(http_port).await;
     wait_for_service(port).await;
     wait_for_service(grpc_port).await;
+    wait_for_service(xmrig_proxy_port).await;
 }
 
 impl BaseNodeProcess {
@@ -283,7 +297,12 @@ impl BaseNodeProcess {
     pub fn kill(&mut self) {
         self.kill_signal.trigger();
         let deadline = std::time::Instant::now() + Duration::from_secs(30);
-        for (label, port) in [("p2p", self.port), ("grpc", self.grpc_port), ("http", self.http_port)] {
+        for (label, port) in [
+            ("p2p", self.port),
+            ("grpc", self.grpc_port),
+            ("http", self.http_port),
+            ("xmrig_proxy", self.xmrig_proxy_port),
+        ] {
             while std::time::Instant::now() < deadline {
                 if TcpListener::bind(("127.0.0.1", port)).is_ok() {
                     break;

--- a/integration_tests/src/base_node_process.rs
+++ b/integration_tests/src/base_node_process.rs
@@ -193,8 +193,7 @@ pub async fn spawn_base_node_with_config(
         base_node_config.base_node.xmrig_proxy_enabled = true;
         base_node_config.base_node.xmrig_proxy_address =
             format!("/ip4/127.0.0.1/tcp/{xmrig_proxy_port}").parse().unwrap();
-        base_node_config.base_node.xmrig_proxy_wallet_payment_address =
-            world_default_payment_address.clone();
+        base_node_config.base_node.xmrig_proxy_wallet_payment_address = world_default_payment_address.clone();
 
         base_node_config.base_node.data_dir = temp_dir_path.to_path_buf();
         base_node_config.base_node.identity_file = PathBuf::from("base_node_id.json");

--- a/integration_tests/src/merge_mining_proxy.rs
+++ b/integration_tests/src/merge_mining_proxy.rs
@@ -20,27 +20,15 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryInto, thread};
-
-use minotari_app_utilities::common_cli_args::CommonCliArgs;
-use minotari_merge_mining_proxy::{Cli, run_merge_miner::start_merge_miner};
-use minotari_wallet_grpc_client::{WalletGrpcClient, grpc};
 use serde_json::{Value, json};
-use tari_common::{configuration::Network, network_check::set_network_if_choice_valid};
-use tari_common_types::tari_address::TariAddress;
-use tempfile::tempdir;
-use tokio::runtime;
-use tonic::transport::Channel;
 
-use crate::{TariWorld, port_pool, wait_for_service};
+use crate::TariWorld;
 
 #[derive(Clone, Debug)]
 pub struct MergeMiningProxyProcess {
     pub name: String,
     pub base_node_name: String,
-    pub wallet_name: String,
     pub port: u16,
-    pub origin_submission: bool,
     id: u64,
 }
 
@@ -48,111 +36,25 @@ pub async fn register_merge_mining_proxy_process(
     world: &mut TariWorld,
     merge_mining_proxy_name: String,
     base_node_name: String,
-    wallet_name: String,
-    origin_submission: bool,
 ) {
-    let proxy_port = port_pool::global_port_pool()
-        .allocate_merge_mining_proxy_port()
-        .expect("Port pool exhausted — too many concurrent merge mining proxies");
+    let base_node = world
+        .get_node(&base_node_name)
+        .expect("Base node not found for merge mining proxy");
+    let proxy_port = base_node.xmrig_proxy_port;
+
     let merge_mining_proxy = MergeMiningProxyProcess {
         name: merge_mining_proxy_name.clone(),
         base_node_name,
-        wallet_name,
         port: proxy_port,
-        origin_submission,
         id: 0,
     };
 
-    merge_mining_proxy.start(world).await;
     world
         .merge_mining_proxies
         .insert(merge_mining_proxy_name, merge_mining_proxy);
 }
 
 impl MergeMiningProxyProcess {
-    pub async fn start(&self, world: &mut TariWorld) {
-        set_network_if_choice_valid(Network::LocalNet).unwrap();
-
-        let temp_dir = tempdir().unwrap();
-        let data_dir = temp_dir.path().join("data/miner");
-        let data_dir_str = data_dir.clone().into_os_string().into_string().unwrap();
-        let mut config_path = data_dir;
-        config_path.push("config.toml");
-        let base_node_grpc_port = world.get_node(&self.base_node_name).unwrap().grpc_port;
-        let proxy_full_address = format! {"/ip4/127.0.0.1/tcp/{}", self.port};
-        let origin_submission = self.origin_submission;
-        let mut wallet_client = create_wallet_client(world, self.wallet_name.clone())
-            .await
-            .expect("wallet grpc client");
-        let wallet_address = &wallet_client
-            .get_address(grpc::Empty {})
-            .await
-            .unwrap()
-            .into_inner()
-            .interactive_address;
-        let wallet_payment_address = TariAddress::from_bytes(wallet_address).unwrap();
-        let proxy_port = self.port;
-        thread::spawn(move || {
-            let cli = Cli {
-                common: CommonCliArgs {
-                    base_path: data_dir_str,
-                    config: config_path.into_os_string().into_string().unwrap(),
-                    log_config: None,
-                    log_path: None,
-                    network: Some("localnet".to_string().try_into().unwrap()),
-                    config_property_overrides: vec![
-                        ("merge_mining_proxy.listener_address".to_string(), proxy_full_address),
-                        (
-                            "merge_mining_proxy.base_node_grpc_address".to_string(),
-                            format!("http://127.0.0.1:{base_node_grpc_port}"),
-                        ),
-                        (
-                            "merge_mining_proxy.monerod_url".to_string(),
-                            [
-                                "http://stagenet.xmr-tw.org:38081",
-                                "http://node.monerodevs.org:38089",
-                                "http://node3.monerodevs.org:38089",
-                                "http://xmr-lux.boldsuck.org:38081",
-                                "http://singapore.node.xmr.pm:38081",
-                            ]
-                            .join(","),
-                        ),
-                        ("merge_mining_proxy.monerod_use_auth".to_string(), "false".to_string()),
-                        ("merge_mining_proxy.monerod_username".to_string(), "".to_string()),
-                        ("merge_mining_proxy.monerod_password".to_string(), "".to_string()),
-                        (
-                            "merge_mining_proxy.wait_for_initial_sync_at_startup".to_string(),
-                            "false".to_string(),
-                        ),
-                        (
-                            "merge_mining_proxy.submit_to_origin".to_string(),
-                            origin_submission.to_string(),
-                        ),
-                        (
-                            "merge_mining_proxy.wallet_payment_address".to_string(),
-                            wallet_payment_address.to_base58(),
-                        ),
-                        (
-                            "merge_mining_proxy.use_dynamic_fail_data".to_string(),
-                            "false".to_string(),
-                        ),
-                        (
-                            "merge_mining_proxy.monerod_connection_timeout".to_string(),
-                            "10".to_string(),
-                        ),
-                    ],
-                },
-                non_interactive_mode: false,
-            };
-            let rt = runtime::Builder::new_multi_thread().enable_all().build().unwrap();
-            if let Err(e) = rt.block_on(start_merge_miner(cli)) {
-                println!("Error running merge mining proxy : {e:?}");
-                panic!("Error running merge mining proxy");
-            }
-        });
-        wait_for_service(proxy_port).await;
-    }
-
     async fn get_response(&self, path: &str) -> Value {
         let full_address = format!("http://127.0.0.1:{}", self.port);
         reqwest::get(format!("{full_address}/{path}"))
@@ -169,7 +71,7 @@ impl MergeMiningProxyProcess {
             "jsonrpc": "2.0",
             "method": method_name,
             "params": params,
-            "id":self.id}
+            "id": self.id}
         );
         println!("json_rpc_call {method_name}");
         println!("json payload {json}");
@@ -191,24 +93,11 @@ impl MergeMiningProxyProcess {
     }
 
     pub async fn get_block_template(&mut self) -> Value {
-        let params = json!({
-            "wallet_address":"5AUoj81i63cBUbiKY5jybsZXRDYb9CppmSjiZXC8ZYT6HZH6ebsQvBecYfRKDYoyzKF2uML9FKkTAc7nJvHKdoDYQEeteRW",
-            "reserve_size":60
-        });
-        self.json_rpc_call("getblocktemplate", &params).await
+        self.json_rpc_call("getblocktemplate", &json!({})).await
     }
 
     pub async fn submit_block(&mut self, block_template_blob: &Value) -> Value {
-        self.json_rpc_call("submit_block", &json!(vec![block_template_blob]))
-            .await
-    }
-
-    pub async fn get_last_block_header(&mut self) -> Value {
-        self.json_rpc_call("get_last_block_header", &json!({})).await
-    }
-
-    pub async fn get_block_header_by_hash(&mut self, hash: Value) -> Value {
-        self.json_rpc_call("get_block_header_by_hash", &json!({ "hash": hash }))
+        self.json_rpc_call("submitblock", &json!(vec![block_template_blob]))
             .await
     }
 
@@ -231,13 +120,4 @@ impl MergeMiningProxyProcess {
         let block = template_result.get("blocktemplate_blob").unwrap();
         self.submit_block(block).await
     }
-}
-
-pub async fn create_wallet_client(world: &TariWorld, wallet_name: String) -> anyhow::Result<WalletGrpcClient<Channel>> {
-    let wallet_grpc_port = world.wallets.get(&wallet_name).unwrap().grpc_port;
-    let wallet_addr = format!("http://127.0.0.1:{wallet_grpc_port}");
-
-    eprintln!("Wallet GRPC at {wallet_addr}");
-
-    Ok(WalletGrpcClient::connect(wallet_addr.as_str()).await?)
 }

--- a/integration_tests/src/port_pool.rs
+++ b/integration_tests/src/port_pool.rs
@@ -42,8 +42,8 @@ struct PortPoolInner {
     wallet_grpc_ports: VecDeque<u16>,
     /// Pre-validated available ports for wallet HTTP (20000-20499)
     wallet_http_ports: VecDeque<u16>,
-    /// Pre-validated available ports for merge mining proxy (20500-20999)
-    merge_mining_proxy_ports: VecDeque<u16>,
+    /// Pre-validated available ports for xmrig proxy (20500-20999)
+    xmrig_proxy_ports: VecDeque<u16>,
 }
 
 /// A set of ports allocated for a single base node.
@@ -52,6 +52,7 @@ pub struct BaseNodePorts {
     pub p2p: u16,
     pub grpc: u16,
     pub http: u16,
+    pub xmrig_proxy: u16,
 }
 
 /// A set of ports allocated for a single wallet.
@@ -72,17 +73,17 @@ impl PortPool {
         let http_ports = scan_available_ports(19000, 19499, capacity);
         let wallet_grpc_ports = scan_available_ports(19500, 19999, capacity);
         let wallet_http_ports = scan_available_ports(20000, 20499, capacity);
-        let merge_mining_proxy_ports = scan_available_ports(20500, 20999, capacity);
+        let xmrig_proxy_ports = scan_available_ports(20500, 20999, capacity);
 
         println!(
-            "PortPool initialized: {} p2p, {} grpc, {} http, {} wallet_grpc, {} wallet_http, {} merge_mining_proxy \
-             ports available",
+            "PortPool initialized: {} p2p, {} grpc, {} http, {} wallet_grpc, {} wallet_http, {} xmrig_proxy ports \
+             available",
             p2p_ports.len(),
             grpc_ports.len(),
             http_ports.len(),
             wallet_grpc_ports.len(),
             wallet_http_ports.len(),
-            merge_mining_proxy_ports.len(),
+            xmrig_proxy_ports.len(),
         );
 
         Self {
@@ -92,7 +93,7 @@ impl PortPool {
                 http_ports,
                 wallet_grpc_ports,
                 wallet_http_ports,
-                merge_mining_proxy_ports,
+                xmrig_proxy_ports,
             }),
         }
     }
@@ -105,7 +106,13 @@ impl PortPool {
         let p2p = inner.p2p_ports.pop_front()?;
         let grpc = inner.grpc_ports.pop_front()?;
         let http = inner.http_ports.pop_front()?;
-        Some(BaseNodePorts { p2p, grpc, http })
+        let xmrig_proxy = inner.xmrig_proxy_ports.pop_front()?;
+        Some(BaseNodePorts {
+            p2p,
+            grpc,
+            http,
+            xmrig_proxy,
+        })
     }
 
     /// Allocate a set of ports for a wallet.
@@ -122,6 +129,7 @@ impl PortPool {
         inner.p2p_ports.push_back(ports.p2p);
         inner.grpc_ports.push_back(ports.grpc);
         inner.http_ports.push_back(ports.http);
+        inner.xmrig_proxy_ports.push_back(ports.xmrig_proxy);
     }
 
     /// Return wallet ports to the pool.
@@ -129,18 +137,6 @@ impl PortPool {
         let mut inner = self.pools.lock().unwrap();
         inner.wallet_grpc_ports.push_back(ports.grpc);
         inner.wallet_http_ports.push_back(ports.http);
-    }
-
-    /// Allocate a port for a merge mining proxy.
-    pub fn allocate_merge_mining_proxy_port(&self) -> Option<u16> {
-        let mut inner = self.pools.lock().unwrap();
-        inner.merge_mining_proxy_ports.pop_front()
-    }
-
-    /// Return a merge mining proxy port to the pool.
-    pub fn return_merge_mining_proxy_port(&self, port: u16) {
-        let mut inner = self.pools.lock().unwrap();
-        inner.merge_mining_proxy_ports.push_back(port);
     }
 }
 

--- a/integration_tests/src/world.rs
+++ b/integration_tests/src/world.rs
@@ -349,10 +349,9 @@ impl TariWorld {
             });
         }
 
-        // Shut down merge mining proxies and return ports to the pool
-        for (name, proxy) in self.merge_mining_proxies.drain(..) {
+        // Clear merge mining proxies (they are lightweight HTTP clients, no ports to return)
+        for (name, _proxy) in self.merge_mining_proxies.drain(..) {
             println!("Shutting down merge mining proxy {name}");
-            pool.return_merge_mining_proxy_port(proxy.port);
         }
 
         // Drop miners (they don't own ports or long-lived resources, but clear them
@@ -369,6 +368,7 @@ impl TariWorld {
                 p2p: p.port,
                 grpc: p.grpc_port,
                 http: p.http_port,
+                xmrig_proxy: p.xmrig_proxy_port,
             };
             p.kill();
             // Return ports to pool for reuse by next scenario

--- a/integration_tests/tests/features/BlockExplorerGRPC.feature
+++ b/integration_tests/tests/features/BlockExplorerGRPC.feature
@@ -7,8 +7,7 @@ Feature: Block Explorer GRPC
   @critical
   Scenario: As a user I want to get the network difficulties
     Given I have a seed node NODE
-    When I have wallet WALLET connected to all seed nodes
-    And I have a merge mining proxy PROXY connected to NODE and WALLET with default config
+    When I have a merge mining proxy PROXY connected to NODE with default config
     When I merge mine 2 blocks via PROXY
     Then all nodes are at height 2
     When I request the difficulties of a node NODE

--- a/integration_tests/tests/features/MergeMining.feature
+++ b/integration_tests/tests/features/MergeMining.feature
@@ -4,39 +4,20 @@
 @merge-mining @base-node
 Feature: Merge Mining
 
-  @broken
-  Scenario: Merge Mining Functionality Test Without Submitting To Origin
-    Given I have a seed node NODE
-    When I have wallet WALLET connected to all seed nodes
-    And I have a merge mining proxy PROXY connected to NODE and WALLET with origin submission disabled
-    When I wait 2 seconds
-    When I ask for a block height from proxy PROXY
-    Then Proxy response height is valid
-    When I ask for a block template from proxy PROXY
-    Then Proxy response block template is valid
-    When I submit a block through proxy PROXY
-    Then Proxy response block submission is valid without submitting to origin
-
   @critical
-  Scenario: Merge Mining Functionality Test With Submitting To Origin
+  Scenario: Merge Mining Proxy API Test
     Given I have a seed node NODE
-    When I have wallet WALLET connected to all seed nodes
-    And I have a merge mining proxy PROXY connected to NODE and WALLET with origin submission enabled
+    When I have a merge mining proxy PROXY connected to NODE with default config
     When I ask for a block height from proxy PROXY
     Then Proxy response height is valid
     When I ask for a block template from proxy PROXY
     Then Proxy response block template is valid
     When I submit a block through proxy PROXY
-    Then Proxy response block submission is valid with submitting to origin
-    When I ask for the last block header from proxy PROXY
-    Then Proxy response for last block header is valid
-    When I ask for a block header by hash using last block header from proxy PROXY
-    Then Proxy response for block header by hash is valid
+    Then Proxy response block submission is valid
 
   @critical
   Scenario: Simple Merge Mining
     Given I have a seed node NODE
-    When I have wallet WALLET connected to all seed nodes
-    And I have a merge mining proxy PROXY connected to NODE and WALLET with default config
+    When I have a merge mining proxy PROXY connected to NODE with default config
     When I merge mine 2 blocks via PROXY
     Then all nodes are at height 2

--- a/integration_tests/tests/steps/merge_mining_steps.rs
+++ b/integration_tests/tests/steps/merge_mining_steps.rs
@@ -25,30 +25,13 @@ use tari_integration_tests::{TariWorld, merge_mining_proxy::register_merge_minin
 
 // Merge mining proxy steps
 
-#[when(expr = "I have a merge mining proxy {word} connected to {word} and {word} with origin submission {word}")]
-async fn merge_mining_proxy_with_submission(
-    world: &mut TariWorld,
-    mining_proxy_name: String,
-    base_node_name: String,
-    wallet_name: String,
-    enabled: String,
-) {
-    let enabled = match enabled.as_str() {
-        "enabled" => true,
-        "disabled" => false,
-        _ => panic!("This should be a boolean"),
-    };
-    register_merge_mining_proxy_process(world, mining_proxy_name, base_node_name, wallet_name, enabled).await;
-}
-
-#[when(expr = "I have a merge mining proxy {word} connected to {word} and {word} with default config")]
+#[when(expr = "I have a merge mining proxy {word} connected to {word} with default config")]
 async fn merge_mining_proxy_with_default_config(
     world: &mut TariWorld,
     mining_proxy_name: String,
     base_node_name: String,
-    wallet_name: String,
 ) {
-    register_merge_mining_proxy_process(world, mining_proxy_name, base_node_name, wallet_name, true).await;
+    register_merge_mining_proxy_process(world, mining_proxy_name, base_node_name).await;
 }
 
 #[when(expr = "I ask for a block height from proxy {word}")]
@@ -59,14 +42,21 @@ async fn merge_mining_ask_for_block_height(world: &mut TariWorld, mining_proxy_n
 
 #[then(expr = "Proxy response height is valid")]
 async fn merge_mining_response_height(world: &mut TariWorld) {
-    let height = world.last_merge_miner_response.get("height");
+    let count = world.last_merge_miner_response.get("result");
     assert!(
-        height.is_some(),
+        count.is_some(),
         "Response is invalid {}",
         world.last_merge_miner_response
     );
-    let height = height.unwrap();
-    assert!(height.as_u64().is_some(), "Height is invalid {height}");
+    let result = count.unwrap();
+    assert!(
+        result.get("count").is_some(),
+        "Result has no `count` {result}"
+    );
+    assert!(
+        result.get("count").unwrap().as_u64().is_some(),
+        "Count is invalid {result}"
+    );
 }
 
 #[when(expr = "I ask for a block template from proxy {word}")]
@@ -84,7 +74,18 @@ async fn merge_mining_response_block_template_is_valid(world: &mut TariWorld) {
         world.last_merge_miner_response
     );
     let result = result.unwrap();
-    assert!(result.get("_aux").is_some(), "Result has no `_aux` {result}");
+    assert!(
+        result.get("blocktemplate_blob").is_some(),
+        "Result has no `blocktemplate_blob` {result}"
+    );
+    assert!(
+        result.get("seed_hash").is_some(),
+        "Result has no `seed_hash` {result}"
+    );
+    assert!(
+        result.get("difficulty").is_some(),
+        "Result has no `difficulty` {result}"
+    );
     assert_eq!(
         result.get("status").unwrap().as_str().unwrap(),
         "OK",
@@ -109,12 +110,10 @@ async fn merge_mining_submit_block(world: &mut TariWorld, mining_proxy_name: Str
     println!("block_template {block_template_blob:?}");
     world.last_merge_miner_response = merge_miner.submit_block(&block_template_blob).await;
     println!("last_merge_miner_response {:?}", world.last_merge_miner_response);
-    println!("last_merge_miner_response {:?}", world.last_merge_miner_response);
-    println!("last_merge_miner_response {:?}", world.last_merge_miner_response);
 }
 
-#[then(expr = "Proxy response block submission is valid {word} submitting to origin")]
-async fn merge_mining_submission_is_valid(world: &mut TariWorld, how: String) {
+#[then(expr = "Proxy response block submission is valid")]
+async fn merge_mining_submission_is_valid(world: &mut TariWorld) {
     let result = world.last_merge_miner_response.get("result");
     assert!(
         result.is_some(),
@@ -122,17 +121,17 @@ async fn merge_mining_submission_is_valid(world: &mut TariWorld, how: String) {
         world.last_merge_miner_response
     );
     let result = result.unwrap();
-    if how == *"with" {
-        assert!(result.get("_aux").is_some(), "Result has no `_aux` {result}");
-        let status = result.get("status");
-        assert!(status.is_some(), "Result has no status {result}");
-    } else {
-        assert!(
-            result.get("status").is_some(),
-            "Response has no `status` {}",
-            world.last_merge_miner_response
-        );
-    }
+    assert!(
+        result.get("status").is_some(),
+        "Response has no `status` {}",
+        world.last_merge_miner_response
+    );
+    assert_eq!(
+        result.get("status").unwrap().as_str().unwrap(),
+        "OK",
+        "Status is not OK {}",
+        world.last_merge_miner_response
+    );
 }
 
 #[when(expr = "I merge mine {int} blocks via {word}")]
@@ -141,69 +140,4 @@ async fn merge_mining_mine(world: &mut TariWorld, count: u64, mining_proxy_name:
     for _ in 0..count {
         merge_miner.mine().await;
     }
-}
-
-#[when(expr = "I ask for the last block header from proxy {word}")]
-async fn merge_mining_ask_for_last_block_header(world: &mut TariWorld, mining_proxy_name: String) {
-    let merge_miner = world.get_mut_merge_miner(&mining_proxy_name).unwrap();
-    world.last_merge_miner_response = merge_miner.get_last_block_header().await;
-}
-
-#[then(expr = "Proxy response for block header by hash is valid")]
-async fn merge_mining_bloch_header_by_hash_is_valid(world: &mut TariWorld) {
-    let result = world.last_merge_miner_response.get("result");
-    assert!(
-        result.is_some(),
-        "Response is invalid {}",
-        world.last_merge_miner_response
-    );
-    let result = result.unwrap();
-    let status = result.get("status");
-    assert!(status.is_some(), "Result has no status {result}");
-    assert_eq!(
-        result.get("status").unwrap().as_str().unwrap(),
-        "OK",
-        "Result has no `status` {result}"
-    );
-}
-
-#[then(expr = "Proxy response for last block header is valid")]
-async fn merge_mining_response_last_block_header_is_valid(world: &mut TariWorld) {
-    let result = world.last_merge_miner_response.get("result");
-    assert!(
-        result.is_some(),
-        "Response is invalid {}",
-        world.last_merge_miner_response
-    );
-    let result = result.unwrap();
-    assert!(result.get("_aux").is_some(), "Result has no `_aux` {result}");
-    let status = result.get("status");
-    assert!(status.is_some(), "Result has no status {result}");
-    assert_eq!(
-        result.get("status").unwrap().as_str().unwrap(),
-        "OK",
-        "Result has no `status` {result}"
-    );
-    let block_header = result.get("block_header");
-    assert!(block_header.is_some(), "Result has no `block_header` {result}");
-    let block_header = block_header.unwrap();
-    assert!(
-        block_header.get("hash").is_some(),
-        "Block_header has no `hash` {block_header}"
-    );
-}
-
-#[when(expr = "I ask for a block header by hash using last block header from proxy {word}")]
-async fn merge_mining_ask_for_block_header_by_hash(world: &mut TariWorld, mining_proxy_name: String) {
-    let hash = world
-        .last_merge_miner_response
-        .get("result")
-        .unwrap()
-        .get("block_header")
-        .unwrap()
-        .get("hash")
-        .unwrap()
-        .clone();
-    let merge_miner = world.get_mut_merge_miner(&mining_proxy_name).unwrap();
-    world.last_merge_miner_response = merge_miner.get_block_header_by_hash(hash).await;
 }

--- a/integration_tests/tests/steps/merge_mining_steps.rs
+++ b/integration_tests/tests/steps/merge_mining_steps.rs
@@ -49,10 +49,7 @@ async fn merge_mining_response_height(world: &mut TariWorld) {
         world.last_merge_miner_response
     );
     let result = count.unwrap();
-    assert!(
-        result.get("count").is_some(),
-        "Result has no `count` {result}"
-    );
+    assert!(result.get("count").is_some(), "Result has no `count` {result}");
     assert!(
         result.get("count").unwrap().as_u64().is_some(),
         "Count is invalid {result}"
@@ -78,10 +75,7 @@ async fn merge_mining_response_block_template_is_valid(world: &mut TariWorld) {
         result.get("blocktemplate_blob").is_some(),
         "Result has no `blocktemplate_blob` {result}"
     );
-    assert!(
-        result.get("seed_hash").is_some(),
-        "Result has no `seed_hash` {result}"
-    );
+    assert!(result.get("seed_hash").is_some(), "Result has no `seed_hash` {result}");
     assert!(
         result.get("difficulty").is_some(),
         "Result has no `difficulty` {result}"


### PR DESCRIPTION
Description
---
Convert merge mining integration tests from RandomX-Monero (RxM) to RandomX-Tari (RxT) by switching from the standalone `minotari_merge_mining_proxy` to the base node's built-in `xmrig_proxy`.

Key changes:
- **`port_pool.rs`**: Added `xmrig_proxy` port to `BaseNodePorts`; renamed `merge_mining_proxy_ports` -> `xmrig_proxy_ports`; removed standalone proxy port allocation methods.
- **`base_node_process.rs`**: Enabled built-in `xmrig_proxy` during base node spawn (`xmrig_proxy_enabled`, `xmrig_proxy_address`, `xmrig_proxy_wallet_payment_address`).
- **`merge_mining_proxy.rs`**: Rewrote from external process launcher to lightweight HTTP client targeting the base node's built-in proxy; removed all Monero-specific config (`monerod_url`, wallet gRPC); removed unsupported methods (`get_last_block_header`, `get_block_header_by_hash`).
- **`merge_mining_steps.rs`**: Updated step definitions for new RxT API response format (76-byte hex blobs, `submitblock` instead of `submit_block`, `count` instead of `height`).
- **`MergeMining.feature`**: Removed `@broken` tag; removed Monero origin submission scenario; adapted validation steps.
- **`BlockExplorerGRPC.feature`**: Removed wallet dependency that was only needed for the old standalone proxy.
- **`Cargo.toml`**: Removed `minotari_merge_mining_proxy` dependency.
- **`world.rs`**: Updated `after` hook to return `xmrig_proxy` ports to pool on base node shutdown.

Motivation and Context
---
Fixes #7737 

How Has This Been Tested?
---
```bash
cargo test --test cucumber --package tari_integration_tests -- --tags "@merge-mining"
```

Results:
- 2 scenarios passed (Merge Mining Proxy API Test, Simple Merge Mining)
- 12 steps passed
- 0 failures

What process can a PR reviewer use to test or verify this change?
---
1. Run the merge mining integration tests:
   ```bash
   cargo test --test cucumber --package tari_integration_tests -- --tags "@merge-mining"
   ```
2. Verify both scenarios pass without any external Monero daemon running – the tests should be fully self-contained.
3. Confirm no `monerod` connections are attempted (no network calls to Monero stagenet nodes).

Breaking Changes
---
- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
