### PR TITLE
fix: sync peer swapping

### DIFF
--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -94,6 +94,29 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
     }
 
     pub async fn synchronize(&mut self) -> Result<(), BlockSyncError> {
+        // Protect every sync-candidate peer from being collaterally disconnected by unrelated
+        // subsystems (e.g. DhtConnectivity's random-pool-full pruning) while this sync runs.
+        // `add_peer_to_sync_list` returns an `Arc<NodeId>` handle; holding the handles alive for
+        // the duration of sync keeps each peer on the connectivity manager's sync list. When
+        // this function returns and the handles drop, the manager's next sweep prunes the
+        // entries and the peers become eligible for normal disconnect behaviour again.
+        let mut _sync_guards: Vec<Arc<NodeId>> = Vec::with_capacity(self.sync_peers.len());
+        for peer in self.sync_peers.iter() {
+            match self.connectivity.add_peer_to_sync_list(peer.node_id().clone()).await {
+                Ok(handle) => _sync_guards.push(handle),
+                Err(e) => debug!(
+                    target: LOG_TARGET,
+                    "Failed to register sync peer {} on sync list: {e}", peer.node_id()
+                ),
+            }
+        }
+
+        self.synchronize_inner().await
+        // `_sync_guards` drops here (success or error), releasing this sync's references on
+        // each peer's sync-list entry.
+    }
+
+    async fn synchronize_inner(&mut self) -> Result<(), BlockSyncError> {
         let mut max_latency = self.config.initial_max_sync_latency;
         let mut sync_round = 0;
         let mut latency_increases_counter = 0;
@@ -132,6 +155,7 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn attempt_block_sync(&mut self, max_latency: Duration) -> Result<(), BlockSyncError> {
         let sync_peer_node_ids = self.sync_peers.iter().map(|p| p.node_id()).cloned().collect::<Vec<_>>();
         info!(
@@ -155,18 +179,42 @@ impl<'a, B: BlockchainBackend + 'static> BlockSynchronizer<'a, B> {
                     continue;
                 },
             };
+            // Defensive: the connection may have been torn down by another subsystem between
+            // dial_peer() returning and this point (e.g. DhtConnectivity pruning). Without this
+            // check we would attempt an RPC negotiation on a dead channel.
+            if !conn.is_connected() {
+                warn!(
+                    target: LOG_TARGET,
+                    "Sync peer `{node_id}` was disconnected before RPC negotiation could begin"
+                );
+                self.remove_sync_peer(&node_id);
+                continue;
+            }
             let config = RpcClient::builder()
                 .with_deadline(self.config.rpc_deadline)
                 .with_deadline_grace_period(Duration::from_secs(5));
-            let mut client = match conn
-                .connect_rpc_using_builder::<rpc::BaseNodeSyncRpcClient>(config)
-                .await
+            // Bound RPC negotiation: without this the negotiation itself (as opposed to
+            // individual RPC requests) has no timeout and can wedge the sync loop indefinitely.
+            let mut client = match tokio::time::timeout(
+                self.config.rpc_deadline,
+                conn.connect_rpc_using_builder::<rpc::BaseNodeSyncRpcClient>(config),
+            )
+            .await
             {
-                Ok(val) => val,
-                Err(e) => {
+                Ok(Ok(val)) => val,
+                Ok(Err(e)) => {
                     warn!(
                         target: LOG_TARGET,
                         "Failed to obtain RPC connection from sync peer `{node_id}`: {e}"
+                    );
+                    self.remove_sync_peer(&node_id);
+                    continue;
+                },
+                Err(_) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Timed out establishing RPC connection with sync peer `{node_id}` after {:.2?}",
+                        self.config.rpc_deadline,
                     );
                     self.remove_sync_peer(&node_id);
                     continue;

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -119,6 +119,26 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
             "Synchronizing headers ({} candidate peers selected)",
             self.sync_peers.len()
         );
+
+        // Hold `Arc<NodeId>` sync-list handles for each candidate peer. While these guards are
+        // alive the connectivity manager marks the peers as "in use by sync", which prevents
+        // opportunistic disconnects (e.g. DhtConnectivity random-pool pruning). The guards are
+        // dropped automatically when this function returns.
+        let mut _sync_guards: Vec<Arc<NodeId>> = Vec::with_capacity(self.sync_peers.len());
+        for peer in self.sync_peers.iter() {
+            match self.connectivity.add_peer_to_sync_list(peer.node_id().clone()).await {
+                Ok(handle) => _sync_guards.push(handle),
+                Err(e) => debug!(
+                    target: LOG_TARGET,
+                    "Failed to register sync peer {} on sync list: {e}", peer.node_id()
+                ),
+            }
+        }
+
+        self.synchronize_inner().await
+    }
+
+    async fn synchronize_inner(&mut self) -> Result<(SyncPeer, AttemptSyncResult), BlockHeaderSyncError> {
         let mut max_latency = self.config.initial_max_sync_latency;
         let mut latency_increases_counter = 0;
         loop {
@@ -201,13 +221,27 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
             target: LOG_TARGET,
             "Attempting to synchronize headers with `{node_id}`"
         );
+        // Defensive: the connection may have been torn down by another subsystem between
+        // dial returning and this point (e.g. DhtConnectivity pruning). This is not the peer's
+        // fault, so use NotInSync (no ban) to trigger a skip-and-retry with the next peer.
+        if !conn.is_connected() {
+            warn!(
+                target: LOG_TARGET,
+                "Sync peer `{node_id}` was disconnected before RPC negotiation could begin"
+            );
+            return Err(BlockHeaderSyncError::NotInSync);
+        }
 
         let config = RpcClient::builder()
             .with_deadline(self.config.rpc_deadline)
             .with_deadline_grace_period(Duration::from_secs(5));
-        let mut client = conn
-            .connect_rpc_using_builder::<rpc::BaseNodeSyncRpcClient>(config)
-            .await?;
+        // Bound RPC negotiation so a stuck negotiation cannot wedge the sync loop.
+        let mut client = tokio::time::timeout(
+            self.config.rpc_deadline,
+            conn.connect_rpc_using_builder::<rpc::BaseNodeSyncRpcClient>(config),
+        )
+        .await
+        .map_err(|_| BlockHeaderSyncError::RpcError(RpcError::ReplyTimeout))??;
 
         let latency = client
             .get_last_request_latency()

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -35,7 +35,7 @@ use tari_comms::{
     PeerConnection,
     connectivity::ConnectivityRequester,
     peer_manager::NodeId,
-    protocol::rpc::{RpcClient, RpcStatus},
+    protocol::rpc::{RpcClient, RpcError, RpcStatus},
 };
 use tari_crypto::commitment::HomomorphicCommitment;
 use tari_node_components::blocks::{BlockHeader, ChainHeader};
@@ -154,9 +154,28 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             }
         })?;
 
