### PR TITLE
fix: consume merge mining proxy monero reservation

### DIFF
--- a/applications/minotari_merge_mining_proxy/src/block_template_manager.rs
+++ b/applications/minotari_merge_mining_proxy/src/block_template_manager.rs
@@ -27,6 +27,7 @@ use log::*;
 use minotari_app_grpc::tari_rpc::{GetNewBlockRequest, MinerData, NewBlockTemplate, PowAlgo, pow_algo::PowAlgos};
 use minotari_app_utilities::parse_miner_input::{BaseNodeGrpcClient, ShaP2PoolGrpcClient};
 use minotari_node_grpc_client::grpc;
+use monero::blockdata::transaction::{ExtraField, RawExtraField, SubField};
 use tari_common_types::{tari_address::TariAddress, types::FixedHash};
 use tari_core::{
     AuxChainHashes,
@@ -44,7 +45,7 @@ use tari_utilities::{ByteArray, hex::Hex};
 
 use crate::{
     block_template_data::{BlockTemplateData, BlockTemplateDataBuilder},
-    common::merge_mining,
+    common::{merge_mining, monero_rpc::TARI_MERGE_MINING_TAG_SIZE},
     config::MergeMiningProxyConfig,
     error::MmProxyError,
 };
@@ -301,6 +302,7 @@ fn add_monero_data(
     debug!(target: LOG_TARGET, "Insert aux chain merkle root (merge_mining_hash) into Monero block");
     let aux_chain_mr = calculate_aux_chain_merkle_root(aux_chain_hashes.clone())?.0;
     monero_rx::insert_aux_chain_mr_and_info_into_block(&mut monero_block, aux_chain_mr.to_bytes(), 1, 0)?;
+    remove_reserved_merge_mining_tag_space(&mut monero_block.miner_tx.prefix.extra)?;
 
     debug!(target: LOG_TARGET, "Create blockhashing blob from blocktemplate blob",);
     // Must be done after the aux_chain_mr is inserted since it will affect the hash of the miner tx
@@ -326,6 +328,33 @@ fn add_monero_data(
         aux_chain_mr: AuxChainMr::try_from(aux_chain_mr.to_bytes().to_vec())
             .map_err(|e| MmProxyError::ConversionError(e.to_string()))?,
     })
+}
+
+/// Remove the placeholder bytes that were added to the Monero extra nonce so the final block weight matches the
+/// template weight used by monerod to calculate the reward.
+fn remove_reserved_merge_mining_tag_space(extra: &mut RawExtraField) -> Result<(), MmProxyError> {
+    let mut extra_field = ExtraField::try_parse(extra)
+        .map_err(|_| MmProxyError::ConversionError("Invalid Monero coinbase extra field".to_string()))?;
+    let nonce = extra_field
+        .0
+        .iter_mut()
+        .find_map(|field| match field {
+            SubField::Nonce(nonce) => Some(nonce),
+            _ => None,
+        })
+        .ok_or_else(|| MmProxyError::MissingDataError("Monero coinbase extra nonce field not found".to_string()))?;
+
+    if nonce.len() < TARI_MERGE_MINING_TAG_SIZE {
+        return Err(MmProxyError::InvalidMonerodResponse(format!(
+            "Monero coinbase extra nonce field is too small to contain the reserved merge mining tag space: {} < {}",
+            nonce.len(),
+            TARI_MERGE_MINING_TAG_SIZE,
+        )));
+    }
+
+    nonce.truncate(nonce.len() - TARI_MERGE_MINING_TAG_SIZE);
+    *extra = extra_field.into();
+    Ok(())
 }
 
 /// Private convenience container struct for new template data
