### PR TITLE
feat: unified cross-platform Minotari Ledger installer with auto-detection

### DIFF
--- a/applications/minotari_ledger_wallet/wallet/install_scripts/README.md
+++ b/applications/minotari_ledger_wallet/wallet/install_scripts/README.md
@@ -4,13 +4,14 @@ A single cross-platform installer that automatically detects your connected Ledg
 
 ## Supported Ledger Models
 
-| Model | Detected via |
-|---|---|
-| Nano S | USB HID (PID 0x0001 / 0x1000) |
-| Nano S Plus | USB HID (PID 0x0004 / 0x4000) |
-| Nano X | USB HID (PID 0x0005 / 0x5000) |
-| Stax | USB HID (PID 0x0006 / 0x6000) |
-| Flex | USB HID (PID 0x0007 / 0x7000) |
+> Minotari does not ship an app for the original Nano S, only the Nano S Plus. The original Nano S is intentionally **not** detected by this installer.
+
+| Model | Slug | Detected via |
+|---|---|---|
+| Nano S Plus | `nanos+` | USB HID (PID 0x0004 / 0x4000) |
+| Nano X | `nanox` | USB HID (PID 0x0005 / 0x5000) |
+| Stax | `stax` | USB HID (PID 0x0006 / 0x6000) |
+| Flex | `flex` | USB HID (PID 0x0007 / 0x7000) |
 
 ## Requirements
 
@@ -40,11 +41,11 @@ python3 install_minotari_ledger.py
 
 ## What it does
 
-1. Installs Python dependencies (`ledgerctl`, `hid`, etc.) into an isolated virtual environment
-2. Detects the connected Ledger model via USB HID (with `ledgerctl info` as fallback)
-3. Fetches the latest Minotari release from GitHub
-4. Downloads and extracts the correct firmware zip for your model
-5. Installs the app onto the Ledger via `ledgerctl install`
+1. Installs Python dependencies (`ledgerwallet`, `protobuf`, `ecdsa`) into an isolated virtual environment. `hidapi` is pulled in transitively by `ledgerwallet`.
+2. Detects the connected Ledger model via USB HID (with `python -m ledgerwallet info` as fallback).
+3. Fetches the latest Minotari release from GitHub.
+4. Downloads and extracts the correct firmware zip for your model.
+5. Installs the app onto the Ledger via `python -m ledgerwallet install`.
 
 ## Troubleshooting
 

--- a/applications/minotari_ledger_wallet/wallet/install_scripts/README.md
+++ b/applications/minotari_ledger_wallet/wallet/install_scripts/README.md
@@ -1,0 +1,61 @@
+# Minotari Ledger Wallet — Unified Installer
+
+A single cross-platform installer that automatically detects your connected Ledger hardware wallet model and installs the correct Minotari app — no manual model selection needed.
+
+## Supported Ledger Models
+
+| Model | Detected via |
+|---|---|
+| Nano S | USB HID (PID 0x0001 / 0x1000) |
+| Nano S Plus | USB HID (PID 0x0004 / 0x4000) |
+| Nano X | USB HID (PID 0x0005 / 0x5000) |
+| Stax | USB HID (PID 0x0006 / 0x6000) |
+| Flex | USB HID (PID 0x0007 / 0x7000) |
+
+## Requirements
+
+- Python 3.8 or later
+- Ledger device connected via USB, unlocked, with **Developer Mode** enabled
+
+## Usage
+
+### macOS / Linux
+
+```bash
+chmod +x install_minotari_ledger.sh
+./install_minotari_ledger.sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+.\install_minotari_ledger.ps1
+```
+
+### Direct Python (any platform)
+
+```bash
+python3 install_minotari_ledger.py
+```
+
+## What it does
+
+1. Installs Python dependencies (`ledgerctl`, `hid`, etc.) into an isolated virtual environment
+2. Detects the connected Ledger model via USB HID (with `ledgerctl info` as fallback)
+3. Fetches the latest Minotari release from GitHub
+4. Downloads and extracts the correct firmware zip for your model
+5. Installs the app onto the Ledger via `ledgerctl install`
+
+## Troubleshooting
+
+**No device detected:**
+- Make sure the Ledger is connected via USB (not Bluetooth)
+- Enter your PIN to unlock the device
+- Enable Developer Mode: Settings → Security → Developer Mode
+
+**`ledgerctl` errors on Linux (permission denied on USB):**
+```bash
+wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
+```
+
+**macOS: run without `sudo`** — macOS grants HID access to the current user session automatically.

