### PR TITLE
test: add standalone offline signer cucumber coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7981,6 +7981,7 @@ dependencies = [
  "minotari_miner",
  "minotari_node",
  "minotari_node_grpc_client",
+ "minotari_offline_signer",
  "minotari_wallet",
  "minotari_wallet_ffi",
  "minotari_wallet_grpc_client",

--- a/applications/minotari_offline_signer/Cargo.toml
+++ b/applications/minotari_offline_signer/Cargo.toml
@@ -7,6 +7,9 @@ license = { workspace = true }
 version = { workspace = true }
 edition = { workspace = true }
 
+[features]
+test-keystore = []
+
 [[bin]]
 name = "minotari_offline_signer"
 path = "src/main.rs"
@@ -28,4 +31,3 @@ argon2 = { version = "0.6.0-rc.8", features = ["password-hash"] }
 phc = { version = "0.6.1"}
 rand = { workspace = true }
 zeroize = "^1"
-

--- a/applications/minotari_offline_signer/src/cli.rs
+++ b/applications/minotari_offline_signer/src/cli.rs
@@ -186,7 +186,10 @@ fn init_with_keys(args: InitKeysArgs) -> Result<()> {
     keystore::init_keystore(&spend_key, &view_key, &passphrase)?;
 
     println!("✓ Offline signer initialized successfully!");
-    println!("  Keys have been encrypted and stored in the OS keystore.");
+    println!(
+        "  Keys have been encrypted and stored in {}.",
+        keystore::storage_description()
+    );
 
     Ok(())
 }
@@ -222,7 +225,10 @@ fn init_with_seed_words(args: InitSeedWordsArgs) -> Result<()> {
     keystore::init_keystore(&spend_key, &view_key, &passphrase)?;
 
     println!("✓ Offline signer initialized successfully from seed words!");
-    println!("  Keys have been derived and encrypted in the OS keystore.");
+    println!(
+        "  Keys have been derived and encrypted in {}.",
+        keystore::storage_description()
+    );
 
     Ok(())
 }
@@ -295,7 +301,7 @@ fn sign_transaction(args: SignArgs) -> Result<()> {
 fn check_status() -> Result<()> {
     if keystore::is_initialized() {
         println!("✓ Offline signer is initialized");
-        println!("  Keys are stored in the OS keystore");
+        println!("  Keys are stored in {}", keystore::storage_description());
     } else {
         println!("✗ Offline signer is not initialized");
         println!("  Run 'init keys' or 'init seed-words' command to set up keys");

--- a/applications/minotari_offline_signer/src/cli.rs
+++ b/applications/minotari_offline_signer/src/cli.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{fs, path::PathBuf, str::FromStr};
+use std::{ffi::OsString, fs, path::PathBuf, str::FromStr};
 
 use anyhow::{Context, Result, anyhow};
 use clap::{Args, Parser, Subcommand};
@@ -51,6 +51,11 @@ use crate::{error::OfflineSignerError, keystore};
 #[derive(Debug, Parser)]
 #[clap(name = "minotari_offline_signer", version, about)]
 pub struct Cli {
+    /// Use a file-backed keystore instead of the OS keyring.
+    #[cfg(feature = "test-keystore")]
+    #[clap(long, global = true, hide = true)]
+    pub test_keystore_file: Option<PathBuf>,
+
     #[clap(subcommand)]
     pub command: Commands,
 }
@@ -133,6 +138,9 @@ pub struct SignArgs {
 
 impl Cli {
     pub fn execute(self) -> Result<()> {
+        #[cfg(feature = "test-keystore")]
+        let _test_keystore_guard = keystore::set_test_keystore_file(self.test_keystore_file.clone());
+
         match self.command {
             Commands::Init { method } => match method {
                 InitMethod::Keys(args) => init_with_keys(args),
@@ -143,6 +151,14 @@ impl Cli {
             Commands::Clear => clear_keystore(),
         }
     }
+}
+
+pub fn execute_from_args<I, T>(args: I) -> Result<()>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    Cli::try_parse_from(args)?.execute()
 }
 
 fn check_already_initialized() -> Result<()> {

--- a/applications/minotari_offline_signer/src/keystore.rs
+++ b/applications/minotari_offline_signer/src/keystore.rs
@@ -65,48 +65,11 @@ trait KeystoreBackend {
     fn description(&self) -> &'static str;
 }
 
-enum KeystoreBackendKind {
-    OsKeyring(OsKeyringBackend),
-    #[cfg(feature = "test-keystore")]
-    TestFile(test_keystore::TestFileBackend),
-}
 
-impl KeystoreBackend for KeystoreBackendKind {
-    fn store(&self, entry_name: &str, data: &EncryptedKeyData) -> Result<(), OfflineSignerError> {
-        match self {
-            Self::OsKeyring(backend) => backend.store(entry_name, data),
-            #[cfg(feature = "test-keystore")]
-            Self::TestFile(backend) => backend.store(entry_name, data),
-        }
-    }
 
-    fn retrieve(&self, entry_name: &str) -> Result<EncryptedKeyData, OfflineSignerError> {
-        match self {
-            Self::OsKeyring(backend) => backend.retrieve(entry_name),
-            #[cfg(feature = "test-keystore")]
-            Self::TestFile(backend) => backend.retrieve(entry_name),
-        }
-    }
-
-    fn delete(&self, entry_name: &str) -> Result<(), OfflineSignerError> {
-        match self {
-            Self::OsKeyring(backend) => backend.delete(entry_name),
-            #[cfg(feature = "test-keystore")]
-            Self::TestFile(backend) => backend.delete(entry_name),
-        }
-    }
-
-    fn description(&self) -> &'static str {
-        match self {
-            Self::OsKeyring(backend) => backend.description(),
-            #[cfg(feature = "test-keystore")]
-            Self::TestFile(backend) => backend.description(),
-        }
-    }
-}
 
 pub struct Keystore {
-    backend: KeystoreBackendKind,
+    backend: Box<dyn KeystoreBackend>,
 }
 
 impl Keystore {
@@ -114,12 +77,12 @@ impl Keystore {
         #[cfg(feature = "test-keystore")]
         if let Some(path) = test_keystore::current_file() {
             return Self {
-                backend: KeystoreBackendKind::TestFile(test_keystore::TestFileBackend::new(path)),
+                backend: Box::new(test_keystore::TestFileBackend::new(path)),
             };
         }
 
         Self {
-            backend: KeystoreBackendKind::OsKeyring(OsKeyringBackend),
+            backend: Box::new(OsKeyringBackend),
         }
     }
 
@@ -129,6 +92,7 @@ impl Keystore {
         view_key: &PrivateKey,
         passphrase: &str,
     ) -> Result<(), OfflineSignerError> {
+
         let encrypted_spend = encrypt_key(spend_key, passphrase)?;
         let encrypted_view = encrypt_key(view_key, passphrase)?;
 

--- a/applications/minotari_offline_signer/src/keystore.rs
+++ b/applications/minotari_offline_signer/src/keystore.rs
@@ -27,8 +27,7 @@
 
 use argon2::{Argon2, password_hash::PasswordHasher};
 use chacha20poly1305::{
-    ChaCha20Poly1305,
-    Nonce,
+    ChaCha20Poly1305, Nonce,
     aead::{Aead, KeyInit},
 };
 use keyring::Entry;
@@ -45,8 +44,11 @@ const SERVICE_NAME: &str = "minotari_offline_signer";
 const SPEND_KEY_ENTRY: &str = "spend_key";
 const VIEW_KEY_ENTRY: &str = "view_key";
 
-/// Encrypted key data stored in the keyring
-#[derive(Serialize, Deserialize)]
+#[cfg(feature = "test-keystore")]
+pub(crate) use test_keystore::set_test_keystore_file;
+
+/// Encrypted key data stored by a keystore backend.
+#[derive(Clone, Serialize, Deserialize)]
 struct EncryptedKeyData {
     /// Salt used for key derivation (base64 encoded)
     salt: String,
@@ -56,7 +58,256 @@ struct EncryptedKeyData {
     ciphertext: String,
 }
 
-/// Derives an encryption key from a passphrase and salt using Argon2id
+trait KeystoreBackend {
+    fn store(&self, entry_name: &str, data: &EncryptedKeyData) -> Result<(), OfflineSignerError>;
+    fn retrieve(&self, entry_name: &str) -> Result<EncryptedKeyData, OfflineSignerError>;
+    fn delete(&self, entry_name: &str) -> Result<(), OfflineSignerError>;
+    fn description(&self) -> &'static str;
+}
+
+enum KeystoreBackendKind {
+    OsKeyring(OsKeyringBackend),
+    #[cfg(feature = "test-keystore")]
+    TestFile(test_keystore::TestFileBackend),
+}
+
+impl KeystoreBackend for KeystoreBackendKind {
+    fn store(&self, entry_name: &str, data: &EncryptedKeyData) -> Result<(), OfflineSignerError> {
+        match self {
+            Self::OsKeyring(backend) => backend.store(entry_name, data),
+            #[cfg(feature = "test-keystore")]
+            Self::TestFile(backend) => backend.store(entry_name, data),
+        }
+    }
+
+    fn retrieve(&self, entry_name: &str) -> Result<EncryptedKeyData, OfflineSignerError> {
+        match self {
+            Self::OsKeyring(backend) => backend.retrieve(entry_name),
+            #[cfg(feature = "test-keystore")]
+            Self::TestFile(backend) => backend.retrieve(entry_name),
+        }
+    }
+
+    fn delete(&self, entry_name: &str) -> Result<(), OfflineSignerError> {
+        match self {
+            Self::OsKeyring(backend) => backend.delete(entry_name),
+            #[cfg(feature = "test-keystore")]
+            Self::TestFile(backend) => backend.delete(entry_name),
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        match self {
+            Self::OsKeyring(backend) => backend.description(),
+            #[cfg(feature = "test-keystore")]
+            Self::TestFile(backend) => backend.description(),
+        }
+    }
+}
+
+pub struct Keystore {
+    backend: KeystoreBackendKind,
+}
+
+impl Keystore {
+    pub fn new() -> Self {
+        #[cfg(feature = "test-keystore")]
+        if let Some(path) = test_keystore::current_file() {
+            return Self {
+                backend: KeystoreBackendKind::TestFile(test_keystore::TestFileBackend::new(path)),
+            };
+        }
+
+        Self {
+            backend: KeystoreBackendKind::OsKeyring(OsKeyringBackend),
+        }
+    }
+
+    pub fn init(
+        &self,
+        spend_key: &PrivateKey,
+        view_key: &PrivateKey,
+        passphrase: &str,
+    ) -> Result<(), OfflineSignerError> {
+        let encrypted_spend = encrypt_key(spend_key, passphrase)?;
+        let encrypted_view = encrypt_key(view_key, passphrase)?;
+
+        self.backend.store(SPEND_KEY_ENTRY, &encrypted_spend)?;
+        self.backend.store(VIEW_KEY_ENTRY, &encrypted_view)?;
+
+        Ok(())
+    }
+
+    pub fn get_keys(&self, passphrase: &str) -> Result<(PrivateKey, PrivateKey), OfflineSignerError> {
+        let encrypted_spend = self.backend.retrieve(SPEND_KEY_ENTRY)?;
+        let encrypted_view = self.backend.retrieve(VIEW_KEY_ENTRY)?;
+
+        let spend_key = decrypt_key(&encrypted_spend, passphrase)?;
+        let view_key = decrypt_key(&encrypted_view, passphrase)?;
+
+        Ok((spend_key, view_key))
+    }
+
+    pub fn is_initialized(&self) -> bool {
+        self.backend.retrieve(SPEND_KEY_ENTRY).is_ok()
+    }
+
+    pub fn clear(&self) -> Result<(), OfflineSignerError> {
+        // Try to delete both keys, ignoring errors if they do not exist.
+        let _unused = self.backend.delete(SPEND_KEY_ENTRY);
+        let _unused = self.backend.delete(VIEW_KEY_ENTRY);
+        Ok(())
+    }
+
+    pub fn description(&self) -> &'static str {
+        self.backend.description()
+    }
+}
+
+impl Default for Keystore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct OsKeyringBackend;
+
+impl KeystoreBackend for OsKeyringBackend {
+    fn store(&self, entry_name: &str, data: &EncryptedKeyData) -> Result<(), OfflineSignerError> {
+        let entry = Entry::new(SERVICE_NAME, entry_name)
+            .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to create keyring entry: {}", e)))?;
+
+        let json = serde_json::to_string(data)
+            .map_err(|e| OfflineSignerError::SerializationError(format!("Failed to serialize key data: {}", e)))?;
+
+        entry
+            .set_password(&json)
+            .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to store in keyring: {}", e)))?;
+
+        Ok(())
+    }
+
+    fn retrieve(&self, entry_name: &str) -> Result<EncryptedKeyData, OfflineSignerError> {
+        let entry = Entry::new(SERVICE_NAME, entry_name)
+            .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to create keyring entry: {}", e)))?;
+
+        let json = entry
+            .get_password()
+            .map_err(|e| OfflineSignerError::NotInitialized(format!("Key not found in keyring: {}", e)))?;
+
+        serde_json::from_str(&json)
+            .map_err(|e| OfflineSignerError::ParseError(format!("Failed to parse key data: {}", e)))
+    }
+
+    fn delete(&self, entry_name: &str) -> Result<(), OfflineSignerError> {
+        let entry = Entry::new(SERVICE_NAME, entry_name)
+            .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to create keyring entry: {}", e)))?;
+
+        entry
+            .delete_credential()
+            .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to delete from keyring: {}", e)))?;
+
+        Ok(())
+    }
+
+    fn description(&self) -> &'static str {
+        "the OS keystore"
+    }
+}
+
+#[cfg(feature = "test-keystore")]
+mod test_keystore {
+    use std::{cell::RefCell, collections::BTreeMap, path::PathBuf};
+
+    use super::{EncryptedKeyData, KeystoreBackend, OfflineSignerError};
+
+    thread_local! {
+        static TEST_KEYSTORE_FILE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+    }
+
+    pub(crate) struct TestKeystoreFileGuard {
+        previous_path: Option<PathBuf>,
+    }
+
+    pub fn set_test_keystore_file(path: Option<PathBuf>) -> TestKeystoreFileGuard {
+        let previous_path = TEST_KEYSTORE_FILE.replace(path);
+        TestKeystoreFileGuard { previous_path }
+    }
+
+    pub(super) fn current_file() -> Option<PathBuf> {
+        TEST_KEYSTORE_FILE.with(|path| path.borrow().clone())
+    }
+
+    impl Drop for TestKeystoreFileGuard {
+        fn drop(&mut self) {
+            TEST_KEYSTORE_FILE.replace(self.previous_path.take());
+        }
+    }
+
+    pub(super) struct TestFileBackend {
+        path: PathBuf,
+    }
+
+    impl TestFileBackend {
+        pub(super) fn new(path: PathBuf) -> Self {
+            Self { path }
+        }
+
+        fn read(&self) -> Result<BTreeMap<String, EncryptedKeyData>, OfflineSignerError> {
+            match std::fs::read_to_string(&self.path) {
+                Ok(json) => serde_json::from_str(&json)
+                    .map_err(|e| OfflineSignerError::ParseError(format!("Failed to parse test keystore: {}", e))),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(BTreeMap::new()),
+                Err(e) => Err(OfflineSignerError::KeystoreError(format!(
+                    "Failed to read test keystore: {}",
+                    e
+                ))),
+            }
+        }
+
+        fn write(&self, entries: &BTreeMap<String, EncryptedKeyData>) -> Result<(), OfflineSignerError> {
+            if let Some(parent) = self.path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    OfflineSignerError::KeystoreError(format!("Failed to create test keystore directory: {}", e))
+                })?;
+            }
+            let json = serde_json::to_string(entries).map_err(|e| {
+                OfflineSignerError::SerializationError(format!("Failed to serialize test keystore: {}", e))
+            })?;
+            std::fs::write(&self.path, json)
+                .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to write test keystore: {}", e)))?;
+            Ok(())
+        }
+    }
+
+    impl KeystoreBackend for TestFileBackend {
+        fn store(&self, entry_name: &str, data: &EncryptedKeyData) -> Result<(), OfflineSignerError> {
+            let mut entries = self.read()?;
+            entries.insert(entry_name.to_string(), data.clone());
+            self.write(&entries)
+        }
+
+        fn retrieve(&self, entry_name: &str) -> Result<EncryptedKeyData, OfflineSignerError> {
+            let entries = self.read()?;
+            entries
+                .get(entry_name)
+                .cloned()
+                .ok_or_else(|| OfflineSignerError::NotInitialized("Key not found in test keystore".to_string()))
+        }
+
+        fn delete(&self, entry_name: &str) -> Result<(), OfflineSignerError> {
+            let mut entries = self.read()?;
+            entries.remove(entry_name);
+            self.write(&entries)
+        }
+
+        fn description(&self) -> &'static str {
+            "the test keystore"
+        }
+    }
+}
+
+/// Derives an encryption key from a passphrase and salt using Argon2id.
 fn derive_encryption_key(passphrase: &str, salt: &Salt) -> Result<Zeroizing<[u8; 32]>, OfflineSignerError> {
     let argon2 = Argon2::default();
     let hash = argon2
@@ -77,18 +328,15 @@ fn derive_encryption_key(passphrase: &str, salt: &Salt) -> Result<Zeroizing<[u8;
     Ok(key)
 }
 
-/// Encrypts a private key using ChaCha20-Poly1305
+/// Encrypts a private key using ChaCha20-Poly1305.
 fn encrypt_key(key: &PrivateKey, passphrase: &str) -> Result<EncryptedKeyData, OfflineSignerError> {
-    // Generate random salt and nonce
     let salt = Salt::generate();
     let mut nonce_bytes = [0u8; 12];
     rand::rng().fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
 
-    // Derive encryption key from passphrase
     let encryption_key = derive_encryption_key(passphrase, &salt)?;
 
-    // Encrypt the private key
     let cipher = ChaCha20Poly1305::new_from_slice(&*encryption_key)
         .map_err(|e| OfflineSignerError::EncryptionError(format!("Failed to create cipher: {}", e)))?;
 
@@ -104,9 +352,8 @@ fn encrypt_key(key: &PrivateKey, passphrase: &str) -> Result<EncryptedKeyData, O
     })
 }
 
-/// Decrypts a private key using ChaCha20-Poly1305
+/// Decrypts a private key using ChaCha20-Poly1305.
 fn decrypt_key(data: &EncryptedKeyData, passphrase: &str) -> Result<PrivateKey, OfflineSignerError> {
-    // Parse salt and nonce
     let salt =
         Salt::from_b64(&data.salt).map_err(|e| OfflineSignerError::DecryptionError(format!("Invalid salt: {}", e)))?;
 
@@ -117,10 +364,8 @@ fn decrypt_key(data: &EncryptedKeyData, passphrase: &str) -> Result<PrivateKey, 
     let ciphertext = Vec::from_hex(&data.ciphertext)
         .map_err(|e| OfflineSignerError::DecryptionError(format!("Invalid ciphertext: {}", e)))?;
 
-    // Derive encryption key from passphrase
     let encryption_key = derive_encryption_key(passphrase, &salt)?;
 
-    // Decrypt the private key
     let cipher = ChaCha20Poly1305::new_from_slice(&*encryption_key)
         .map_err(|e| OfflineSignerError::DecryptionError(format!("Failed to create cipher: {}", e)))?;
 
@@ -132,84 +377,31 @@ fn decrypt_key(data: &EncryptedKeyData, passphrase: &str) -> Result<PrivateKey, 
         .map_err(|e| OfflineSignerError::DecryptionError(format!("Invalid key data: {}", e)))
 }
 
-/// Stores a key in the OS keyring
-fn store_in_keyring(entry_name: &str, data: &EncryptedKeyData) -> Result<(), OfflineSignerError> {
-    let entry = Entry::new(SERVICE_NAME, entry_name)
-        .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to create keyring entry: {}", e)))?;
-
-    let json = serde_json::to_string(data)
-        .map_err(|e| OfflineSignerError::SerializationError(format!("Failed to serialize key data: {}", e)))?;
-
-    entry
-        .set_password(&json)
-        .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to store in keyring: {}", e)))?;
-
-    Ok(())
-}
-
-/// Retrieves a key from the OS keyring
-fn retrieve_from_keyring(entry_name: &str) -> Result<EncryptedKeyData, OfflineSignerError> {
-    let entry = Entry::new(SERVICE_NAME, entry_name)
-        .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to create keyring entry: {}", e)))?;
-
-    let json = entry
-        .get_password()
-        .map_err(|e| OfflineSignerError::NotInitialized(format!("Key not found in keyring: {}", e)))?;
-
-    serde_json::from_str(&json).map_err(|e| OfflineSignerError::ParseError(format!("Failed to parse key data: {}", e)))
-}
-
-/// Deletes a key from the OS keyring
-fn delete_from_keyring(entry_name: &str) -> Result<(), OfflineSignerError> {
-    let entry = Entry::new(SERVICE_NAME, entry_name)
-        .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to create keyring entry: {}", e)))?;
-
-    entry
-        .delete_credential()
-        .map_err(|e| OfflineSignerError::KeystoreError(format!("Failed to delete from keyring: {}", e)))?;
-
-    Ok(())
-}
-
-/// Initializes the keystore with spend and view keys
+/// Initializes the keystore with spend and view keys.
 pub fn init_keystore(
     spend_key: &PrivateKey,
     view_key: &PrivateKey,
     passphrase: &str,
 ) -> Result<(), OfflineSignerError> {
-    // Encrypt both keys
-    let encrypted_spend = encrypt_key(spend_key, passphrase)?;
-    let encrypted_view = encrypt_key(view_key, passphrase)?;
-
-    // Store in keyring
-    store_in_keyring(SPEND_KEY_ENTRY, &encrypted_spend)?;
-    store_in_keyring(VIEW_KEY_ENTRY, &encrypted_view)?;
-
-    Ok(())
+    Keystore::new().init(spend_key, view_key, passphrase)
 }
 
-/// Retrieves the spend and view keys from the keystore
+/// Retrieves the spend and view keys from the keystore.
 pub fn get_keys(passphrase: &str) -> Result<(PrivateKey, PrivateKey), OfflineSignerError> {
-    let encrypted_spend = retrieve_from_keyring(SPEND_KEY_ENTRY)?;
-    let encrypted_view = retrieve_from_keyring(VIEW_KEY_ENTRY)?;
-
-    let spend_key = decrypt_key(&encrypted_spend, passphrase)?;
-    let view_key = decrypt_key(&encrypted_view, passphrase)?;
-
-    Ok((spend_key, view_key))
+    Keystore::new().get_keys(passphrase)
 }
 
-/// Checks if the keystore has been initialized
+/// Checks if the keystore has been initialized.
 pub fn is_initialized() -> bool {
-    Entry::new(SERVICE_NAME, SPEND_KEY_ENTRY)
-        .and_then(|e| e.get_password())
-        .is_ok()
+    Keystore::new().is_initialized()
 }
 
-/// Clears all keys from the keystore
+/// Clears all keys from the keystore.
 pub fn clear_keystore() -> Result<(), OfflineSignerError> {
-    // Try to delete both keys, ignoring errors if they don't exist
-    let _unused = delete_from_keyring(SPEND_KEY_ENTRY);
-    let _unused = delete_from_keyring(VIEW_KEY_ENTRY);
-    Ok(())
+    Keystore::new().clear()
+}
+
+/// Returns a human-readable description of the active keystore backend.
+pub fn storage_description() -> &'static str {
+    Keystore::new().description()
 }

--- a/applications/minotari_offline_signer/src/keystore.rs
+++ b/applications/minotari_offline_signer/src/keystore.rs
@@ -27,7 +27,8 @@
 
 use argon2::{Argon2, password_hash::PasswordHasher};
 use chacha20poly1305::{
-    ChaCha20Poly1305, Nonce,
+    ChaCha20Poly1305,
+    Nonce,
     aead::{Aead, KeyInit},
 };
 use keyring::Entry;
@@ -65,9 +66,6 @@ trait KeystoreBackend {
     fn description(&self) -> &'static str;
 }
 
-
-
-
 pub struct Keystore {
     backend: Box<dyn KeystoreBackend>,
 }
@@ -92,7 +90,6 @@ impl Keystore {
         view_key: &PrivateKey,
         passphrase: &str,
     ) -> Result<(), OfflineSignerError> {
-
         let encrypted_spend = encrypt_key(spend_key, passphrase)?;
         let encrypted_view = encrypt_key(view_key, passphrase)?;
 

--- a/applications/minotari_offline_signer/src/lib.rs
+++ b/applications/minotari_offline_signer/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2025. The Tari Project
+// Copyright 2026. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,20 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! Minotari Offline Signer
-//!
-//! A standalone binary for signing one-sided transactions offline.
-//! This tool allows signing transactions without requiring a full wallet connection,
-//! using only the private spend and view keys.
-//!
-//! Keys are securely stored in the OS keystore (Keychain on macOS, Credential Manager on Windows,
-//! Secret Service on Linux), encrypted with a passphrase using ChaCha20-Poly1305.
-
-use anyhow::Result;
-use clap::Parser;
-use minotari_offline_signer::cli::Cli;
-
-fn main() -> Result<()> {
-    let cli = Cli::parse();
-    cli.execute()
-}
+pub mod cli;
+pub mod error;
+mod keystore;

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -25,6 +25,9 @@ tari_node_components = { path = "../base_layer/node_components" }
 minotari_console_wallet = { path = "../applications/minotari_console_wallet", features = [
     "grpc",
 ] }
+minotari_offline_signer = { path = "../applications/minotari_offline_signer", features = [
+    "test-keystore",
+] }
 tari_core = { path = "../base_layer/core" }
 minotari_miner = { path = "../applications/minotari_miner" }
 tari_p2p = { path = "../base_layer/p2p" }

--- a/integration_tests/src/world.rs
+++ b/integration_tests/src/world.rs
@@ -101,6 +101,7 @@ pub struct TariWorld {
     // Used for offline signing integration test — stores prepared and signed transaction JSON between steps.
     pub offline_signing_prepared: Option<String>,
     pub offline_signing_signed: Option<String>,
+    pub offline_signer_keystores: IndexMap<String, PathBuf>,
     pub key_manager: KeyManager,
     // This will be used for all one-sided coinbase payments
     pub wallet_private_key: PrivateKey,
@@ -135,6 +136,7 @@ impl Debug for TariWorld {
             .field("last_merge_miner_response", &self.last_merge_miner_response)
             .field("offline_signing_prepared", &self.offline_signing_prepared)
             .field("offline_signing_signed", &self.offline_signing_signed)
+            .field("offline_signer_keystores", &self.offline_signer_keystores)
             .finish()
     }
 }
@@ -178,6 +180,7 @@ impl TariWorld {
             last_merge_miner_response: Default::default(),
             offline_signing_prepared: None,
             offline_signing_signed: None,
+            offline_signer_keystores: Default::default(),
             key_manager: KeyManager::new_random().unwrap(),
             wallet_private_key,
             default_payment_address,

--- a/integration_tests/tests/features/OfflineSigning.feature
+++ b/integration_tests/tests/features/OfflineSigning.feature
@@ -32,3 +32,33 @@ Feature: Offline One-Sided Transaction Signing
     Then all nodes are at height 9
     # Step 4: Verify receiving wallet has confirmed funds
     When I wait for wallet WALLET_RECEIVER to have at least 100000 uT
+
+  @standalone-offline-signer
+  Scenario: Full offline signing flow via standalone offline signer
+    # Set up infrastructure
+    Given I have a seed node NODE
+    When I have wallet WALLET_SENDER connected to all seed nodes
+    When I have wallet WALLET_RECEIVER connected to all seed nodes
+    When I have SHA3X mining node MINER connected to base node NODE and wallet WALLET_SENDER
+    # Fund the sender wallet
+    When mining node MINER mines 4 blocks
+    Then all nodes are at height 4
+    When I wait for wallet WALLET_SENDER to have at least 1002000 uT
+    # Initialize the standalone offline signer from the sender seed words, then export keys for the view-only wallet
+    Then I initialize standalone offline signer OFFLINE_SIGNER from wallet WALLET_SENDER seed words
+    Then I export wallet WALLET_SENDER view and spend keys as SENDER_KEYS
+    # Create view-only wallet from exported keys
+    Then I create view wallet VIEW_WALLET from view and spend keys SENDER_KEYS on node NODE
+    # Wait for view wallet to discover UTXOs via chain scan
+    When I wait for wallet VIEW_WALLET to have at least 1002000 uT
+    # Step 1: View-only wallet prepares transaction for offline signing via gRPC
+    When I prepare an offline one-sided transaction of 100000 uT from wallet VIEW_WALLET to wallet WALLET_RECEIVER at fee 20
+    # Step 2: Sign the prepared transaction using the standalone offline signer
+    Then I sign the prepared transaction using standalone offline signer OFFLINE_SIGNER
+    # Step 3: Broadcast the signed transaction back via the view-only wallet
+    When I broadcast the signed transaction via wallet VIEW_WALLET
+    # Mine blocks to confirm
+    When mining node MINER mines 5 blocks
+    Then all nodes are at height 9
+    # Step 4: Verify receiving wallet has confirmed funds
+    When I wait for wallet WALLET_RECEIVER to have at least 100000 uT

--- a/integration_tests/tests/steps/offline_signing_steps.rs
+++ b/integration_tests/tests/steps/offline_signing_steps.rs
@@ -20,17 +20,30 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+use std::{ffi::OsString, time::Duration};
 
 use cucumber::{then, when};
 use grpc::{PaymentRecipient, payment_recipient::PaymentType};
 use minotari_app_grpc::tari_rpc as grpc;
 use minotari_console_wallet::{CliCommands, SignOneSidedTransactionArgs};
+use minotari_offline_signer::cli::execute_from_args as execute_offline_signer_from_args;
 use tari_integration_tests::{
     TariWorld,
     wallet_process::{create_wallet_client, get_default_cli, spawn_wallet},
 };
 use tari_transaction_components::transaction_components::memo_field::{MemoField, TxType};
+
+use crate::steps::get_saved_seed_words;
+
+const OFFLINE_SIGNER_TEST_PASSPHRASE: &str = "test";
+
+fn os_args<I, T>(args: I) -> Vec<OsString>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
+    args.into_iter().map(Into::into).collect()
+}
 
 #[when(
     expr = "I prepare an offline one-sided transaction of {int} uT from wallet {word} to wallet {word} at fee {int}"
@@ -146,6 +159,82 @@ async fn sign_prepared_transaction_using_wallet(world: &mut TariWorld, wallet_na
     assert!(!signed_json.is_empty(), "Signed transaction file is empty");
 
     println!("Transaction signed via wallet CLI: {} bytes of JSON", signed_json.len());
+    world.offline_signing_signed = Some(signed_json);
+}
+
+#[then(expr = "I initialize standalone offline signer {word} from wallet {word} seed words")]
+async fn initialize_standalone_offline_signer(world: &mut TariWorld, signer_name: String, wallet_name: String) {
+    let seed_words = get_saved_seed_words(world, &wallet_name).join(" ");
+    let signer_dir = world
+        .current_base_dir
+        .as_ref()
+        .expect("Base dir on world")
+        .join("offline_signers")
+        .join(&signer_name);
+    std::fs::create_dir_all(&signer_dir)
+        .unwrap_or_else(|e| panic!("Failed to create offline signer dir {signer_dir:?}: {e}"));
+    let keystore_file = signer_dir.join("keystore.json");
+    drop(std::fs::remove_file(&keystore_file));
+
+    execute_offline_signer_from_args(os_args([
+        OsString::from("minotari_offline_signer"),
+        OsString::from("--test-keystore-file"),
+        keystore_file.as_os_str().to_os_string(),
+        OsString::from("init"),
+        OsString::from("seed-words"),
+        OsString::from("--seed-words"),
+        OsString::from(seed_words),
+        OsString::from("--passphrase"),
+        OsString::from(OFFLINE_SIGNER_TEST_PASSPHRASE),
+    ]))
+    .unwrap_or_else(|e| panic!("Failed to initialize standalone offline signer: {e}"));
+
+    world.offline_signer_keystores.insert(signer_name, keystore_file);
+}
+
+#[then(expr = "I sign the prepared transaction using standalone offline signer {word}")]
+async fn sign_prepared_transaction_using_standalone_offline_signer(world: &mut TariWorld, signer_name: String) {
+    let prepared_json = world
+        .offline_signing_prepared
+        .as_ref()
+        .expect("No prepared transaction found — run the prepare step first")
+        .clone();
+    let keystore_file = world
+        .offline_signer_keystores
+        .get(&signer_name)
+        .unwrap_or_else(|| panic!("Standalone offline signer '{signer_name}' not initialized"));
+    let signer_dir = keystore_file
+        .parent()
+        .unwrap_or_else(|| panic!("Keystore file {keystore_file:?} has no parent directory"));
+    let input_file = signer_dir.join("offline_signing_input.json");
+    let output_file = signer_dir.join("offline_signing_output.json");
+    drop(std::fs::remove_file(&output_file));
+    std::fs::write(&input_file, prepared_json).expect("Failed to write prepared transaction file");
+
+    execute_offline_signer_from_args(os_args([
+        OsString::from("minotari_offline_signer"),
+        OsString::from("--test-keystore-file"),
+        keystore_file.as_os_str().to_os_string(),
+        OsString::from("sign"),
+        OsString::from("--input-file"),
+        input_file.as_os_str().to_os_string(),
+        OsString::from("--output-file"),
+        output_file.as_os_str().to_os_string(),
+        OsString::from("--passphrase"),
+        OsString::from(OFFLINE_SIGNER_TEST_PASSPHRASE),
+        OsString::from("--network"),
+        OsString::from("localnet"),
+    ]))
+    .unwrap_or_else(|e| panic!("Failed to sign transaction with standalone offline signer: {e}"));
+
+    let signed_json =
+        std::fs::read_to_string(&output_file).unwrap_or_else(|e| panic!("Failed to read signed transaction file: {e}"));
+    assert!(!signed_json.is_empty(), "Signed transaction file is empty");
+
+    println!(
+        "Transaction signed via standalone offline signer: {} bytes of JSON",
+        signed_json.len()
+    );
     world.offline_signing_signed = Some(signed_json);
 }
 


### PR DESCRIPTION
Description
---
Adds standalone `minotari_offline_signer` coverage to the offline one-sided transaction cucumber feature.

This introduces a library entrypoint for the offline signer CLI and a `test-keystore` feature with a hidden file-backed keystore option so cucumber can exercise signer init/sign flows deterministically without relying on OS keyring services in CI.

Motivation and Context
---
Closes #7785.

The existing offline signing cucumber scenario signs through the console wallet CLI. This adds a separate scenario that:
- initializes the standalone offline signer from the sender wallet seed words
- prepares a transaction from a view-only wallet
- signs the prepared transaction with the standalone signer
- broadcasts via the view wallet and verifies receiver funds

How Has This Been Tested?
---
- `cargo check --locked --ignore-rust-version -p minotari_offline_signer --all-features`
- `PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" cargo check --locked --ignore-rust-version -p tari_integration_tests --test cucumber`
- `PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" cargo test --locked --ignore-rust-version -p tari_integration_tests --test cucumber --no-run`
- `../target/debug/deps/cucumber-8e26c7f49d7fa52a --tags @standalone-offline-signer --concurrency 1 --fail-fast` from `integration_tests/` passed: 1 scenario, 17 steps.

What process can a PR reviewer use to test or verify this change?
---
From the workspace root:

```bash
cargo check --locked --ignore-rust-version -p minotari_offline_signer --all-features
cargo check --locked --ignore-rust-version -p tari_integration_tests --test cucumber
cargo test --locked --ignore-rust-version -p tari_integration_tests --test cucumber --no-run
```

Then run the standalone scenario from `integration_tests/`:

```bash
../target/debug/deps/cucumber-<hash> --tags @standalone-offline-signer --concurrency 1 --fail-fast
```

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