@@ -360,4 +389,53 @@ pub(crate) struct MoneroMiningData {
     pub seed_hash: FixedByteArray,
     pub blocktemplate_blob: String,
     pub difficulty: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use monero::{Hash, VarInt};
+
+    use super::*;
+
+    fn extra_with_nonce(nonce: Vec<u8>) -> RawExtraField {
+        ExtraField(vec![
+            SubField::MergeMining(VarInt(0), Hash::default()),
+            SubField::Nonce(nonce),
+        ])
+        .into()
+    }
+
+    #[test]
+    fn it_removes_the_proxy_reserved_merge_mining_tag_space() {
+        let miner_nonce = vec![1, 2, 3, 4];
+        let mut reserved_nonce = miner_nonce.clone();
+        reserved_nonce.extend([0; TARI_MERGE_MINING_TAG_SIZE]);
+        let mut extra = extra_with_nonce(reserved_nonce);
+
+        remove_reserved_merge_mining_tag_space(&mut extra).unwrap();
+
+        let extra_field = ExtraField::try_parse(&extra).unwrap();
+        assert!(
+            extra_field
+                .0
+                .iter()
+                .any(|field| matches!(field, SubField::MergeMining(_, _)))
+        );
+        let nonce = extra_field
+            .0
+            .iter()
+            .find_map(|field| match field {
+                SubField::Nonce(nonce) => Some(nonce),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(nonce, &miner_nonce);
+    }
+
+    #[test]
+    fn it_rejects_nonce_fields_smaller_than_the_proxy_reservation() {
+        let mut extra = extra_with_nonce(vec![0; TARI_MERGE_MINING_TAG_SIZE - 1]);
+
+        assert!(remove_reserved_merge_mining_tag_space(&mut extra).is_err());
+    }
 }

--- a/applications/minotari_merge_mining_proxy/src/common/monero_rpc.rs
+++ b/applications/minotari_merge_mining_proxy/src/common/monero_rpc.rs
@@ -26,6 +26,8 @@
 //!
 //! Response codes taken from <https://github.com/monero-project/monero/blob/8286f07b265d16a87b3fe3bb53e8d7bf37b5265a/src/rpc/core_rpc_server_error_codes.h>
 
+pub const TARI_MERGE_MINING_TAG_SIZE: usize = 35;
+
 // Even though we don't construct all variants, we want a complete list of them.
 #[allow(dead_code)]
 #[repr(i32)]

--- a/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
@@ -54,7 +54,12 @@ use url::Url;
 use crate::{
     block_template_data::BlockTemplateRepository,
     block_template_manager::{BlockTemplateManager, MoneroMiningData},
-    common::{json_rpc, monero_rpc::CoreRpcErrorCode, proxy, proxy::convert_json_to_hyper_json_response},
+    common::{
+        json_rpc,
+        monero_rpc::{CoreRpcErrorCode, TARI_MERGE_MINING_TAG_SIZE},
+        proxy,
+        proxy::convert_json_to_hyper_json_response,
+    },
     config::MergeMiningProxyConfig,
     error::MmProxyError,
     proxy::{
@@ -68,7 +73,6 @@ const LOG_TARGET: &str = "minotari_mm_proxy::proxy::inner";
 /// The identifier used to identify the tari aux chain data
 const TARI_CHAIN_ID: &str = "xtr";
 const BUSY_QUALIFYING: &str = "BusyQualifyingMonerodUrl";
-const TARI_MERGE_MINING_DATA_SIZE: u64 = 35;
 
 #[derive(Debug, Clone)]
 pub struct InnerService {
@@ -433,7 +437,9 @@ impl InnerService {
         // We must shift the reserved_offset so the miner writes its nonce in the correct place,
         // preventing coinbase corruption.
         if let Some(offset) = monerod_resp["result"]["reserved_offset"].as_u64() {
-            monerod_resp["result"]["reserved_offset"] = (offset + TARI_MERGE_MINING_DATA_SIZE).into();
+            let tag_size = u64::try_from(TARI_MERGE_MINING_TAG_SIZE)
+                .map_err(|err| MmProxyError::ConversionError(err.to_string()))?;
+            monerod_resp["result"]["reserved_offset"] = (offset + tag_size).into();
         }
 
         let tari_difficulty = final_block_template_data.template.tari_difficulty;
@@ -788,18 +794,17 @@ impl InnerService {
             .map(|s| s.to_string())
         {
             // XMRig sent `extra_nonce`. Append hex zeroes to force weight calculation.
-            let padding = "0".repeat(
-                usize::try_from(TARI_MERGE_MINING_DATA_SIZE * 2)
-                    .map_err(|err| MmProxyError::ConversionError(err.to_string()))?,
-            );
+            let padding = "0".repeat(TARI_MERGE_MINING_TAG_SIZE * 2);
             let new_extra_nonce = format!("{}{}", extra_nonce, padding);
             params.insert("extra_nonce".to_string(), serde_json::json!(new_extra_nonce));
             params.remove("reserve_size");
         } else {
+            let tag_size = u64::try_from(TARI_MERGE_MINING_TAG_SIZE)
+                .map_err(|err| MmProxyError::ConversionError(err.to_string()))?;
             let current_reserve = params.get("reserve_size").and_then(|v| v.as_u64()).unwrap_or(0);
             params.insert(
                 "reserve_size".to_string(),
-                serde_json::json!(current_reserve + TARI_MERGE_MINING_DATA_SIZE),
+                serde_json::json!(current_reserve + tag_size),
             );
         }
 

--- a/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
+++ b/applications/minotari_merge_mining_proxy/src/proxy/inner.rs
@@ -437,8 +437,7 @@ impl InnerService {
         // We must shift the reserved_offset so the miner writes its nonce in the correct place,
         // preventing coinbase corruption.
         if let Some(offset) = monerod_resp["result"]["reserved_offset"].as_u64() {
-            let tag_size = u64::try_from(TARI_MERGE_MINING_TAG_SIZE)
-                .map_err(|err| MmProxyError::ConversionError(err.to_string()))?;
+            let tag_size = TARI_MERGE_MINING_TAG_SIZE as u64;
             monerod_resp["result"]["reserved_offset"] = (offset + tag_size).into();
         }
 
@@ -799,8 +798,7 @@ impl InnerService {
             params.insert("extra_nonce".to_string(), serde_json::json!(new_extra_nonce));
             params.remove("reserve_size");
         } else {
-            let tag_size = u64::try_from(TARI_MERGE_MINING_TAG_SIZE)
-                .map_err(|err| MmProxyError::ConversionError(err.to_string()))?;
+            let tag_size = TARI_MERGE_MINING_TAG_SIZE as u64;
             let current_reserve = params.get("reserve_size").and_then(|v| v.as_u64()).unwrap_or(0);
             params.insert(
                 "reserve_size".to_string(),


### PR DESCRIPTION
Fixes #7045.

  The merge mining proxy asks `monerod` to reserve the 35 bytes needed for the Tari merge-mining tag when requesting a Monero block template. That lets `monerod` calculate the miner transaction reward and any block weight penalty with those bytes included.

  The proxy then inserted the Tari tag but still returned the reserved placeholder bytes, making the final Monero block 35 bytes larger than the template `monerod` used for reward calculation. Under block weight penalty conditions, this can make Monero reject the submitted block because the miner transaction spends too much.

  This change consumes the placeholder bytes after inserting the Tari merge-mining tag, so the final Monero block weight matches the weight `monerod` already accounted for.

  Motivation and Context
  ---
  The fix is proxy-only and does not require any `monerod` changes.

  It preserves:
  - the Tari merge-mining tag in the Monero coinbase extra field,
  - the miner's original extra nonce bytes,
  - the shifted `reserved_offset` used by miners,
  - regenerated Monero `blockhashing_blob`/`blocktemplate_blob`.

  How Has This Been Tested?
  ---
  - `cargo +nightly fmt -p minotari_merge_mining_proxy --check`
  - `cargo test -p minotari_merge_mining_proxy --lib`
  - `cargo build -p minotari_merge_mining_proxy --bin minotari_merge_mining_proxy`
  - Local Monero regtest `submitblock` checks for both `extra_nonce` and `reserve_size` template request paths.

  What process can a PR reviewer use to test or verify this change?
  ---
  Request a Monero block template through the proxy and compare the final proxy-returned block template size with the template size that `monerod` accounted for after the proxy reservation. They should match after the Tari merge-mining tag is inserted.

  The focused unit tests also verify that the proxy removes only the reserved placeholder bytes, keeps the Tari merge-mining tag, and keeps the miner's original nonce bytes.

  Breaking Changes
  ---
  - [x] None
  - [ ] Requires data directory on base node to be deleted
  - [ ] Requires hard fork
  - [ ] Other - Please specify