--- a/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.ps1
+++ b/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.ps1
@@ -1,0 +1,62 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    install_minotari_ledger.ps1 — Windows launcher for the Minotari Ledger installer.
+
+.DESCRIPTION
+    Checks Python, creates a virtual environment, and runs the unified
+    install_minotari_ledger.py which auto-detects your Ledger model.
+
+.EXAMPLE
+    .\install_minotari_ledger.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "\U0001f680 Minotari Ledger Wallet — Windows Launcher" -ForegroundColor Cyan
+Write-Host ""
+
+# Check Python
+$Python = $null
+foreach ($candidate in @("python", "python3")) {
+    try {
+        $ver = & $candidate --version 2>&1
+        if ($ver -match "Python 3") {
+            $Python = $candidate
+            Write-Host "   Found $ver" -ForegroundColor Green
+            break
+        }
+    } catch {}
+}
+
+if (-not $Python) {
+    Write-Error "Python 3 is required but not found on PATH. Install from https://python.org"
+    exit 1
+}
+
+# Create / reuse venv
+$VenvDir = "$env:USERPROFILE\.minotari-ledger-installer"
+
+if (-not (Test-Path $VenvDir)) {
+    Write-Host "\U0001f40d Creating Python virtual environment at $VenvDir..." -ForegroundColor Yellow
+    & $Python -m venv $VenvDir
+}
+
+$ActivateScript = "$VenvDir\Scripts\Activate.ps1"
+if (-not (Test-Path $ActivateScript)) {
+    Write-Error "Could not find venv activation script at $ActivateScript"
+    exit 1
+}
+
+. $ActivateScript
+
+# Run installer
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$InstallerScript = Join-Path $ScriptDir "install_minotari_ledger.py"
+
+if (-not (Test-Path $InstallerScript)) {
+    Write-Error "Installer script not found: $InstallerScript"
+    exit 1
+}
+
+& python $InstallerScript @args

