### PR TITLE
fix(sidechain)!: include epoch_hash in sidechain block header

### DIFF
--- a/applications/minotari_app_grpc/proto/sidechain_types.proto
+++ b/applications/minotari_app_grpc/proto/sidechain_types.proto
@@ -143,6 +143,7 @@ message SidechainBlockHeader {
   bytes metadata_hash = 10;
   Signature signature = 11;
   ShardGroupAccumulatedData accumulated_data = 12;
+  bytes epoch_hash = 13;
 }
 
 message ShardGroup {

--- a/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
@@ -461,6 +461,7 @@ impl TryFrom<grpc::SidechainBlockHeader> for SidechainBlockHeader {
             justify_id: value.justify_id.try_into().map_err(|_| "Invalid justify id")?,
             height: value.height,
             epoch: value.epoch,
+            epoch_hash: value.epoch_hash.try_into().map_err(|_| "Invalid epoch hash")?,
             shard_group: value.shard_group.ok_or("missing shard_group")?.try_into()?,
             proposed_by: CompressedPublicKey::from_canonical_bytes(&value.proposed_by)
                 .map_err(|_| "Invalid proposed_by public key")?,
@@ -493,6 +494,7 @@ impl From<&SidechainBlockHeader> for grpc::SidechainBlockHeader {
             justify_id: value.justify_id.to_vec(),
             height: value.height,
             epoch: value.epoch,
+            epoch_hash: value.epoch_hash.to_vec(),
             shard_group: Some(value.shard_group.into()),
             proposed_by: value.proposed_by.to_vec(),
             state_merkle_root: value.state_merkle_root.to_vec(),

--- a/base_layer/core/src/proto/sidechain_feature.proto
+++ b/base_layer/core/src/proto/sidechain_feature.proto
@@ -125,6 +125,7 @@ message SidechainBlockHeader {
   Signature signature = 10;
   bytes metadata_hash = 11;
   ShardGroupAccumulatedData accumulated_data = 12;
+  bytes epoch_hash = 13;
 }
 
 message EvictAtom {

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -454,6 +454,7 @@ impl TryFrom<proto::types::SidechainBlockHeader> for SidechainBlockHeader {
             justify_id: value.justify_id.try_into().map_err(|_| "Invalid justify id")?,
             height: value.height,
             epoch: value.epoch,
+            epoch_hash: value.epoch_hash.try_into().map_err(|_| "Invalid epoch hash")?,
             shard_group: value.shard_group.ok_or("missing shard_group")?.try_into()?,
             proposed_by: CompressedPublicKey::from_canonical_bytes(&value.proposed_by)
                 .map_err(|_| "Invalid proposed_by public key")?,
@@ -483,6 +484,7 @@ impl From<&SidechainBlockHeader> for proto::types::SidechainBlockHeader {
             justify_id: value.justify_id.to_vec(),
             height: value.height,
             epoch: value.epoch,
+            epoch_hash: value.epoch_hash.to_vec(),
             shard_group: Some(value.shard_group.into()),
             proposed_by: value.proposed_by.to_vec(),
             state_merkle_root: value.state_merkle_root.to_vec(),

--- a/base_layer/sidechain/src/commit_proof.rs
+++ b/base_layer/sidechain/src/commit_proof.rs
@@ -191,6 +191,8 @@ pub struct SidechainBlockHeader {
     pub justify_id: FixedHash,
     pub height: u64,
     pub epoch: u64,
+    #[serde(with = "hex_or_bytes")]
+    pub epoch_hash: FixedHash,
     pub shard_group: ShardGroup,
     pub proposed_by: CompressedPublicKey,
     #[serde(with = "hex_or_bytes")]
@@ -211,6 +213,7 @@ impl SidechainBlockHeader {
             justify_id: &self.justify_id,
             height: self.height,
             epoch: self.epoch,
+            epoch_hash: &self.epoch_hash,
             shard_group: self.shard_group,
             proposed_by: self.proposed_by.as_bytes(),
             state_merkle_root: &self.state_merkle_root,
@@ -368,6 +371,7 @@ pub struct BlockHeaderHashFieldsV1<'a> {
     pub justify_id: &'a FixedHash,
     pub height: u64,
     pub epoch: u64,
+    pub epoch_hash: &'a FixedHash,
     pub shard_group: ShardGroup,
     pub accumulated_data: &'a ShardGroupAccumulatedData,
     // NOTE this is borsh encoded as variable length bytes - technically should always be 32

--- a/base_layer/sidechain/tests/fixtures/README.md
+++ b/base_layer/sidechain/tests/fixtures/README.md
@@ -1,0 +1,11 @@
+# Fixtures
+
+## How to update the eviction proof fixture
+
+To get a new eviction proof fixture, run the `single_shard_node_goes_down_and_gets_evicted` test in the consensus tests
+on the ootle repo
+(uncomment the lines the write the fixture to disk, and comment them out again after the fixture is generated).
+
+## How to update the commit proof fixture
+
+Easiest way is to take the `commit_proof` part from the eviction proof

--- a/base_layer/sidechain/tests/fixtures/commit_proof.json
+++ b/base_layer/sidechain/tests/fixtures/commit_proof.json
@@ -1,58 +1,59 @@
 {
   "header": {
     "network": 16,
-    "parent_id": "80d8355520a36f1479a3f5042adab0b37b299420265e9b7d6b626a6a276859d1",
-    "justify_id": "69e54cd339f0c138ec0d797be7a21fb7bb33bf9c1906ee45a59828ae3857cd34",
+    "parent_id": "5a428b774d4c591f9a15a17b94c75d57d8c83921a7a283538fa538064b1361a5",
+    "justify_id": "a4a7916a22aa03b1f111e03e82bfc82eed04d57122f818588b7399737ace9866",
     "height": 20,
     "epoch": 1,
+    "epoch_hash": "0000000000000000000000000000000000000000000000000000000000000000",
     "shard_group": {
       "start": 1,
       "end_inclusive": 256
     },
     "proposed_by": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
-    "state_merkle_root": "cc3b8382fb5c199dd7dcee291c7b03cf12d6a59a61638881815ed7a64d7f6f30",
-    "command_merkle_root": "89ea0f4a026ab60f17e826b64b132306c40e502e5b25d5faa4c4635b5f06e153",
+    "state_merkle_root": "1203a47d22a6005c7aea28251f6e0ff99c945db28c3580ebffb9d21315286dbd",
+    "command_merkle_root": "09a05c7cf2498e067f9f270eb3464ddfc1342f79ef42c11d20829c8c4f6b815e",
     "signature": {
-      "public_nonce": "aabfb198a2cdc524bb0dbb81cf7c810d40bca0cf8005b863e25e129c5d883457",
-      "signature": "0782f481fd4ca0281ad80f77461f1ba86352aa71737e39be83ecb9eeeccf0a06"
+      "public_nonce": "62006b26e394e3a520d6f18a2239c0bc4b456f35e5a61b18fa4b057423122d5f",
+      "signature": "05fe06dac441b1777c90ed2fc8034c59e2aaec59967db21106619a736594790f"
     },
     "accumulated_data": {
       "total_exhaust_burn": 0
     },
-    "metadata_hash": "0356b697d0db4bb5adb6bc6bac7d9c9e82ee5a9c4d840049e1b62d9182fc03ef"
+    "metadata_hash": "99acde2324e02c66d4b2f4341a72e00b29755bf7523095c7a67e9a1ba121189c"
   },
   "proof_elements": [
     {
       "QuorumCertificate": {
-        "header_hash": "4d90d4c9226577f19e13723d37559085e7bfda2f6615355def5cbc257ff3d081",
-        "parent_id": "2942514688a08aed1fb8a1ccc350dc132d006fe7cf3939aa764519e29d4c3f60",
+        "header_hash": "7426b2711db5ace80104b10dba867d8ffeb9a238282c5363b9aacd0651ea9d37",
+        "parent_id": "50d17a8b1c1354d154a5b33f01bad26ce8fe2112eff7fdd9b06f53dcb897fd95",
         "signatures": [
-          {
-            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
-            "signature": {
-              "public_nonce": "16be2539aca91de5ad092834ebe97956f8fc88bdd4534cad74b72a5860b50034",
-              "signature": "2ee59c2d3aca471e6631222bc1ad604c2fc94548c237bb77d619509f44f3b70c"
-            }
-          },
           {
             "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
             "signature": {
-              "public_nonce": "beac20141c3306e2193fdadfe7885660f3e8453d3459e4a15c3f882980ec5e39",
-              "signature": "f59fed3f5b7d0afaadf2f15282fb987a448454068d44d4d05706b39a7711300f"
+              "public_nonce": "e8e3b0aca98f57690cf2b2546a07fe53abc309b2ce65e59b393e7944c2cb316a",
+              "signature": "e6f0a3dda83521f926eb26604c19928e02246f3029347ef7b3441a506d31dd09"
             }
           },
           {
             "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
             "signature": {
-              "public_nonce": "4ee0cdab102629936eaac12639c2e638de2f598a898d2fb1c83dc22709a1660e",
-              "signature": "a6e51af802d9bbf5bb95229277a40132ac7c661df5ea7806393254adc5b65200"
+              "public_nonce": "d85bedf7b4793950ec435e880a1f41c29e65a40a75fe15e195a65327365a9f6c",
+              "signature": "6fee4e3a764270090f809acca4d8be6c5f6347fa9084b55162293766a5cf330c"
+            }
+          },
+          {
+            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
+            "signature": {
+              "public_nonce": "96161f546fc95019d272c1d950732e8e7ae291f1c65970f3705746d935e90932",
+              "signature": "58ab4abcd5340d833f73642c8f08217e253fe656a2db49d6f64fb584385ee205"
             }
           },
           {
             "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
             "signature": {
-              "public_nonce": "08d21b2a7d5f0727915fefdbfe9187dcd975f852d9e376196667a97126fe7b09",
-              "signature": "bc494bffa8f786ad9ad9677847ba59a7b06235a6ca3605efa7458ab4b9c87a06"
+              "public_nonce": "b8788d29da0134aa0d451c1d03730597776d9d00fe7e5f08711a974b0b529743",
+              "signature": "12f9803f3063646d94edd8aa3bbede36320e95bf696c3ed92293d8aeff51f509"
             }
           }
         ],
@@ -61,35 +62,35 @@
     },
     {
       "QuorumCertificate": {
-        "header_hash": "61044f28ed76524b4f3f6721fea0215aeb78d2fcbfa990f459b5072f15e9f28a",
-        "parent_id": "76ee44f54236e63d64c8efc638135507be89ee4700af09f388b23bec2c39d88d",
+        "header_hash": "cac42461be726177697c79eac99a57955b9c94e78c131274e8c7fb8b15d8f279",
+        "parent_id": "de20d47e42ab85620d5623c4ab526b55ae5919b962238c63e29782027a3208a5",
         "signatures": [
-          {
-            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
-            "signature": {
-              "public_nonce": "e0d46ddba2480569479ef1749ee6374742575e0a87195dc301baa106561dd44d",
-              "signature": "1008cb5e8ee8ea7ea4e94eaa3a4be0a1beb74be7e4869e861628c6615d9e6d02"
-            }
-          },
           {
             "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
             "signature": {
-              "public_nonce": "184b1a031feaadead6086f6100e65ea01675ac8641c80c9ef25bca89dfc19533",
-              "signature": "8eb2a31fa5de5479224a877ebe5e0750bfa8419fbef3c13b17a0ef0023ce2502"
-            }
-          },
-          {
-            "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
-            "signature": {
-              "public_nonce": "c803ab1f571a68d126a11553ca2423b56b17f8177f06b8af256bd80e2861e97b",
-              "signature": "9bb951f96ab3db2e75f16546b58fe1b2d6d09f3287cffca785d19377c301b206"
+              "public_nonce": "90f50e93d9218eb92da6befa9a09df476627dce388f305c70fe1a4c67faaeb00",
+              "signature": "95c4fb9af500af2d66cc4b6476657315da43b9ab13032c28706744e38534d807"
             }
           },
           {
             "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
             "signature": {
-              "public_nonce": "9810bfb2c239af78bb44b5627554d21286be43362f61b1d2bf0e1866d292855e",
-              "signature": "dad0caa25adabc7d2aba47b332f054aedcb5578286c68e9ccb852182a855ee0e"
+              "public_nonce": "9247ee8ede92f20d411e19dc053bdd3916a141ac5f38313e3388bc4ecdda4c36",
+              "signature": "11eec34fb8101c84794e2d616a794b35924ae53dd951ac345b67f5120caffd03"
+            }
+          },
+          {
+            "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
+            "signature": {
+              "public_nonce": "cca8f25fbc5d3722a7ff327944f72f3159bb221c0e363a8d10786ba3413ac85d",
+              "signature": "351e39c88854229cab2df4fd2bf078be98511fe61a93949074a0546b12988e0a"
+            }
+          },
+          {
+            "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
+            "signature": {
+              "public_nonce": "0659de5188e683adf1d517578da6316736ea2b0204df76cc49dd676029e39b71",
+              "signature": "4056376a76161b995bed1408709cbbb2acd56521e64cdc0c843545ae0a69cc0f"
             }
           }
         ],
@@ -98,35 +99,35 @@
     },
     {
       "QuorumCertificate": {
-        "header_hash": "d82abf6ca0c7ea1cb17baeb369f8e3e6076e5b4eedd187bbfc9a004abc0d9449",
-        "parent_id": "80d8355520a36f1479a3f5042adab0b37b299420265e9b7d6b626a6a276859d1",
+        "header_hash": "386694d688ba886e253bbd1c3014ac334af1f5ec61a2e6f471efaf4e3803f4d8",
+        "parent_id": "5a428b774d4c591f9a15a17b94c75d57d8c83921a7a283538fa538064b1361a5",
         "signatures": [
           {
             "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
             "signature": {
-              "public_nonce": "48b8fc9274594140ca847547ea85d333ce250c49d43f3ac11680e94f0de67117",
-              "signature": "9565dd6d9cb1e4be6ac7a29ed223ffbff9c859b8d6253f35933382484c509f06"
-            }
-          },
-          {
-            "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
-            "signature": {
-              "public_nonce": "38f384433a3b0f27264cb3df8545658d2d32bc18a2379bcb948cf56f30e6ff1d",
-              "signature": "50ff1924c8aad7ac16d624178d8c45360aca680c83452c3f811292fc8de2ea05"
+              "public_nonce": "f4f81ca73f5827857b217855a2492db3ead0a4fe32d0bba769b4896b281e236b",
+              "signature": "dbce2a8232b7c195ea3cd3a6ca35cdd474946f3c21f9ac69bfffef411c71b609"
             }
           },
           {
             "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
             "signature": {
-              "public_nonce": "0860bf3fd73187ca4e7718256e7a31876758dda59b7fbb680d48624b5a54bc5a",
-              "signature": "930985a7662daa621761d1551a40d09629d525a5582a22d01d655c621178c908"
+              "public_nonce": "a2754753d0d13af4e5d2af0da68518db0227df43bd48ee36f589950d6ced5461",
+              "signature": "cbd152faade419ce02e4f6ff2091e6b7fb2de3beb8448553f5a2e45d117c3c00"
+            }
+          },
+          {
+            "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
+            "signature": {
+              "public_nonce": "406dc7519173b18501addce24e17055bf7f0af6ae1c52932d3af2c3c3470b803",
+              "signature": "894f2513c9132fba5fa887b9f219cff796e20dcedec0fba6791bdd42065b6e05"
             }
           },
           {
             "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
             "signature": {
-              "public_nonce": "e8aab61610a979b91643bce2d51750fb0846ee2c7d206e14d26b5601ab140e3d",
-              "signature": "4dd262eeabdd3f53f2f955424d93259f18f440def78ec5610567e7ad7698790d"
+              "public_nonce": "80a509c17ec60851a6df72083257a826d3fc316d5eaf9d07edfdb1df64e0b257",
+              "signature": "e5131f1dab6f3e9b3d98a2f6bc4b62e8d129590d83e7f1d8f0ebb20c756d1709"
             }
           }
         ],

--- a/base_layer/sidechain/tests/fixtures/eviction_proof1.json
+++ b/base_layer/sidechain/tests/fixtures/eviction_proof1.json
@@ -7,58 +7,59 @@
       "commit_proof": {
         "header": {
           "network": 16,
-          "parent_id": "80d8355520a36f1479a3f5042adab0b37b299420265e9b7d6b626a6a276859d1",
-          "justify_id": "69e54cd339f0c138ec0d797be7a21fb7bb33bf9c1906ee45a59828ae3857cd34",
+          "parent_id": "5a428b774d4c591f9a15a17b94c75d57d8c83921a7a283538fa538064b1361a5",
+          "justify_id": "a4a7916a22aa03b1f111e03e82bfc82eed04d57122f818588b7399737ace9866",
           "height": 20,
           "epoch": 1,
+          "epoch_hash": "0000000000000000000000000000000000000000000000000000000000000000",
           "shard_group": {
             "start": 1,
             "end_inclusive": 256
           },
           "proposed_by": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
-          "state_merkle_root": "cc3b8382fb5c199dd7dcee291c7b03cf12d6a59a61638881815ed7a64d7f6f30",
-          "command_merkle_root": "89ea0f4a026ab60f17e826b64b132306c40e502e5b25d5faa4c4635b5f06e153",
+          "state_merkle_root": "1203a47d22a6005c7aea28251f6e0ff99c945db28c3580ebffb9d21315286dbd",
+          "command_merkle_root": "09a05c7cf2498e067f9f270eb3464ddfc1342f79ef42c11d20829c8c4f6b815e",
           "signature": {
-            "public_nonce": "aabfb198a2cdc524bb0dbb81cf7c810d40bca0cf8005b863e25e129c5d883457",
-            "signature": "0782f481fd4ca0281ad80f77461f1ba86352aa71737e39be83ecb9eeeccf0a06"
+            "public_nonce": "62006b26e394e3a520d6f18a2239c0bc4b456f35e5a61b18fa4b057423122d5f",
+            "signature": "05fe06dac441b1777c90ed2fc8034c59e2aaec59967db21106619a736594790f"
           },
           "accumulated_data": {
             "total_exhaust_burn": 0
           },
-          "metadata_hash": "0356b697d0db4bb5adb6bc6bac7d9c9e82ee5a9c4d840049e1b62d9182fc03ef"
+          "metadata_hash": "99acde2324e02c66d4b2f4341a72e00b29755bf7523095c7a67e9a1ba121189c"
         },
         "proof_elements": [
           {
             "QuorumCertificate": {
-              "header_hash": "4d90d4c9226577f19e13723d37559085e7bfda2f6615355def5cbc257ff3d081",
-              "parent_id": "2942514688a08aed1fb8a1ccc350dc132d006fe7cf3939aa764519e29d4c3f60",
+              "header_hash": "7426b2711db5ace80104b10dba867d8ffeb9a238282c5363b9aacd0651ea9d37",
+              "parent_id": "50d17a8b1c1354d154a5b33f01bad26ce8fe2112eff7fdd9b06f53dcb897fd95",
               "signatures": [
-                {
-                  "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
-                  "signature": {
-                    "public_nonce": "16be2539aca91de5ad092834ebe97956f8fc88bdd4534cad74b72a5860b50034",
-                    "signature": "2ee59c2d3aca471e6631222bc1ad604c2fc94548c237bb77d619509f44f3b70c"
-                  }
-                },
                 {
                   "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
                   "signature": {
-                    "public_nonce": "beac20141c3306e2193fdadfe7885660f3e8453d3459e4a15c3f882980ec5e39",
-                    "signature": "f59fed3f5b7d0afaadf2f15282fb987a448454068d44d4d05706b39a7711300f"
+                    "public_nonce": "e8e3b0aca98f57690cf2b2546a07fe53abc309b2ce65e59b393e7944c2cb316a",
+                    "signature": "e6f0a3dda83521f926eb26604c19928e02246f3029347ef7b3441a506d31dd09"
                   }
                 },
                 {
                   "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
                   "signature": {
-                    "public_nonce": "4ee0cdab102629936eaac12639c2e638de2f598a898d2fb1c83dc22709a1660e",
-                    "signature": "a6e51af802d9bbf5bb95229277a40132ac7c661df5ea7806393254adc5b65200"
+                    "public_nonce": "d85bedf7b4793950ec435e880a1f41c29e65a40a75fe15e195a65327365a9f6c",
+                    "signature": "6fee4e3a764270090f809acca4d8be6c5f6347fa9084b55162293766a5cf330c"
+                  }
+                },
+                {
+                  "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
+                  "signature": {
+                    "public_nonce": "96161f546fc95019d272c1d950732e8e7ae291f1c65970f3705746d935e90932",
+                    "signature": "58ab4abcd5340d833f73642c8f08217e253fe656a2db49d6f64fb584385ee205"
                   }
                 },
                 {
                   "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
                   "signature": {
-                    "public_nonce": "08d21b2a7d5f0727915fefdbfe9187dcd975f852d9e376196667a97126fe7b09",
-                    "signature": "bc494bffa8f786ad9ad9677847ba59a7b06235a6ca3605efa7458ab4b9c87a06"
+                    "public_nonce": "b8788d29da0134aa0d451c1d03730597776d9d00fe7e5f08711a974b0b529743",
+                    "signature": "12f9803f3063646d94edd8aa3bbede36320e95bf696c3ed92293d8aeff51f509"
                   }
                 }
               ],
@@ -67,35 +68,35 @@
           },
           {
             "QuorumCertificate": {
-              "header_hash": "61044f28ed76524b4f3f6721fea0215aeb78d2fcbfa990f459b5072f15e9f28a",
-              "parent_id": "76ee44f54236e63d64c8efc638135507be89ee4700af09f388b23bec2c39d88d",
+              "header_hash": "cac42461be726177697c79eac99a57955b9c94e78c131274e8c7fb8b15d8f279",
+              "parent_id": "de20d47e42ab85620d5623c4ab526b55ae5919b962238c63e29782027a3208a5",
               "signatures": [
-                {
-                  "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
-                  "signature": {
-                    "public_nonce": "e0d46ddba2480569479ef1749ee6374742575e0a87195dc301baa106561dd44d",
-                    "signature": "1008cb5e8ee8ea7ea4e94eaa3a4be0a1beb74be7e4869e861628c6615d9e6d02"
-                  }
-                },
                 {
                   "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
                   "signature": {
-                    "public_nonce": "184b1a031feaadead6086f6100e65ea01675ac8641c80c9ef25bca89dfc19533",
-                    "signature": "8eb2a31fa5de5479224a877ebe5e0750bfa8419fbef3c13b17a0ef0023ce2502"
-                  }
-                },
-                {
-                  "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
-                  "signature": {
-                    "public_nonce": "c803ab1f571a68d126a11553ca2423b56b17f8177f06b8af256bd80e2861e97b",
-                    "signature": "9bb951f96ab3db2e75f16546b58fe1b2d6d09f3287cffca785d19377c301b206"
+                    "public_nonce": "90f50e93d9218eb92da6befa9a09df476627dce388f305c70fe1a4c67faaeb00",
+                    "signature": "95c4fb9af500af2d66cc4b6476657315da43b9ab13032c28706744e38534d807"
                   }
                 },
                 {
                   "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
                   "signature": {
-                    "public_nonce": "9810bfb2c239af78bb44b5627554d21286be43362f61b1d2bf0e1866d292855e",
-                    "signature": "dad0caa25adabc7d2aba47b332f054aedcb5578286c68e9ccb852182a855ee0e"
+                    "public_nonce": "9247ee8ede92f20d411e19dc053bdd3916a141ac5f38313e3388bc4ecdda4c36",
+                    "signature": "11eec34fb8101c84794e2d616a794b35924ae53dd951ac345b67f5120caffd03"
+                  }
+                },
+                {
+                  "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
+                  "signature": {
+                    "public_nonce": "cca8f25fbc5d3722a7ff327944f72f3159bb221c0e363a8d10786ba3413ac85d",
+                    "signature": "351e39c88854229cab2df4fd2bf078be98511fe61a93949074a0546b12988e0a"
+                  }
+                },
+                {
+                  "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
+                  "signature": {
+                    "public_nonce": "0659de5188e683adf1d517578da6316736ea2b0204df76cc49dd676029e39b71",
+                    "signature": "4056376a76161b995bed1408709cbbb2acd56521e64cdc0c843545ae0a69cc0f"
                   }
                 }
               ],
@@ -104,35 +105,35 @@
           },
           {
             "QuorumCertificate": {
-              "header_hash": "d82abf6ca0c7ea1cb17baeb369f8e3e6076e5b4eedd187bbfc9a004abc0d9449",
-              "parent_id": "80d8355520a36f1479a3f5042adab0b37b299420265e9b7d6b626a6a276859d1",
+              "header_hash": "386694d688ba886e253bbd1c3014ac334af1f5ec61a2e6f471efaf4e3803f4d8",
+              "parent_id": "5a428b774d4c591f9a15a17b94c75d57d8c83921a7a283538fa538064b1361a5",
               "signatures": [
                 {
                   "public_key": "6efb3b5ede2c8abba5280b58cd5e3bd1887101f7ffb973cf46cb2542bdbd202f",
                   "signature": {
-                    "public_nonce": "48b8fc9274594140ca847547ea85d333ce250c49d43f3ac11680e94f0de67117",
-                    "signature": "9565dd6d9cb1e4be6ac7a29ed223ffbff9c859b8d6253f35933382484c509f06"
-                  }
-                },
-                {
-                  "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
-                  "signature": {
-                    "public_nonce": "38f384433a3b0f27264cb3df8545658d2d32bc18a2379bcb948cf56f30e6ff1d",
-                    "signature": "50ff1924c8aad7ac16d624178d8c45360aca680c83452c3f811292fc8de2ea05"
+                    "public_nonce": "f4f81ca73f5827857b217855a2492db3ead0a4fe32d0bba769b4896b281e236b",
+                    "signature": "dbce2a8232b7c195ea3cd3a6ca35cdd474946f3c21f9ac69bfffef411c71b609"
                   }
                 },
                 {
                   "public_key": "9e504f9b10c40230ec4e1570dcf295d5da01aa0daeced57316b160c80bc57e0c",
                   "signature": {
-                    "public_nonce": "0860bf3fd73187ca4e7718256e7a31876758dda59b7fbb680d48624b5a54bc5a",
-                    "signature": "930985a7662daa621761d1551a40d09629d525a5582a22d01d655c621178c908"
+                    "public_nonce": "a2754753d0d13af4e5d2af0da68518db0227df43bd48ee36f589950d6ced5461",
+                    "signature": "cbd152faade419ce02e4f6ff2091e6b7fb2de3beb8448553f5a2e45d117c3c00"
+                  }
+                },
+                {
+                  "public_key": "cec1426a33965eb2a7d82b281964ad39f06d6fba7d8e57f8da4fcfefd946d855",
+                  "signature": {
+                    "public_nonce": "406dc7519173b18501addce24e17055bf7f0af6ae1c52932d3af2c3c3470b803",
+                    "signature": "894f2513c9132fba5fa887b9f219cff796e20dcedec0fba6791bdd42065b6e05"
                   }
                 },
                 {
                   "public_key": "a45af5c5eeb3db9687fe9edae95387f91ff5a90c442159204c3f97514dddad7c",
                   "signature": {
-                    "public_nonce": "e8aab61610a979b91643bce2d51750fb0846ee2c7d206e14d26b5601ab140e3d",
-                    "signature": "4dd262eeabdd3f53f2f955424d93259f18f440def78ec5610567e7ad7698790d"
+                    "public_nonce": "80a509c17ec60851a6df72083257a826d3fc316d5eaf9d07edfdb1df64e0b257",
+                    "signature": "e5131f1dab6f3e9b3d98a2f6bc4b62e8d129590d83e7f1d8f0ebb20c756d1709"
                   }
                 }
               ],
@@ -216,185 +217,111 @@
         },
         "siblings": [
           {
-            "Leaf": {
-              "key": {
-                "bytes": [
-                  89,
-                  213,
-                  203,
-                  172,
-                  177,
-                  134,
-                  100,
-                  131,
-                  197,
-                  49,
-                  20,
-                  210,
-                  243,
-                  66,
-                  136,
-                  155,
-                  136,
-                  156,
-                  191,
-                  16,
-                  199,
-                  138,
-                  23,
-                  227,
-                  170,
-                  73,
-                  153,
-                  58,
-                  103,
-                  29,
-                  172,
-                  90
-                ]
-              },
-              "value_hash": [
-                89,
-                213,
-                203,
-                172,
-                177,
-                134,
-                100,
-                131,
-                197,
-                49,
-                20,
-                210,
-                243,
-                66,
-                136,
-                155,
-                136,
-                156,
-                191,
-                16,
-                199,
-                138,
-                23,
-                227,
-                170,
-                73,
-                153,
-                58,
-                103,
-                29,
-                172,
-                90
-              ]
-            }
-          },
-          {
             "Other": [
-              58,
-              252,
-              250,
-              39,
-              46,
-              210,
-              95,
-              114,
-              21,
-              101,
-              59,
-              51,
-              210,
-              88,
-              106,
-              167,
-              160,
-              77,
-              142,
-              76,
-              134,
               198,
-              212,
-              221,
-              211,
-              2,
-              126,
-              246,
-              188,
-              121,
-              165,
-              184
-            ]
-          },
-          {
-            "Other": [
-              238,
-              101,
-              204,
-              27,
-              136,
-              252,
-              224,
-              234,
-              114,
-              227,
-              34,
-              235,
-              248,
-              161,
+              1,
+              207,
+              131,
+              105,
+              57,
+              85,
+              84,
+              206,
+              111,
               179,
-              42,
-              101,
-              27,
-              38,
-              109,
-              40,
-              69,
-              155,
-              56,
-              187,
-              49,
-              239,
-              199,
-              201,
-              14,
-              22,
-              137
+              179,
+              46,
+              165,
+              231,
+              51,
+              212,
+              136,
+              110,
+              207,
+              255,
+              148,
+              94,
+              74,
+              133,
+              229,
+              54,
+              117,
+              18,
+              221,
+              210,
+              191
             ]
           },
           {
             "Other": [
-              233,
-              219,
-              216,
-              243,
-              175,
-              174,
-              153,
-              53,
-              90,
-              93,
-              137,
-              96,
-              141,
-              253,
-              157,
-              132,
-              113,
-              20,
-              138,
-              60,
-              188,
+              102,
               156,
-              39,
-              255,
-              59,
-              149,
+              37,
+              118,
+              94,
+              183,
+              57,
+              61,
+              113,
+              35,
+              218,
+              137,
+              94,
+              29,
+              206,
               162,
-              108,
-              181,
-              202,
+              6,
+              120,
+              111,
+              131,
+              236,
+              136,
+              223,
               134,
-              216
+              210,
+              135,
+              213,
+              122,
+              158,
+              15,
+              119,
+              82
+            ]
+          },
+          {
+            "Other": [
+              245,
+              51,
+              176,
+              183,
+              134,
+              97,
+              158,
+              175,
+              204,
+              169,
+              82,
+              235,
+              224,
+              52,
+              172,
+              67,
+              244,
+              129,
+              47,
+              17,
+              163,
+              224,
+              76,
+              57,
+              119,
+              29,
+              135,
+              101,
+              156,
+              171,
+              159,
+              9
             ]
           }
         ]


### PR DESCRIPTION
Description
---
fix(sidechain)!: include epoch_hash in sidechain block header

Motivation and Context
---
We need to read the epoch_hash from the sidechain header on Ootle (https://github.com/tari-project/tari-ootle/pull/2017#issuecomment-4259006786)

This increases the proof size (over the wire) by 33 bytes

How Has This Been Tested?
---
Existing sidechain tests (fixtures updated)

Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

BREAKING CHANGE: this has no breaking change on current testnets or mainnet. However, it is a breaking change for Ootle when it upgrades to use these changes.