### PR TITLE
Improve HTTP transaction rejection feedback

### DIFF
--- a/applications/minotari_node/src/http/handler/json_rpc/mod.rs
+++ b/applications/minotari_node/src/http/handler/json_rpc/mod.rs
@@ -26,6 +26,7 @@ use axum::{Extension, Json, http::StatusCode};
 use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use tari_core::{base_node::rpc::query_service, chain_storage::BlockchainBackend, mempool::service::MempoolHandle};
+use tari_transaction_components::rpc::models::{TxSubmissionResponse, TxSubmissionResponseV1};
 
 use crate::http::handler::ErrorResponse;
 
@@ -50,9 +51,15 @@ pub async fn handle<B: BlockchainBackend + 'static>(
             })?;
             let transaction = serde_json::from_value(tx.clone())
                 .map_err(|e| (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(e.to_string()))))?;
+            let version = request
+                .params
+                .get("version")
+                .and_then(serde_json::Value::as_u64)
+                .map(|version| if version == 0 { 0 } else { 1 })
+                .unwrap_or_default();
             match submit_transaction::handle(query_service.clone(), &mut (mempool_service.clone()), transaction).await {
                 Ok(response) => Ok(Json(JsonRpcResponse {
-                    result: serde_json::to_value(response).unwrap_or_else(|e| {
+                    result: submit_transaction_response_value(response, version).unwrap_or_else(|e| {
                         warn!(target: LOG_TARGET, "Failed to serialize response: {e}");
                         serde_json::Value::Null
                     }),
@@ -77,6 +84,16 @@ pub async fn handle<B: BlockchainBackend + 'static>(
     }
 }
 
+fn submit_transaction_response_value(
+    response: TxSubmissionResponseV1,
+    version: u8,
+) -> Result<serde_json::Value, serde_json::Error> {
+    match version {
+        0 => serde_json::to_value(TxSubmissionResponse::from(response)),
+        _ => serde_json::to_value(response),
+    }
+}
+
 #[derive(Deserialize, Debug, Serialize)]
 pub struct JsonRpcRequest {
     pub jsonrpc: String,
@@ -91,4 +108,33 @@ pub struct JsonRpcResponse {
     pub result: serde_json::Value,
     pub error: Option<String>,
     pub id: String,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tari_transaction_components::rpc::models::TxSubmissionRejectionReason;
+
+    fn response_with_details() -> TxSubmissionResponseV1 {
+        TxSubmissionResponseV1 {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::ValidationFailed,
+            rejection_reason_details: Some("specific validation error".to_string()),
+            is_synced: true,
+        }
+    }
+
+    #[test]
+    fn submit_transaction_response_version_zero_omits_details() {
+        let value = submit_transaction_response_value(response_with_details(), 0).unwrap();
+
+        assert!(value.get("rejection_reason_details").is_none());
+    }
+
+    #[test]
+    fn submit_transaction_response_version_one_includes_details() {
+        let value = submit_transaction_response_value(response_with_details(), 1).unwrap();
+
+        assert_eq!(value["rejection_reason_details"], "specific validation error");
+    }
 }

--- a/applications/minotari_node/src/http/handler/json_rpc/submit_transaction.rs
+++ b/applications/minotari_node/src/http/handler/json_rpc/submit_transaction.rs
@@ -26,10 +26,10 @@ use log::{debug, error};
 use tari_core::{
     base_node::rpc::{BaseNodeWalletQueryService, query_service},
     chain_storage::BlockchainBackend,
-    mempool::{TxStorageResponse, service::MempoolHandle},
+    mempool::{TxStorageResponse, TxStorageResponseWithDetails, service::MempoolHandle},
 };
 use tari_transaction_components::{
-    rpc::models::{Signature, TxLocation, TxSubmissionRejectionReason, TxSubmissionResponse},
+    rpc::models::{Signature, TxLocation, TxSubmissionRejectionReason, TxSubmissionResponseV1},
     transaction_components::Transaction,
 };
 use tari_utilities::ByteArray;
@@ -40,7 +40,7 @@ pub async fn handle<T: BlockchainBackend + 'static>(
     query_service: Arc<query_service::Service<T>>,
     mempool_service: &mut MempoolHandle,
     transaction: Transaction,
-) -> Result<TxSubmissionResponse, anyhow::Error> {
+) -> Result<TxSubmissionResponseV1, anyhow::Error> {
     let transaction_signature = transaction.first_kernel_excess_sig().map(|excess_sig| Signature {
         public_nonce: excess_sig.get_compressed_public_nonce().as_bytes().to_vec(),
         signature: excess_sig.get_signature().as_bytes().to_vec(),
@@ -54,10 +54,15 @@ pub async fn handle<T: BlockchainBackend + 'static>(
             anyhow::anyhow!("Failed to get tip info: {e}")
         })?
         .is_synced;
-    let res = match mempool_service.submit_transaction(transaction).await {
+    let res = match mempool_service.submit_transaction_with_details(transaction).await {
         Ok(response) => {
             debug!(target: LOG_TARGET, "Transaction submitted successfully: {response:?}");
-            match response {
+            let TxStorageResponseWithDetails {
+                response: tx_storage_response,
+                rejection_reason,
+            } = response;
+
+            match tx_storage_response {
                 TxStorageResponse::UnconfirmedPool => {
                     submission_response(true, TxSubmissionRejectionReason::None, is_synced, None)
                 },
@@ -66,37 +71,52 @@ pub async fn handle<T: BlockchainBackend + 'static>(
                     false,
                     TxSubmissionRejectionReason::Orphan,
                     is_synced,
-                    Some("Transaction refers to inputs that are not available to this node."),
+                    rejection_reason.as_deref().or(Some(
+                        "Transaction refers to inputs that are not available to this node.",
+                    )),
                 ),
                 TxStorageResponse::NotStoredFeeTooLow => submission_response(
                     false,
                     TxSubmissionRejectionReason::FeeTooLow,
                     is_synced,
-                    Some("Transaction fee is below the minimum fee per gram accepted by this mempool."),
+                    rejection_reason.as_deref().or(Some(
+                        "Transaction fee is below the minimum fee per gram accepted by this mempool.",
+                    )),
                 ),
                 TxStorageResponse::NotStoredTimeLocked => submission_response(
                     false,
                     TxSubmissionRejectionReason::TimeLocked,
                     is_synced,
-                    Some("Transaction is timelocked and cannot be accepted at the current chain height."),
+                    rejection_reason.as_deref().or(Some(
+                        "Transaction is timelocked and cannot be accepted at the current chain height.",
+                    )),
                 ),
                 TxStorageResponse::NotStoredConsensus => submission_response(
                     false,
                     TxSubmissionRejectionReason::ValidationFailed,
                     is_synced,
-                    Some("Transaction failed consensus validation rules."),
+                    rejection_reason
+                        .as_deref()
+                        .or(Some("Transaction failed consensus validation rules.")),
                 ),
                 TxStorageResponse::NotStored => submission_response(
                     false,
                     TxSubmissionRejectionReason::ValidationFailed,
                     is_synced,
-                    Some("Transaction was not stored by the mempool."),
+                    rejection_reason
+                        .as_deref()
+                        .or(Some("Transaction was not stored by the mempool.")),
                 ),
                 response @ (TxStorageResponse::NotStoredAlreadySpent
                 | TxStorageResponse::ReorgPool
                 | TxStorageResponse::NotStoredAlreadyMined) => {
-                    already_spent_or_mined_response(query_service.as_ref(), transaction_signature, is_synced, response)
-                        .await
+                    already_spent_or_mined_response(
+                        query_service.as_ref(),
+                        transaction_signature,
+                        is_synced,
+                        TxStorageResponseWithDetails::new(response, rejection_reason.clone()),
+                    )
+                    .await
                 },
             }
         },
@@ -112,8 +132,8 @@ fn submission_response(
     rejection_reason: TxSubmissionRejectionReason,
     is_synced: bool,
     rejection_reason_details: Option<&str>,
-) -> TxSubmissionResponse {
-    TxSubmissionResponse {
+) -> TxSubmissionResponseV1 {
+    TxSubmissionResponseV1 {
         accepted,
         rejection_reason,
         rejection_reason_details: rejection_reason_details.map(ToString::to_string),
@@ -125,12 +145,13 @@ async fn already_spent_or_mined_response<T: BlockchainBackend + 'static>(
     query_service: &query_service::Service<T>,
     signature: Option<Signature>,
     is_synced: bool,
-    tx_storage_response: TxStorageResponse,
-) -> TxSubmissionResponse {
+    tx_storage_response: TxStorageResponseWithDetails,
+) -> TxSubmissionResponseV1 {
     let Some(signature) = signature else {
         return default_already_spent_or_mined_response(tx_storage_response, is_synced);
     };
 
+    let fallback_detail = tx_storage_response.rejection_reason.clone();
     let response = match query_service.transaction_query(signature).await {
         Ok(response) => response,
         Err(e) => {
@@ -144,45 +165,62 @@ async fn already_spent_or_mined_response<T: BlockchainBackend + 'static>(
             false,
             TxSubmissionRejectionReason::AlreadyMined,
             is_synced,
-            Some("Transaction kernel was found in the blockchain; this exact transaction has already been mined."),
+            fallback_detail.as_deref().or(Some(
+                "Transaction kernel was found in the blockchain; this exact transaction has already been mined.",
+            )),
         ),
         TxLocation::InMempool => submission_response(
             false,
             TxSubmissionRejectionReason::DoubleSpend,
             is_synced,
-            Some("Transaction conflicts with an existing transaction already in the mempool."),
+            fallback_detail.as_deref().or(Some(
+                "Transaction conflicts with an existing transaction already in the mempool.",
+            )),
         ),
         TxLocation::None | TxLocation::NotStored => submission_response(
             false,
             TxSubmissionRejectionReason::DoubleSpend,
             is_synced,
-            Some("Transaction spends an output that is already spent or conflicts with another transaction."),
+            fallback_detail.as_deref().or(Some(
+                "Transaction spends an output that is already spent or conflicts with another transaction.",
+            )),
         ),
     }
 }
 
 fn default_already_spent_or_mined_response(
-    tx_storage_response: TxStorageResponse,
+    tx_storage_response: TxStorageResponseWithDetails,
     is_synced: bool,
-) -> TxSubmissionResponse {
-    match tx_storage_response {
+) -> TxSubmissionResponseV1 {
+    let TxStorageResponseWithDetails {
+        response,
+        rejection_reason,
+    } = tx_storage_response;
+    let fallback_detail = rejection_reason.as_deref();
+    match response {
         TxStorageResponse::NotStoredAlreadySpent => submission_response(
             false,
             TxSubmissionRejectionReason::DoubleSpend,
             is_synced,
-            Some("Transaction spends an output that is already spent or conflicts with another transaction."),
+            fallback_detail.or(Some(
+                "Transaction spends an output that is already spent or conflicts with another transaction.",
+            )),
         ),
         TxStorageResponse::ReorgPool | TxStorageResponse::NotStoredAlreadyMined => submission_response(
             false,
             TxSubmissionRejectionReason::AlreadyMined,
             is_synced,
-            Some("Transaction was rejected because it was already mined or is currently in the reorg pool."),
+            fallback_detail.or(Some(
+                "Transaction was rejected because it was already mined or is currently in the reorg pool.",
+            )),
         ),
         _ => submission_response(
             false,
             TxSubmissionRejectionReason::AlreadyMined,
             is_synced,
-            Some("Transaction was rejected because its outputs were already spent or it was already mined."),
+            fallback_detail.or(Some(
+                "Transaction was rejected because its outputs were already spent or it was already mined.",
+            )),
         ),
     }
 }
@@ -219,15 +257,31 @@ mod test {
 
     #[test]
     fn default_already_spent_response_returns_double_spend() {
-        let response = default_already_spent_or_mined_response(TxStorageResponse::NotStoredAlreadySpent, true);
+        let response = default_already_spent_or_mined_response(TxStorageResponse::NotStoredAlreadySpent.into(), true);
 
         assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::DoubleSpend);
     }
 
     #[test]
     fn default_already_mined_response_returns_already_mined() {
-        let response = default_already_spent_or_mined_response(TxStorageResponse::NotStoredAlreadyMined, true);
+        let response = default_already_spent_or_mined_response(TxStorageResponse::NotStoredAlreadyMined.into(), true);
 
         assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::AlreadyMined);
+    }
+
+    #[test]
+    fn default_already_spent_response_uses_mempool_detail() {
+        let response = default_already_spent_or_mined_response(
+            TxStorageResponseWithDetails::new(
+                TxStorageResponse::NotStoredAlreadySpent,
+                Some("Transaction contains already spent input commitment abc with output hash def".to_string()),
+            ),
+            true,
+        );
+
+        assert_eq!(
+            response.rejection_reason_details.as_deref(),
+            Some("Transaction contains already spent input commitment abc with output hash def")
+        );
     }
 }

--- a/applications/minotari_node/src/http/handler/json_rpc/submit_transaction.rs
+++ b/applications/minotari_node/src/http/handler/json_rpc/submit_transaction.rs
@@ -29,9 +29,10 @@ use tari_core::{
     mempool::{TxStorageResponse, service::MempoolHandle},
 };
 use tari_transaction_components::{
-    rpc::models::{TxSubmissionRejectionReason, TxSubmissionResponse},
+    rpc::models::{Signature, TxLocation, TxSubmissionRejectionReason, TxSubmissionResponse},
     transaction_components::Transaction,
 };
+use tari_utilities::ByteArray;
 
 const LOG_TARGET: &str = "c::base_node::rpc::http::handler::json_rpc::submit_transaction";
 
@@ -40,6 +41,11 @@ pub async fn handle<T: BlockchainBackend + 'static>(
     mempool_service: &mut MempoolHandle,
     transaction: Transaction,
 ) -> Result<TxSubmissionResponse, anyhow::Error> {
+    let transaction_signature = transaction.first_kernel_excess_sig().map(|excess_sig| Signature {
+        public_nonce: excess_sig.get_compressed_public_nonce().as_bytes().to_vec(),
+        signature: excess_sig.get_signature().as_bytes().to_vec(),
+    });
+
     let is_synced = query_service
         .get_tip_info()
         .await
@@ -52,38 +58,45 @@ pub async fn handle<T: BlockchainBackend + 'static>(
         Ok(response) => {
             debug!(target: LOG_TARGET, "Transaction submitted successfully: {response:?}");
             match response {
-                TxStorageResponse::UnconfirmedPool => TxSubmissionResponse {
-                    accepted: true,
-                    rejection_reason: TxSubmissionRejectionReason::None,
-                    is_synced,
+                TxStorageResponse::UnconfirmedPool => {
+                    submission_response(true, TxSubmissionRejectionReason::None, is_synced, None)
                 },
 
-                TxStorageResponse::NotStoredOrphan => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::Orphan,
+                TxStorageResponse::NotStoredOrphan => submission_response(
+                    false,
+                    TxSubmissionRejectionReason::Orphan,
                     is_synced,
-                },
-                TxStorageResponse::NotStoredFeeTooLow => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::FeeTooLow,
+                    Some("Transaction refers to inputs that are not available to this node."),
+                ),
+                TxStorageResponse::NotStoredFeeTooLow => submission_response(
+                    false,
+                    TxSubmissionRejectionReason::FeeTooLow,
                     is_synced,
-                },
-                TxStorageResponse::NotStoredTimeLocked => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::TimeLocked,
+                    Some("Transaction fee is below the minimum fee per gram accepted by this mempool."),
+                ),
+                TxStorageResponse::NotStoredTimeLocked => submission_response(
+                    false,
+                    TxSubmissionRejectionReason::TimeLocked,
                     is_synced,
-                },
-                TxStorageResponse::NotStoredConsensus | TxStorageResponse::NotStored => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::ValidationFailed,
+                    Some("Transaction is timelocked and cannot be accepted at the current chain height."),
+                ),
+                TxStorageResponse::NotStoredConsensus => submission_response(
+                    false,
+                    TxSubmissionRejectionReason::ValidationFailed,
                     is_synced,
-                },
-                TxStorageResponse::NotStoredAlreadySpent |
-                TxStorageResponse::ReorgPool |
-                TxStorageResponse::NotStoredAlreadyMined => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::AlreadyMined,
+                    Some("Transaction failed consensus validation rules."),
+                ),
+                TxStorageResponse::NotStored => submission_response(
+                    false,
+                    TxSubmissionRejectionReason::ValidationFailed,
                     is_synced,
+                    Some("Transaction was not stored by the mempool."),
+                ),
+                response @ (TxStorageResponse::NotStoredAlreadySpent
+                | TxStorageResponse::ReorgPool
+                | TxStorageResponse::NotStoredAlreadyMined) => {
+                    already_spent_or_mined_response(query_service.as_ref(), transaction_signature, is_synced, response)
+                        .await
                 },
             }
         },
@@ -92,4 +105,129 @@ pub async fn handle<T: BlockchainBackend + 'static>(
         },
     };
     Ok(res)
+}
+
+fn submission_response(
+    accepted: bool,
+    rejection_reason: TxSubmissionRejectionReason,
+    is_synced: bool,
+    rejection_reason_details: Option<&str>,
+) -> TxSubmissionResponse {
+    TxSubmissionResponse {
+        accepted,
+        rejection_reason,
+        rejection_reason_details: rejection_reason_details.map(ToString::to_string),
+        is_synced,
+    }
+}
+
+async fn already_spent_or_mined_response<T: BlockchainBackend + 'static>(
+    query_service: &query_service::Service<T>,
+    signature: Option<Signature>,
+    is_synced: bool,
+    tx_storage_response: TxStorageResponse,
+) -> TxSubmissionResponse {
+    let Some(signature) = signature else {
+        return default_already_spent_or_mined_response(tx_storage_response, is_synced);
+    };
+
+    let response = match query_service.transaction_query(signature).await {
+        Ok(response) => response,
+        Err(e) => {
+            error!(target: LOG_TARGET, "Failed to query submitted transaction kernel: {e}");
+            return default_already_spent_or_mined_response(tx_storage_response, is_synced);
+        },
+    };
+
+    match response.location {
+        TxLocation::Mined => submission_response(
+            false,
+            TxSubmissionRejectionReason::AlreadyMined,
+            is_synced,
+            Some("Transaction kernel was found in the blockchain; this exact transaction has already been mined."),
+        ),
+        TxLocation::InMempool => submission_response(
+            false,
+            TxSubmissionRejectionReason::DoubleSpend,
+            is_synced,
+            Some("Transaction conflicts with an existing transaction already in the mempool."),
+        ),
+        TxLocation::None | TxLocation::NotStored => submission_response(
+            false,
+            TxSubmissionRejectionReason::DoubleSpend,
+            is_synced,
+            Some("Transaction spends an output that is already spent or conflicts with another transaction."),
+        ),
+    }
+}
+
+fn default_already_spent_or_mined_response(
+    tx_storage_response: TxStorageResponse,
+    is_synced: bool,
+) -> TxSubmissionResponse {
+    match tx_storage_response {
+        TxStorageResponse::NotStoredAlreadySpent => submission_response(
+            false,
+            TxSubmissionRejectionReason::DoubleSpend,
+            is_synced,
+            Some("Transaction spends an output that is already spent or conflicts with another transaction."),
+        ),
+        TxStorageResponse::ReorgPool | TxStorageResponse::NotStoredAlreadyMined => submission_response(
+            false,
+            TxSubmissionRejectionReason::AlreadyMined,
+            is_synced,
+            Some("Transaction was rejected because it was already mined or is currently in the reorg pool."),
+        ),
+        _ => submission_response(
+            false,
+            TxSubmissionRejectionReason::AlreadyMined,
+            is_synced,
+            Some("Transaction was rejected because its outputs were already spent or it was already mined."),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn submission_response_omits_details_for_accepted_transaction() {
+        let response = submission_response(true, TxSubmissionRejectionReason::None, true, None);
+
+        assert!(response.accepted);
+        assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::None);
+        assert!(response.rejection_reason_details.is_none());
+    }
+
+    #[test]
+    fn submission_response_includes_rejection_details() {
+        let response = submission_response(
+            false,
+            TxSubmissionRejectionReason::ValidationFailed,
+            true,
+            Some("Transaction failed consensus validation rules."),
+        );
+
+        assert!(!response.accepted);
+        assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::ValidationFailed);
+        assert_eq!(
+            response.rejection_reason_details.as_deref(),
+            Some("Transaction failed consensus validation rules.")
+        );
+    }
+
+    #[test]
+    fn default_already_spent_response_returns_double_spend() {
+        let response = default_already_spent_or_mined_response(TxStorageResponse::NotStoredAlreadySpent, true);
+
+        assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::DoubleSpend);
+    }
+
+    #[test]
+    fn default_already_mined_response_returns_already_mined() {
+        let response = default_already_spent_or_mined_response(TxStorageResponse::NotStoredAlreadyMined, true);
+
+        assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::AlreadyMined);
+    }
 }

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -31,12 +31,8 @@ use tokio::task;
 use crate::{
     consensus::BaseNodeConsensusManager,
     mempool::{
-        MempoolConfig,
-        StateResponse,
-        StatsResponse,
-        TxStorageResponse,
-        error::MempoolError,
-        mempool_storage::MempoolStorage,
+        MempoolConfig, StateResponse, StatsResponse, TxStorageResponse, TxStorageResponseWithDetails,
+        error::MempoolError, mempool_storage::MempoolStorage,
     },
     validation::TransactionValidator,
 };