+        // Hold `Arc<NodeId>` sync-list handles for each candidate peer. While these guards are
+        // alive the connectivity manager marks the peers as "in use by sync", which prevents
+        // opportunistic disconnects (e.g. DhtConnectivity random-pool pruning). The guards are
+        // dropped automatically when this function returns.
+        let mut _sync_guards: Vec<Arc<NodeId>> = Vec::with_capacity(self.sync_peers.len());
+        for peer in self.sync_peers.iter() {
+            match self.connectivity.add_peer_to_sync_list(peer.node_id().clone()).await {
+                Ok(handle) => _sync_guards.push(handle),
+                Err(e) => debug!(
+                    target: LOG_TARGET,
+                    "Failed to register sync peer {} on sync list: {e}", peer.node_id()
+                ),
+            }
+        }
+
+        self.synchronize_inner(&to_header).await
+    }
+
+    async fn synchronize_inner(&mut self, to_header: &BlockHeader) -> Result<(), HorizonSyncError> {
         let mut latency_increases_counter = 0;
         loop {
-            match self.sync(&to_header).await {
+            match self.sync(to_header).await {
                 Ok(()) => return Ok(()),
                 Err(err @ HorizonSyncError::AllSyncPeersExceedLatency) => {
                     // If we don't have many sync peers to select from, return the listening state and see if we can get
@@ -262,14 +281,27 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             target: LOG_TARGET,
             "Attempting to synchronize horizon state with `{node_id}`"
         );
+        // Defensive: the connection may have been torn down by another subsystem between
+        // dial returning and this point (e.g. DhtConnectivity pruning).
+        if !conn.is_connected() {
+            warn!(
+                target: LOG_TARGET,
+                "Sync peer `{node_id}` was disconnected before RPC negotiation could begin"
+            );
+            return Err(HorizonSyncError::RpcError(RpcError::ClientClosed));
+        }
 
         let config = RpcClient::builder()
             .with_deadline(self.config.rpc_deadline)
             .with_deadline_grace_period(Duration::from_secs(5));
 
-        let mut client = conn
-            .connect_rpc_using_builder::<rpc::BaseNodeSyncRpcClient>(config)
-            .await?;
+        // Bound RPC negotiation so a stuck negotiation cannot wedge the sync loop.
+        let mut client = tokio::time::timeout(
+            self.config.rpc_deadline,
+            conn.connect_rpc_using_builder::<rpc::BaseNodeSyncRpcClient>(config),
+        )
+        .await
+        .map_err(|_| HorizonSyncError::RpcError(RpcError::ReplyTimeout))??;
 
         let latency = client
             .get_last_request_latency()

--- a/comms/core/src/connection_manager/peer_connection.rs
+++ b/comms/core/src/connection_manager/peer_connection.rs
@@ -229,8 +229,11 @@ impl PeerConnection {
         protocol_id: &ProtocolId,
     ) -> Result<NegotiatedSubstream<Substream>, PeerConnectionError> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        let _unused = self
-            .request_tx
+        // NB: on send failure the returned SendError owns the unsent request — and therefore the
+        // reply_tx inside it. We must not hold that error alive across the reply_rx.await below, or
+        // the await will block forever waiting for a sender that can never send. Propagate via `?`
+        // so the error (and its captured reply_tx) is dropped immediately.
+        self.request_tx
             .send(PeerConnectionRequest::OpenSubstream {
                 protocol_id: protocol_id.clone(),
                 reply_tx,
@@ -244,7 +247,7 @@ impl PeerConnection {
                     self.peer_node_id,
                     e
                 );
-            });
+            })?;
         reply_rx
             .await
             .map_err(|_| PeerConnectionError::InternalReplyCancelled)?

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -110,6 +110,7 @@ impl ConnectivityManager {
             #[cfg(feature = "metrics")]
             uptime: Some(Instant::now()),
             allow_list: vec![],
+            sync_peers: vec![],
             proactive_dialer,
             seeds: vec![],
         }
@@ -169,6 +170,15 @@ struct ConnectivityManagerActor {
     #[cfg(feature = "metrics")]
     uptime: Option<Instant>,
     allow_list: Vec<NodeId>,
+    /// Peers currently being used for a sync operation.
+    ///
+    /// Each entry is an `Arc<NodeId>`; when a caller registers a peer via `AddPeerToSyncList`
+    /// they receive an `Arc<NodeId>` clone and this list keeps its own. When the caller drops
+    /// their handle the list entry's strong-count drops to 1, and the manager prunes such
+    /// entries on the next access (see `sweep_sync_peers`). While an entry has strong-count >= 2
+    /// it signals "in use by sync" and other subsystems should not proactively disconnect the
+    /// peer (see DhtConnectivity::handle_new_peer_connected).
+    sync_peers: Vec<Arc<NodeId>>,
     proactive_dialer: ProactiveDialer,
     seeds: Vec<NodeId>,
 }
@@ -263,6 +273,7 @@ impl ConnectivityManagerActor {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn handle_request(&mut self, req: ConnectivityRequest) {
         #[allow(clippy::enum_glob_use)]
         use ConnectivityRequest::*;
@@ -335,6 +346,15 @@ impl ConnectivityManagerActor {
             GetAllowList(reply) => {
                 let allow_list = self.allow_list.clone();
                 let _result = reply.send(allow_list);
+            },
+            AddPeerToSyncList(node_id, reply) => {
+                let handle = self.acquire_sync_peer_handle(node_id);
+                let _result = reply.send(handle);
+            },
+            GetSyncPeerList(reply) => {
+                self.sweep_sync_peers();
+                let list = self.sync_peers.iter().map(|p| (**p).clone()).collect();
+                let _result = reply.send(list);
             },
             GetSeeds(reply) => {
                 let seeds = self.peer_manager.get_seed_peers().await.unwrap_or_else(|e| {
@@ -522,8 +542,12 @@ impl ConnectivityManagerActor {
         };
         let num_connections = connections.len();
 
-        // Remove peers that are on the allow list
-        connections.retain(|conn| !self.allow_list.contains(conn.peer_node_id()));
+        // Remove peers that are on the allow list or are currently in use for sync
+        self.sweep_sync_peers();
+        connections.retain(|conn| {
+            !self.allow_list.contains(conn.peer_node_id()) &&
+                !self.sync_peers.iter().any(|p| **p == *conn.peer_node_id())
+        });
         debug!(
             target: LOG_TARGET,
             "minimize_connections: ({}) Filtered peers: {}, Handles: {}",
@@ -1230,6 +1254,32 @@ impl ConnectivityManagerActor {
     fn publish_event(&mut self, event: ConnectivityEvent) {
         // A send operation can only fail if there are no subscribers, so it is safe to ignore the error
         let _result = self.event_tx.send(event);
+    }
+
+    /// Drop sync-peer entries whose caller-side handles have all been released.
+    ///
+    /// An entry with `Arc::strong_count == 1` means only this manager still holds a reference,
+    /// so no active sync is using the peer. Pruning is run lazily on every sync-list access to
+    /// avoid keeping a timer purely for this list.
+    fn sweep_sync_peers(&mut self) {
+        self.sync_peers.retain(|p| Arc::strong_count(p) > 1);
+    }
+
+    /// Register `node_id` on the sync-peer list and return a shared `Arc<NodeId>` handle.
+    ///
+    /// If the peer is already registered, the existing `Arc` is cloned and returned (so all
+    /// callers interested in the same peer share the same handle). Otherwise a fresh `Arc` is
+    /// created, one clone is retained by the manager and another is returned. The caller must
+    /// keep the returned handle alive for as long as the peer should remain protected; dropping
+    /// it signals to the manager that the peer is no longer in use for sync.
+    fn acquire_sync_peer_handle(&mut self, node_id: NodeId) -> Arc<NodeId> {
+        self.sweep_sync_peers();
+        if let Some(existing) = self.sync_peers.iter().find(|p| ***p == node_id) {
+            return existing.clone();
+        }
+        let handle = Arc::new(node_id);
+        self.sync_peers.push(handle.clone());
+        handle
     }
 
     async fn ban_peer(

--- a/comms/core/src/connectivity/requester.rs
+++ b/comms/core/src/connectivity/requester.rs
@@ -22,6 +22,7 @@
 
 use std::{
     fmt,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -104,6 +105,12 @@ pub enum ConnectivityRequest {
     AddPeerToAllowList(NodeId),
     RemovePeerFromAllowList(NodeId),
     GetAllowList(oneshot::Sender<Vec<NodeId>>),
+    /// Register a peer as currently in use for sync and get back a ref-counted handle.
+    /// The peer remains in the sync list while any `Arc<NodeId>` clone of this handle is
+    /// alive; once every clone is dropped the manager will prune it on its next sweep.
+    AddPeerToSyncList(NodeId, oneshot::Sender<Arc<NodeId>>),
+    /// Retrieve the current sync-peer list (only peers with active sync references).
+    GetSyncPeerList(oneshot::Sender<Vec<NodeId>>),
     GetSeeds(oneshot::Sender<Vec<Peer>>),
     GetPeerStats(NodeId, oneshot::Sender<Option<Peer>>),
     GetNodeIdentity(oneshot::Sender<NodeIdentity>),
@@ -325,6 +332,33 @@ impl ConnectivityRequester {
             .await
             .map_err(|_| ConnectivityError::ActorDisconnected)?;
         Ok(())
+    }
+
+    /// Register `node_id` as currently in use for a sync and return an `Arc<NodeId>` handle.
+    ///
+    /// While the returned handle (or any clone of it) is alive, other subsystems that query the
+    /// sync-peer list (e.g. DhtConnectivity) will treat the peer as protected from opportunistic
+    /// disconnection such as random-pool pruning. The connectivity manager keeps its own
+    /// `Arc<NodeId>` clone in a list and periodically prunes entries whose strong-count has
+    /// dropped to 1 (only the manager's own copy remaining).
+    pub async fn add_peer_to_sync_list(&mut self, node_id: NodeId) -> Result<Arc<NodeId>, ConnectivityError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectivityRequest::AddPeerToSyncList(node_id, reply_tx))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
+    }
+
+    /// Retrieve the current sync-peer list. Entries whose caller-side handles have all been
+    /// dropped will have been pruned on the manager's previous sweep.
+    pub async fn get_sync_peer_list(&mut self) -> Result<Vec<NodeId>, ConnectivityError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectivityRequest::GetSyncPeerList(reply_tx))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
     }
 
     /// Returns a Future that resolves when the connectivity actor has started.

--- a/comms/core/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/core/src/test_utils/mocks/connectivity_manager.rs
@@ -301,6 +301,12 @@ impl ConnectivityManagerMock {
             GetAllowList(reply) => {
                 let _result = reply.send(vec![]);
             },
+            AddPeerToSyncList(node_id, reply) => {
+                let _result = reply.send(std::sync::Arc::new(node_id));
+            },
+            GetSyncPeerList(reply) => {
+                let _result = reply.send(vec![]);
+            },
             GetMinimizeConnectionsThreshold(_) => unimplemented!(),
         }
     }

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -487,6 +487,18 @@ impl DhtConnectivity {
             return Ok(());
         }
 
+        // Peers currently being used by a sync operation must not be disconnected by pool
+        // pruning — the sync code holds an Arc<NodeId> handle on the connectivity manager
+        // that keeps the peer on the sync list until sync finishes.
+        if self.is_sync_peer(conn.peer_node_id()).await? {
+            debug!(
+                target: LOG_TARGET,
+                "Sync peer '{}' connected — leaving connection alone while sync holds a handle",
+                conn.peer_node_id()
+            );
+            return Ok(());
+        }
+
         if self.is_pool_peer(conn.peer_node_id()) {
             debug!(
                 target: LOG_TARGET,
@@ -549,7 +561,8 @@ impl DhtConnectivity {
         // Retrieve all communication node peers with an active connection status
         let mut peers_by_distance = self.pool_peers_with_active_connections().await?;
         let peer_allow_list = self.peer_allow_list().await?;
-        peers_by_distance.retain(|p| !peer_allow_list.contains(&p.node_id));
+        let peer_sync_list = self.peer_sync_list().await?;
+        peers_by_distance.retain(|p| !peer_allow_list.contains(&p.node_id) && !peer_sync_list.contains(&p.node_id));
 
         // Remove all above threshold connections
         let threshold = self.config.num_neighbouring_nodes + self.config.num_random_nodes;
@@ -683,6 +696,14 @@ impl DhtConnectivity {
 
     async fn peer_allow_list(&mut self) -> Result<Vec<NodeId>, DhtConnectivityError> {
         Ok(self.connectivity.get_allow_list().await?)
+    }
+
+    async fn peer_sync_list(&mut self) -> Result<Vec<NodeId>, DhtConnectivityError> {
+        Ok(self.connectivity.get_sync_peer_list().await?)
+    }
+
+    async fn is_sync_peer(&mut self, node_id: &NodeId) -> Result<bool, DhtConnectivityError> {
+        Ok(self.peer_sync_list().await?.contains(node_id))
     }
 
     async fn replace_pool_peer(&mut self, current_peer: &NodeId) -> Result<(), DhtConnectivityError> {


### PR DESCRIPTION
Description
---
Its possible for a peer to be disconnected, banned, etc during peer sync. 
If this happens a the next sync peer should be used, but its possible for the peer manager to reap that connection. 
This causes the sync to get stuck trying to await a connection thats not made. 
This fixes the issue where it awaits a connection to a disconnected peer, 
and it adds a sync peer list to the peer manager telling it that these peers are being used, dont reap their connections