### PR TITLE
Include mempool rejection details in transaction submission responses

### DIFF
--- a/applications/minotari_node/src/http/handler/json_rpc/submit_transaction.rs
+++ b/applications/minotari_node/src/http/handler/json_rpc/submit_transaction.rs
@@ -26,7 +26,7 @@ use log::{debug, error};
 use tari_core::{
     base_node::rpc::{BaseNodeWalletQueryService, query_service},
     chain_storage::BlockchainBackend,
-    mempool::{TxStorageResponse, service::MempoolHandle},
+    mempool::{TxStorageResponse, TxStorageResponseWithRejectionReason, service::MempoolHandle},
 };
 use tari_transaction_components::{
     rpc::models::{TxSubmissionRejectionReason, TxSubmissionResponse},
@@ -48,48 +48,104 @@ pub async fn handle<T: BlockchainBackend + 'static>(
             anyhow::anyhow!("Failed to get tip info: {e}")
         })?
         .is_synced;
-    let res = match mempool_service.submit_transaction(transaction).await {
+    let res = match mempool_service
+        .submit_transaction_with_rejection_reason(transaction)
+        .await
+    {
         Ok(response) => {
             debug!(target: LOG_TARGET, "Transaction submitted successfully: {response:?}");
-            match response {
-                TxStorageResponse::UnconfirmedPool => TxSubmissionResponse {
-                    accepted: true,
-                    rejection_reason: TxSubmissionRejectionReason::None,
-                    is_synced,
-                },
-
-                TxStorageResponse::NotStoredOrphan => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::Orphan,
-                    is_synced,
-                },
-                TxStorageResponse::NotStoredFeeTooLow => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::FeeTooLow,
-                    is_synced,
-                },
-                TxStorageResponse::NotStoredTimeLocked => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::TimeLocked,
-                    is_synced,
-                },
-                TxStorageResponse::NotStoredConsensus | TxStorageResponse::NotStored => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::ValidationFailed,
-                    is_synced,
-                },
-                TxStorageResponse::NotStoredAlreadySpent |
-                TxStorageResponse::ReorgPool |
-                TxStorageResponse::NotStoredAlreadyMined => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::AlreadyMined,
-                    is_synced,
-                },
-            }
+            tx_submission_response_from_mempool_response(response, is_synced)
         },
         Err(e) => {
             return Err(anyhow::anyhow!("Failed to submit transaction: {e}"));
         },
     };
     Ok(res)
+}
+
+fn tx_submission_response_from_mempool_response(
+    response: TxStorageResponseWithRejectionReason,
+    is_synced: bool,
+) -> TxSubmissionResponse {
+    match response.storage_response {
+        TxStorageResponse::UnconfirmedPool => TxSubmissionResponse {
+            accepted: true,
+            rejection_reason: TxSubmissionRejectionReason::None,
+            rejection_reason_details: response.rejection_reason,
+            is_synced,
+        },
+        TxStorageResponse::NotStoredOrphan => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::Orphan,
+            rejection_reason_details: response.rejection_reason,
+            is_synced,
+        },
+        TxStorageResponse::NotStoredFeeTooLow => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::FeeTooLow,
+            rejection_reason_details: response.rejection_reason,
+            is_synced,
+        },
+        TxStorageResponse::NotStoredTimeLocked => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::TimeLocked,
+            rejection_reason_details: response.rejection_reason,
+            is_synced,
+        },
+        TxStorageResponse::NotStoredConsensus | TxStorageResponse::NotStored => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::ValidationFailed,
+            rejection_reason_details: response.rejection_reason,
+            is_synced,
+        },
+        TxStorageResponse::NotStoredAlreadySpent => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::DoubleSpend,
+            rejection_reason_details: response.rejection_reason,
+            is_synced,
+        },
+        TxStorageResponse::ReorgPool | TxStorageResponse::NotStoredAlreadyMined => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::AlreadyMined,
+            rejection_reason_details: response.rejection_reason,
+            is_synced,
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn includes_detailed_rejection_reason_in_http_response() {
+        let detail = "Consensus rule violation: range proof verification failed".to_string();
+        let response = tx_submission_response_from_mempool_response(
+            TxStorageResponseWithRejectionReason::rejected(TxStorageResponse::NotStoredConsensus, detail.clone()),
+            true,
+        );
+
+        assert!(!response.accepted);
+        assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::ValidationFailed);
+        assert_eq!(response.rejection_reason_details, Some(detail));
+        assert!(response.is_synced);
+    }
+
+    #[test]
+    fn maps_already_spent_to_double_spend_for_http_wallet_feedback() {
+        let response = tx_submission_response_from_mempool_response(
+            TxStorageResponseWithRejectionReason::rejected(
+                TxStorageResponse::NotStoredAlreadySpent,
+                "Transaction contains input(s) that have already been spent".to_string(),
+            ),
+            true,
+        );
+
+        assert!(!response.accepted);
+        assert_eq!(response.rejection_reason, TxSubmissionRejectionReason::DoubleSpend);
+        assert_eq!(
+            response.rejection_reason_details.as_deref(),
+            Some("Transaction contains input(s) that have already been spent")
+        );
+    }
 }

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -35,6 +35,7 @@ use crate::{
         StateResponse,
         StatsResponse,
         TxStorageResponse,
+        TxStorageResponseWithRejectionReason,
         error::MempoolError,
         mempool_storage::MempoolStorage,
     },