@@ -65,9 +61,17 @@ impl Mempool {
 
     /// Insert an unconfirmed transaction into the Mempool.
     pub async fn insert(&self, tx: Arc<Transaction>) -> Result<TxStorageResponse, MempoolError> {
+        Ok(self.insert_with_details(tx).await?.into_response())
+    }
+
+    /// Insert an unconfirmed transaction into the Mempool, including rejection details when validation fails.
+    pub async fn insert_with_details(
+        &self,
+        tx: Arc<Transaction>,
+    ) -> Result<TxStorageResponseWithDetails, MempoolError> {
         self.with_write_access(|storage| {
             storage
-                .insert(tx)
+                .insert_with_details(tx)
                 .map_err(|e| MempoolError::InternalError(e.to_string()))
         })
         .await

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -37,10 +37,7 @@ use crate::mempool::metrics;
 use crate::{
     consensus::BaseNodeConsensusManager,
     mempool::{
-        MempoolConfig,
-        StateResponse,
-        StatsResponse,
-        TxStorageResponse,
+        MempoolConfig, StateResponse, StatsResponse, TxStorageResponse, TxStorageResponseWithDetails,
         error::MempoolError,
         reorg_pool::ReorgPool,
         unconfirmed_pool::{RetrieveResults, TransactionKey, UnconfirmedPool, UnconfirmedPoolError},
@@ -81,6 +78,14 @@ impl MempoolStorage {
 
     /// Insert an unconfirmed transaction into the Mempool.
     pub fn insert(&mut self, tx: Arc<Transaction>) -> Result<TxStorageResponse, UnconfirmedPoolError> {
+        Ok(self.insert_with_details(tx)?.into_response())
+    }
+
+    /// Insert an unconfirmed transaction into the Mempool, including rejection details when validation fails.
+    pub fn insert_with_details(
+        &mut self,
+        tx: Arc<Transaction>,
+    ) -> Result<TxStorageResponseWithDetails, UnconfirmedPoolError> {
         let tx_id = tx
             .body
             .kernels()
@@ -93,13 +98,23 @@ impl MempoolStorage {
             Ok(fee) => fee,
             Err(e) => {
                 warn!(target: LOG_TARGET, "Invalid transaction: {e}");
-                return Ok(TxStorageResponse::NotStoredConsensus);
+                return Ok(TxStorageResponseWithDetails::new(
+                    TxStorageResponse::NotStoredConsensus,
+                    Some(format!("Transaction fee could not be calculated: {e}")),
+                ));
             },
         };
         // This check is almost free, so lets check this before we do any expensive validation.
         if tx_fee.as_u64() < self.unconfirmed_pool.config.min_fee {
             debug!(target: LOG_TARGET, "Tx: ({tx_id}) fee too low, rejecting");
-            return Ok(TxStorageResponse::NotStoredFeeTooLow);
+            return Ok(TxStorageResponseWithDetails::new(
+                TxStorageResponse::NotStoredFeeTooLow,
+                Some(format!(
+                    "Transaction fee {} is below the minimum fee per gram accepted by this mempool ({})",
+                    tx_fee.as_u64(),
+                    self.unconfirmed_pool.config.min_fee
+                )),
+            ));
         }
         match self.validator.validate(&tx) {
             Ok(()) => {
@@ -118,36 +133,63 @@ impl MempoolStorage {
                     tx_id,
                     timer.elapsed()
                 );
-                Ok(TxStorageResponse::UnconfirmedPool)
+                Ok(TxStorageResponse::UnconfirmedPool.into())
             },
             Err(ValidationError::UnknownInputs(dependent_outputs)) => {
                 if self.unconfirmed_pool.contains_all_outputs(&dependent_outputs) {
                     let weight = self.get_transaction_weighting();
                     self.unconfirmed_pool.insert(tx, Some(dependent_outputs), &weight)?;
-                    Ok(TxStorageResponse::UnconfirmedPool)
+                    Ok(TxStorageResponse::UnconfirmedPool.into())
                 } else {
-                    Ok(TxStorageResponse::NotStoredOrphan)
+                    let details = dependent_outputs
+                        .iter()
+                        .map(|hash| hash.to_hex())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    Ok(TxStorageResponseWithDetails::new(
+                        TxStorageResponse::NotStoredOrphan,
+                        Some(format!(
+                            "Transaction refers to {} input(s) that are not available to this node: {}",
+                            dependent_outputs.len(),
+                            details
+                        )),
+                    ))
                 }
             },
-            Err(ValidationError::ContainsSTxO) => {
+            Err(e @ ValidationError::ContainsSTxO { .. }) => {
                 info!(target: LOG_TARGET, "Validation failed due to already spent input");
-                Ok(TxStorageResponse::NotStoredAlreadySpent)
+                Ok(TxStorageResponseWithDetails::new(
+                    TxStorageResponse::NotStoredAlreadySpent,
+                    Some(e.to_string()),
+                ))
             },
-            Err(ValidationError::MaturityError) => Ok(TxStorageResponse::NotStoredTimeLocked),
+            Err(e @ ValidationError::MaturityError) => Ok(TxStorageResponseWithDetails::new(
+                TxStorageResponse::NotStoredTimeLocked,
+                Some(e.to_string()),
+            )),
             Err(ValidationError::ConsensusError(msg)) => {
                 warn!(target: LOG_TARGET, "Validation failed due to consensus rule: {msg}");
-                Ok(TxStorageResponse::NotStoredConsensus)
+                Ok(TxStorageResponseWithDetails::new(
+                    TxStorageResponse::NotStoredConsensus,
+                    Some(msg),
+                ))
             },
             Err(ValidationError::DuplicateKernelError(msg)) => {
                 debug!(
                     target: LOG_TARGET,
                     "Validation failed due to already mined kernel: {msg}"
                 );
-                Ok(TxStorageResponse::NotStoredAlreadyMined)
+                Ok(TxStorageResponseWithDetails::new(
+                    TxStorageResponse::NotStoredAlreadyMined,
+                    Some(msg),
+                ))
             },
             Err(e) => {
                 info!(target: LOG_TARGET, "Validation failed due to error: {e}");
-                Ok(TxStorageResponse::NotStored)
+                Ok(TxStorageResponseWithDetails::new(
+                    TxStorageResponse::NotStored,
+                    Some(e.to_string()),
+                ))
             },
         }
     }
@@ -393,16 +435,16 @@ impl MempoolStorage {
                     },
                     // Some kernels from the transaction have already been processed, and others exist in the
                     // unconfirmed pool, therefore this specific transaction has not been stored (already spent)
-                    (TxStorageResponse::UnconfirmedPool, TxStorageResponse::ReorgPool) |
-                    (TxStorageResponse::ReorgPool, TxStorageResponse::UnconfirmedPool) => {
+                    (TxStorageResponse::UnconfirmedPool, TxStorageResponse::ReorgPool)
+                    | (TxStorageResponse::ReorgPool, TxStorageResponse::UnconfirmedPool) => {
                         Some(TxStorageResponse::NotStoredAlreadySpent)
                     },
                     // All (so far) in reorg pool
                     (TxStorageResponse::ReorgPool, TxStorageResponse::ReorgPool) => Some(TxStorageResponse::ReorgPool),
                     // Not stored
-                    (TxStorageResponse::UnconfirmedPool, other) |
-                    (TxStorageResponse::ReorgPool, other) |
-                    (other, _) => Some(other),
+                    (TxStorageResponse::UnconfirmedPool, other)
+                    | (TxStorageResponse::ReorgPool, other)
+                    | (other, _) => Some(other),
                 }
             })
             .ok_or(MempoolError::TransactionNoKernels)

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -105,6 +105,38 @@ pub enum TxStorageResponse {
     NotStoredFeeTooLow,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TxStorageResponseWithDetails {
+    pub response: TxStorageResponse,
+    pub rejection_reason: Option<String>,
+}
+
+impl TxStorageResponseWithDetails {
+    pub fn new(response: TxStorageResponse, rejection_reason: Option<String>) -> Self {
+        Self {
+            response,
+            rejection_reason,
+        }
+    }
+
+    pub fn is_stored(&self) -> bool {
+        self.response.is_stored()
+    }
+
+    pub fn into_response(self) -> TxStorageResponse {
+        self.response
+    }
+}
+
+impl From<TxStorageResponse> for TxStorageResponseWithDetails {
+    fn from(response: TxStorageResponse) -> Self {
+        Self {
+            response,
+            rejection_reason: None,
+        }
+    }
+}
+
 impl TxStorageResponse {
     pub fn is_stored(&self) -> bool {
         matches!(self, Self::UnconfirmedPool | Self::ReorgPool)

--- a/base_layer/core/src/mempool/service/handle.rs
+++ b/base_layer/core/src/mempool/service/handle.rs
@@ -25,10 +25,7 @@ use tari_service_framework::{Service, reply_channel::TrySenderService};
 use tari_transaction_components::{rpc::models::FeePerGramStat, transaction_components::Transaction};
 
 use crate::mempool::{
-    MempoolServiceError,
-    StateResponse,
-    StatsResponse,
-    TxStorageResponse,
+    MempoolServiceError, StateResponse, StatsResponse, TxStorageResponse, TxStorageResponseWithDetails,
     service::{MempoolRequest, MempoolResponse},
 };
 
@@ -76,6 +73,20 @@ impl MempoolHandle {
             .await??
         {
             MempoolResponse::TxStorage(response) => Ok(response),
+            _ => Err(MempoolServiceError::InvalidResponse("Incorrect response".to_string())),
+        }
+    }
+
+    pub async fn submit_transaction_with_details(
+        &mut self,
+        transaction: Transaction,
+    ) -> Result<TxStorageResponseWithDetails, MempoolServiceError> {
+        match self
+            .inner
+            .call(MempoolRequest::SubmitTransactionWithDetails(transaction))
+            .await??
+        {
+            MempoolResponse::TxStorageWithDetails(response) => Ok(response),
             _ => Err(MempoolServiceError::InvalidResponse("Incorrect response".to_string())),
         }
     }

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -33,8 +33,7 @@ use crate::{
     base_node::comms_interface::{BlockEvent, BlockEvent::AddBlockErrored},
     chain_storage::BlockAddResult,
     mempool::{
-        Mempool,
-        TxStorageResponse,
+        Mempool, TxStorageResponse, TxStorageResponseWithDetails,
         service::{MempoolRequest, MempoolResponse, MempoolServiceError, OutboundMempoolServiceInterface},
     },
 };
@@ -62,12 +61,8 @@ impl MempoolInboundHandlers {
     pub async fn handle_request(&mut self, request: MempoolRequest) -> Result<MempoolResponse, MempoolServiceError> {
         trace!(target: LOG_TARGET, "Handling remote request: {request}");
         use MempoolRequest::{
-            FilterOutputsInMempool,
-            GetFeePerGramStats,
-            GetState,
-            GetStats,
-            GetTxStateByExcessSig,
-            SubmitTransaction,
+            FilterOutputsInMempool, GetFeePerGramStats, GetState, GetStats, GetTxStateByExcessSig, SubmitTransaction,
+            SubmitTransactionWithDetails,
         };
         match request {
             GetStats => Ok(MempoolResponse::Stats(self.mempool.stats().await?)),
@@ -86,6 +81,20 @@ impl MempoolInboundHandlers {
                     "Transaction ({first_tx_kernel_excess_sig}) submitted using request."
                 );
                 Ok(MempoolResponse::TxStorage(self.submit_transaction(tx, None).await?))
+            },
+            SubmitTransactionWithDetails(tx) => {
+                let first_tx_kernel_excess_sig = tx
+                    .first_kernel_excess_sig()
+                    .ok_or(MempoolServiceError::TransactionNoKernels)?
+                    .get_signature()
+                    .to_hex();
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction ({first_tx_kernel_excess_sig}) submitted using request with details."
+                );
+                Ok(MempoolResponse::TxStorageWithDetails(
+                    self.submit_transaction_with_details(tx, None).await?,
+                ))
             },
             GetFeePerGramStats { count, tip_height } => {
                 let stats = self.mempool.get_fee_per_gram_stats(count, tip_height).await?;
@@ -127,6 +136,17 @@ impl MempoolInboundHandlers {
         tx: Transaction,
         source_peer: Option<NodeId>,
     ) -> Result<TxStorageResponse, MempoolServiceError> {
+        Ok(self
+            .submit_transaction_with_details(tx, source_peer)
+            .await?
+            .into_response())
+    }
+
+    async fn submit_transaction_with_details(
+        &mut self,
+        tx: Transaction,
+        source_peer: Option<NodeId>,
+    ) -> Result<TxStorageResponseWithDetails, MempoolServiceError> {
         trace!(target: LOG_TARGET, "submit_transaction: {tx}");
 
         let tx = Arc::new(tx);
@@ -141,9 +161,9 @@ impl MempoolInboundHandlers {
                 target: LOG_TARGET,
                 "Mempool already has transaction: {kernel_excess_sig}"
             );
-            return Ok(tx_storage);
+            return Ok(tx_storage.into());
         }
-        match self.mempool.insert(tx.clone()).await {
+        match self.mempool.insert_with_details(tx.clone()).await {
             Ok(tx_storage) => {
                 #[cfg(feature = "metrics")]
                 if tx_storage.is_stored() {
@@ -155,10 +175,11 @@ impl MempoolInboundHandlers {
 
                 debug!(
                     target: LOG_TARGET,
-                    "Transaction inserted into mempool: {kernel_excess_sig}, pool: {tx_storage}"
+                    "Transaction inserted into mempool: {kernel_excess_sig}, pool: {}",
+                    tx_storage.response
                 );
                 // propagate the tx if it was accepted to the unconfirmed pool
-                if matches!(tx_storage, TxStorageResponse::UnconfirmedPool) {
+                if matches!(tx_storage.response, TxStorageResponse::UnconfirmedPool) {
                     debug!(
                         target: LOG_TARGET,
                         "Propagate transaction ({kernel_excess_sig}) to network."

--- a/base_layer/core/src/mempool/service/local_service.rs
+++ b/base_layer/core/src/mempool/service/local_service.rs
@@ -25,9 +25,7 @@ use tari_service_framework::{Service, reply_channel::SenderService};
 use tari_transaction_components::transaction_components::Transaction;
 
 use crate::mempool::{
-    StateResponse,
-    StatsResponse,
-    TxStorageResponse,
+    StateResponse, StatsResponse, TxStorageResponse, TxStorageResponseWithDetails,
     service::{MempoolRequest, MempoolResponse, MempoolServiceError},
 };
 pub type LocalMempoolRequester = SenderService<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>;
@@ -84,6 +82,20 @@ impl LocalMempoolService {
         }
     }
 
+    pub async fn submit_transaction_with_details(
+        &mut self,
+        transaction: Transaction,
+    ) -> Result<TxStorageResponseWithDetails, MempoolServiceError> {
+        match self
+            .request_sender
+            .call(MempoolRequest::SubmitTransactionWithDetails(transaction))
+            .await??
+        {
+            MempoolResponse::TxStorageWithDetails(s) => Ok(s),
+            _ => Err(MempoolServiceError::UnexpectedApiResponse),
+        }
+    }
+
     pub async fn get_transaction_state_by_excess_sig(
         &mut self,
         sig: CompressedSignature,
@@ -106,8 +118,7 @@ mod test {
     use tokio::task;
 
     use crate::mempool::{
-        MempoolServiceError,
-        StatsResponse,
+        MempoolServiceError, StatsResponse,
         service::{MempoolRequest, MempoolResponse, local_service::LocalMempoolService},
     };
 

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -37,6 +37,7 @@ pub enum MempoolRequest {
     GetState,
     GetTxStateByExcessSig(CompressedSignature),
     SubmitTransaction(Transaction),
+    SubmitTransactionWithDetails(Transaction),
     GetFeePerGramStats { count: usize, tip_height: u64 },
     FilterOutputsInMempool(Vec<HashOutput>),
 }
@@ -55,6 +56,13 @@ impl Display for MempoolRequest {
                     .map(|sig| sig.get_signature().to_hex())
                     .unwrap_or_else(|| "No kernels!".to_string());
                 write!(f, "SubmitTransaction ({sig_hex})")
+            },
+            MempoolRequest::SubmitTransactionWithDetails(tx) => {
+                let sig_hex = tx
+                    .first_kernel_excess_sig()
+                    .map(|sig| sig.get_signature().to_hex())
+                    .unwrap_or_else(|| "No kernels!".to_string());
+                write!(f, "SubmitTransactionWithDetails ({sig_hex})")
             },
             MempoolRequest::GetFeePerGramStats { count, tip_height } => {
                 write!(f, "GetFeePerGramStats(count: {}, tip_height: {})", *count, *tip_height)

--- a/base_layer/core/src/mempool/service/response.rs
+++ b/base_layer/core/src/mempool/service/response.rs
@@ -27,7 +27,7 @@ use tari_transaction_components::rpc::models::FeePerGramStat;
 
 use crate::{
     common::RequestKey,
-    mempool::{StateResponse, StatsResponse, TxStorageResponse},
+    mempool::{StateResponse, StatsResponse, TxStorageResponse, TxStorageResponseWithDetails},
 };
 
 /// API Response enum for Mempool responses.
@@ -36,17 +36,19 @@ pub enum MempoolResponse {
     Stats(StatsResponse),
     State(StateResponse),
     TxStorage(TxStorageResponse),
+    TxStorageWithDetails(TxStorageResponseWithDetails),
     FeePerGramStats { response: Vec<FeePerGramStat> },
     FilteredOutputs(Vec<HashOutput>),
 }
 
 impl fmt::Display for MempoolResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        use MempoolResponse::{FeePerGramStats, FilteredOutputs, State, Stats, TxStorage};
+        use MempoolResponse::{FeePerGramStats, FilteredOutputs, State, Stats, TxStorage, TxStorageWithDetails};
         match &self {
             Stats(_) => write!(f, "Stats"),
             State(_) => write!(f, "State"),
             TxStorage(_) => write!(f, "TxStorage"),
+            TxStorageWithDetails(_) => write!(f, "TxStorageWithDetails"),
             FeePerGramStats { response } => write!(f, "FeePerGramStats({} item(s))", response.len()),
             FilteredOutputs(outputs) => write!(f, "FilteredOutputs({} item(s))", outputs.len()),
         }

--- a/base_layer/core/src/mempool/test_utils/mock.rs
+++ b/base_layer/core/src/mempool/test_utils/mock.rs
@@ -30,10 +30,7 @@ use tari_service_framework::reply_channel;
 use tokio::{sync::Mutex, task};
 
 use crate::mempool::{
-    MempoolServiceError,
-    StateResponse,
-    StatsResponse,
-    TxStorageResponse,
+    MempoolServiceError, StateResponse, StatsResponse, TxStorageResponse,
     service::{MempoolHandle, MempoolRequest, MempoolResponse},
 };
 
@@ -125,12 +122,8 @@ impl MempoolServiceMock {
 
     async fn handle_request(&self, req: MempoolRequest) -> Result<MempoolResponse, MempoolServiceError> {
         use MempoolRequest::{
-            FilterOutputsInMempool,
-            GetFeePerGramStats,
-            GetState,
-            GetStats,
-            GetTxStateByExcessSig,
-            SubmitTransaction,
+            FilterOutputsInMempool, GetFeePerGramStats, GetState, GetStats, GetTxStateByExcessSig, SubmitTransaction,
+            SubmitTransactionWithDetails,
         };
 
         self.state.inc_call_count();
@@ -142,6 +135,9 @@ impl MempoolServiceMock {
             )),
             SubmitTransaction(_) => Ok(MempoolResponse::TxStorage(
                 self.state.submit_transaction.lock().await.clone(),
+            )),
+            SubmitTransactionWithDetails(_) => Ok(MempoolResponse::TxStorageWithDetails(
+                self.state.submit_transaction.lock().await.clone().into(),
             )),
             GetFeePerGramStats { .. } => {
                 unimplemented!()

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -38,11 +38,7 @@ use tari_transaction_components::{
     tari_proof_of_work::Difficulty,
     test_helpers::schema_to_transaction,
     transaction_components::{
-        EncryptedData,
-        MemoField,
-        RangeProofType,
-        TransactionError,
-        encrypted_data::STATIC_ENCRYPTED_DATA_SIZE_TOTAL,
+        EncryptedData, MemoField, RangeProofType, TransactionError, encrypted_data::STATIC_ENCRYPTED_DATA_SIZE_TOTAL,
     },
     txn_schema,
     validation::AggregatedBodyValidationError,
@@ -314,7 +310,7 @@ async fn it_checks_double_spends() {
     );
     let txn = blockchain.db().db_read_access().unwrap();
     let err = validator.validate_body(&*txn, block.block()).unwrap_err();
-    assert!(matches!(err, ValidationError::ContainsSTxO));
+    assert!(matches!(err, ValidationError::ContainsSTxO { .. }));
 }
 
 #[tokio::test]
@@ -596,12 +592,14 @@ mod orphan_validator {
                         (OutputType::Standard, vec![RangeProofType::RevealedValue]),
                         (OutputType::Coinbase, vec![RangeProofType::RevealedValue]),
                         (OutputType::Burn, vec![RangeProofType::RevealedValue]),
-                        (OutputType::ValidatorNodeRegistration, vec![
-                            RangeProofType::RevealedValue,
-                        ]),
-                        (OutputType::CodeTemplateRegistration, vec![
-                            RangeProofType::RevealedValue,
-                        ]),
+                        (
+                            OutputType::ValidatorNodeRegistration,
+                            vec![RangeProofType::RevealedValue],
+                        ),
+                        (
+                            OutputType::CodeTemplateRegistration,
+                            vec![RangeProofType::RevealedValue],
+                        ),
                     ])
                     .with_coinbase_lockheight(0)
                     .build(),
@@ -633,12 +631,14 @@ mod orphan_validator {
                         (OutputType::Standard, vec![RangeProofType::BulletProofPlus]),
                         (OutputType::Coinbase, vec![RangeProofType::BulletProofPlus]),
                         (OutputType::Burn, vec![RangeProofType::BulletProofPlus]),
-                        (OutputType::ValidatorNodeRegistration, vec![
-                            RangeProofType::BulletProofPlus,
-                        ]),
-                        (OutputType::CodeTemplateRegistration, vec![
-                            RangeProofType::BulletProofPlus,
-                        ]),
+                        (
+                            OutputType::ValidatorNodeRegistration,
+                            vec![RangeProofType::BulletProofPlus],
+                        ),
+                        (
+                            OutputType::CodeTemplateRegistration,
+                            vec![RangeProofType::BulletProofPlus],
+                        ),
                     ])
                     .with_coinbase_lockheight(0)
                     .build(),
@@ -663,9 +663,10 @@ mod orphan_validator {
         let rules = BaseNodeConsensusManager::builder(Network::LocalNet)
             .add_consensus_constants(
                 ConsensusConstantsBuilder::new(Network::LocalNet)
-                    .with_permitted_range_proof_types(vec![(OutputType::CodeTemplateRegistration, vec![
-                        RangeProofType::BulletProofPlus,
-                    ])])
+                    .with_permitted_range_proof_types(vec![(
+                        OutputType::CodeTemplateRegistration,
+                        vec![RangeProofType::BulletProofPlus],
+                    )])
                     .with_coinbase_lockheight(0)
                     .build(),
             )

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -23,8 +23,7 @@ use tari_common_types::{epoch::VnEpoch, types::HashOutput};
 use tari_node_components::blocks::{BlockHeaderValidationError, BlockValidationError};
 use tari_sidechain::SidechainProofValidationError;
 use tari_transaction_components::{
-    BanPeriod,
-    BanReason,
+    BanPeriod, BanReason,
     tari_proof_of_work::{DifficultyError, PowError},
     transaction_components::{OutputType, TransactionError, covenants::CovenantError},
     validation::AggregatedBodyValidationError,
@@ -62,8 +61,8 @@ pub enum ValidationError {
          commitments."
     )]
     InvalidAccountingBalance,
-    #[error("Transaction contains already spent inputs")]
-    ContainsSTxO,
+    #[error("Transaction contains already spent input commitment {commitment} with output hash {output_hash}")]
+    ContainsSTxO { commitment: String, output_hash: String },
     #[error("Transaction contains an output commitment that already exists")]
     ContainsDuplicateUtxoCommitment,
     #[error("Final state validation failed: The UTXO set did not balance with the expected emission at height {0}")]
@@ -160,54 +159,54 @@ impl ValidationError {
     pub fn get_ban_reason(&self) -> Option<BanReason> {
         match self {
             ValidationError::ProofOfWorkError(e) => e.get_ban_reason(),
-            err @ ValidationError::SerializationError(_) |
-            err @ ValidationError::BlockHeaderError(_) |
-            err @ ValidationError::BlockError(_) |
-            err @ ValidationError::MaturityError |
-            err @ ValidationError::BlockTooLarge { .. } |
-            err @ ValidationError::UnknownInputs(_) |
-            err @ ValidationError::UnknownInput |
-            err @ ValidationError::TransactionError(_) |
-            err @ ValidationError::InvalidAccountingBalance |
-            err @ ValidationError::ContainsSTxO |
-            err @ ValidationError::ContainsDuplicateUtxoCommitment |
-            err @ ValidationError::ChainBalanceValidationFailed(_) |
-            err @ ValidationError::ValidatingGenesis |
-            err @ ValidationError::UnsortedOrDuplicateInput |
-            err @ ValidationError::UnsortedOrDuplicateOutput |
-            err @ ValidationError::MaxTransactionWeightExceeded |
-            err @ ValidationError::IncorrectHeight { .. } |
-            err @ ValidationError::IncorrectPreviousHash { .. } |
-            err @ ValidationError::BadBlockFound { .. } |
-            err @ ValidationError::ConsensusError(_) |
-            err @ ValidationError::DuplicateKernelError(_) |
-            err @ ValidationError::CovenantError(_) |
-            err @ ValidationError::InvalidBlockchainVersion { .. } |
-            err @ ValidationError::InvalidBurnError(_) |
-            err @ ValidationError::DifficultyError(_) |
-            err @ ValidationError::CoinbaseExceedsMaxLimit |
-            err @ ValidationError::InvalidSerializedPublicKey(_) |
-            err @ ValidationError::SidechainEvictionProofValidatorNotFound { .. } |
-            err @ ValidationError::SidechainProofInvalid(_) |
-            err @ ValidationError::SidechainEvictionProofInvalidEpoch { .. } |
-            err @ ValidationError::ValidatorNodeAlreadyRegistered { .. } |
-            err @ ValidationError::ValidatorNodeNotRegistered { .. } |
-            err @ ValidationError::ValidatorNodeRegistrationMaxEpoch { .. } |
-            err @ ValidationError::OutputTypeNotMatchSidechainData { .. } |
-            err @ ValidationError::AggregatedBodyValidationError(_) |
-            err @ ValidationError::CuckarooPowError(_) |
-            err @ ValidationError::OutputSpendRuleDisallow { .. } => Some(BanReason {
+            err @ ValidationError::SerializationError(_)
+            | err @ ValidationError::BlockHeaderError(_)
+            | err @ ValidationError::BlockError(_)
+            | err @ ValidationError::MaturityError
+            | err @ ValidationError::BlockTooLarge { .. }
+            | err @ ValidationError::UnknownInputs(_)
+            | err @ ValidationError::UnknownInput
+            | err @ ValidationError::TransactionError(_)
+            | err @ ValidationError::InvalidAccountingBalance
+            | err @ ValidationError::ContainsSTxO { .. }
+            | err @ ValidationError::ContainsDuplicateUtxoCommitment
+            | err @ ValidationError::ChainBalanceValidationFailed(_)
+            | err @ ValidationError::ValidatingGenesis
+            | err @ ValidationError::UnsortedOrDuplicateInput
+            | err @ ValidationError::UnsortedOrDuplicateOutput
+            | err @ ValidationError::MaxTransactionWeightExceeded
+            | err @ ValidationError::IncorrectHeight { .. }
+            | err @ ValidationError::IncorrectPreviousHash { .. }
+            | err @ ValidationError::BadBlockFound { .. }
+            | err @ ValidationError::ConsensusError(_)
+            | err @ ValidationError::DuplicateKernelError(_)
+            | err @ ValidationError::CovenantError(_)
+            | err @ ValidationError::InvalidBlockchainVersion { .. }
+            | err @ ValidationError::InvalidBurnError(_)
+            | err @ ValidationError::DifficultyError(_)
+            | err @ ValidationError::CoinbaseExceedsMaxLimit
+            | err @ ValidationError::InvalidSerializedPublicKey(_)
+            | err @ ValidationError::SidechainEvictionProofValidatorNotFound { .. }
+            | err @ ValidationError::SidechainProofInvalid(_)
+            | err @ ValidationError::SidechainEvictionProofInvalidEpoch { .. }
+            | err @ ValidationError::ValidatorNodeAlreadyRegistered { .. }
+            | err @ ValidationError::ValidatorNodeNotRegistered { .. }
+            | err @ ValidationError::ValidatorNodeRegistrationMaxEpoch { .. }
+            | err @ ValidationError::OutputTypeNotMatchSidechainData { .. }
+            | err @ ValidationError::AggregatedBodyValidationError(_)
+            | err @ ValidationError::CuckarooPowError(_)
+            | err @ ValidationError::OutputSpendRuleDisallow { .. } => Some(BanReason {
                 reason: err.to_string(),
                 ban_duration: BanPeriod::Long,
             }),
             ValidationError::MergeMineError(e) => e.get_ban_reason(),
-            ValidationError::FatalStorageError(_) |
-            ValidationError::IncorrectNumberOfTimestampsProvided { .. } |
-            ValidationError::MissingKernelError(_) |
-            ValidationError::MissingOutputError(_) |
-            ValidationError::InputSpentBeforeMined(_) |
-            ValidationError::HeaderHashMismatch(_) |
-            ValidationError::HeaderHeightMismatch(_) => None,
+            ValidationError::FatalStorageError(_)
+            | ValidationError::IncorrectNumberOfTimestampsProvided { .. }
+            | ValidationError::MissingKernelError(_)
+            | ValidationError::MissingOutputError(_)
+            | ValidationError::InputSpentBeforeMined(_)
+            | ValidationError::HeaderHashMismatch(_)
+            | ValidationError::HeaderHeightMismatch(_) => None,
         }
     }
 }

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -40,12 +40,8 @@ use crate::{
     chain_storage::{BlockchainBackend, MmrRoots, MmrTree},
     consensus::BaseNodeConsensusManager,
     proof_of_work::{
-        AchievedTargetDifficulty,
-        cuckaroo_pow::cuckaroo_difficulty,
-        monero_randomx_difficulty,
-        randomx_factory::RandomXFactory,
-        sha3x_difficulty,
-        tari_randomx_difficulty,
+        AchievedTargetDifficulty, cuckaroo_pow::cuckaroo_difficulty, monero_randomx_difficulty,
+        randomx_factory::RandomXFactory, sha3x_difficulty, tari_randomx_difficulty,
     },
     validation::ValidationError,
 };
@@ -82,9 +78,9 @@ pub fn calc_median_timestamp(timestamps: &[EpochTime]) -> Result<EpochTime, Vali
         // To make the linter happy, we use `u64::MAX` in the impossible case that the cast fails
         EpochTime::from(
             u64::try_from(
-                (u128::from(timestamps.get(mid_index - 1).expect("Already checked").as_u64()) +
-                    u128::from(timestamps.get(mid_index).expect("Already checked").as_u64())) /
-                    2,
+                (u128::from(timestamps.get(mid_index - 1).expect("Already checked").as_u64())
+                    + u128::from(timestamps.get(mid_index).expect("Already checked").as_u64()))
+                    / 2,
             )
             .unwrap_or(u64::MAX),
         )
@@ -198,7 +194,10 @@ pub fn check_input_is_utxo<B: BlockchainBackend>(db: &B, input: &TransactionInpu
         );
         // We know that the output here must be spent because `fetch_unspent_output_hash_by_commitment` would have
         // been Some
-        return Err(ValidationError::ContainsSTxO);
+        return Err(ValidationError::ContainsSTxO {
+            commitment: input.commitment()?.to_hex(),
+            output_hash: output_hash.to_hex(),
+        });
     }
 
     debug!(

--- a/base_layer/transaction_components/src/rpc/models/tx_submission_response.rs
+++ b/base_layer/transaction_components/src/rpc/models/tx_submission_response.rs
@@ -28,6 +28,8 @@ use serde::{Deserialize, Serialize};
 pub struct TxSubmissionResponse {
     pub accepted: bool,
     pub rejection_reason: TxSubmissionRejectionReason,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejection_reason_details: Option<String>,
     pub is_synced: bool,
 }
 
@@ -40,6 +42,41 @@ pub enum TxSubmissionRejectionReason {
     TimeLocked,
     ValidationFailed,
     FeeTooLow,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn deserializes_submission_response_without_details() {
+        let response = serde_json::json!({
+            "accepted": false,
+            "rejection_reason": "TimeLocked",
+            "is_synced": true
+        });
+
+        let response = serde_json::from_value::<TxSubmissionResponse>(response).unwrap();
+
+        assert!(!response.accepted);
+        assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::TimeLocked);
+        assert!(response.rejection_reason_details.is_none());
+        assert!(response.is_synced);
+    }
+
+    #[test]
+    fn serializes_submission_response_details_when_present() {
+        let response = TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::DoubleSpend,
+            rejection_reason_details: Some("Transaction spends an output that is already spent.".to_string()),
+            is_synced: true,
+        };
+
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["rejection_reason_details"], "Transaction spends an output that is already spent.");
+    }
 }
 
 impl Display for TxSubmissionRejectionReason {

--- a/base_layer/transaction_components/src/rpc/models/tx_submission_response.rs
+++ b/base_layer/transaction_components/src/rpc/models/tx_submission_response.rs
@@ -28,9 +28,37 @@ use serde::{Deserialize, Serialize};
 pub struct TxSubmissionResponse {
     pub accepted: bool,
     pub rejection_reason: TxSubmissionRejectionReason,
+    pub is_synced: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TxSubmissionResponseV1 {
+    pub accepted: bool,
+    pub rejection_reason: TxSubmissionRejectionReason,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rejection_reason_details: Option<String>,
     pub is_synced: bool,
+}
+
+impl From<TxSubmissionResponseV1> for TxSubmissionResponse {
+    fn from(value: TxSubmissionResponseV1) -> Self {
+        Self {
+            accepted: value.accepted,
+            rejection_reason: value.rejection_reason,
+            is_synced: value.is_synced,
+        }
+    }
+}
+
+impl From<TxSubmissionResponse> for TxSubmissionResponseV1 {
+    fn from(value: TxSubmissionResponse) -> Self {
+        Self {
+            accepted: value.accepted,
+            rejection_reason: value.rejection_reason,
+            rejection_reason_details: None,
+            is_synced: value.is_synced,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -49,14 +77,14 @@ mod test {
     use super::*;
 
     #[test]
-    fn deserializes_submission_response_without_details() {
+    fn deserializes_submission_response_v1_without_details() {
         let response = serde_json::json!({
             "accepted": false,
             "rejection_reason": "TimeLocked",
             "is_synced": true
         });
 
-        let response = serde_json::from_value::<TxSubmissionResponse>(response).unwrap();
+        let response = serde_json::from_value::<TxSubmissionResponseV1>(response).unwrap();
 
         assert!(!response.accepted);
         assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::TimeLocked);
@@ -65,8 +93,8 @@ mod test {
     }
 
     #[test]
-    fn serializes_submission_response_details_when_present() {
-        let response = TxSubmissionResponse {
+    fn serializes_submission_response_v1_details_when_present() {
+        let response = TxSubmissionResponseV1 {
             accepted: false,
             rejection_reason: TxSubmissionRejectionReason::DoubleSpend,
             rejection_reason_details: Some("Transaction spends an output that is already spent.".to_string()),
@@ -75,7 +103,39 @@ mod test {
 
         let value = serde_json::to_value(response).unwrap();
 
-        assert_eq!(value["rejection_reason_details"], "Transaction spends an output that is already spent.");
+        assert_eq!(
+            value["rejection_reason_details"],
+            "Transaction spends an output that is already spent."
+        );
+    }
+
+    #[test]
+    fn serializes_submission_response_without_v1_details() {
+        let response = TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::DoubleSpend,
+            is_synced: true,
+        };
+
+        let value = serde_json::to_value(response).unwrap();
+
+        assert!(value.get("rejection_reason_details").is_none());
+    }
+
+    #[test]
+    fn converts_submission_response_v1_to_legacy_response() {
+        let response = TxSubmissionResponseV1 {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::DoubleSpend,
+            rejection_reason_details: Some("already spent".to_string()),
+            is_synced: true,
+        };
+
+        let legacy = TxSubmissionResponse::from(response);
+
+        assert!(!legacy.accepted);
+        assert_eq!(legacy.rejection_reason, TxSubmissionRejectionReason::DoubleSpend);
+        assert!(legacy.is_synced);
     }
 }
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -109,9 +109,9 @@ where
                 },
             };
 
-            if !(completed_tx.status == LegacyTransactionStatus::Completed ||
-                completed_tx.status == LegacyTransactionStatus::Broadcast ||
-                completed_tx.status == LegacyTransactionStatus::MinedUnconfirmed)
+            if !(completed_tx.status == LegacyTransactionStatus::Completed
+                || completed_tx.status == LegacyTransactionStatus::Broadcast
+                || completed_tx.status == LegacyTransactionStatus::MinedUnconfirmed)
             {
                 debug!(
                     target: LOG_TARGET,
@@ -198,7 +198,10 @@ where
         }
 
         if !response.accepted && response.rejection_reason != TxSubmissionRejectionReason::AlreadyMined {
-            let rejection_reason_details = response.rejection_reason_details.as_deref().unwrap_or("No details provided");
+            let rejection_reason_details = response
+                .rejection_reason_details
+                .as_deref()
+                .unwrap_or("No details provided");
             error!(
                 target: LOG_TARGET,
                 "Transaction (TxId: {}) rejected by Base Node for reason: {}. Details: {}",
@@ -207,7 +210,8 @@ where
                 rejection_reason_details
             );
 
-            let (reason_error, reason) = match response.rejection_reason {
+            let rejection_reason = response.rejection_reason.clone();
+            let (fallback_error, reason) = match rejection_reason {
                 TxSubmissionRejectionReason::None | TxSubmissionRejectionReason::ValidationFailed => (
                     TransactionServiceError::MempoolRejectionInvalidTransaction,
                     TxCancellationReason::InvalidTransaction,
@@ -233,6 +237,14 @@ where
                     TxCancellationReason::AlreadyMined,
                 ),
             };
+            let reason_error = response
+                .rejection_reason_details
+                .as_deref()
+                .filter(|details| !details.is_empty())
+                .map(|details| TransactionServiceError::MempoolRejection {
+                    reason: format!("{}: {details}", response.rejection_reason),
+                })
+                .unwrap_or(fallback_error);
 
             self.cancel_pending_transaction(reason).await;
 
@@ -249,7 +261,10 @@ where
 
             return Err(TransactionServiceProtocolError::new(self.tx_id, reason_error));
         } else if response.rejection_reason == TxSubmissionRejectionReason::AlreadyMined {
-            let rejection_reason_details = response.rejection_reason_details.as_deref().unwrap_or("No details provided");
+            let rejection_reason_details = response
+                .rejection_reason_details
+                .as_deref()
+                .unwrap_or("No details provided");
             info!(
                 target: LOG_TARGET,
                 "Transaction (TxId: {}) is Already Mined according to Base Node. Details: {}. Will be completed by \
@@ -315,9 +330,9 @@ where
             );
             Ok(true)
         } else if response.location != TxLocation::InMempool {
-            if self.last_rejection.is_none() ||
-                self.last_rejection.unwrap().elapsed() >
-                    self.resources.config.transaction_mempool_resubmission_window
+            if self.last_rejection.is_none()
+                || self.last_rejection.unwrap().elapsed()
+                    > self.resources.config.transaction_mempool_resubmission_window
             {
                 info!(
                     target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -198,9 +198,13 @@ where
         }
 
         if !response.accepted && response.rejection_reason != TxSubmissionRejectionReason::AlreadyMined {
+            let rejection_reason_details = response.rejection_reason_details.as_deref().unwrap_or("No details provided");
             error!(
                 target: LOG_TARGET,
-                "Transaction (TxId: {}) rejected by Base Node for reason: {}", self.tx_id, response.rejection_reason
+                "Transaction (TxId: {}) rejected by Base Node for reason: {}. Details: {}",
+                self.tx_id,
+                response.rejection_reason,
+                rejection_reason_details
             );
 
             let (reason_error, reason) = match response.rejection_reason {
@@ -245,11 +249,13 @@ where
 
             return Err(TransactionServiceProtocolError::new(self.tx_id, reason_error));
         } else if response.rejection_reason == TxSubmissionRejectionReason::AlreadyMined {
+            let rejection_reason_details = response.rejection_reason_details.as_deref().unwrap_or("No details provided");
             info!(
                 target: LOG_TARGET,
-                "Transaction (TxId: {}) is Already Mined according to Base Node. Will be completed by transaction \
-                 validation protocol.",
-                self.tx_id
+                "Transaction (TxId: {}) is Already Mined according to Base Node. Details: {}. Will be completed by \
+                 transaction validation protocol.",
+                self.tx_id,
+                rejection_reason_details
             );
         } else {
             info!(

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -176,6 +176,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
         Ok(TxSubmissionResponse {
             accepted: true,
             rejection_reason: models::TxSubmissionRejectionReason::None,
+            rejection_reason_details: None,
             is_synced: true,
         })
     }

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -30,15 +30,8 @@ use minotari_wallet::client::http_client_factory::HttpClientFactory;
 use tari_shutdown::ShutdownSignal;
 use tari_transaction_components::{
     rpc::models::{
-        self,
-        BlockHeader,
-        BlockUtxoInfo,
-        FeePerGramStat,
-        GenerateKernelMerkleProofResponse,
-        GetUtxosDeletedInfoResponse,
-        GetUtxosMinedInfoResponse,
-        SyncUtxosByBlockResponseV0,
-        TxSubmissionResponse,
+        self, BlockHeader, BlockUtxoInfo, FeePerGramStat, GenerateKernelMerkleProofResponse,
+        GetUtxosDeletedInfoResponse, GetUtxosMinedInfoResponse, SyncUtxosByBlockResponseV0, TxSubmissionResponseV1,
     },
     transaction_components::{Transaction, TransactionOutput},
 };
@@ -172,8 +165,8 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
         todo!()
     }
 
-    async fn submit_transaction(&self, _transaction: Transaction) -> Result<TxSubmissionResponse, Error> {
-        Ok(TxSubmissionResponse {
+    async fn submit_transaction(&self, _transaction: Transaction) -> Result<TxSubmissionResponseV1, Error> {
+        Ok(TxSubmissionResponseV1 {
             accepted: true,
             rejection_reason: models::TxSubmissionRejectionReason::None,
             rejection_reason_details: None,

--- a/clients/rust/base_node_wallet_client/src/client/http.rs
+++ b/clients/rust/base_node_wallet_client/src/client/http.rs
@@ -13,16 +13,9 @@ use tari_transaction_components::{
     rpc::{
         models,
         models::{
-            BlockHeader,
-            FeePerGramStat,
-            GenerateKernelMerkleProofResponse,
-            GetUtxosDeletedInfoResponse,
-            GetUtxosMinedInfoResponse,
-            SyncUtxosByBlockResponseV0,
-            SyncUtxosByBlockResponseV1,
-            TipInfoResponse,
-            TxQueryResponse,
-            TxSubmissionResponse,
+            BlockHeader, FeePerGramStat, GenerateKernelMerkleProofResponse, GetUtxosDeletedInfoResponse,
+            GetUtxosMinedInfoResponse, SyncUtxosByBlockResponseV0, SyncUtxosByBlockResponseV1, TipInfoResponse,
+            TxQueryResponse, TxSubmissionResponseV1,
         },
     },
     transaction_components::{Transaction, TransactionOutput},
@@ -454,7 +447,7 @@ impl BaseNodeWalletClient for Client {
         Ok(res.json::<Option<TransactionOutput>>().await?)
     }
 
-    async fn submit_transaction(&self, transaction: Transaction) -> Result<TxSubmissionResponse, anyhow::Error> {
+    async fn submit_transaction(&self, transaction: Transaction) -> Result<TxSubmissionResponseV1, anyhow::Error> {
         let server_address = self.http_server_address().await?;
         debug!(target: LOG_TARGET, "Submitting transaction to Base Node wallet service at {server_address}");
         let target_url = server_address.join("/json_rpc")?;
@@ -464,6 +457,7 @@ impl BaseNodeWalletClient for Client {
             "method": "submit_transaction",
             "params": {
                 "transaction": transaction,
+                "version": 1,
             }
         });
 
@@ -485,7 +479,7 @@ impl BaseNodeWalletClient for Client {
             ));
         }
         info!(target: LOG_TARGET, "Transaction submitted successfully to Base Node wallet service at {server_address}");
-        let response = res.json::<JsonRpcResponse<TxSubmissionResponse>>().await?;
+        let response = res.json::<JsonRpcResponse<TxSubmissionResponseV1>>().await?;
         match response.result {
             Some(result) => {
                 debug!(target: LOG_TARGET, "Transaction submission response: {result:?}");
@@ -602,10 +596,13 @@ impl BaseNodeWalletClient for Client {
         excess_sig: &[u8],
     ) -> Result<GenerateKernelMerkleProofResponse, anyhow::Error> {
         let resp = self
-            .send_get_request("/generate_kernel_merkle_proof", &[
-                ("excess_sig_public_nonce", to_hex(excess_sig_nonce)),
-                ("excess_sig_signature", to_hex(excess_sig)),
-            ])
+            .send_get_request(
+                "/generate_kernel_merkle_proof",
+                &[
+                    ("excess_sig_public_nonce", to_hex(excess_sig_nonce)),
+                    ("excess_sig_signature", to_hex(excess_sig)),
+                ],
+            )
             .await?;
 
         Ok(resp)

--- a/clients/rust/base_node_wallet_client/src/client/mod.rs
+++ b/clients/rust/base_node_wallet_client/src/client/mod.rs
@@ -7,19 +7,14 @@ use serde::{Deserialize, Serialize};
 use tari_shutdown::ShutdownSignal;
 use tari_transaction_components::{
     rpc::models::{
-        self,
-        BlockHeader,
-        FeePerGramStat,
-        GenerateKernelMerkleProofResponse,
-        GetUtxosDeletedInfoResponse,
-        GetUtxosMinedInfoResponse,
-        SyncUtxosByBlockResponseV0,
+        self, BlockHeader, FeePerGramStat, GenerateKernelMerkleProofResponse, GetUtxosDeletedInfoResponse,
+        GetUtxosMinedInfoResponse, SyncUtxosByBlockResponseV0,
     },
     transaction_components::{Transaction, TransactionOutput},
 };
 use tokio::sync::mpsc;
 
-use crate::client::models::TxSubmissionResponse;
+use crate::client::models::TxSubmissionResponseV1;
 
 /// Trait that a base node wallet client must implement.
 #[async_trait::async_trait]
@@ -58,7 +53,7 @@ pub trait BaseNodeWalletClient: Send + Sync + Clone + 'static {
         must_include_header: Vec<u8>,
     ) -> Result<GetUtxosDeletedInfoResponse, Error>;
 
-    async fn submit_transaction(&self, transaction: Transaction) -> Result<TxSubmissionResponse, Error>;
+    async fn submit_transaction(&self, transaction: Transaction) -> Result<TxSubmissionResponseV1, Error>;
 
     async fn transaction_query(
         &self,


### PR DESCRIPTION
## Summary
- add an optional \\ejection_reason_details\\ field to HTTP transaction submission responses
- include human-readable details for mempool rejection paths
- distinguish double-spend from already-mined responses in the HTTP handler using the existing wallet query service
- log rejection details in wallet transaction broadcast handling

Closes #7776

## Tests
- Added unit coverage for backwards-compatible deserialization and detail serialization.
- Not run locally: Rust toolchain (\\cargo\\) is not available in this environment.