--- a/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.py
+++ b/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.py
@@ -2,8 +2,11 @@
 """
 Unified Minotari Ledger Wallet Installer
 
-Automatically detects the connected Ledger model (Nano S, Nano S Plus, Nano X,
-Stax, Flex) and installs the correct Minotari app firmware — no user input needed.
+Automatically detects the connected Ledger model (Nano S Plus, Nano X, Stax,
+Flex) and installs the correct Minotari app firmware — no user input needed.
+
+The original Nano S is **not** supported by Minotari and is intentionally
+omitted here.
 
 Supports: macOS, Windows, Linux
 Requires: Python 3.8+, pip
@@ -15,7 +18,6 @@ import subprocess
 import platform
 import json
 import tempfile
-import shutil
 import urllib.request
 import urllib.error
 import zipfile
@@ -27,15 +29,16 @@ import zipfile
 # All Ledger devices share vendor ID 0x2c97
 LEDGER_VENDOR_ID = 0x2C97
 
+# Slugs match the asset names in `ledger_app.toml` and the published release
+# bundles (`minotari_ledger_wallet-<slug>...zip`, `app_<slug>.json`). In
+# particular Nano S Plus is `nanos+`, NOT `nanosplus`.
+#
 # Some firmware versions expose different product IDs per transport;
 # we keep a broader map covering all known values.
 LEDGER_PRODUCT_IDS: dict = {
-    # Nano S
-    0x0001: "nanos",
-    0x1000: "nanos",
     # Nano S Plus
-    0x0004: "nanosplus",
-    0x4000: "nanosplus",
+    0x0004: "nanos+",
+    0x4000: "nanos+",
     # Nano X
     0x0005: "nanox",
     0x4005: "nanox",
@@ -83,7 +86,12 @@ def run(cmd, **kwargs):
 
 def ensure_dependencies():
     print("\n\U0001f4e6 Installing Python dependencies...")
-    packages = ["hid", "protobuf", "setuptools", "ecdsa", "ledgerwallet", "ledgerctl"]
+    # NOTE: ``ledgerctl`` is *not* a standalone PyPI package — the
+    # ``ledgerctl`` command is provided by ``ledgerwallet``. Likewise
+    # ``hid`` is pulled in transitively (as ``hidapi``) by ``ledgerwallet``,
+    # so we don't request it directly: doing so used to install a
+    # different, unrelated ``hid`` package and break import order.
+    packages = ["ledgerwallet", "protobuf", "ecdsa"]
     run([sys.executable, "-m", "pip", "install", "--upgrade", "pip"], capture_output=True)
     run([sys.executable, "-m", "pip", "install"] + packages)
     success("Dependencies installed")
@@ -113,22 +121,35 @@ def detect_ledger_model():
     except Exception as exc:
         warn(f"hid enumeration failed ({exc}) — falling back to ledgerctl.")
 
-    # Fallback: ask ledgerctl for device info
+    # Fallback: ask ledgerctl (via ledgerwallet) for device info.
+    #
+    # Match against full model names rather than slug substrings \u2014 the raw
+    # output is something like "Connected to Ledger Nano S Plus", and a
+    # naive substring check on "nanos" would mis-classify a Nano S Plus
+    # as a Nano S. Order doesn't matter once we use full names.
+    detection_map = {
+        "nano s plus": "nanos+",
+        "nano x": "nanox",
+        "flex": "flex",
+        "stax": "stax",
+    }
     try:
         result = subprocess.run(
-            ["ledgerctl", "info"],
+            [sys.executable, "-m", "ledgerwallet", "info"],
             capture_output=True, text=True, timeout=10
         )
-        output = result.stdout + result.stderr
-        for slug in ["flex", "stax", "nanosplus", "nanox", "nanos"]:
-            if slug in output.lower():
-                success(f"Detected Ledger {slug} via ledgerctl")
+        output = (result.stdout + result.stderr).lower()
+        for pattern, slug in detection_map.items():
+            if pattern in output:
+                success(f"Detected Ledger {pattern} via ledgerctl (slug={slug})")
                 return slug
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 
     raise RuntimeError(
-        "No Ledger device detected.\n"
+        "No supported Ledger device detected.\n"
+        "Minotari supports Nano S Plus, Nano X, Stax, and Flex (the original "
+        "Nano S is not supported).\n"
         "Make sure the device is:\n"
         "  \u2022 Connected via USB\n"
         "  \u2022 Unlocked (PIN entered)\n"
@@ -233,7 +254,13 @@ def install_app(app_json):
     print("   \u2022 Ledger is connected via USB")
     print("   \u2022 Device is unlocked")
     print("   \u2022 Developer Mode is enabled\n")
-    run(["ledgerctl", "install", app_json])
+    # Use ``sys.executable -m ledgerwallet`` rather than a bare
+    # ``ledgerctl`` invocation: the latter relies on the active venv's
+    # console-scripts being on PATH, which is unreliable when this script
+    # is run from a non-interactive subprocess (CI, double-click launcher,
+    # etc.). Going through the interpreter pins the same Python install
+    # we used for ``ensure_dependencies``.
+    run([sys.executable, "-m", "ledgerwallet", "install", app_json])
 
 
 # ---------------------------------------------------------------------------
@@ -263,17 +290,19 @@ def main():
         error(str(exc))
         sys.exit(1)
 
-    # Download + extract into a temp dir
-    tmp_dir = tempfile.mkdtemp(prefix="minotari_ledger_")
-    try:
-        download_and_extract(url, filename, tmp_dir)
-        app_json = find_app_json(model, tmp_dir)
-        install_app(app_json)
-    except RuntimeError as exc:
-        error(str(exc))
-        sys.exit(1)
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
+    # Download + extract into a temp dir. Using ``TemporaryDirectory`` as a
+    # context manager guarantees cleanup even if the script is interrupted
+    # or an unexpected (non-RuntimeError) exception bubbles up — the manual
+    # mkdtemp / shutil.rmtree pair previously leaked the directory in those
+    # cases.
+    with tempfile.TemporaryDirectory(prefix="minotari_ledger_") as tmp_dir:
+        try:
+            download_and_extract(url, filename, tmp_dir)
+            app_json = find_app_json(model, tmp_dir)
+            install_app(app_json)
+        except RuntimeError as exc:
+            error(str(exc))
+            sys.exit(1)
 
     print()
     success("Minotari Ledger Wallet installed successfully!")

--- a/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.py
+++ b/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.py
@@ -204,12 +204,24 @@ def download_and_extract(url, filename, dest_dir):
     zip_path = os.path.join(dest_dir, filename)
     print(f"\n\u2b07\ufe0f  Downloading {filename}...")
 
-    def progress(count, block_size, total_size):
-        if total_size > 0:
-            pct = min(100, count * block_size * 100 // total_size)
-            print(f"\r   {pct}%", end="", flush=True)
-
-    urllib.request.urlretrieve(url, zip_path, reporthook=progress)
+    # ``urlopen`` is the supported modern API; ``urlretrieve`` is in the
+    # legacy interface section of the urllib.request docs and is
+    # discouraged. Stream the response body to disk in chunks so we
+    # can also render a percentage indicator without pulling the whole
+    # archive into memory.
+    chunk_size = 64 * 1024
+    with urllib.request.urlopen(url) as response, open(zip_path, "wb") as out:
+        total = int(response.headers.get("Content-Length") or 0)
+        downloaded = 0
+        while True:
+            chunk = response.read(chunk_size)
+            if not chunk:
+                break
+            out.write(chunk)
+            downloaded += len(chunk)
+            if total > 0:
+                pct = min(100, downloaded * 100 // total)
+                print(f"\r   {pct}%", end="", flush=True)
     print()  # newline after progress
 
     print(f"\U0001f4e6 Extracting {filename}...")

--- a/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.py
+++ b/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Unified Minotari Ledger Wallet Installer
+
+Automatically detects the connected Ledger model (Nano S, Nano S Plus, Nano X,
+Stax, Flex) and installs the correct Minotari app firmware — no user input needed.
+
+Supports: macOS, Windows, Linux
+Requires: Python 3.8+, pip
+"""
+
+import sys
+import os
+import subprocess
+import platform
+import json
+import tempfile
+import shutil
+import urllib.request
+import urllib.error
+import zipfile
+
+# ---------------------------------------------------------------------------
+# Ledger USB identifiers
+# ---------------------------------------------------------------------------
+
+# All Ledger devices share vendor ID 0x2c97
+LEDGER_VENDOR_ID = 0x2C97
+
+# Some firmware versions expose different product IDs per transport;
+# we keep a broader map covering all known values.
+LEDGER_PRODUCT_IDS: dict = {
+    # Nano S
+    0x0001: "nanos",
+    0x1000: "nanos",
+    # Nano S Plus
+    0x0004: "nanosplus",
+    0x4000: "nanosplus",
+    # Nano X
+    0x0005: "nanox",
+    0x4005: "nanox",
+    0x5000: "nanox",
+    # Stax
+    0x0006: "stax",
+    0x6000: "stax",
+    # Flex
+    0x0007: "flex",
+    0x7000: "flex",
+}
+
+GITHUB_RELEASES_URL = (
+    "https://api.github.com/repos/tari-project/tari/releases/latest"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def info(msg):
+    print(f"  {msg}")
+
+
+def success(msg):
+    print(f"\u2705 {msg}")
+
+
+def error(msg):
+    print(f"\u274c {msg}", file=sys.stderr)
+
+
+def warn(msg):
+    print(f"\u26a0\ufe0f  {msg}")
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, check=True, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Step 1 – install Python dependencies
+# ---------------------------------------------------------------------------
+
+def ensure_dependencies():
+    print("\n\U0001f4e6 Installing Python dependencies...")
+    packages = ["hid", "protobuf", "setuptools", "ecdsa", "ledgerwallet", "ledgerctl"]
+    run([sys.executable, "-m", "pip", "install", "--upgrade", "pip"], capture_output=True)
+    run([sys.executable, "-m", "pip", "install"] + packages)
+    success("Dependencies installed")
+
+
+# ---------------------------------------------------------------------------
+# Step 2 – detect Ledger model
+# ---------------------------------------------------------------------------
+
+def detect_ledger_model():
+    """Return the model slug (e.g. 'flex') or raise RuntimeError."""
+
+    print("\n\U0001f50d Detecting connected Ledger device...")
+
+    # Try hid library first (most reliable cross-platform)
+    try:
+        import hid  # type: ignore
+        devices = hid.enumerate(LEDGER_VENDOR_ID, 0)
+        for dev in devices:
+            pid = dev.get("product_id", 0)
+            model = LEDGER_PRODUCT_IDS.get(pid)
+            if model:
+                success(f"Detected Ledger {model.title()} (PID=0x{pid:04x})")
+                return model
+    except ImportError:
+        warn("hid module not installed — falling back to ledgerctl detection.")
+    except Exception as exc:
+        warn(f"hid enumeration failed ({exc}) — falling back to ledgerctl.")
+
+    # Fallback: ask ledgerctl for device info
+    try:
+        result = subprocess.run(
+            ["ledgerctl", "info"],
+            capture_output=True, text=True, timeout=10
+        )
+        output = result.stdout + result.stderr
+        for slug in ["flex", "stax", "nanosplus", "nanox", "nanos"]:
+            if slug in output.lower():
+                success(f"Detected Ledger {slug} via ledgerctl")
+                return slug
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    raise RuntimeError(
+        "No Ledger device detected.\n"
+        "Make sure the device is:\n"
+        "  \u2022 Connected via USB\n"
+        "  \u2022 Unlocked (PIN entered)\n"
+        "  \u2022 Developer Mode enabled (Settings \u2192 Developer Mode)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 3 – fetch latest release asset URL
+# ---------------------------------------------------------------------------
+
+def fetch_asset_url(model):
+    """Return (download_url, filename) for the given model."""
+
+    print(f"\n\U0001f310 Fetching latest Minotari Ledger release for '{model}'...")
+
+    try:
+        req = urllib.request.Request(
+            GITHUB_RELEASES_URL,
+            headers={"User-Agent": "minotari-ledger-installer/1.0"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            release = json.loads(resp.read())
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Failed to fetch release info: {exc}") from exc
+
+    pattern = f"minotari_ledger_wallet-{model}"
+    candidates = [
+        a for a in release.get("assets", [])
+        if pattern in a["name"].lower() and a["name"].endswith(".zip")
+    ]
+
+    if not candidates:
+        available = [a["name"] for a in release.get("assets", [])]
+        raise RuntimeError(
+            f"No release asset found for model '{model}'.\n"
+            f"Available assets: {available}"
+        )
+
+    asset = candidates[0]
+    info(f"Found: {asset['name']}")
+    return asset["browser_download_url"], asset["name"]
+
+
+# ---------------------------------------------------------------------------
+# Step 4 – download + extract
+# ---------------------------------------------------------------------------
+
+def download_and_extract(url, filename, dest_dir):
+    """Download zip, extract, return path to extracted directory."""
+
+    zip_path = os.path.join(dest_dir, filename)
+    print(f"\n\u2b07\ufe0f  Downloading {filename}...")
+
+    def progress(count, block_size, total_size):
+        if total_size > 0:
+            pct = min(100, count * block_size * 100 // total_size)
+            print(f"\r   {pct}%", end="", flush=True)
+
+    urllib.request.urlretrieve(url, zip_path, reporthook=progress)
+    print()  # newline after progress
+
+    print(f"\U0001f4e6 Extracting {filename}...")
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(dest_dir)
+
+    success("Download and extraction complete")
+    return dest_dir
+
+
+# ---------------------------------------------------------------------------
+# Step 5 – find and install app JSON
+# ---------------------------------------------------------------------------
+
+def find_app_json(model, search_dir):
+    """Find the app_<model>.json manifest."""
+
+    candidates = []
+    for root, _dirs, files in os.walk(search_dir):
+        for fname in files:
+            if fname == f"app_{model}.json":
+                candidates.append(os.path.join(root, fname))
+
+    if not candidates:
+        # Fallback: any app*.json
+        for root, _dirs, files in os.walk(search_dir):
+            for fname in files:
+                if fname.startswith("app") and fname.endswith(".json"):
+                    candidates.append(os.path.join(root, fname))
+
+    if not candidates:
+        raise RuntimeError(
+            f"Could not find app_{model}.json after extraction in {search_dir}"
+        )
+
+    return candidates[0]
+
+
+def install_app(app_json):
+    print(f"\n\U0001f510 Installing app from: {app_json}")
+    print("\U0001f449 Make sure:")
+    print("   \u2022 Ledger is connected via USB")
+    print("   \u2022 Device is unlocked")
+    print("   \u2022 Developer Mode is enabled\n")
+    run(["ledgerctl", "install", app_json])
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("=" * 60)
+    print(" \U0001f680 Minotari Ledger Wallet \u2014 Unified Installer")
+    print(f"    Platform: {platform.system()} {platform.machine()}")
+    print("=" * 60)
+
+    # Install deps first so hid is available for detection
+    ensure_dependencies()
+
+    # Detect model
+    try:
+        model = detect_ledger_model()
+    except RuntimeError as exc:
+        error(str(exc))
+        sys.exit(1)
+
+    # Fetch asset
+    try:
+        url, filename = fetch_asset_url(model)
+    except RuntimeError as exc:
+        error(str(exc))
+        sys.exit(1)
+
+    # Download + extract into a temp dir
+    tmp_dir = tempfile.mkdtemp(prefix="minotari_ledger_")
+    try:
+        download_and_extract(url, filename, tmp_dir)
+        app_json = find_app_json(model, tmp_dir)
+        install_app(app_json)
+    except RuntimeError as exc:
+        error(str(exc))
+        sys.exit(1)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    print()
+    success("Minotari Ledger Wallet installed successfully!")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.sh
+++ b/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.sh
@@ -16,20 +16,35 @@ fi
 PYTHON_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 echo "   Found Python $PYTHON_VER"
 
-# macOS: install brew dependencies if needed
+# Detect missing system libraries and *advise* the user instead of running
+# `sudo apt-get install` blindly. Calling `sudo` from a launcher script is
+# disruptive (prompts for a password mid-flow, fails outright in
+# non-interactive contexts like CI) and `|| true` would mask real failures
+# that surface later as cryptic Python import errors.
+
+advise_install() {
+  echo
+  echo "  System library '$1' was not found."
+  echo "  Please install it before continuing, e.g.:"
+  echo "    $2"
+  echo
+}
+
 if [[ "$(uname)" == "Darwin" ]]; then
-  if command -v brew &>/dev/null; then
-    echo "\U0001f37a Installing system dependencies via Homebrew..."
-    brew install libusb 2>/dev/null || true
+  if ! pkg-config --exists libusb-1.0 2>/dev/null && ! [[ -f /opt/homebrew/lib/libusb-1.0.dylib ]] && ! [[ -f /usr/local/lib/libusb-1.0.dylib ]]; then
+    advise_install "libusb" "brew install libusb"
   fi
 fi
 
-# Linux: install libusb if missing
 if [[ "$(uname)" == "Linux" ]]; then
-  if command -v apt-get &>/dev/null; then
-    sudo apt-get install -y libhidapi-dev libusb-1.0-0-dev 2>/dev/null || true
-  elif command -v dnf &>/dev/null; then
-    sudo dnf install -y hidapi-devel libusb-devel 2>/dev/null || true
+  if ! pkg-config --exists libusb-1.0 2>/dev/null; then
+    if command -v apt-get &>/dev/null; then
+      advise_install "libusb / hidapi" "sudo apt-get install -y libhidapi-dev libusb-1.0-0-dev"
+    elif command -v dnf &>/dev/null; then
+      advise_install "libusb / hidapi" "sudo dnf install -y hidapi-devel libusb-devel"
+    else
+      advise_install "libusb / hidapi" "(use your distribution's package manager)"
+    fi
   fi
 fi
 

--- a/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.sh
+++ b/applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# install_minotari_ledger.sh — macOS/Linux launcher for the unified Minotari Ledger installer
+# Usage: chmod +x install_minotari_ledger.sh && ./install_minotari_ledger.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "\U0001f527 Checking Python..."
+
+if ! command -v python3 &>/dev/null; then
+  echo "\u274c Python 3 is required. Install it from https://python.org or via your package manager."
+  exit 1
+fi
+
+PYTHON_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+echo "   Found Python $PYTHON_VER"
+
+# macOS: install brew dependencies if needed
+if [[ "$(uname)" == "Darwin" ]]; then
+  if command -v brew &>/dev/null; then
+    echo "\U0001f37a Installing system dependencies via Homebrew..."
+    brew install libusb 2>/dev/null || true
+  fi
+fi
+
+# Linux: install libusb if missing
+if [[ "$(uname)" == "Linux" ]]; then
+  if command -v apt-get &>/dev/null; then
+    sudo apt-get install -y libhidapi-dev libusb-1.0-0-dev 2>/dev/null || true
+  elif command -v dnf &>/dev/null; then
+    sudo dnf install -y hidapi-devel libusb-devel 2>/dev/null || true
+  fi
+fi
+
+# Create venv if it doesn't exist
+VENV_DIR="$HOME/.minotari-ledger-installer"
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "\U0001f40d Creating Python virtual environment at $VENV_DIR..."
+  python3 -m venv "$VENV_DIR"
+fi
+
+# Activate and run
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+python3 "$SCRIPT_DIR/install_minotari_ledger.py" "$@"


### PR DESCRIPTION
Closes #7795

## What this does

Replaces the per-model/per-OS scripts with a single installer that works on **macOS, Windows, and Linux** and auto-detects which Ledger is connected — no user input needed.

## How to run

**macOS / Linux:**
```bash
chmod +x applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.sh
./applications/minotari_ledger_wallet/wallet/install_scripts/install_minotari_ledger.sh
```

**Windows (PowerShell):**
```powershell
.\applications\minotari_ledger_wallet\wallet\install_scripts\install_minotari_ledger.ps1
```

## How detection works

1. Enumerates USB HID devices filtered by Ledger's vendor ID (`0x2C97`)
2. Maps the product ID to a model slug (`flex`, `stax`, `nanosplus`, `nanox`, `nanos`)
3. Falls back to `ledgerctl info` output parsing if the `hid` library isn't available

All known PID variants per model are covered (including alternate transport PIDs like `0x5000` for Nano X).

## Error handling

- No device detected → clear message with checklist (USB connected, PIN entered, Developer Mode on)
- Release asset not found → lists available assets so the user can report it
- Reports clear success/failure status for each step

## Files changed

| File | Description |
|---|---|
| `install_scripts/install_minotari_ledger.py` | Core installer (Python 3.8+, stdlib only + pip deps) |
| `install_scripts/install_minotari_ledger.sh` | macOS/Linux launcher (creates isolated venv, handles libusb) |
| `install_scripts/install_minotari_ledger.ps1` | Windows launcher (creates isolated venv) |
| `install_scripts/README.md` | Usage docs + troubleshooting |

The existing per-model scripts are untouched — this adds the unified option alongside them.