@@ -65,9 +66,16 @@ impl Mempool {
 
     /// Insert an unconfirmed transaction into the Mempool.
     pub async fn insert(&self, tx: Arc<Transaction>) -> Result<TxStorageResponse, MempoolError> {
+        Ok(self.insert_with_rejection_reason(tx).await?.storage_response)
+    }
+
+    pub async fn insert_with_rejection_reason(
+        &self,
+        tx: Arc<Transaction>,
+    ) -> Result<TxStorageResponseWithRejectionReason, MempoolError> {
         self.with_write_access(|storage| {
             storage
-                .insert(tx)
+                .insert_with_rejection_reason(tx)
                 .map_err(|e| MempoolError::InternalError(e.to_string()))
         })
         .await

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -41,6 +41,7 @@ use crate::{
         StateResponse,
         StatsResponse,
         TxStorageResponse,
+        TxStorageResponseWithRejectionReason,
         error::MempoolError,
         reorg_pool::ReorgPool,
         unconfirmed_pool::{RetrieveResults, TransactionKey, UnconfirmedPool, UnconfirmedPoolError},
@@ -49,6 +50,7 @@ use crate::{
 };
 
 pub const LOG_TARGET: &str = "c::mp::mempool_storage";
+const MAX_REJECTION_DETAIL_ITEMS: usize = 3;
 
 /// The Mempool consists of an Unconfirmed Transaction Pool and Reorg Pool and is responsible
 /// for managing and maintaining all unconfirmed transactions have not yet been included in a block, and transactions
@@ -81,6 +83,13 @@ impl MempoolStorage {
 
     /// Insert an unconfirmed transaction into the Mempool.
     pub fn insert(&mut self, tx: Arc<Transaction>) -> Result<TxStorageResponse, UnconfirmedPoolError> {
+        Ok(self.insert_with_rejection_reason(tx)?.storage_response)
+    }
+
+    pub fn insert_with_rejection_reason(
+        &mut self,
+        tx: Arc<Transaction>,
+    ) -> Result<TxStorageResponseWithRejectionReason, UnconfirmedPoolError> {
         let tx_id = tx
             .body
             .kernels()
@@ -93,13 +102,23 @@ impl MempoolStorage {
             Ok(fee) => fee,
             Err(e) => {
                 warn!(target: LOG_TARGET, "Invalid transaction: {e}");
-                return Ok(TxStorageResponse::NotStoredConsensus);
+                return Ok(TxStorageResponseWithRejectionReason::rejected(
+                    TxStorageResponse::NotStoredConsensus,
+                    format!("Transaction fee could not be calculated: {e}"),
+                ));
             },
         };
         // This check is almost free, so lets check this before we do any expensive validation.
         if tx_fee.as_u64() < self.unconfirmed_pool.config.min_fee {
             debug!(target: LOG_TARGET, "Tx: ({tx_id}) fee too low, rejecting");
-            return Ok(TxStorageResponse::NotStoredFeeTooLow);
+            return Ok(TxStorageResponseWithRejectionReason::rejected(
+                TxStorageResponse::NotStoredFeeTooLow,
+                format!(
+                    "Transaction fee {} is below this mempool's minimum fee of {}",
+                    tx_fee.as_u64(),
+                    self.unconfirmed_pool.config.min_fee
+                ),
+            ));
         }
         match self.validator.validate(&tx) {
             Ok(()) => {
@@ -118,36 +137,95 @@ impl MempoolStorage {
                     tx_id,
                     timer.elapsed()
                 );
-                Ok(TxStorageResponse::UnconfirmedPool)
+                Ok(TxStorageResponseWithRejectionReason::accepted(
+                    TxStorageResponse::UnconfirmedPool,
+                ))
             },
             Err(ValidationError::UnknownInputs(dependent_outputs)) => {
                 if self.unconfirmed_pool.contains_all_outputs(&dependent_outputs) {
                     let weight = self.get_transaction_weighting();
                     self.unconfirmed_pool.insert(tx, Some(dependent_outputs), &weight)?;
-                    Ok(TxStorageResponse::UnconfirmedPool)
+                    Ok(TxStorageResponseWithRejectionReason::accepted(
+                        TxStorageResponse::UnconfirmedPool,
+                    ))
                 } else {
-                    Ok(TxStorageResponse::NotStoredOrphan)
+                    let total_unknown_inputs = dependent_outputs.len();
+                    let displayed_unknown_inputs = total_unknown_inputs.min(MAX_REJECTION_DETAIL_ITEMS);
+                    let unknown_inputs = dependent_outputs
+                        .iter()
+                        .take(MAX_REJECTION_DETAIL_ITEMS)
+                        .map(|hash| hash.to_hex())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let omitted_unknown_inputs = total_unknown_inputs.saturating_sub(displayed_unknown_inputs);
+                    let omitted_suffix = if omitted_unknown_inputs > 0 {
+                        format!("; {omitted_unknown_inputs} additional unknown input(s) omitted")
+                    } else {
+                        String::new()
+                    };
+                    Ok(TxStorageResponseWithRejectionReason::rejected(
+                        TxStorageResponse::NotStoredOrphan,
+                        format!("Transaction contains unknown input(s): {unknown_inputs}{omitted_suffix}"),
+                    ))
                 }
             },
             Err(ValidationError::ContainsSTxO) => {
                 info!(target: LOG_TARGET, "Validation failed due to already spent input");
-                Ok(TxStorageResponse::NotStoredAlreadySpent)
+                let total_input_count = tx.body.inputs().len();
+                let input_commitments = tx
+                    .body
+                    .inputs()
+                    .iter()
+                    .take(MAX_REJECTION_DETAIL_ITEMS)
+                    .filter_map(|input| input.commitment().ok().map(|commitment| commitment.to_hex()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let omitted_input_count = total_input_count.saturating_sub(MAX_REJECTION_DETAIL_ITEMS);
+                let omitted_suffix = if omitted_input_count > 0 {
+                    format!("; {omitted_input_count} additional input(s) omitted")
+                } else {
+                    String::new()
+                };
+                let reason = if input_commitments.is_empty() {
+                    "Transaction contains input(s) that have already been spent".to_string()
+                } else {
+                    format!(
+                        "Transaction contains one or more already-spent inputs; sampled transaction input \
+                         commitment(s): {input_commitments}{omitted_suffix}"
+                    )
+                };
+                Ok(TxStorageResponseWithRejectionReason::rejected(
+                    TxStorageResponse::NotStoredAlreadySpent,
+                    reason,
+                ))
             },
-            Err(ValidationError::MaturityError) => Ok(TxStorageResponse::NotStoredTimeLocked),
+            Err(ValidationError::MaturityError) => Ok(TxStorageResponseWithRejectionReason::rejected(
+                TxStorageResponse::NotStoredTimeLocked,
+                "Transaction contains kernels or inputs that are not yet spendable".to_string(),
+            )),
             Err(ValidationError::ConsensusError(msg)) => {
                 warn!(target: LOG_TARGET, "Validation failed due to consensus rule: {msg}");
-                Ok(TxStorageResponse::NotStoredConsensus)
+                Ok(TxStorageResponseWithRejectionReason::rejected(
+                    TxStorageResponse::NotStoredConsensus,
+                    format!("Consensus rule violation: {msg}"),
+                ))
             },
             Err(ValidationError::DuplicateKernelError(msg)) => {
                 debug!(
                     target: LOG_TARGET,
                     "Validation failed due to already mined kernel: {msg}"
                 );
-                Ok(TxStorageResponse::NotStoredAlreadyMined)
+                Ok(TxStorageResponseWithRejectionReason::rejected(
+                    TxStorageResponse::NotStoredAlreadyMined,
+                    format!("Transaction kernel already exists on chain: {msg}"),
+                ))
             },
             Err(e) => {
                 info!(target: LOG_TARGET, "Validation failed due to error: {e}");
-                Ok(TxStorageResponse::NotStored)
+                Ok(TxStorageResponseWithRejectionReason::rejected(
+                    TxStorageResponse::NotStored,
+                    e.to_string(),
+                ))
             },
         }
     }

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -105,6 +105,28 @@ pub enum TxStorageResponse {
     NotStoredFeeTooLow,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TxStorageResponseWithRejectionReason {
+    pub storage_response: TxStorageResponse,
+    pub rejection_reason: Option<String>,
+}
+
+impl TxStorageResponseWithRejectionReason {
+    pub fn accepted(storage_response: TxStorageResponse) -> Self {
+        Self {
+            storage_response,
+            rejection_reason: None,
+        }
+    }
+
+    pub fn rejected(storage_response: TxStorageResponse, rejection_reason: String) -> Self {
+        Self {
+            storage_response,
+            rejection_reason: Some(rejection_reason),
+        }
+    }
+}
+
 impl TxStorageResponse {
     pub fn is_stored(&self) -> bool {
         matches!(self, Self::UnconfirmedPool | Self::ReorgPool)

--- a/base_layer/core/src/mempool/service/handle.rs
+++ b/base_layer/core/src/mempool/service/handle.rs
@@ -29,6 +29,7 @@ use crate::mempool::{
     StateResponse,
     StatsResponse,
     TxStorageResponse,
+    TxStorageResponseWithRejectionReason,
     service::{MempoolRequest, MempoolResponse},
 };
 
@@ -76,6 +77,20 @@ impl MempoolHandle {
             .await??
         {
             MempoolResponse::TxStorage(response) => Ok(response),
+            _ => Err(MempoolServiceError::InvalidResponse("Incorrect response".to_string())),
+        }
+    }
+
+    pub async fn submit_transaction_with_rejection_reason(
+        &mut self,
+        transaction: Transaction,
+    ) -> Result<TxStorageResponseWithRejectionReason, MempoolServiceError> {
+        match self
+            .inner
+            .call(MempoolRequest::SubmitTransactionWithRejectionReason(transaction))
+            .await??
+        {
+            MempoolResponse::TxStorageWithRejectionReason(response) => Ok(response),
             _ => Err(MempoolServiceError::InvalidResponse("Incorrect response".to_string())),
         }
     }

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -35,6 +35,7 @@ use crate::{
     mempool::{
         Mempool,
         TxStorageResponse,
+        TxStorageResponseWithRejectionReason,
         service::{MempoolRequest, MempoolResponse, MempoolServiceError, OutboundMempoolServiceInterface},
     },
 };
@@ -68,6 +69,7 @@ impl MempoolInboundHandlers {
             GetStats,
             GetTxStateByExcessSig,
             SubmitTransaction,
+            SubmitTransactionWithRejectionReason,
         };
         match request {
             GetStats => Ok(MempoolResponse::Stats(self.mempool.stats().await?)),
@@ -86,6 +88,20 @@ impl MempoolInboundHandlers {
                     "Transaction ({first_tx_kernel_excess_sig}) submitted using request."
                 );
                 Ok(MempoolResponse::TxStorage(self.submit_transaction(tx, None).await?))
+            },
+            SubmitTransactionWithRejectionReason(tx) => {
+                let first_tx_kernel_excess_sig = tx
+                    .first_kernel_excess_sig()
+                    .ok_or(MempoolServiceError::TransactionNoKernels)?
+                    .get_signature()
+                    .to_hex();
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction ({first_tx_kernel_excess_sig}) submitted using detailed request."
+                );
+                Ok(MempoolResponse::TxStorageWithRejectionReason(
+                    self.submit_transaction_with_rejection_reason(tx, None).await?,
+                ))
             },
             GetFeePerGramStats { count, tip_height } => {
                 let stats = self.mempool.get_fee_per_gram_stats(count, tip_height).await?;
@@ -127,6 +143,17 @@ impl MempoolInboundHandlers {
         tx: Transaction,
         source_peer: Option<NodeId>,
     ) -> Result<TxStorageResponse, MempoolServiceError> {
+        Ok(self
+            .submit_transaction_with_rejection_reason(tx, source_peer)
+            .await?
+            .storage_response)
+    }
+
+    async fn submit_transaction_with_rejection_reason(
+        &mut self,
+        tx: Transaction,
+        source_peer: Option<NodeId>,
+    ) -> Result<TxStorageResponseWithRejectionReason, MempoolServiceError> {
         trace!(target: LOG_TARGET, "submit_transaction: {tx}");
 
         let tx = Arc::new(tx);
@@ -141,10 +168,11 @@ impl MempoolInboundHandlers {
                 target: LOG_TARGET,
                 "Mempool already has transaction: {kernel_excess_sig}"
             );
-            return Ok(tx_storage);
+            return Ok(TxStorageResponseWithRejectionReason::accepted(tx_storage));
         }
-        match self.mempool.insert(tx.clone()).await {
-            Ok(tx_storage) => {
+        match self.mempool.insert_with_rejection_reason(tx.clone()).await {
+            Ok(response) => {
+                let tx_storage = response.storage_response.clone();
                 #[cfg(feature = "metrics")]
                 if tx_storage.is_stored() {
                     metrics::inbound_transactions().inc();
@@ -167,7 +195,7 @@ impl MempoolInboundHandlers {
                         .propagate_tx(tx, source_peer.into_iter().collect())
                         .await?;
                 }
-                Ok(tx_storage)
+                Ok(response)
             },
             Err(e) => Err(MempoolServiceError::MempoolError(e)),
         }

--- a/base_layer/core/src/mempool/service/local_service.rs
+++ b/base_layer/core/src/mempool/service/local_service.rs
@@ -28,6 +28,7 @@ use crate::mempool::{
     StateResponse,
     StatsResponse,
     TxStorageResponse,
+    TxStorageResponseWithRejectionReason,
     service::{MempoolRequest, MempoolResponse, MempoolServiceError},
 };
 pub type LocalMempoolRequester = SenderService<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>;
@@ -80,6 +81,20 @@ impl LocalMempoolService {
             .await??
         {
             MempoolResponse::TxStorage(s) => Ok(s),
+            _ => Err(MempoolServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn submit_transaction_with_rejection_reason(
+        &mut self,
+        transaction: Transaction,
+    ) -> Result<TxStorageResponseWithRejectionReason, MempoolServiceError> {
+        match self
+            .request_sender
+            .call(MempoolRequest::SubmitTransactionWithRejectionReason(transaction))
+            .await??
+        {
+            MempoolResponse::TxStorageWithRejectionReason(s) => Ok(s),
             _ => Err(MempoolServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -37,6 +37,7 @@ pub enum MempoolRequest {
     GetState,
     GetTxStateByExcessSig(CompressedSignature),
     SubmitTransaction(Transaction),
+    SubmitTransactionWithRejectionReason(Transaction),
     GetFeePerGramStats { count: usize, tip_height: u64 },
     FilterOutputsInMempool(Vec<HashOutput>),
 }
@@ -55,6 +56,13 @@ impl Display for MempoolRequest {
                     .map(|sig| sig.get_signature().to_hex())
                     .unwrap_or_else(|| "No kernels!".to_string());
                 write!(f, "SubmitTransaction ({sig_hex})")
+            },
+            MempoolRequest::SubmitTransactionWithRejectionReason(tx) => {
+                let sig_hex = tx
+                    .first_kernel_excess_sig()
+                    .map(|sig| sig.get_signature().to_hex())
+                    .unwrap_or_else(|| "No kernels!".to_string());
+                write!(f, "SubmitTransactionWithRejectionReason ({sig_hex})")
             },
             MempoolRequest::GetFeePerGramStats { count, tip_height } => {
                 write!(f, "GetFeePerGramStats(count: {}, tip_height: {})", *count, *tip_height)

--- a/base_layer/core/src/mempool/service/response.rs
+++ b/base_layer/core/src/mempool/service/response.rs
@@ -27,7 +27,7 @@ use tari_transaction_components::rpc::models::FeePerGramStat;
 
 use crate::{
     common::RequestKey,
-    mempool::{StateResponse, StatsResponse, TxStorageResponse},
+    mempool::{StateResponse, StatsResponse, TxStorageResponse, TxStorageResponseWithRejectionReason},
 };
 
 /// API Response enum for Mempool responses.
@@ -36,17 +36,21 @@ pub enum MempoolResponse {
     Stats(StatsResponse),
     State(StateResponse),
     TxStorage(TxStorageResponse),
+    TxStorageWithRejectionReason(TxStorageResponseWithRejectionReason),
     FeePerGramStats { response: Vec<FeePerGramStat> },
     FilteredOutputs(Vec<HashOutput>),
 }
 
 impl fmt::Display for MempoolResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        use MempoolResponse::{FeePerGramStats, FilteredOutputs, State, Stats, TxStorage};
+        use MempoolResponse::{
+            FeePerGramStats, FilteredOutputs, State, Stats, TxStorage, TxStorageWithRejectionReason,
+        };
         match &self {
             Stats(_) => write!(f, "Stats"),
             State(_) => write!(f, "State"),
             TxStorage(_) => write!(f, "TxStorage"),
+            TxStorageWithRejectionReason(_) => write!(f, "TxStorageWithRejectionReason"),
             FeePerGramStats { response } => write!(f, "FeePerGramStats({} item(s))", response.len()),
             FilteredOutputs(outputs) => write!(f, "FilteredOutputs({} item(s))", outputs.len()),
         }

--- a/base_layer/core/src/mempool/test_utils/mock.rs
+++ b/base_layer/core/src/mempool/test_utils/mock.rs
@@ -34,6 +34,7 @@ use crate::mempool::{
     StateResponse,
     StatsResponse,
     TxStorageResponse,
+    TxStorageResponseWithRejectionReason,
     service::{MempoolHandle, MempoolRequest, MempoolResponse},
 };
 
@@ -51,6 +52,7 @@ pub struct MempoolMockState {
     get_state: Arc<Mutex<StateResponse>>,
     get_tx_state_by_excess_sig: Arc<Mutex<TxStorageResponse>>,
     submit_transaction: Arc<Mutex<TxStorageResponse>>,
+    submit_transaction_with_rejection_reason: Arc<Mutex<TxStorageResponseWithRejectionReason>>,
     calls: Arc<AtomicUsize>,
 }
 
@@ -68,6 +70,9 @@ impl Default for MempoolMockState {
             })),
             get_tx_state_by_excess_sig: Arc::new(Mutex::new(TxStorageResponse::NotStored)),
             submit_transaction: Arc::new(Mutex::new(TxStorageResponse::NotStored)),
+            submit_transaction_with_rejection_reason: Arc::new(Mutex::new(
+                TxStorageResponseWithRejectionReason::accepted(TxStorageResponse::NotStored),
+            )),
             calls: Arc::new(Default::default()),
         }
     }
@@ -88,6 +93,13 @@ impl MempoolMockState {
 
     pub async fn set_submit_transaction_response(&self, resp: TxStorageResponse) {
         *self.submit_transaction.lock().await = resp;
+    }
+
+    pub async fn set_submit_transaction_with_rejection_reason_response(
+        &self,
+        resp: TxStorageResponseWithRejectionReason,
+    ) {
+        *self.submit_transaction_with_rejection_reason.lock().await = resp;
     }
 
     fn inc_call_count(&self) {
@@ -131,6 +143,7 @@ impl MempoolServiceMock {
             GetStats,
             GetTxStateByExcessSig,
             SubmitTransaction,
+            SubmitTransactionWithRejectionReason,
         };
 
         self.state.inc_call_count();
@@ -142,6 +155,13 @@ impl MempoolServiceMock {
             )),
             SubmitTransaction(_) => Ok(MempoolResponse::TxStorage(
                 self.state.submit_transaction.lock().await.clone(),
+            )),
+            SubmitTransactionWithRejectionReason(_) => Ok(MempoolResponse::TxStorageWithRejectionReason(
+                self.state
+                    .submit_transaction_with_rejection_reason
+                    .lock()
+                    .await
+                    .clone(),
             )),
             GetFeePerGramStats { .. } => {
                 unimplemented!()

--- a/base_layer/core/tests/tests/mempool.rs
+++ b/base_layer/core/tests/tests/mempool.rs
@@ -1437,9 +1437,17 @@ async fn validation_reject_min_fee() {
     let validator =
         TransactionInternalConsistencyValidator::new(true, consensus_manager.consensus_manager(), factories);
     validator.validate(&tx, None, None, u64::MAX).unwrap();
-    let response = mempool.insert(Arc::new(tx)).await.unwrap();
+    let response = mempool.insert_with_rejection_reason(Arc::new(tx)).await.unwrap();
     // make sure the tx was not accepted into the mempool
-    assert!(matches!(response, TxStorageResponse::NotStoredFeeTooLow));
+    assert!(matches!(
+        response.storage_response,
+        TxStorageResponse::NotStoredFeeTooLow
+    ));
+    assert!(response
+        .rejection_reason
+        .as_deref()
+        .unwrap_or_default()
+        .contains("below this mempool's minimum fee"));
 }
 
 #[tokio::test]

--- a/base_layer/transaction_components/src/rpc/models/tx_submission_response.rs
+++ b/base_layer/transaction_components/src/rpc/models/tx_submission_response.rs
@@ -28,6 +28,8 @@ use serde::{Deserialize, Serialize};
 pub struct TxSubmissionResponse {
     pub accepted: bool,
     pub rejection_reason: TxSubmissionRejectionReason,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejection_reason_details: Option<String>,
     pub is_synced: bool,
 }
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -32,7 +32,7 @@ use tari_common_types::{
     types::CompressedSignature,
 };
 use tari_transaction_components::{
-    rpc::models::{TxLocation, TxSubmissionRejectionReason},
+    rpc::models::{TxLocation, TxSubmissionRejectionReason, TxSubmissionResponse},
     transaction_components::Transaction,
 };
 use tari_transaction_key_manager::legacy_key_manager::LegacyTransactionKeyManagerInterface;
@@ -109,9 +109,9 @@ where
                 },
             };
 
-            if !(completed_tx.status == LegacyTransactionStatus::Completed ||
-                completed_tx.status == LegacyTransactionStatus::Broadcast ||
-                completed_tx.status == LegacyTransactionStatus::MinedUnconfirmed)
+            if !(completed_tx.status == LegacyTransactionStatus::Completed
+                || completed_tx.status == LegacyTransactionStatus::Broadcast
+                || completed_tx.status == LegacyTransactionStatus::MinedUnconfirmed)
             {
                 debug!(
                     target: LOG_TARGET,
@@ -197,38 +197,11 @@ where
             return Ok(false);
         }
 
-        if !response.accepted && response.rejection_reason != TxSubmissionRejectionReason::AlreadyMined {
+        if let Some((rejection_reason, reason_error, reason)) = rejection_error_and_cancellation_reason(&response) {
             error!(
                 target: LOG_TARGET,
-                "Transaction (TxId: {}) rejected by Base Node for reason: {}", self.tx_id, response.rejection_reason
+                "Transaction (TxId: {}) rejected by Base Node for reason: {}", self.tx_id, rejection_reason
             );
-
-            let (reason_error, reason) = match response.rejection_reason {
-                TxSubmissionRejectionReason::None | TxSubmissionRejectionReason::ValidationFailed => (
-                    TransactionServiceError::MempoolRejectionInvalidTransaction,
-                    TxCancellationReason::InvalidTransaction,
-                ),
-                TxSubmissionRejectionReason::DoubleSpend => (
-                    TransactionServiceError::MempoolRejectionDoubleSpend,
-                    TxCancellationReason::DoubleSpend,
-                ),
-                TxSubmissionRejectionReason::Orphan => (
-                    TransactionServiceError::MempoolRejectionOrphan,
-                    TxCancellationReason::Orphan,
-                ),
-                TxSubmissionRejectionReason::TimeLocked => (
-                    TransactionServiceError::MempoolRejectionTimeLocked,
-                    TxCancellationReason::TimeLocked,
-                ),
-                TxSubmissionRejectionReason::FeeTooLow => (
-                    TransactionServiceError::MempoolRejectionFeeTooLow,
-                    TxCancellationReason::FeeTooLow,
-                ),
-                TxSubmissionRejectionReason::AlreadyMined => (
-                    TransactionServiceError::MempoolRejectionAlreadyMined,
-                    TxCancellationReason::AlreadyMined,
-                ),
-            };
 
             self.cancel_pending_transaction(reason).await;
 
@@ -309,9 +282,9 @@ where
             );
             Ok(true)
         } else if response.location != TxLocation::InMempool {
-            if self.last_rejection.is_none() ||
-                self.last_rejection.unwrap().elapsed() >
-                    self.resources.config.transaction_mempool_resubmission_window
+            if self.last_rejection.is_none()
+                || self.last_rejection.unwrap().elapsed()
+                    > self.resources.config.transaction_mempool_resubmission_window
             {
                 info!(
                     target: LOG_TARGET,
@@ -406,8 +379,65 @@ where
     }
 }
 
+fn rejection_error_and_cancellation_reason(
+    response: &TxSubmissionResponse,
+) -> Option<(String, TransactionServiceError, TxCancellationReason)> {
+    if response.accepted || response.rejection_reason == TxSubmissionRejectionReason::AlreadyMined {
+        return None;
+    }
+
+    let rejection_reason = response
+        .rejection_reason_details
+        .clone()
+        .unwrap_or_else(|| response.rejection_reason.to_string());
+
+    let reason = match response.rejection_reason {
+        TxSubmissionRejectionReason::None | TxSubmissionRejectionReason::ValidationFailed => {
+            TxCancellationReason::InvalidTransaction
+        },
+        TxSubmissionRejectionReason::DoubleSpend => TxCancellationReason::DoubleSpend,
+        TxSubmissionRejectionReason::Orphan => TxCancellationReason::Orphan,
+        TxSubmissionRejectionReason::TimeLocked => TxCancellationReason::TimeLocked,
+        TxSubmissionRejectionReason::FeeTooLow => TxCancellationReason::FeeTooLow,
+        TxSubmissionRejectionReason::AlreadyMined => return None,
+    };
+
+    Some((
+        rejection_reason.clone(),
+        TransactionServiceError::MempoolRejection {
+            reason: rejection_reason,
+        },
+        reason,
+    ))
+}
+
 #[derive(Debug, PartialEq)]
 pub enum TxBroadcastMode {
     TransactionSubmission,
     TransactionQuery,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn rejection_error_prefers_detail_text_for_wallet_feedback() {
+        let detail = "Validation failed: input already spent by transaction abc123".to_string();
+        let response = TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::ValidationFailed,
+            rejection_reason_details: Some(detail.clone()),
+            is_synced: true,
+        };
+
+        let (reason_text, error, cancellation_reason) = rejection_error_and_cancellation_reason(&response).unwrap();
+
+        assert_eq!(reason_text, detail);
+        assert_eq!(cancellation_reason, TxCancellationReason::InvalidTransaction);
+        match error {
+            TransactionServiceError::MempoolRejection { reason } => assert_eq!(reason, detail),
+            err => panic!("unexpected error: {err:?}"),
+        }
+    }
 }

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -176,6 +176,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
         Ok(TxSubmissionResponse {
             accepted: true,
             rejection_reason: models::TxSubmissionRejectionReason::None,
+            rejection_reason_details: None,
             is_synced: true,
         })
     }


### PR DESCRIPTION
Fixes #7776.

### Summary

- Add optional `rejection_reason_details` to `TxSubmissionResponse`.
- Preserve the existing coarse `TxSubmissionRejectionReason` enum while carrying
  the underlying mempool validation reason through local service, handle, and
  HTTP response paths.
- Map already-spent mempool rejections to `DoubleSpend` for wallet/API
  feedback.
- Prefer detailed rejection text in wallet broadcast
  `MempoolRejection` errors when the base node provides it.

### Tests

```bash
cargo test -p tari_transaction_components tx_submission_response_ --lib
cargo test -p minotari_node submit_transaction --lib
cargo test -p tari_core mempool --lib
cargo test -p minotari_wallet rejection_error_prefers_detail_text_for_wallet_feedback --lib
```

Local results:

- `tari_transaction_components`: compiled successfully; 0 tests matched the
  filter.
- `minotari_node submit_transaction`: 2 passed.
- `tari_core mempool`: 31 passed.
- `minotari_wallet rejection_error_prefers_detail_text_for_wallet_feedback`: 1
  passed.
