### PR TITLE
fix(deps): update rustls-webpki for RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6540,9 +6540,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Description
---
Update rustls-webpki from 0.103.12 to 0.103.13 in Cargo.lock.

This addresses RUSTSEC-2026-0104, a reachable panic in certificate revocation list parsing.

Motivation and Context
---
Issue #7780 reports the advisory against rustls-webpki 0.103.12. The patched stable release is 0.103.13, so this PR keeps the update lockfile-only and avoids broader TLS dependency churn.

How Has This Been Tested?
---
- cargo tree -i rustls-webpki --locked
- cargo check --locked --ignore-rust-version -p tari_p2p -p minotari_app_grpc

Note: local toolchain in this environment is rustc 1.92.0 while the workspace requires 1.93.0; therefore --ignore-rust-version was used for local cargo check verification.

What process can a PR reviewer use to test or verify this change?
---
1. Confirm Cargo.lock resolves rustls-webpki 0.103.13.
2. Run cargo tree -i rustls-webpki --locked to confirm dependency paths.
3. Run cargo check --locked -p tari_p2p -p minotari_app_grpc with the repo-required Rust toolchain.

Breaking Changes
---
- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

Closes #7780.
