### PR TITLE
fix: jmt data usage

### DIFF
--- a/applications/minotari_app_grpc/proto/base_node.proto
+++ b/applications/minotari_app_grpc/proto/base_node.proto
@@ -214,6 +214,19 @@ message MigrationProgress {
   double progress_percentage = 3;
   uint64 current_db_version = 4;
   uint64 target_db_version = 5;
+  // Which sub-step of the migration is currently running. Lets clients show a more specific
+  // label (e.g. "Rebuilding JMT" vs. "Compacting LMDB") in addition to the numeric progress.
+  MigrationPhase phase = 6;
+}
+
+enum MigrationPhase {
+  MIGRATION_PHASE_UNSPECIFIED = 0;
+  // Walking the UTXO set and (re)building the v2 JMT tables. `current_block`/`total_blocks`
+  // count UTXOs processed during this phase.
+  MIGRATION_PHASE_JMT_REBUILD = 1;
+  // Running `mdb_env_copy2(MDB_CP_COMPACT)` to reclaim disk space freed by the migration.
+  // No fine-grained progress; the call is monolithic from LMDB's side.
+  MIGRATION_PHASE_LMDB_COMPACT = 2;
 }
 
 /// return type of GetNewBlockTemplate

--- a/applications/minotari_node/src/grpc/readiness_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/readiness_grpc_server.rs
@@ -24,11 +24,12 @@ use chrono::Utc;
 use futures::channel::mpsc;
 use minotari_app_grpc::tari_rpc::{
     self,
+    MigrationPhase as RpcMigrationPhase,
     MigrationProgress,
     ReadinessStatus,
     readiness_status::{State, Status as ReadinessStatusEnum},
 };
-use tari_core::chain_storage::DatabaseStats;
+use tari_core::chain_storage::{DatabaseStats, MigrationPhase};
 use tokio::sync::watch;
 use tonic::{Request, Response, Status};
 pub struct ReadinessGrpcServer {
@@ -92,6 +93,7 @@ impl ReadinessService {
                 progress_percentage: db_status.migration_stats.progress_percentage,
                 current_db_version: db_status.migration_stats.current_db_version,
                 target_db_version: db_status.migration_stats.target_db_version,
+                phase: map_migration_phase(db_status.migration_stats.phase).into(),
             });
             ReadinessStatus {
                 status: Some(latest_db_status),
@@ -101,6 +103,14 @@ impl ReadinessService {
             // For non-migration states, use the readiness status as-is
             readiness_status
         }
+    }
+}
+
+fn map_migration_phase(phase: MigrationPhase) -> RpcMigrationPhase {
+    match phase {
+        MigrationPhase::Unspecified => RpcMigrationPhase::Unspecified,
+        MigrationPhase::JmtRebuild => RpcMigrationPhase::JmtRebuild,
+        MigrationPhase::LmdbCompact => RpcMigrationPhase::LmdbCompact,
     }
 }
 

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/events.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/events.rs
@@ -63,7 +63,7 @@ impl HorizonSyncInfo {
                 total,
                 ref sync_peer,
             } => format!(
-                "Syncing outputs: {}/{} ({:.0}%) from {}{} Latency: {:.2?}",
+                "Syncing outputs: block {}/{} ({:.0}%) from {}{} Latency: {:.2?}",
                 current,
                 total,
                 current as f64 / total as f64 * 100.0,
@@ -107,7 +107,7 @@ impl Display for HorizonSyncInfo {
             } => {
                 write!(
                     f,
-                    "Horizon syncing outputs: {}/{} from {} (latency: {:.2?})",
+                    "Horizon syncing outputs: block {}/{} from {} (latency: {:.2?})",
                     current,
                     total,
                     sync_peer.node_id(),

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -338,135 +338,204 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         Ok(conn)
     }
 
+    async fn calculate_output_sync_start_stop(
+        &self,
+        sync_to_header: &BlockHeader,
+    ) -> Result<(u64, BlockHeader), HorizonSyncError> {
+        let stored_checkpoint = self.db.fetch_horizon_sync_output_checkpoint().await?;
+        if stored_checkpoint.is_none() {
+            debug!(target: LOG_TARGET, "No stored checkpoint, starting output sync from scratch");
+            return Ok((1, sync_to_header.clone()));
+        }
+        let stored_checkpoint = stored_checkpoint.expect("Already checked");
+        debug!(target: LOG_TARGET, "We have a stored checkpoint, with height {} and hash {}", stored_checkpoint.checkpoint_height, stored_checkpoint.checkpoint_hash.to_hex());
+        let checkpoint_sync_to_header = if let Some(header) = self.db.fetch_header(stored_checkpoint.sync_target_height).await? {
+            header
+        } else {
+            warn!(target: LOG_TARGET, "Horizon sync target at height {} is no longer on the canonical chain (reorg detected). Discarding checkpoint and restarting output sync from scratch.", stored_checkpoint.sync_target_height);
+            self.db
+                .write_transaction()
+                .clear_horizon_sync_output_checkpoint()
+                .commit()
+                .await?;
+            return Ok((1, sync_to_header.clone()));
+        };
+        if stored_checkpoint.sync_target_hash == sync_to_header.hash() {
+            info!(target: LOG_TARGET, "Resuming output sync from checkpoint at height {}, target unchanged", stored_checkpoint.checkpoint_height);
+            return Ok((stored_checkpoint.checkpoint_height+1, sync_to_header.clone()));
+        }
+        // we have a checkpoint, its target is not the syncing target, so we have two choices, delete it and start over,
+        // or sync to a lower height.
+        if sync_to_header.height < stored_checkpoint.checkpoint_height {
+            // new target is less, so we have to start over
+            debug!(target: LOG_TARGET, "New target is less than stored checkpoint, starting output sync from scratch");
+            self.db
+                .write_transaction()
+                .clear_horizon_sync_output_checkpoint()
+                .commit()
+                .await?;
+            return Ok((1, sync_to_header.clone()));
+        }
+        if sync_to_header
+            .height
+            .saturating_sub(stored_checkpoint.checkpoint_height) >
+            50_000
+        {
+            // we can sync to the checkpoint height first, and then do block sync from there
+            debug!(target: LOG_TARGET, "New target is greater than stored checkpoint, but within 50_000 blocks, resuming output sync from checkpoint");
+            return Ok((stored_checkpoint.checkpoint_height+1, checkpoint_sync_to_header));
+        }
+        debug!(target: LOG_TARGET, "New target is too far away, starting over");
+        self.db
+            .write_transaction()
+            .clear_horizon_sync_output_checkpoint()
+            .commit()
+            .await?;
+        Ok((1, sync_to_header.clone()))
+    }
+
     async fn sync_kernels_and_outputs(
         &mut self,
         sync_peer: SyncPeer,
         client: &mut rpc::BaseNodeSyncRpcClient,
-        to_header: &BlockHeader,
+        sync_to_header: &BlockHeader,
     ) -> Result<(), HorizonSyncError> {
+        let (start_height, to_header) = self.calculate_output_sync_start_stop(sync_to_header).await?;
         // Note: We do not need to rewind kernels if the sync fails due to it being validated when inserted into
         //       the database. Furthermore, these kernels will also be successfully removed when we need to rewind
         //       the blockchain for whatever reason.
         debug!(target: LOG_TARGET, "Synchronizing kernels");
-        self.synchronize_kernels(sync_peer.clone(), client, to_header).await?;
+        self.synchronize_kernels(sync_peer.clone(), client, &to_header).await?;
+
         debug!(target: LOG_TARGET, "Synchronizing outputs");
         // let cloned_backup_smt = self.db.inner().smt_read_access()?.clone();
-        match self.synchronize_outputs(sync_peer, client, to_header).await {
+        match self
+            .synchronize_outputs(sync_peer, client, &to_header, start_height)
+            .await
+        {
             Ok(_) => Ok(()),
             Err(err) => {
                 // We need to clean up the outputs
-                let _ = self.clean_up_failed_output_sync(to_header).await;
+                let clean_up_height = match self.db.fetch_horizon_sync_output_checkpoint().await? {
+                    Some(checkpoint) => checkpoint.checkpoint_height.saturating_add(1),
+                    None => 1,
+                };
+                match self.clean_up_stale_synced_outputs(clean_up_height).await {
+                    Ok(()) => {},
+                    Err(e) => warn!(target: LOG_TARGET, "Failed to clean up after failed output sync: {}", e),
+                };
                 // let mut smt = self.db.inner().smt_write_access()?;
                 // *smt = cloned_backup_smt;
+                debug!(target: LOG_TARGET, "Finished clearing failed output sync");
                 Err(err)
             },
         }
     }
 
     /// Cleanup stops at the last committed checkpoint so that previously-completed tranches are not disturbed.
-    async fn clean_up_failed_output_sync(&mut self, to_header: &BlockHeader) {
+    async fn clean_up_stale_synced_outputs(&mut self, start_height: u64) -> Result<(), ChainStorageError> {
         // Determine where to stop cleaning. If a tranche checkpoint exists, stop at the checkpoint block
         // Otherwise fall back to the current chain tip.
-        let stop_hash = match self.db.fetch_horizon_sync_output_checkpoint().await {
-            Ok(Some(cp)) => match self.db.fetch_header(cp.checkpoint_height).await {
-                Ok(Some(header)) => Some(header.hash()),
-                _ => None,
-            },
-            _ => None,
-        };
-        let stop_hash = match stop_hash {
-            Some(h) => h,
-            None => match self.db.fetch_header(0).await {
-                Ok(Some(header)) => header.hash(),
-                _ => return,
-            },
-        };
 
-        let db = self.db().clone();
-        let mut txn = db.write_transaction();
-        let mut current_header = to_header.clone();
-        loop {
-            if let Ok(outputs) = self.db.fetch_outputs_in_block(current_header.hash()).await {
-                for (count, output) in (1..=outputs.len()).zip(outputs.iter()) {
-                    txn.prune_output_from_all_dbs(
-                        output.hash(),
-                        output.commitment.clone(),
-                        output.features.output_type,
-                    );
-                    if (count % 100 == 0 || count == outputs.len()) &&
-                        let Err(e) = txn.commit().await
-                    {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Clean up failed sync - commit prune outputs for header '{}': {}",
-                            current_header.hash(), e
+        let stop_height = self.db.fetch_last_header().await?.height;
+
+        let mut current_height = start_height;
+        let mut txn = self.db.write_transaction();
+        let mut state_tree_updates = BTreeMap::<FixedHash, Option<FixedHash>>::new();
+        let mut reporting_counter = 0;
+        debug!(target: LOG_TARGET, "Cleaning up failed output sync, {}->{}", current_height, stop_height);
+        while let Some(current_header) = self.db.fetch_header(current_height).await? {
+            reporting_counter += 1;
+            if reporting_counter % 1000 == 0 {
+                debug!(target: LOG_TARGET, "Cleaning up failed output sync, progress: {}->{}",current_height, stop_height);
+            }
+
+            match self.db.fetch_outputs_in_block(current_header.hash()).await {
+                Ok(outputs) => {
+                    for (count, output) in (1..=outputs.len()).zip(outputs.iter()) {
+                        txn.prune_output_from_all_dbs(
+                            output.hash(),
+                            output.commitment.clone(),
+                            output.features.output_type,
                         );
+                        if !output.is_burned() {
+                            let key_bytes: [u8; 32] =
+                                output.commitment.as_bytes().try_into().expect("Malformed commitment");
+                            let smt_key = FixedHash::from(key_bytes);
+                            state_tree_updates.insert(smt_key, None);
+                        }
+                        if (count % 100 == 0 || count == outputs.len()) &&
+                            let Err(e) = txn.commit().await
+                        {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Clean up failed sync - commit prune outputs for header '{}': {}",
+                                current_header.hash(), e
+                            );
+                        }
+                    }
+                },
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "Could not clean up failed output sync, error fetching outputs: {}", e);
+                },
+            }
+            current_height += 1;
+        }
+        debug!(target: LOG_TARGET, "Finished cleaning up failed output sync, cleaned to height {}, proceeding to reinsert genesis outputs", stop_height);
+        // Restore genesis-block outputs that an earlier horizon sync spent: `prune_output_from_all_dbs`
+        // purged them from the UTXO LMDB tables when their STXO marker streamed in. If we don't
+        // restore them after rewinding past their spend height, the next sync can't resolve the
+        // STXO commitment Bob streams for the genesis-spending block and bans the peer with
+        // "Peer sent unknown commitment hash".
+        let genesis_block = self.db.fetch_genesis_block();
+        let genesis_header_hash = *genesis_block.hash();
+        let genesis_timestamp = genesis_block.block().header.timestamp.as_u64();
+        for output in genesis_block.block().body.outputs() {
+            if output.is_burned() {
+                continue;
+            }
+            let present = self
+                .db
+                .fetch_unspent_output_hash_by_commitment(output.commitment.clone())
+                .await?
+                .is_some();
+            if present {
+                debug!(target: LOG_TARGET, "skipping genesis output {} with commitment({}) from pruned state", output.hash(), output.commitment.to_hex());
+                continue;
+            }
+            let spent = self.db.fetch_inputs_mined_info(vec![output.hash()]).await?;
+            if !spent.is_empty() {
+                if let Some(spent_status) = &spent[0] {
+                    if spent_status.spent_height == 0 {
+                        debug!(target: LOG_TARGET, "skipping genesis output {} with commitment({}) from pruned state, it was spent in block {}", output.hash(), output.commitment.to_hex(), spent_status.spent_height);
+                        continue;
                     }
                 }
             }
+            let key_bytes: [u8; 32] = output.commitment.as_bytes().try_into().expect("Malformed commitment");
+            let smt_key = FixedHash::from(key_bytes);
+            let smt_node = output.smt_hash(0);
+            state_tree_updates.insert(smt_key, Some(smt_node));
+            // first make sure its deleted everywhere so we can cleanly reinsert it.
+            debug!(target: LOG_TARGET, "Restoring genesis output {} with commitment({}) from pruned state", output.hash(), output.commitment.to_hex());
 
-            if let Ok(header) = db.fetch_header_by_block_hash(current_header.prev_hash).await {
-                if let Some(previous_header) = header {
-                    current_header = previous_header;
-                } else {
-                    warn!(target: LOG_TARGET, "Could not clean up failed output sync, previous_header link missing from db");
-                    break;
-                }
-            } else {
-                warn!(
-                    target: LOG_TARGET,
-                    "Could not clean up failed output sync, header '{}' not in db",
-                    current_header.prev_hash.to_hex()
-                );
-                break;
-            }
-            if current_header.hash() == stop_hash {
-                debug!(target: LOG_TARGET, "Reached stop point while cleaning up failed output sync");
-                break;
-            }
-        }
-
-        if let Err(e) = txn.commit().await {
-            warn!(
-                target: LOG_TARGET,
-                "Clean up failed output sync - final commit failed: {}",
-                e
+            txn.prune_output_from_all_dbs(
+                output.hash(),
+                output.commitment.clone(),
+                output.features.output_type,
             );
+            txn.insert_output_via_horizon_sync(output.clone(), genesis_header_hash, 0, genesis_timestamp);
         }
-    }
 
-    /// Removes any outputs stored in the given block height range from the database.
-    /// On a fresh start all `fetch_outputs_in_block` calls return empty, so this is a no-op.
-    async fn clean_up_height_range(&mut self, start_height: u64, end_height: u64) -> Result<(), HorizonSyncError> {
-        let db = self.db().clone();
-        let mut txn = db.write_transaction();
-        let mut count: u64 = 0;
-        for height in start_height..=end_height {
-            let header = db
-                .fetch_header(height)
-                .await?
-                .ok_or_else(|| ChainStorageError::ValueNotFound {
-                    entity: "Header",
-                    field: "height",
-                    value: height.to_string(),
-                })?;
-            let outputs = db.fetch_outputs_in_block(header.hash()).await?;
-            for output in outputs {
-                txn.prune_output_from_all_dbs(output.hash(), output.commitment.clone(), output.features.output_type);
-                count += 1;
-                if count.is_multiple_of(PROGRESS_REPORT_INTERVAL) {
-                    txn.commit().await?;
-                    txn = db.write_transaction();
-                }
-            }
-        }
+        let tranche_updates = state_tree_updates
+            .into_iter()
+            .map(|(key, value)| HorizonStateTreeUpdate { key, value })
+            .collect::<Vec<_>>();
+
+        txn.apply_horizon_state_tree_updates(tranche_updates);
+
         txn.commit().await?;
-        if count > 0 {
-            debug!(
-                target: LOG_TARGET,
-                "Cleaned up {} partial output(s) from height range {}-{}", count, start_height, end_height
-            );
-        }
+        debug!(target: LOG_TARGET, "Finished cleaning up failed output sync, cleaned to height {}, genesis outputs restored", stop_height);
         Ok(())
     }
 
@@ -661,72 +730,11 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         mut sync_peer: SyncPeer,
         client: &mut rpc::BaseNodeSyncRpcClient,
         to_header: &BlockHeader,
+        sync_start_height: u64,
     ) -> Result<(), HorizonSyncError> {
         info!(target: LOG_TARGET, "Starting output sync from peer {sync_peer}");
         let db = self.db().clone();
-
-        let stored_checkpoint = db.fetch_horizon_sync_output_checkpoint().await?;
-
-        let checkpoint_height = match stored_checkpoint {
-            Some(ref cp) if cp.sync_target_height == to_header.height && cp.sync_target_hash == to_header.hash() => {
-                match db.fetch_header(cp.checkpoint_height).await? {
-                    Some(header) if header.hash() == cp.checkpoint_hash => {
-                        info!(
-                            target: LOG_TARGET,
-                            "Resuming output sync from checkpoint at height {}, target unchanged",
-                            cp.checkpoint_height
-                        );
-                        Some(cp.checkpoint_height)
-                    },
-                    _ => {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Horizon sync checkpoint at height {} is no longer on the canonical chain (reorg \
-                             detected). Discarding checkpoint and restarting output sync from scratch.",
-                            cp.checkpoint_height
-                        );
-                        db.write_transaction()
-                            .clear_horizon_sync_output_checkpoint()
-                            .commit()
-                            .await?;
-                        None
-                    },
-                }
-            },
-            Some(ref cp) => {
-                warn!(
-                    target: LOG_TARGET,
-                    "Horizon sync target changed from height {} to {}. Discarding checkpoint and cleaning up \
-                     partial outputs.",
-                    cp.sync_target_height,
-                    to_header.height
-                );
-                db.write_transaction()
-                    .clear_horizon_sync_output_checkpoint()
-                    .commit()
-                    .await?;
-                if let Ok(Some(cleanup_header)) = db.fetch_header(cp.checkpoint_height).await {
-                    self.clean_up_failed_output_sync(&cleanup_header).await;
-                }
-                None
-            },
-            None => None,
-        };
-        let (sync_start_height, _jmt_version) = match checkpoint_height {
-            Some(h) => {
-                // Only the in-progress (first resumption) tranche may have partial output data.
-                let first_tranche_end = cmp::min(
-                    (h + 1).saturating_add(HORIZON_SYNC_TRANCHE_SIZE).saturating_sub(1),
-                    to_header.height,
-                );
-                self.clean_up_height_range(h + 1, first_tranche_end).await?;
-                (h + 1, h)
-            },
-            None => {
-                self.clean_up_height_range(0, to_header.height).await?;
-                (0, 0)
-            },
-        };
+        self.clean_up_stale_synced_outputs(sync_start_height).await?;
 
         if sync_start_height > to_header.height {
             info!(
@@ -740,9 +748,13 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
 
         self.num_outputs = to_header.output_smt_size;
 
+        // Progress is reported in block heights: unambiguous, monotonic and resume-correct.
+        // The wire stream sends every output ever created in the range (then deletes spent ones
+        // via STXO markers), so an output count would overshoot `output_smt_size`. Block heights
+        // also preserve visible progress across a resume from a tranche checkpoint.
         let info = HorizonSyncInfo::new(vec![sync_peer.node_id().clone()], HorizonSyncStatus::Outputs {
-            current: 0,
-            total: self.num_outputs,
+            current: sync_start_height,
+            total: to_header.height,
             sync_peer: sync_peer.clone(),
         });
         self.hooks.call_on_progress_horizon_hooks(info);
@@ -769,8 +781,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         while tranche_start_height <= to_header.height {
             let tranche_end_height = cmp::min(
                 tranche_start_height
-                    .saturating_add(HORIZON_SYNC_TRANCHE_SIZE)
-                    .saturating_sub(1),
+                    .saturating_add(HORIZON_SYNC_TRANCHE_SIZE),
                 to_header.height,
             );
 
@@ -799,7 +810,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                 "Syncing output tranche heights {}-{} ({} blocks) from peer {}",
                 tranche_start_height,
                 tranche_end_height,
-                tranche_end_height - tranche_start_height + 1,
+                tranche_end_height.saturating_sub(tranche_start_height) + 1,
                 sync_peer.node_id(),
             );
 
@@ -829,7 +840,12 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             let mut inputs_to_delete = Vec::new();
             let mut batch_op_counter = 0;
             let mut last_mined_header: Option<FixedHash> = None;
-
+            let mut current_header_hash = tranche_start_header.hash();
+            let mut current_header = self
+                .db()
+                .fetch_header_by_block_hash(current_header_hash)
+                .await?
+                .ok_or_else(|| HorizonSyncError::IncorrectResponse("Starting header missing".into()))?;
             while let Some(response) = output_stream.next().await {
                 let latency = last_sync_timer.elapsed();
                 avg_latency.add_sample(latency);
@@ -839,29 +855,47 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                     HorizonSyncError::IncorrectResponse(format!("Peer sent invalid mined header: {}", e))
                 })?;
                 last_mined_header = Some(output_header_hash);
-                let current_header = self
-                    .db()
-                    .fetch_header_by_block_hash(output_header_hash)
-                    .await?
-                    .ok_or_else(|| {
-                        HorizonSyncError::IncorrectResponse("Peer sent mined header we do not know of".into())
-                    })?;
+                if output_header_hash != current_header_hash {
+                    current_header = self
+                        .db()
+                        .fetch_header_by_block_hash(output_header_hash)
+                        .await?
+                        .ok_or_else(|| {
+                            HorizonSyncError::IncorrectResponse("Peer sent mined header we do not know of".into())
+                        })?;
+                    current_header_hash = output_header_hash;
+
+                    debug!(
+                        target: LOG_TARGET,
+                        "Output sync reached new header( height: {}), synced {} outputs, spent {} inputs, \
+                         latency: {:.2?}",
+                        current_header.height,
+                        utxo_counter,
+                        stxo_counter,
+                        latency
+                    );
+                }
 
                 let proto_output = res.txo.ok_or_else(|| {
                     HorizonSyncError::IncorrectResponse("Peer sent no transaction output data".into())
                 })?;
                 match proto_output {
                     Txo::Output(output) => {
+                        if current_header.height == 0 {
+                            continue;
+                        }
                         let output = TransactionOutput::try_from(output).map_err(HorizonSyncError::ConversionError)?;
                         if !output.is_burned() {
                             utxo_counter += 1;
                             let output_hash = output.hash();
-                            debug!(
+                            trace!(
                                 target: LOG_TARGET,
-                                "UTXO `{}` received from sync peer ({} of {})",
+                                "UTXO `{}` received from sync peer at height {} (tranche {}-{}, {} in tranche)",
                                 output_hash,
-                                total_utxo_counter + utxo_counter,
-                                self.num_outputs,
+                                current_header.height,
+                                tranche_start_height,
+                                tranche_end_height,
+                                utxo_counter,
                             );
                             let key_bytes: [u8; 32] = output.commitment.as_bytes().try_into().map_err(|e| {
                                 HorizonSyncError::IncorrectResponse(format!("Peer sent malformed commitment: {}", e))
@@ -901,7 +935,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                             .await?
                         {
                             Some(output_hash) => {
-                                debug!(
+                                trace!(
                                     target: LOG_TARGET,
                                     "STXO hash `{output_hash}` received from sync peer ({stxo_counter})",
                                 );
@@ -938,10 +972,9 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
 
                 items_processed += 1;
                 if items_processed.is_multiple_of(PROGRESS_REPORT_INTERVAL) {
-                    let utxo_progress = total_utxo_counter + utxo_counter;
                     let info = HorizonSyncInfo::new(vec![sync_peer.node_id().clone()], HorizonSyncStatus::Outputs {
-                        current: utxo_progress,
-                        total: self.num_outputs,
+                        current: current_header.height,
+                        total: to_header.height,
                         sync_peer: sync_peer.clone(),
                     });
                     self.hooks.call_on_progress_horizon_hooks(info);
@@ -951,6 +984,15 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                     txn.commit().await?;
                     txn = db.write_transaction();
                     batch_op_counter = 0;
+                    debug!(
+                        target: LOG_TARGET,
+                        "Committed batch of {} output updates at height {} (tranche {}-{}, {} total in tranche)",
+                        HORIZON_SYNC_BATCH_SIZE,
+                        current_header.height,
+                        tranche_start_height,
+                        tranche_end_height,
+                        utxo_counter + stxo_counter,
+                    );
                 }
 
                 sync_peer.set_latency(latency);
@@ -1017,10 +1059,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             tranche_start_height = tranche_end_height + 1;
         }
 
-        if let Err(e) = db
-            .verify_horizon_sync_output_root(to_header.output_mr)
-            .await
-        {
+        if let Err(e) = db.verify_horizon_sync_output_root(to_header.output_mr).await {
             warn!(
                 target: LOG_TARGET,
                 "Final JMT root verification failed! The entire synced state is poisoned. Clearing checkpoint."
@@ -1189,5 +1228,139 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
     #[inline]
     fn db(&self) -> &AsyncBlockchainDb<B> {
         &self.db
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_comms::test_utils::mocks::create_connectivity_mock;
+    use tari_transaction_components::crypto_factories::CryptoFactories;
+
+    use super::*;
+    use crate::{
+        chain_storage::{BlockchainDatabase, DbTransaction, HorizonSyncOutputCheckpoint},
+        test_helpers::{
+            blockchain::{TempDatabase, create_main_chain, create_new_blockchain},
+            create_consensus_rules,
+        },
+        validation::mocks::MockValidator,
+    };
+
+    fn build_synchronizer<'a>(
+        db: BlockchainDatabase<TempDatabase>,
+        sync_peers: &'a mut Vec<SyncPeer>,
+        horizon_sync_height: u64,
+    ) -> HorizonStateSynchronization<'a, TempDatabase> {
+        let (connectivity, _mock) = create_connectivity_mock();
+        let rules = create_consensus_rules();
+        let prover = CryptoFactories::default().range_proof;
+        let validator: Arc<dyn FinalHorizonStateValidation<TempDatabase>> = Arc::new(MockValidator::new(true));
+        HorizonStateSynchronization::new(
+            BlockchainSyncConfig::default(),
+            db.into(),
+            connectivity,
+            rules,
+            sync_peers,
+            horizon_sync_height,
+            prover,
+            validator,
+        )
+    }
+
+    #[tokio::test]
+    async fn calculate_start_no_checkpoint_starts_from_height_one() {
+        let db = create_new_blockchain();
+        let (_, chain) = create_main_chain(&db, block_specs!(["1->GB"], ["2->1"], ["3->2"]));
+        let target = chain.get("3").unwrap().header().clone();
+        let target_hash = target.hash();
+
+        let mut peers: Vec<SyncPeer> = vec![];
+        let sync = build_synchronizer(db, &mut peers, target.height);
+
+        let (start, stop_header) = sync.calculate_output_sync_start_stop(&target).await.unwrap();
+        assert_eq!(start, 1);
+        assert_eq!(stop_header.hash(), target_hash);
+    }
+
+    #[tokio::test]
+    async fn calculate_start_resumes_when_target_unchanged() {
+        let db = create_new_blockchain();
+        let (_, chain) = create_main_chain(&db, block_specs!(["1->GB"], ["2->1"], ["3->2"]));
+        let target = chain.get("3").unwrap().header().clone();
+        let target_hash = target.hash();
+        let checkpoint_block = chain.get("2").unwrap();
+
+        let mut txn = DbTransaction::new();
+        txn.set_horizon_sync_output_checkpoint(HorizonSyncOutputCheckpoint {
+            checkpoint_height: 2,
+            checkpoint_hash: *checkpoint_block.hash(),
+            sync_target_height: target.height,
+            sync_target_hash: target_hash,
+        });
+        db.write(txn).unwrap();
+
+        let mut peers: Vec<SyncPeer> = vec![];
+        let sync = build_synchronizer(db, &mut peers, target.height);
+
+        let (start, stop_header) = sync.calculate_output_sync_start_stop(&target).await.unwrap();
+        assert_eq!(start, 3);
+        assert_eq!(stop_header.hash(), target_hash);
+    }
+
+    #[tokio::test]
+    async fn calculate_start_discards_checkpoint_after_reorg() {
+        let db = create_new_blockchain();
+        let (_, chain) = create_main_chain(&db, block_specs!(["1->GB"], ["2->1"], ["3->2"]));
+        let target = chain.get("3").unwrap().header().clone();
+        let target_hash = target.hash();
+
+        // Store a checkpoint at a height that no longer exists on the canonical chain
+        let mut txn = DbTransaction::new();
+        txn.set_horizon_sync_output_checkpoint(HorizonSyncOutputCheckpoint {
+            checkpoint_height: 99,
+            checkpoint_hash: FixedHash::zero(),
+            sync_target_height: 120,
+            sync_target_hash: FixedHash::zero(),
+        });
+        db.write(txn).unwrap();
+
+        let db_clone = db.clone();
+        let mut peers: Vec<SyncPeer> = vec![];
+        let sync = build_synchronizer(db, &mut peers, target.height);
+
+        let (start, stop_header) = sync.calculate_output_sync_start_stop(&target).await.unwrap();
+        assert_eq!(start, 1);
+        assert_eq!(stop_header.hash(), target_hash);
+        assert!(
+            db_clone.fetch_horizon_sync_output_checkpoint().unwrap().is_none(),
+            "stale checkpoint must be cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn clean_up_stale_synced_outputs_prunes_outputs_above_start_height() {
+        let db = create_new_blockchain();
+        let (_, chain) = create_main_chain(&db, block_specs!(["1->GB"], ["2->1"], ["3->2"]));
+
+        // Pick an output from a block above start_height (we'll clean from height 1)
+        let block2 = chain.get("2").unwrap();
+        let outputs = db.fetch_outputs_in_block(*block2.hash()).unwrap();
+        assert!(!outputs.is_empty(), "block 2 must have outputs");
+        let output_hash = outputs[0].hash();
+        assert!(
+            db.fetch_output(output_hash).unwrap().is_some(),
+            "output must exist before cleanup"
+        );
+
+        let db_clone = db.clone();
+        let mut peers: Vec<SyncPeer> = vec![];
+        let mut sync = build_synchronizer(db, &mut peers, 3);
+
+        sync.clean_up_stale_synced_outputs(1).await.unwrap();
+
+        assert!(
+            db_clone.fetch_output(output_hash).unwrap().is_none(),
+            "output above start_height must be pruned"
+        );
     }
 }

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -349,7 +349,9 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         }
         let stored_checkpoint = stored_checkpoint.expect("Already checked");
         debug!(target: LOG_TARGET, "We have a stored checkpoint, with height {} and hash {}", stored_checkpoint.checkpoint_height, stored_checkpoint.checkpoint_hash.to_hex());
-        let checkpoint_sync_to_header = if let Some(header) = self.db.fetch_header(stored_checkpoint.sync_target_height).await? {
+        let checkpoint_sync_to_header = if let Some(header) =
+            self.db.fetch_header(stored_checkpoint.sync_target_height).await?
+        {
             header
         } else {
             warn!(target: LOG_TARGET, "Horizon sync target at height {} is no longer on the canonical chain (reorg detected). Discarding checkpoint and restarting output sync from scratch.", stored_checkpoint.sync_target_height);
@@ -362,7 +364,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         };
         if stored_checkpoint.sync_target_hash == sync_to_header.hash() {
             info!(target: LOG_TARGET, "Resuming output sync from checkpoint at height {}, target unchanged", stored_checkpoint.checkpoint_height);
-            return Ok((stored_checkpoint.checkpoint_height+1, sync_to_header.clone()));
+            return Ok((stored_checkpoint.checkpoint_height + 1, sync_to_header.clone()));
         }
         // we have a checkpoint, its target is not the syncing target, so we have two choices, delete it and start over,
         // or sync to a lower height.
@@ -383,7 +385,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         {
             // we can sync to the checkpoint height first, and then do block sync from there
             debug!(target: LOG_TARGET, "New target is greater than stored checkpoint, but within 50_000 blocks, resuming output sync from checkpoint");
-            return Ok((stored_checkpoint.checkpoint_height+1, checkpoint_sync_to_header));
+            return Ok((stored_checkpoint.checkpoint_height + 1, checkpoint_sync_to_header));
         }
         debug!(target: LOG_TARGET, "New target is too far away, starting over");
         self.db
@@ -504,13 +506,11 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                 continue;
             }
             let spent = self.db.fetch_inputs_mined_info(vec![output.hash()]).await?;
-            if !spent.is_empty() {
-                if let Some(spent_status) = &spent[0] {
-                    if spent_status.spent_height == 0 {
-                        debug!(target: LOG_TARGET, "skipping genesis output {} with commitment({}) from pruned state, it was spent in block {}", output.hash(), output.commitment.to_hex(), spent_status.spent_height);
-                        continue;
-                    }
-                }
+            if let Some(Some(spent_status)) = spent.first() &&
+                spent_status.spent_height == 0
+            {
+                debug!(target: LOG_TARGET, "skipping genesis output {} with commitment({}) from pruned state, it was spent in block {}", output.hash(), output.commitment.to_hex(), spent_status.spent_height);
+                continue;
             }
             let key_bytes: [u8; 32] = output.commitment.as_bytes().try_into().expect("Malformed commitment");
             let smt_key = FixedHash::from(key_bytes);
@@ -519,11 +519,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             // first make sure its deleted everywhere so we can cleanly reinsert it.
             debug!(target: LOG_TARGET, "Restoring genesis output {} with commitment({}) from pruned state", output.hash(), output.commitment.to_hex());
 
-            txn.prune_output_from_all_dbs(
-                output.hash(),
-                output.commitment.clone(),
-                output.features.output_type,
-            );
+            txn.prune_output_from_all_dbs(output.hash(), output.commitment.clone(), output.features.output_type);
             txn.insert_output_via_horizon_sync(output.clone(), genesis_header_hash, 0, genesis_timestamp);
         }
 
@@ -780,8 +776,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         // Process the full block range in tranches
         while tranche_start_height <= to_header.height {
             let tranche_end_height = cmp::min(
-                tranche_start_height
-                    .saturating_add(HORIZON_SYNC_TRANCHE_SIZE),
+                tranche_start_height.saturating_add(HORIZON_SYNC_TRANCHE_SIZE),
                 to_header.height,
             );
 
@@ -1345,8 +1340,7 @@ mod tests {
         // Pick an output from a block above start_height (we'll clean from height 1)
         let block2 = chain.get("2").unwrap();
         let outputs = db.fetch_outputs_in_block(*block2.hash()).unwrap();
-        assert!(!outputs.is_empty(), "block 2 must have outputs");
-        let output_hash = outputs[0].hash();
+        let output_hash = outputs.first().expect("block 2 must have outputs").hash();
         assert!(
             db.fetch_output(output_hash).unwrap().is_some(),
             "output must exist before cleanup"

--- a/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/horizon_state_sync/synchronizer.rs
@@ -712,7 +712,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
             },
             None => None,
         };
-        let (sync_start_height, mut jmt_version) = match checkpoint_height {
+        let (sync_start_height, _jmt_version) = match checkpoint_height {
             Some(h) => {
                 // Only the in-progress (first resumption) tranche may have partial output data.
                 let first_tranche_end = cmp::min(
@@ -976,7 +976,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                 .map(|(key, value)| HorizonStateTreeUpdate { key, value })
                 .collect::<Vec<_>>();
 
-            txn.apply_horizon_state_tree_updates(jmt_version, tranche_end_header.height, tranche_updates);
+            txn.apply_horizon_state_tree_updates(tranche_updates);
             for output in &inputs_to_delete {
                 if let Some(sidechain_feature) = output.features.sidechain_feature.as_ref() &&
                     let Some(vn_reg) = sidechain_feature.validator_node_registration()
@@ -1002,7 +1002,6 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
                 });
             }
             txn.commit().await?;
-            jmt_version = tranche_end_height;
 
             debug!(
                 target: LOG_TARGET,
@@ -1019,7 +1018,7 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         }
 
         if let Err(e) = db
-            .verify_horizon_sync_output_root(to_header.height, to_header.output_mr)
+            .verify_horizon_sync_output_root(to_header.output_mr)
             .await
         {
             warn!(

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -569,7 +569,7 @@ mod test {
             kernel_mmr.push(k.hash().to_vec()).unwrap();
         }
         let tempdb = TempDatabase::new();
-        let tree_reader = tempdb.create_smt_reader().unwrap();
+        let (tree_reader, current_version) = tempdb.create_smt_reader().unwrap();
         let output_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&tree_reader);
         let mut block_output_mmr = PrunedOutputMmr::new(PrunedHashSet::default());
         let mut normal_output_mmr = PrunedOutputMmr::new(PrunedHashSet::default());
@@ -645,7 +645,7 @@ mod test {
             kernel_mr_hash_from_mmr(&kernel_mmr).unwrap().to_vec().to_hex(),
             block.header().kernel_mr.to_vec().to_hex()
         );
-        let (smt_root, _) = output_smt.put_value_set(smt_batch, 0).unwrap();
+        let (smt_root, _) = output_smt.put_value_set(smt_batch, current_version).unwrap();
         assert_eq!(smt_root.0.to_vec().to_hex(), block.header().output_mr.to_vec().to_hex(),);
 
         let coinbases = block.block().body.get_coinbase_outputs().into_iter().cloned().collect();

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -378,12 +378,8 @@ impl<'a, B: BlockchainBackend + 'static> AsyncDbTransaction<'a, B> {
         self
     }
 
-    pub fn apply_horizon_state_tree_updates(
-        &mut self,
-        updates: Vec<HorizonStateTreeUpdate>,
-    ) -> &mut Self {
-        self.transaction
-            .apply_horizon_state_tree_updates( updates);
+    pub fn apply_horizon_state_tree_updates(&mut self, updates: Vec<HorizonStateTreeUpdate>) -> &mut Self {
+        self.transaction.apply_horizon_state_tree_updates(updates);
         self
     }
 

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -164,7 +164,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_horizon_sync_output_checkpoint() -> Option<HorizonSyncOutputCheckpoint>, "fetch_horizon_sync_output_checkpoint");
 
-    make_async_fn!(verify_horizon_sync_output_root(version: u64, expected_root: HashOutput) -> (), "verify_horizon_sync_output_root");
+    make_async_fn!(verify_horizon_sync_output_root(expected_root: HashOutput) -> (), "verify_horizon_sync_output_root");
 
     //---------------------------------- TXO --------------------------------------------//
 
@@ -380,12 +380,10 @@ impl<'a, B: BlockchainBackend + 'static> AsyncDbTransaction<'a, B> {
 
     pub fn apply_horizon_state_tree_updates(
         &mut self,
-        previous_version: u64,
-        version: u64,
         updates: Vec<HorizonStateTreeUpdate>,
     ) -> &mut Self {
         self.transaction
-            .apply_horizon_state_tree_updates(previous_version, version, updates);
+            .apply_horizon_state_tree_updates( updates);
         self
     }
 

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -221,8 +221,7 @@ pub trait BlockchainBackend: Send + Sync + 'static {
     fn fetch_horizon_sync_output_checkpoint(&self) -> Result<Option<HorizonSyncOutputCheckpoint>, ChainStorageError>;
 
     /// Verify that the JMT output root at the given version matches the expected root.
-    fn verify_horizon_sync_output_root(&self, expected_root: HashOutput)
-    -> Result<(), ChainStorageError>;
+    fn verify_horizon_sync_output_root(&self, expected_root: HashOutput) -> Result<(), ChainStorageError>;
 
     /// Returns basic database stats for each internal database, such as number of entries and page sizes. This call may
     /// not apply to every database implementation.

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -221,7 +221,7 @@ pub trait BlockchainBackend: Send + Sync + 'static {
     fn fetch_horizon_sync_output_checkpoint(&self) -> Result<Option<HorizonSyncOutputCheckpoint>, ChainStorageError>;
 
     /// Verify that the JMT output root at the given version matches the expected root.
-    fn verify_horizon_sync_output_root(&self, version: u64, expected_root: HashOutput)
+    fn verify_horizon_sync_output_root(&self, expected_root: HashOutput)
     -> Result<(), ChainStorageError>;
 
     /// Returns basic database stats for each internal database, such as number of entries and page sizes. This call may
@@ -305,7 +305,7 @@ pub trait BlockchainBackend: Send + Sync + 'static {
     ) -> Result<Vec<TemplateRegistrationEntry>, ChainStorageError>;
 
     /// Creates a reader to construct a JMT
-    fn create_smt_reader(&self) -> Result<OwnedLmdbTreeReader<'_>, ChainStorageError>;
+    fn create_smt_reader(&self) -> Result<(OwnedLmdbTreeReader<'_>, u64), ChainStorageError>;
 
     /// Stats reporting methods for long-running operations
     /// Set the total number of steps for progress tracking

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1290,9 +1290,8 @@ where B: BlockchainBackend
         hashes: Vec<HashOutput>,
     ) -> Result<Vec<Option<(TransactionOutput, bool)>>, ChainStorageError> {
         let db = self.db_read_access()?;
-        let tip = db.fetch_chain_metadata()?.best_block_height();
 
-        let smt_reader = db.create_smt_reader()?;
+        let (smt_reader, current_version) = db.create_smt_reader()?;
 
         let smt = JellyfishMerkleTree::<_, SmtHasher>::new(&smt_reader);
         let mut result = Vec::with_capacity(hashes.len());
@@ -1316,7 +1315,7 @@ where B: BlockchainBackend
                 );
 
                 let spent = smt
-                    .get(smt_key, tip)
+                    .get(smt_key, current_version)
                     .map_err(ChainStorageError::JellyfishMerkleTreeError)?
                     .is_none();
                 trace!(
@@ -2160,11 +2159,10 @@ where B: BlockchainBackend
 
     pub fn verify_horizon_sync_output_root(
         &self,
-        version: u64,
         expected_root: HashOutput,
     ) -> Result<(), ChainStorageError> {
         let db = self.db_read_access()?;
-        db.verify_horizon_sync_output_root(version, expected_root)
+        db.verify_horizon_sync_output_root( expected_root)
     }
 
     pub fn get_stats(&self) -> Result<DbBasicStats, ChainStorageError> {
@@ -2357,7 +2355,7 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
     let header = &block.header;
     let body = &block.body;
 
-    let smt_reader = db.create_smt_reader()?;
+    let (smt_reader, current_version) = db.create_smt_reader()?;
     let metadata = db.fetch_chain_metadata()?;
     if header.prev_hash != *metadata.best_block_hash() {
         return Err(ChainStorageError::CannotCalculateNonTipMmr(format!(
@@ -2431,8 +2429,9 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
 
     let block_output_mr = block_output_mr_hash_from_pruned_mmr(&block_output_mmr)?;
 
+
     let (output_smt_root, changes) = output_smt
-        .put_value_set(batch, header.height)
+        .put_value_set(batch, current_version+1)
         .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
     let mut size = tip_header.output_smt_size;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -2157,12 +2157,9 @@ where B: BlockchainBackend
         db.fetch_horizon_sync_output_checkpoint()
     }
 
-    pub fn verify_horizon_sync_output_root(
-        &self,
-        expected_root: HashOutput,
-    ) -> Result<(), ChainStorageError> {
+    pub fn verify_horizon_sync_output_root(&self, expected_root: HashOutput) -> Result<(), ChainStorageError> {
         let db = self.db_read_access()?;
-        db.verify_horizon_sync_output_root( expected_root)
+        db.verify_horizon_sync_output_root(expected_root)
     }
 
     pub fn get_stats(&self) -> Result<DbBasicStats, ChainStorageError> {
@@ -2429,9 +2426,8 @@ pub fn calculate_mmr_roots<T: BlockchainBackend>(
 
     let block_output_mr = block_output_mr_hash_from_pruned_mmr(&block_output_mmr)?;
 
-
     let (output_smt_root, changes) = output_smt
-        .put_value_set(batch, current_version+1)
+        .put_value_set(batch, current_version + 1)
         .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
     let mut size = tip_header.output_smt_size;

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -319,13 +319,9 @@ impl DbTransaction {
         self
     }
 
-    pub fn apply_horizon_state_tree_updates(
-        &mut self,
-        updates: Vec<HorizonStateTreeUpdate>,
-    ) -> &mut Self {
-        self.operations.push(WriteOperation::ApplyHorizonStateTreeUpdates {
-            updates,
-        });
+    pub fn apply_horizon_state_tree_updates(&mut self, updates: Vec<HorizonStateTreeUpdate>) -> &mut Self {
+        self.operations
+            .push(WriteOperation::ApplyHorizonStateTreeUpdates { updates });
         self
     }
 
@@ -532,11 +528,7 @@ impl fmt::Display for WriteOperation {
             },
             SetHorizonData { .. } => write!(f, "Set horizon data"),
             ApplyHorizonStateTreeUpdates { updates, .. } => {
-                write!(
-                    f,
-                    "Apply horizon state tree updates ({} updates)",
-                    updates.len()
-                )
+                write!(f, "Apply horizon state tree updates ({} updates)", updates.len())
             },
             InsertReorg { .. } => write!(f, "Insert reorg"),
             ClearAllReorgs => write!(f, "Clear all reorgs"),

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -321,13 +321,9 @@ impl DbTransaction {
 
     pub fn apply_horizon_state_tree_updates(
         &mut self,
-        previous_version: u64,
-        version: u64,
         updates: Vec<HorizonStateTreeUpdate>,
     ) -> &mut Self {
         self.operations.push(WriteOperation::ApplyHorizonStateTreeUpdates {
-            previous_version,
-            version,
             updates,
         });
         self
@@ -426,8 +422,6 @@ pub enum WriteOperation {
         horizon_data: HorizonData,
     },
     ApplyHorizonStateTreeUpdates {
-        previous_version: u64,
-        version: u64,
         updates: Vec<HorizonStateTreeUpdate>,
     },
     InsertReorg {
@@ -537,10 +531,10 @@ impl fmt::Display for WriteOperation {
                 write!(f, "Insert bad block #{height} {hash} for {reason}")
             },
             SetHorizonData { .. } => write!(f, "Set horizon data"),
-            ApplyHorizonStateTreeUpdates { version, updates, .. } => {
+            ApplyHorizonStateTreeUpdates { updates, .. } => {
                 write!(
                     f,
-                    "Apply horizon state tree updates at version {version} ({} updates)",
+                    "Apply horizon state tree updates ({} updates)",
                     updates.len()
                 )
             },

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -284,6 +284,7 @@ const LMDB_DB_VALIDATOR_NODES_EXIT: &str = "validator_nodes_exit";
 const LMDB_DB_TEMPLATE_REGISTRATIONS: &str = "template_registrations";
 const LMDB_DB_UTXO_SMT: &str = "utxo_smt";
 const LMDB_DB_JMT_VALUE_DATA: &str = "jmt_value_data";
+#[allow(dead_code)] // Retained for upcoming JMT data migration.
 const LMDB_DB_JMT_NODE_OLD_DATA: &str = "jmt_node_data";
 const LMDB_DB_JMT_NODE_NEW_DATA: &str = "jmt_nodes_data";
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -100,7 +100,7 @@ use fs2::FileExt;
 use jmt::{
     JellyfishMerkleTree,
     KeyHash,
-    storage::{NibblePath, NodeKey, TreeReader, TreeWriter},
+    storage::{TreeWriter},
 };
 use lmdb_zero::{
     ConstTransaction,
@@ -288,8 +288,8 @@ const LMDB_DB_VALIDATOR_NODES_EXIT: &str = "validator_nodes_exit";
 const LMDB_DB_TEMPLATE_REGISTRATIONS: &str = "template_registrations";
 const LMDB_DB_UTXO_SMT: &str = "utxo_smt";
 const LMDB_DB_JMT_VALUE_DATA: &str = "jmt_value_data";
-const LMDB_DB_JMT_NODE_DATA: &str = "jmt_node_data";
-const LMDB_DB_JMT_UNIQUE_KEY_DATA: &str = "jmt_unique_key_data";
+const LMDB_DB_JMT_NODE_OLD_DATA: &str = "jmt_node_data";
+const LMDB_DB_JMT_NODE_NEW_DATA: &str = "jmt_nodes_data";
 
 /// Returns the list of all LMDB database names used by Tari.
 /// This is the authoritative source for database names to avoid duplication.
@@ -328,8 +328,7 @@ pub fn get_all_database_names() -> Vec<&'static str> {
         LMDB_DB_TEMPLATE_REGISTRATIONS,
         LMDB_DB_UTXO_SMT,
         LMDB_DB_JMT_VALUE_DATA,
-        LMDB_DB_JMT_NODE_DATA,
-        LMDB_DB_JMT_UNIQUE_KEY_DATA,
+        LMDB_DB_JMT_NODE_NEW_DATA,
     ]
 }
 
@@ -396,8 +395,7 @@ pub(crate) fn build_lmdb_store<P: AsRef<Path>>(
         .add_database(LMDB_DB_TEMPLATE_REGISTRATIONS, flags | db::DUPSORT)
         .add_database(LMDB_DB_UTXO_SMT, flags)
         .add_database(LMDB_DB_JMT_VALUE_DATA, flags )
-        .add_database(LMDB_DB_JMT_NODE_DATA, flags)
-        .add_database(LMDB_DB_JMT_UNIQUE_KEY_DATA, flags)
+        .add_database(LMDB_DB_JMT_NODE_NEW_DATA, flags)
         .build()
         .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{err}")))?;
     debug!(target: LOG_TARGET, "LMDB database creation successful");
@@ -533,7 +531,6 @@ pub struct LMDBDatabase {
     utxo_smt: DatabaseRef,
     jmt_value_data: DatabaseRef,
     jmt_node_data: DatabaseRef,
-    jmt_unique_key_data: DatabaseRef,
     _file_lock: Arc<File>,
     consensus_manager: BaseNodeConsensusManager,
     stats_collector: LMDBStatsCollector,
@@ -594,8 +591,7 @@ impl LMDBDatabase {
             template_registrations: get_database(store, LMDB_DB_TEMPLATE_REGISTRATIONS)?,
             utxo_smt: get_database(store, LMDB_DB_UTXO_SMT)?,
             jmt_value_data: get_database(store, LMDB_DB_JMT_VALUE_DATA)?,
-            jmt_node_data: get_database(store, LMDB_DB_JMT_NODE_DATA)?,
-            jmt_unique_key_data: get_database(store, LMDB_DB_JMT_UNIQUE_KEY_DATA)?,
+            jmt_node_data: get_database(store, LMDB_DB_JMT_NODE_NEW_DATA)?,
             env,
             env_config: store.env_config(),
             _file_lock: Arc::new(file_lock),
@@ -809,11 +805,9 @@ impl LMDBDatabase {
                     )?;
                 },
                 ApplyHorizonStateTreeUpdates {
-                    previous_version,
-                    version,
                     updates,
                 } => {
-                    self.apply_horizon_state_tree_updates(&write_txn, *previous_version, *version, updates)?;
+                    self.apply_horizon_state_tree_updates(&write_txn, updates)?;
                 },
                 InsertBadBlock { hash, height, reason } => {
                     self.insert_bad_block_and_cleanup(&write_txn, hash, *height, reason.to_string())?;
@@ -848,7 +842,7 @@ impl LMDBDatabase {
         Ok(())
     }
 
-    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 35] {
+    fn all_dbs(&self) -> [(&'static str, &DatabaseRef); 34] {
         [
             (LMDB_DB_METADATA, &self.metadata_db),
             (LMDB_DB_HEADERS, &self.headers_db),
@@ -898,8 +892,7 @@ impl LMDBDatabase {
             (LMDB_DB_TEMPLATE_REGISTRATIONS, &self.template_registrations),
             (LMDB_DB_UTXO_SMT, &self.utxo_smt),
             (LMDB_DB_JMT_VALUE_DATA, &self.jmt_value_data),
-            (LMDB_DB_JMT_NODE_DATA, &self.jmt_node_data),
-            (LMDB_DB_JMT_UNIQUE_KEY_DATA, &self.jmt_unique_key_data),
+            (LMDB_DB_JMT_NODE_NEW_DATA, &self.jmt_node_data),
         ]
     }
 
@@ -1360,22 +1353,13 @@ impl LMDBDatabase {
             .fetch_height_from_hash(write_txn, block_hash)
             .or_not_found("Block", "hash", hash_hex)?;
         let next_height = height.saturating_add(1);
-        let prev_height = height.saturating_sub(1);
         if self.fetch_block_accumulated_data(write_txn, next_height)?.is_some() {
             return Err(ChainStorageError::InvalidOperation(format!(
                 "Attempted to delete block at height {height} while next block still exists"
             )));
         }
 
-        let smt_writer = LmdbTreeWriter::new(
-            write_txn,
-            self.jmt_node_data.clone(),
-            self.jmt_value_data.clone(),
-            self.jmt_unique_key_data.clone(),
-        );
-        smt_writer
-            .delete_all_for_version(height)
-            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+
         lmdb_delete(
             write_txn,
             &self.block_accumulated_data_db,
@@ -1385,27 +1369,10 @@ impl LMDBDatabase {
 
         self.delete_block_inputs_outputs(write_txn, block_hash, height)?;
 
-        let new_tip_header = self.fetch_chain_header_by_height(prev_height)?;
-        let reader = LmdbTreeReader::new(write_txn, self.jmt_node_data.clone(), self.jmt_unique_key_data.clone());
-        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
 
-        let root = jmt
-            .get_root_hash(new_tip_header.header().height)
-            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
-        if root.0.as_slice() != new_tip_header.header().output_mr.as_slice() {
-            error!(
-                target: LOG_TARGET,
-                "Deleting block, new smt root(#{}) did not match expected (#{}) smt root",
-                    hex::encode(root.0.as_slice()),
-                    new_tip_header.header().output_mr.to_hex(),
-            );
-            return Err(ChainStorageError::InvalidOperation(format!(
-                "Deleting block, new smt root(#{}) did not match expected (#{}) smt root",
-                hex::encode(root.0.as_slice()),
-                new_tip_header.header().output_mr.to_hex(),
-            )));
-        }
+
+
         self.delete_block_kernels(write_txn, block_hash.as_slice())?;
 
         Ok(())
@@ -1418,16 +1385,28 @@ impl LMDBDatabase {
         block_hash: &HashOutput,
         height: u64,
     ) -> Result<(), ChainStorageError> {
+
+        let smt_reader = LmdbTreeReader::new(txn, self.jmt_node_data.clone(), self.jmt_value_data.clone());
+
+        let output_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&smt_reader);
         let output_rows =
             lmdb_delete_keys_starting_with::<TransactionOutputRowData>(txn, &self.utxos_db, block_hash.as_slice())?;
         debug!(target: LOG_TARGET, "Deleted {} outputs...", output_rows.len());
         let inputs =
             lmdb_delete_keys_starting_with::<TransactionInputRowData>(txn, &self.inputs_db, block_hash.as_slice())?;
         debug!(target: LOG_TARGET, "Deleted {} input(s)...", inputs.len());
-
+        let mut batch = Vec::new();
         let constants = self.get_consensus_constants(height);
 
         for (_, utxo) in &output_rows {
+            let smt_key = KeyHash(
+                utxo.output
+                    .commitment()
+                    .as_bytes()
+                    .try_into()
+                    .expect("Key hash is always 32 bytes"),
+            );
+            batch.push((smt_key, None));
             let output_hash = utxo.hash;
             let payref = Self::generate_payment_reference_for_output(block_hash, &output_hash);
             trace!(target: LOG_TARGET, "Deleting UTXO `{output_hash}` with payref `{payref}`");
@@ -1539,6 +1518,17 @@ impl LMDBDatabase {
                 }
             })?;
 
+            let smt_key = KeyHash(
+                utxo_mined_info.output
+                    .commitment
+                    .as_bytes()
+                    .try_into()
+                    .expect("Key hash is always 32 bytes"),
+            );
+
+            let smt_node = utxo_mined_info.output.smt_hash(utxo_mined_info.mined_height).to_vec();
+            batch.push((smt_key, Some(smt_node)));
+
             input.add_output_data(utxo_mined_info.output);
 
             lmdb_insert(
@@ -1550,6 +1540,41 @@ impl LMDBDatabase {
             )?;
             trace!(target: LOG_TARGET, "Input moved to UTXO set: {input}");
         }
+        let k = MetadataKey::JMTVersion;
+        let val = match lmdb_get(txn, &self.metadata_db, &k.as_u32())?{
+            Some(MetadataValue::JMTVersion(v)) => v+1,
+            _ => 0u64,
+        };
+
+        let prev_height = height.saturating_sub(1);
+        let new_tip_header = self.fetch_chain_header_by_height(prev_height)?;
+        let (root, ops) = output_smt
+            .put_value_set(batch, val)
+            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+        if root.0.as_slice() != new_tip_header.header().output_mr.as_slice() {
+            error!(
+                target: LOG_TARGET,
+                "Deleting block, new smt root(#{}) did not match expected (#{}) smt root",
+                    hex::encode(root.0.as_slice()),
+                    new_tip_header.header().output_mr.to_hex(),
+            );
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "Deleting block, new smt root(#{}) did not match expected (#{}) smt root",
+                hex::encode(root.0.as_slice()),
+                new_tip_header.header().output_mr.to_hex(),
+            )));
+        }
+        let smt_writer = LmdbTreeWriter::new(
+            txn,
+            self.jmt_node_data.clone(),
+            self.jmt_value_data.clone(),
+            self.metadata_db.clone(),
+        );
+        smt_writer
+            .write_node_batch(&ops.node_batch)
+            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+        smt_writer.cleanup_stale(&ops.stale_node_index_batch).map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+
         Ok(())
     }
 
@@ -1656,7 +1681,7 @@ impl LMDBDatabase {
         header: &BlockHeader,
         body: AggregateBody,
     ) -> Result<(), ChainStorageError> {
-        let smt_reader = LmdbTreeReader::new(txn, self.jmt_node_data.clone(), self.jmt_unique_key_data.clone());
+        let smt_reader = LmdbTreeReader::new(txn, self.jmt_node_data.clone(), self.jmt_value_data.clone());
         let output_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&smt_reader);
         if self.fetch_block_accumulated_data(txn, header.height + 1)?.is_some() {
             return Err(ChainStorageError::InvalidOperation(format!(
@@ -1784,10 +1809,15 @@ impl LMDBDatabase {
                 input_with_output_data,
             )?;
         }
-
+        let k = MetadataKey::JMTVersion;
+        let val = match lmdb_get(txn, &self.metadata_db, &k.as_u32())?{
+            Some(MetadataValue::JMTVersion(v)) => v+1,
+            _ => 0u64,
+        };
         let (root, ops) = output_smt
-            .put_value_set(batch, header.height)
+            .put_value_set(batch, val)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+
 
         if header.output_mr.as_slice() != root.0.as_slice() {
             warn!(
@@ -1810,11 +1840,14 @@ impl LMDBDatabase {
             txn,
             self.jmt_node_data.clone(),
             self.jmt_value_data.clone(),
-            self.jmt_unique_key_data.clone(),
+            self.metadata_db.clone()
         );
+
         smt_writer
             .write_node_batch(&ops.node_batch)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+        smt_writer.cleanup_stale(&ops.stale_node_index_batch).map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+
 
         self.insert_block_accumulated_data(
             txn,
@@ -2208,35 +2241,17 @@ impl LMDBDatabase {
     fn apply_horizon_state_tree_updates(
         &self,
         write_txn: &WriteTransaction<'_>,
-        previous_version: u64,
-        version: u64,
         updates: &[HorizonStateTreeUpdate],
     ) -> Result<(), ChainStorageError> {
-        let reader = LmdbTreeReader::new(write_txn, self.jmt_node_data.clone(), self.jmt_unique_key_data.clone());
+        let reader = LmdbTreeReader::new(write_txn, self.jmt_node_data.clone(), self.jmt_value_data.clone());
         let writer = LmdbTreeWriter::new(
             write_txn,
             self.jmt_node_data.clone(),
             self.jmt_value_data.clone(),
-            self.jmt_unique_key_data.clone(),
+            self.metadata_db.clone(),
         );
 
-        // if the previous committed version is not contiguous with the new version,
-        // write a bridge root node at (version - 1) that copies the root from previous_version
-        if version > 0 && previous_version != version.saturating_sub(1) {
-            let empty_path: NibblePath = std::iter::empty().collect();
-            let prev_root_key = NodeKey::new(previous_version, empty_path.clone());
-            let bridge_key = NodeKey::new(version - 1, empty_path);
 
-            let old_root = reader
-                .get_node_option(&prev_root_key)
-                .map_err(|e| ChainStorageError::CriticalError(e.to_string()))?;
-
-            if let Some(root_node) = old_root {
-                writer
-                    .put_node(&bridge_key, &root_node)
-                    .map_err(|e| ChainStorageError::CriticalError(e.to_string()))?;
-            }
-        }
 
         let output_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
         let batch = updates
@@ -2244,13 +2259,19 @@ impl LMDBDatabase {
             .map(|update| (KeyHash(update.key.into_array()), update.value.map(|v| v.to_vec())))
             .collect::<Vec<_>>();
 
+        let k = MetadataKey::JMTVersion;
+        let val = match lmdb_get(write_txn, &self.metadata_db, &k.as_u32())?{
+            Some(MetadataValue::JMTVersion(v)) => v+1,
+            _ => 0u64,
+        };
         let (_root, ops) = output_smt
-            .put_value_set(batch, version)
+            .put_value_set(batch, val)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
         writer
             .write_node_batch(&ops.node_batch)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+        writer.cleanup_stale(&ops.stale_node_index_batch).map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
         Ok(())
     }
@@ -2537,7 +2558,7 @@ impl LMDBDatabase {
             txn,
             self.jmt_node_data.clone(),
             self.jmt_value_data.clone(),
-            self.jmt_unique_key_data.clone(),
+            self.metadata_db.clone(),
         )
     }
 }
@@ -2572,12 +2593,17 @@ fn acquire_exclusive_file_lock(db_path: &Path) -> Result<File, ChainStorageError
 }
 
 impl BlockchainBackend for LMDBDatabase {
-    fn create_smt_reader(&self) -> Result<OwnedLmdbTreeReader<'_>, ChainStorageError> {
+    fn create_smt_reader(&self) -> Result<(OwnedLmdbTreeReader<'_>, u64), ChainStorageError> {
         let read_tx = self.read_transaction()?;
+        let k = MetadataKey::JMTVersion;
+        let val = match lmdb_get(&read_tx, &self.metadata_db, &k.as_u32())?{
+            Some(MetadataValue::JMTVersion(v)) => v,
+            _ => 0u64,
+        };
         let smt_reader =
-            OwnedLmdbTreeReader::new(read_tx, self.jmt_node_data.clone(), self.jmt_unique_key_data.clone());
+            OwnedLmdbTreeReader::new(read_tx, self.jmt_node_data.clone(), self.jmt_value_data.clone());
 
-        Ok(smt_reader)
+        Ok((smt_reader, val))
     }
 
     fn write(&mut self, txn: DbTransaction) -> Result<(), ChainStorageError> {
@@ -3459,18 +3485,23 @@ impl BlockchainBackend for LMDBDatabase {
 
     fn verify_horizon_sync_output_root(
         &self,
-        version: u64,
         expected_root: HashOutput,
     ) -> Result<(), ChainStorageError> {
         let txn = self.read_transaction()?;
-        let reader = OwnedLmdbTreeReader::new(txn, self.jmt_node_data.clone(), self.jmt_unique_key_data.clone());
+        let k = MetadataKey::JMTVersion;
+        let val = match lmdb_get(&txn, &self.metadata_db, &k.as_u32())?{
+            Some(MetadataValue::JMTVersion(v)) => v+1,
+            _ => 0u64,
+        };
+
+        let reader = OwnedLmdbTreeReader::new(txn, self.jmt_node_data.clone(), self.jmt_value_data.clone());
         let output_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
         let root = output_smt
-            .get_root_hash(version)
+            .get_root_hash(val)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
         if root.0.as_slice() != expected_root.as_slice() {
             return Err(ChainStorageError::InvalidOperation(format!(
-                "Horizon sync output root mismatch at version {version}. Expected {}, got {}",
+                "Horizon sync output root mismatch at version {val}. Expected {}, got {}",
                 expected_root.to_hex(),
                 root.0.to_hex()
             )));
@@ -4101,6 +4132,7 @@ pub enum MetadataKey {
     AccumulatedDataCheckStatus,
     BlockchainConsistencyCheckStatus,
     HorizonSyncOutputCheckpoint,
+    JMTVersion,
 }
 
 impl MetadataKey {
@@ -4126,6 +4158,7 @@ impl fmt::Display for MetadataKey {
             MetadataKey::AccumulatedDataCheckStatus => write!(f, "Accumulated data check status"),
             MetadataKey::BlockchainConsistencyCheckStatus => write!(f, "Blockchain check status"),
             MetadataKey::HorizonSyncOutputCheckpoint => write!(f, "Horizon sync output checkpoint"),
+            MetadataKey::JMTVersion => write!(f, "JMT written version"),
         }
     }
 }
@@ -4317,6 +4350,7 @@ pub enum MetadataValue {
     AccumulatedDataRebuildStatus(AccumulatedDataRebuildStatus),
     BlockchainCheckStatus(BlockchainCheckStatus),
     HorizonSyncOutputCheckpoint(HorizonSyncOutputCheckpoint),
+    JMTVersion(u64),
 }
 
 impl fmt::Display for MetadataValue {
@@ -4344,6 +4378,7 @@ impl fmt::Display for MetadataValue {
                 "Horizon sync output checkpoint at height {} targeting height {}",
                 cp.checkpoint_height, cp.sync_target_height
             ),
+            MetadataValue::JMTVersion(version) => write!(f, "JMT version is {version}"),
         }
     }
 }
@@ -4917,7 +4952,8 @@ fn verify_metadata_keys(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
                 Some(MetadataKey::AccumulatedDataRebuildStatus) |
                 Some(MetadataKey::AccumulatedDataCheckStatus) |
                 Some(MetadataKey::BlockchainConsistencyCheckStatus) |
-                Some(MetadataKey::HorizonSyncOutputCheckpoint) => {
+                Some(MetadataKey::HorizonSyncOutputCheckpoint) |
+                Some(MetadataKey::JMTVersion)=> {
                     warn!(
                         target: LOG_TARGET,
                         "Removed corrupt metadata entry {metadata_key:?} with key bytes: 0x{hex_key}",
@@ -4990,6 +5026,7 @@ fn variant_name(v: &MetadataValue) -> &'static str {
         MetadataValue::AccumulatedDataRebuildStatus(_) => "AccumulatedDataRebuildStatus",
         MetadataValue::BlockchainCheckStatus(_) => "BlockchainCheckStatus",
         MetadataValue::HorizonSyncOutputCheckpoint(_) => "HorizonSyncOutputCheckpoint",
+        MetadataValue::JMTVersion(_) => "JMTVersion",
     }
 }
 
@@ -5009,5 +5046,6 @@ fn summarize_value(v: &MetadataValue) -> String {
         MetadataValue::HorizonSyncOutputCheckpoint(cp) => {
             format!("{} targeting {}", cp.checkpoint_height, cp.sync_target_height)
         },
+        MetadataValue::JMTVersion(v) => format!("{v}"),
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -293,7 +293,6 @@ const LMDB_DB_JMT_NODE_DATA_V1: &str = "jmt_node_data";
 const LMDB_DB_JMT_NODE_DATA_V2: &str = "jmt_nodes_data";
 const LMDB_DB_JMT_UNIQUE_KEY_DATA: &str = "jmt_unique_key_data";
 
-
 /// Returns the list of all LMDB database names used by Tari.
 /// This is the authoritative source for database names to avoid duplication.
 pub fn get_all_database_names() -> Vec<&'static str> {
@@ -487,6 +486,7 @@ fn open_lmdb_database_with_compaction(
 }
 
 /// Compact the env behind `db` into a new file and reopen the database against the compacted copy.
+#[allow(clippy::too_many_lines)]
 fn compact_and_reopen_lmdb_database(
     db: LMDBDatabase,
     lmdb_store: LMDBStore,
@@ -504,7 +504,10 @@ fn compact_and_reopen_lmdb_database(
     // Emit a phase=LmdbCompact update through the readiness channel before the long-running
     // env.copy call so clients can show "Compacting LMDB" instead of a stuck progress bar.
     publish_compaction_progress(stats_sender.as_ref(), MigrationPhase::LmdbCompact, 0, 0);
-    println!("Compacting LMDB env at {} to reclaim space freed by JMT v1 → v2 migration",env_path.display());
+    println!(
+        "Compacting LMDB env at {} to reclaim space freed by JMT v1 → v2 migration",
+        env_path.display()
+    );
 
     let original_data = env_path.join("data.mdb");
     let original_lock = env_path.join("lock.mdb");
@@ -520,7 +523,7 @@ fn compact_and_reopen_lmdb_database(
             ))
         })?;
     }
-    fs::create_dir(&compact_dir).map_err(|e| {
+    fs::create_dir_all(&compact_dir).map_err(|e| {
         ChainStorageError::AccessError(format!(
             "Could not create compaction tempdir {}: {e}",
             compact_dir.display()
@@ -532,9 +535,7 @@ fn compact_and_reopen_lmdb_database(
     // file, so this is an upper bound. If we run out mid-copy we'd leave a half-written file
     // that we still have to clean up, so check first.
     let original_size = fs::metadata(&original_data)
-        .map_err(|e| {
-            ChainStorageError::AccessError(format!("Could not stat {}: {e}", original_data.display()))
-        })?
+        .map_err(|e| ChainStorageError::AccessError(format!("Could not stat {}: {e}", original_data.display())))?
         .len();
     let pre_size_mb = original_size / BYTES_PER_MB as u64;
     info!(
@@ -549,7 +550,7 @@ fn compact_and_reopen_lmdb_database(
         Ok(size) => size,
         Err(e) => {
             warn!(target: LOG_TARGET, "[MIGRATIONS] env.copy(COMPACT) failed: {e}");
-            let _ = fs::remove_dir_all(&compact_dir);
+            let _unused = fs::remove_dir_all(&compact_dir);
             return Err(e);
         },
     };
@@ -569,7 +570,10 @@ fn compact_and_reopen_lmdb_database(
         pre_size_mb,
         pre_size_mb,
     );
-    println!("[MIGRATIONS] Compacted data.mdb size: {post_size_mb} MB (reclaimed {} MB)",pre_size_mb.saturating_sub(post_size_mb));
+    println!(
+        "[MIGRATIONS] Compacted data.mdb size: {post_size_mb} MB (reclaimed {} MB)",
+        pre_size_mb.saturating_sub(post_size_mb)
+    );
 
     // Drop every Arc<Environment> reference so the OS lets us swap data.mdb. `LMDBDatabase`,
     // `LMDBStore` and the chain_storage `file_lock` together hold all of them in this process.
@@ -587,7 +591,7 @@ fn compact_and_reopen_lmdb_database(
         })?;
     }
     fs::rename(&original_data, &backup_data).map_err(|e| {
-        let _ = fs::remove_dir_all(&compact_dir);
+        let _unused = fs::remove_dir_all(&compact_dir);
         ChainStorageError::AccessError(format!(
             "Could not rename {} -> {}: {e}",
             original_data.display(),
@@ -603,27 +607,27 @@ fn compact_and_reopen_lmdb_database(
             target: LOG_TARGET,
             "[MIGRATIONS] Could not move compacted data.mdb into place: {e}; restoring backup"
         );
-        let _ = fs::rename(&backup_data, &original_data);
-        let _ = fs::remove_dir_all(&compact_dir);
+        let _unused = fs::rename(&backup_data, &original_data);
+        let _unused = fs::remove_dir_all(&compact_dir);
         return Err(ChainStorageError::AccessError(format!(
             "Could not rename compacted file into place: {e}"
         )));
     }
 
     // Stale lock.mdb from the old env confuses some platforms; LMDB recreates it on reopen.
-    let _ = fs::remove_file(&original_lock);
-    let _ = fs::remove_dir_all(&compact_dir);
+    let _unused = fs::remove_file(&original_lock);
+    let _unused = fs::remove_dir_all(&compact_dir);
 
     // Reopen against the compacted file.
     let (new_store, new_lock) = build_lmdb_store(&env_path, config).inspect_err(|_| {
         // Best-effort restore so the operator isn't left with a missing data.mdb.
         if !original_data.exists() {
-            let _ = fs::rename(&backup_data, &original_data);
+            let _unused = fs::rename(&backup_data, &original_data);
         }
     })?;
     let new_db = LMDBDatabase::new(&new_store, new_lock, consensus_manager, stats_sender).inspect_err(|_| {
         if !original_data.exists() {
-            let _ = fs::rename(&backup_data, &original_data);
+            let _unused = fs::rename(&backup_data, &original_data);
         }
     })?;
 
@@ -853,10 +857,7 @@ impl LMDBDatabase {
         let copied = dest_dir.join("data.mdb");
         let size = fs::metadata(&copied)
             .map_err(|e| {
-                ChainStorageError::AccessError(format!(
-                    "Could not stat compacted file {}: {e}",
-                    copied.display()
-                ))
+                ChainStorageError::AccessError(format!("Could not stat compacted file {}: {e}", copied.display()))
             })?
             .len();
         Ok(size)
@@ -4990,13 +4991,12 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
 /// so the rows cannot be copied across. Instead this migration:
 ///
 /// 1. Walks `utxo_commitment_index` to enumerate every unspent UTXO commitment.
-/// 2. Splits the commitments into fixed-size chunks. For each chunk we resolve the mined
-///    output, compute `output.smt_hash(mined_height)`, and apply the chunk as one JMT
-///    version in its own write transaction so the LMDB env can resize between commits.
-/// 3. The chunked write transactions are wrapped in a retry loop that reacts to
-///    `DbResizeRequired` by growing the LMDB map and reapplying the failed chunk.
-/// 4. Deletes the three legacy v1 tables with `Database::delete` so their pages are
-///    reclaimed.
+/// 2. Splits the commitments into fixed-size chunks. For each chunk we resolve the mined output, compute
+///    `output.smt_hash(mined_height)`, and apply the chunk as one JMT version in its own write transaction so the LMDB
+///    env can resize between commits.
+/// 3. The chunked write transactions are wrapped in a retry loop that reacts to `DbResizeRequired` by growing the LMDB
+///    map and reapplying the failed chunk.
+/// 4. Deletes the three legacy v1 tables with `Database::delete` so their pages are reclaimed.
 ///
 /// On a fresh database (no v1 tables present) the function is a no-op.
 ///
@@ -5005,6 +5005,7 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
 /// the JMT bookkeeping cost across enough entries.
 const JMT_MIGRATION_BATCH_SIZE: usize = 5_000;
 
+#[allow(clippy::too_many_lines)]
 fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<bool, ChainStorageError> {
     info!(target: LOG_TARGET, "[MIGRATIONS] v6: Starting JMT v1 → v2 rebuild");
 
@@ -5059,9 +5060,7 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<bool, ChainStorageError
             bytes.copy_from_slice(commitment);
             out.push(bytes);
             entry = cursor.next::<[u8], [u8]>(&access).to_opt().map_err(|e| {
-                ChainStorageError::AccessError(format!(
-                    "Failed to advance cursor on utxo_commitment_index: {e}"
-                ))
+                ChainStorageError::AccessError(format!("Failed to advance cursor on utxo_commitment_index: {e}"))
             })?;
         }
         out
@@ -5114,13 +5113,11 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<bool, ChainStorageError
             let read_txn = db.read_transaction()?;
             let mut entries = Vec::with_capacity(chunk.len());
             for commitment in chunk {
-                let output_hash: HashOutput =
-                    lmdb_get(&read_txn, &db.utxo_commitment_index, commitment.as_ref())?.ok_or_else(|| {
-                        ChainStorageError::ValueNotFound {
-                            entity: "utxo_commitment_index",
-                            field: "commitment",
-                            value: to_hex(commitment.as_ref()),
-                        }
+                let output_hash: HashOutput = lmdb_get(&read_txn, &db.utxo_commitment_index, commitment.as_ref())?
+                    .ok_or_else(|| ChainStorageError::ValueNotFound {
+                        entity: "utxo_commitment_index",
+                        field: "commitment",
+                        value: to_hex(commitment.as_ref()),
                     })?;
                 let utxo_info = db
                     .fetch_output_in_txn(&read_txn, output_hash.as_slice())?
@@ -5167,7 +5164,9 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<bool, ChainStorageError
                     }
                 },
                 Err(ChainStorageError::JellyfishMerkleTreeError(jmt_err)) => {
-                    if let Some(ChainStorageError::DbResizeRequired(size_hint)) = jmt_err.downcast_ref::<ChainStorageError>() {
+                    if let Some(ChainStorageError::DbResizeRequired(size_hint)) =
+                        jmt_err.downcast_ref::<ChainStorageError>()
+                    {
                         resize_attempts += 1;
                         if resize_attempts >= max_resizes {
                             return Err(ChainStorageError::DbTransactionTooLarge(batch_entries.len()));
@@ -5234,10 +5233,7 @@ fn apply_jmt_migration_batch(
     let write_txn = db.write_transaction()?;
     let reader = LmdbTreeReader::new(&write_txn, db.jmt_node_data.clone(), db.jmt_value_data.clone());
     let new_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
-    let value_set: Vec<(KeyHash, Option<Vec<u8>>)> = batch
-        .iter()
-        .map(|(k, v)| (*k, Some(v.clone())))
-        .collect();
+    let value_set: Vec<(KeyHash, Option<Vec<u8>>)> = batch.iter().map(|(k, v)| (*k, Some(v.clone()))).collect();
     let (_root, ops) = new_smt
         .put_value_set(value_set, version)
         .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
@@ -5253,9 +5249,7 @@ fn apply_jmt_migration_batch(
         .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
     write_txn.commit().map_err(|e| match e {
-        lmdb_zero::Error::Code(code) if code == lmdb_zero::error::MAP_FULL => {
-            ChainStorageError::DbResizeRequired(None)
-        },
+        lmdb_zero::Error::Code(code) if code == lmdb_zero::error::MAP_FULL => ChainStorageError::DbResizeRequired(None),
         other => ChainStorageError::AccessError(format!("Failed to commit JMT migration batch: {other}")),
     })?;
     Ok(())

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -91,7 +91,7 @@ use std::{
     fmt,
     fs::{self, File},
     ops::Deref,
-    path::Path,
+    path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
 };
@@ -451,8 +451,7 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
     config: LMDBConfig,
     consensus_manager: BaseNodeConsensusManager,
 ) -> Result<LMDBDatabase, ChainStorageError> {
-    let (lmdb_store, file_lock) = build_lmdb_store(path, config)?;
-    LMDBDatabase::new(&lmdb_store, file_lock, consensus_manager, None)
+    open_lmdb_database_with_compaction(path.as_ref(), config, consensus_manager, None)
 }
 
 pub fn create_lmdb_database_with_stats_channel<P: AsRef<Path>>(
@@ -461,8 +460,175 @@ pub fn create_lmdb_database_with_stats_channel<P: AsRef<Path>>(
     consensus_manager: BaseNodeConsensusManager,
     stats_sender: Option<watch::Sender<DatabaseStats>>,
 ) -> Result<LMDBDatabase, ChainStorageError> {
-    let (lmdb_store, file_lock) = build_lmdb_store(path, config)?;
-    LMDBDatabase::new(&lmdb_store, file_lock, consensus_manager, stats_sender)
+    open_lmdb_database_with_compaction(path.as_ref(), config, consensus_manager, stats_sender)
+}
+
+/// Open the LMDB env, run migrations, and — if a migration freed pages that can no longer be
+/// returned to the OS via `mdb_drop` — compact the env into a fresh file and reopen it.
+///
+/// The compaction step writes a fresh `data.mdb` next to the original via `mdb_env_copy2` with
+/// `MDB_CP_COMPACT`, then atomically swaps it in. The original is renamed to `data.mdb.bak` as a
+/// safety net: if any of the swap/reopen steps fail the operator can restore it manually.
+fn open_lmdb_database_with_compaction(
+    path: &Path,
+    config: LMDBConfig,
+    consensus_manager: BaseNodeConsensusManager,
+    stats_sender: Option<watch::Sender<DatabaseStats>>,
+) -> Result<LMDBDatabase, ChainStorageError> {
+    let env_path = path.to_path_buf();
+    let (lmdb_store, file_lock) = build_lmdb_store(&env_path, config.clone())?;
+    let db = LMDBDatabase::new(&lmdb_store, file_lock, consensus_manager.clone(), stats_sender.clone())?;
+
+    if !db.needs_compaction() {
+        return Ok(db);
+    }
+
+    compact_and_reopen_lmdb_database(db, lmdb_store, env_path, config, consensus_manager, stats_sender)
+}
+
+/// Compact the env behind `db` into a new file and reopen the database against the compacted copy.
+fn compact_and_reopen_lmdb_database(
+    db: LMDBDatabase,
+    lmdb_store: LMDBStore,
+    env_path: PathBuf,
+    config: LMDBConfig,
+    consensus_manager: BaseNodeConsensusManager,
+    stats_sender: Option<watch::Sender<DatabaseStats>>,
+) -> Result<LMDBDatabase, ChainStorageError> {
+    info!(
+        target: LOG_TARGET,
+        "[MIGRATIONS] Compacting LMDB env at {} to reclaim space freed by JMT v1 → v2 migration",
+        env_path.display()
+    );
+    println!("Compacting LMDB env at {} to reclaim space freed by JMT v1 → v2 migration",env_path.display());
+
+    let original_data = env_path.join("data.mdb");
+    let original_lock = env_path.join("lock.mdb");
+    let backup_data = env_path.join("data.mdb.bak");
+    let compact_dir = env_path.join(".compact_tmp");
+
+    // Pre-flight: ensure no stale temp directory from a previous interrupted run.
+    if compact_dir.exists() {
+        fs::remove_dir_all(&compact_dir).map_err(|e| {
+            ChainStorageError::AccessError(format!(
+                "Could not remove stale compaction tempdir {}: {e}",
+                compact_dir.display()
+            ))
+        })?;
+    }
+    fs::create_dir(&compact_dir).map_err(|e| {
+        ChainStorageError::AccessError(format!(
+            "Could not create compaction tempdir {}: {e}",
+            compact_dir.display()
+        ))
+    })?;
+
+    // Pre-flight: confirm we have at least the current data.mdb size free on the volume.
+    // `mdb_env_copy2(COMPACT)` writes a brand-new file that is at most the size of the current
+    // file, so this is an upper bound. If we run out mid-copy we'd leave a half-written file
+    // that we still have to clean up, so check first.
+    let original_size = fs::metadata(&original_data)
+        .map_err(|e| {
+            ChainStorageError::AccessError(format!("Could not stat {}: {e}", original_data.display()))
+        })?
+        .len();
+    let pre_size_mb = original_size / BYTES_PER_MB as u64;
+    info!(
+        target: LOG_TARGET,
+        "[MIGRATIONS] Pre-compaction data.mdb size: {pre_size_mb} MB"
+    );
+    println!("[MIGRATIONS] Pre-compaction data.mdb size: {pre_size_mb} MB");
+
+    // Write the compacted copy. This uses an internal long-lived read transaction; we run
+    // single-threaded at startup so nothing else is writing.
+    let compacted_size = match db.compact_copy_env(&compact_dir) {
+        Ok(size) => size,
+        Err(e) => {
+            warn!(target: LOG_TARGET, "[MIGRATIONS] env.copy(COMPACT) failed: {e}");
+            let _ = fs::remove_dir_all(&compact_dir);
+            return Err(e);
+        },
+    };
+    let post_size_mb = compacted_size / BYTES_PER_MB as u64;
+    info!(
+        target: LOG_TARGET,
+        "[MIGRATIONS] Compacted data.mdb size: {post_size_mb} MB (reclaimed {} MB)",
+        pre_size_mb.saturating_sub(post_size_mb)
+    );
+    println!("[MIGRATIONS] Compacted data.mdb size: {post_size_mb} MB (reclaimed {} MB)",pre_size_mb.saturating_sub(post_size_mb));
+
+    // Drop every Arc<Environment> reference so the OS lets us swap data.mdb. `LMDBDatabase`,
+    // `LMDBStore` and the chain_storage `file_lock` together hold all of them in this process.
+    drop(db);
+    drop(lmdb_store);
+
+    // Rename data.mdb -> data.mdb.bak (atomic on the same filesystem). On Windows, the
+    // pre-existing backup is removed first because rename-over is not always atomic.
+    if backup_data.exists() {
+        fs::remove_file(&backup_data).map_err(|e| {
+            ChainStorageError::AccessError(format!(
+                "Could not remove stale backup file {}: {e}",
+                backup_data.display()
+            ))
+        })?;
+    }
+    fs::rename(&original_data, &backup_data).map_err(|e| {
+        let _ = fs::remove_dir_all(&compact_dir);
+        ChainStorageError::AccessError(format!(
+            "Could not rename {} -> {}: {e}",
+            original_data.display(),
+            backup_data.display()
+        ))
+    })?;
+
+    // Move the compacted file into place. If this fails we restore the backup so the caller can
+    // retry the migration on a subsequent startup.
+    let new_data = compact_dir.join("data.mdb");
+    if let Err(e) = fs::rename(&new_data, &original_data) {
+        warn!(
+            target: LOG_TARGET,
+            "[MIGRATIONS] Could not move compacted data.mdb into place: {e}; restoring backup"
+        );
+        let _ = fs::rename(&backup_data, &original_data);
+        let _ = fs::remove_dir_all(&compact_dir);
+        return Err(ChainStorageError::AccessError(format!(
+            "Could not rename compacted file into place: {e}"
+        )));
+    }
+
+    // Stale lock.mdb from the old env confuses some platforms; LMDB recreates it on reopen.
+    let _ = fs::remove_file(&original_lock);
+    let _ = fs::remove_dir_all(&compact_dir);
+
+    // Reopen against the compacted file.
+    let (new_store, new_lock) = build_lmdb_store(&env_path, config).inspect_err(|_| {
+        // Best-effort restore so the operator isn't left with a missing data.mdb.
+        if !original_data.exists() {
+            let _ = fs::rename(&backup_data, &original_data);
+        }
+    })?;
+    let new_db = LMDBDatabase::new(&new_store, new_lock, consensus_manager, stats_sender).inspect_err(|_| {
+        if !original_data.exists() {
+            let _ = fs::rename(&backup_data, &original_data);
+        }
+    })?;
+
+    // Everything succeeded: drop the backup. If this fails it's not fatal — operators can
+    // remove the .bak manually.
+    if let Err(e) = fs::remove_file(&backup_data) {
+        warn!(
+            target: LOG_TARGET,
+            "[MIGRATIONS] Could not remove backup file {}: {e}",
+            backup_data.display()
+        );
+    }
+
+    info!(
+        target: LOG_TARGET,
+        "[MIGRATIONS] LMDB compaction complete: {pre_size_mb} MB -> {post_size_mb} MB"
+    );
+    println!("[MIGRATIONS] LMDB compaction complete: {pre_size_mb} MB -> {post_size_mb} MB");
+    Ok(new_db)
 }
 /// This is a lmdb-based blockchain database for persistent storage of the chain state.
 pub struct LMDBDatabase {
@@ -537,6 +703,11 @@ pub struct LMDBDatabase {
     _file_lock: Arc<File>,
     consensus_manager: BaseNodeConsensusManager,
     stats_collector: LMDBStatsCollector,
+    /// Set by `run_migrations` if a migration step freed enough pages that the env should be
+    /// compacted (copied with `MDB_CP_COMPACT`) to reclaim the disk space. The freed pages
+    /// from `mdb_drop` are reused by future writes but never returned to the OS, so without
+    /// this step the file size never shrinks.
+    needs_compaction: bool,
 }
 
 impl LMDBDatabase {
@@ -600,6 +771,7 @@ impl LMDBDatabase {
             _file_lock: Arc::new(file_lock),
             consensus_manager,
             stats_collector: LMDBStatsCollector::new(),
+            needs_compaction: false,
         };
 
         // If a stats sender was provided, add it to the collector
@@ -610,6 +782,35 @@ impl LMDBDatabase {
         run_migrations(&mut db)?;
 
         Ok(db)
+    }
+
+    /// Returns true if a migration step in this `new()` call freed pages that should be
+    /// reclaimed via an `MDB_CP_COMPACT` copy of the env. The caller (typically
+    /// `create_lmdb_database`) is responsible for performing the compact-and-swap.
+    pub fn needs_compaction(&self) -> bool {
+        self.needs_compaction
+    }
+
+    /// Copy the environment to `dest_dir` with `MDB_CP_COMPACT`. The destination directory must
+    /// already exist and be empty; the env writes `data.mdb` (and optionally `lock.mdb`) into it.
+    /// Returns the size of the freshly-compacted `data.mdb` for logging.
+    pub fn compact_copy_env(&self, dest_dir: &Path) -> Result<u64, ChainStorageError> {
+        let dest_str = dest_dir
+            .to_str()
+            .ok_or_else(|| ChainStorageError::CriticalError("compact_copy_env: non-utf8 path".to_string()))?;
+        self.env
+            .copy(dest_str, lmdb_zero::copy::COMPACT)
+            .map_err(|e| ChainStorageError::AccessError(format!("env.copy(COMPACT) failed: {e}")))?;
+        let copied = dest_dir.join("data.mdb");
+        let size = fs::metadata(&copied)
+            .map_err(|e| {
+                ChainStorageError::AccessError(format!(
+                    "Could not stat compacted file {}: {e}",
+                    copied.display()
+                ))
+            })?
+            .len();
+        Ok(size)
     }
 
     /// Get a reference to the stats collector
@@ -4706,8 +4907,10 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
         // Rather than translating the old data, we re-derive the JMT from the canonical UTXO set:
         // insert every unspent UTXO into a fresh tree, write it to the v2 tables, then drop the
         // legacy tables entirely so their pages return to disk.
-        if migrate_from_version == 6 {
-            migrate_jmt_v1_to_v2(db)?;
+        if migrate_from_version == 6 && migrate_jmt_v1_to_v2(db)? {
+            // The v1 tables were dropped from the env; their pages are now on the free list
+            // but the file size has not shrunk. Signal the caller to compact-copy the env.
+            db.needs_compaction = true;
         }
 
         // Let's update the migration version
@@ -4753,7 +4956,7 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
 /// the JMT bookkeeping cost across enough entries.
 const JMT_MIGRATION_BATCH_SIZE: usize = 5_000;
 
-fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
+fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<bool, ChainStorageError> {
     info!(target: LOG_TARGET, "[MIGRATIONS] v6: Starting JMT v1 → v2 rebuild");
 
     // Open the legacy v1 databases by name. We deliberately avoid registering these in
@@ -4778,7 +4981,7 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> 
             target: LOG_TARGET,
             "[MIGRATIONS] v6: No v1 JMT tables present, nothing to migrate"
         );
-        return Ok(());
+        return Ok(false);
     }
 
     println!("Starting JMT v1 → v2 rebuild");
@@ -4965,7 +5168,7 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> 
     println!("JMT rebuild complete");
 
     info!(target: LOG_TARGET, "[MIGRATIONS] v6: JMT v1 → v2 rebuild complete");
-    Ok(())
+    Ok(true)
 }
 
 /// Apply a single chunk of commitments to the v2 JMT tables in its own write transaction.

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -283,10 +283,12 @@ const LMDB_DB_VALIDATOR_NODES_ACTIVATION: &str = "validator_nodes_activation_que
 const LMDB_DB_VALIDATOR_NODES_EXIT: &str = "validator_nodes_exit";
 const LMDB_DB_TEMPLATE_REGISTRATIONS: &str = "template_registrations";
 const LMDB_DB_UTXO_SMT: &str = "utxo_smt";
-const LMDB_DB_JMT_VALUE_DATA: &str = "jmt_value_data";
-#[allow(dead_code)] // Retained for upcoming JMT data migration.
-const LMDB_DB_JMT_NODE_OLD_DATA: &str = "jmt_node_data";
-const LMDB_DB_JMT_NODE_NEW_DATA: &str = "jmt_nodes_data";
+const LMDB_DB_JMT_VALUE_DATA_v1: &str = "jmt_value_data";
+const LMDB_DB_JMT_VALUE_DATA_V2: &str = "jmt_values_data";
+const LMDB_DB_JMT_NODE_DATA_V1: &str = "jmt_node_data";
+const LMDB_DB_JMT_NODE_DATA_V2: &str = "jmt_nodes_data";
+const LMDB_DB_JMT_UNIQUE_KEY_DATA: &str = "jmt_unique_key_data";
+
 
 /// Returns the list of all LMDB database names used by Tari.
 /// This is the authoritative source for database names to avoid duplication.
@@ -324,8 +326,8 @@ pub fn get_all_database_names() -> Vec<&'static str> {
         LMDB_DB_VALIDATOR_NODES_EXIT,
         LMDB_DB_TEMPLATE_REGISTRATIONS,
         LMDB_DB_UTXO_SMT,
-        LMDB_DB_JMT_VALUE_DATA,
-        LMDB_DB_JMT_NODE_NEW_DATA,
+        LMDB_DB_JMT_VALUE_DATA_V2,
+        LMDB_DB_JMT_NODE_DATA_V1,
     ]
 }
 
@@ -391,8 +393,8 @@ pub(crate) fn build_lmdb_store<P: AsRef<Path>>(
         .add_database(LMDB_DB_VALIDATOR_NODES_EXIT, flags)
         .add_database(LMDB_DB_TEMPLATE_REGISTRATIONS, flags | db::DUPSORT)
         .add_database(LMDB_DB_UTXO_SMT, flags)
-        .add_database(LMDB_DB_JMT_VALUE_DATA, flags )
-        .add_database(LMDB_DB_JMT_NODE_NEW_DATA, flags)
+        .add_database(LMDB_DB_JMT_VALUE_DATA_V2, flags )
+        .add_database(LMDB_DB_JMT_NODE_DATA_V2, flags)
         .build()
         .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{err}")))?;
     debug!(target: LOG_TARGET, "LMDB database creation successful");
@@ -587,8 +589,8 @@ impl LMDBDatabase {
             validator_nodes_exit_queue: get_database(store, LMDB_DB_VALIDATOR_NODES_EXIT)?,
             template_registrations: get_database(store, LMDB_DB_TEMPLATE_REGISTRATIONS)?,
             utxo_smt: get_database(store, LMDB_DB_UTXO_SMT)?,
-            jmt_value_data: get_database(store, LMDB_DB_JMT_VALUE_DATA)?,
-            jmt_node_data: get_database(store, LMDB_DB_JMT_NODE_NEW_DATA)?,
+            jmt_value_data: get_database(store, LMDB_DB_JMT_VALUE_DATA_V2)?,
+            jmt_node_data: get_database(store, LMDB_DB_JMT_NODE_DATA_V2)?,
             env,
             env_config: store.env_config(),
             _file_lock: Arc::new(file_lock),
@@ -886,8 +888,8 @@ impl LMDBDatabase {
             (LMDB_DB_VALIDATOR_NODES_EXIT, &self.validator_nodes_exit_queue),
             (LMDB_DB_TEMPLATE_REGISTRATIONS, &self.template_registrations),
             (LMDB_DB_UTXO_SMT, &self.utxo_smt),
-            (LMDB_DB_JMT_VALUE_DATA, &self.jmt_value_data),
-            (LMDB_DB_JMT_NODE_NEW_DATA, &self.jmt_node_data),
+            (LMDB_DB_JMT_VALUE_DATA_V2, &self.jmt_value_data),
+            (LMDB_DB_JMT_NODE_DATA_V2, &self.jmt_node_data),
         ]
     }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -97,11 +97,7 @@ use std::{
 };
 
 use fs2::FileExt;
-use jmt::{
-    JellyfishMerkleTree,
-    KeyHash,
-    storage::{TreeWriter},
-};
+use jmt::{JellyfishMerkleTree, KeyHash, storage::TreeWriter};
 use lmdb_zero::{
     ConstTransaction,
     Database,
@@ -804,9 +800,7 @@ impl LMDBDatabase {
                         &MetadataValue::HorizonData(horizon_data.clone()),
                     )?;
                 },
-                ApplyHorizonStateTreeUpdates {
-                    updates,
-                } => {
+                ApplyHorizonStateTreeUpdates { updates } => {
                     self.apply_horizon_state_tree_updates(&write_txn, updates)?;
                 },
                 InsertBadBlock { hash, height, reason } => {
@@ -920,13 +914,23 @@ impl LMDBDatabase {
 
         // Generate PayRef and add to index
         let payref = Self::generate_payment_reference_for_output(header_hash, &output_hash);
-        lmdb_insert(
-            txn,
-            &self.payref_to_output_index,
-            payref.as_slice(),
-            &output_hash,
-            "payref_to_output_index",
-        )?;
+        let payref_needs_to_be_inserted = if header_height == 0 {
+            // this is a special edge case where we are reinserting genesis outputs that where spent, their payref might
+            // already exist, so let's delete it first, then we can readd it safely
+            let exists = lmdb_exists(txn, &self.payref_to_output_index, payref.as_slice())?;
+            !exists
+        } else {
+            true
+        };
+        if payref_needs_to_be_inserted {
+            lmdb_insert(
+                txn,
+                &self.payref_to_output_index,
+                payref.as_slice(),
+                &output_hash,
+                "payref_to_output_index",
+            )?;
+        }
 
         lmdb_insert(
             txn,
@@ -1359,7 +1363,6 @@ impl LMDBDatabase {
             )));
         }
 
-
         lmdb_delete(
             write_txn,
             &self.block_accumulated_data_db,
@@ -1368,10 +1371,6 @@ impl LMDBDatabase {
         )?;
 
         self.delete_block_inputs_outputs(write_txn, block_hash, height)?;
-
-
-
-
 
         self.delete_block_kernels(write_txn, block_hash.as_slice())?;
 
@@ -1385,7 +1384,6 @@ impl LMDBDatabase {
         block_hash: &HashOutput,
         height: u64,
     ) -> Result<(), ChainStorageError> {
-
         let smt_reader = LmdbTreeReader::new(txn, self.jmt_node_data.clone(), self.jmt_value_data.clone());
 
         let output_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&smt_reader);
@@ -1519,7 +1517,8 @@ impl LMDBDatabase {
             })?;
 
             let smt_key = KeyHash(
-                utxo_mined_info.output
+                utxo_mined_info
+                    .output
                     .commitment
                     .as_bytes()
                     .try_into()
@@ -1541,8 +1540,8 @@ impl LMDBDatabase {
             trace!(target: LOG_TARGET, "Input moved to UTXO set: {input}");
         }
         let k = MetadataKey::JMTVersion;
-        let val = match lmdb_get(txn, &self.metadata_db, &k.as_u32())?{
-            Some(MetadataValue::JMTVersion(v)) => v+1,
+        let val = match lmdb_get(txn, &self.metadata_db, &k.as_u32())? {
+            Some(MetadataValue::JMTVersion(v)) => v + 1,
             _ => 0u64,
         };
 
@@ -1573,7 +1572,9 @@ impl LMDBDatabase {
         smt_writer
             .write_node_batch(&ops.node_batch)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
-        smt_writer.cleanup_stale(&ops.stale_node_index_batch).map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+        smt_writer
+            .cleanup_stale(&ops.stale_node_index_batch)
+            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
         Ok(())
     }
@@ -1810,14 +1811,13 @@ impl LMDBDatabase {
             )?;
         }
         let k = MetadataKey::JMTVersion;
-        let val = match lmdb_get(txn, &self.metadata_db, &k.as_u32())?{
-            Some(MetadataValue::JMTVersion(v)) => v+1,
+        let val = match lmdb_get(txn, &self.metadata_db, &k.as_u32())? {
+            Some(MetadataValue::JMTVersion(v)) => v + 1,
             _ => 0u64,
         };
         let (root, ops) = output_smt
             .put_value_set(batch, val)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
-
 
         if header.output_mr.as_slice() != root.0.as_slice() {
             warn!(
@@ -1840,14 +1840,15 @@ impl LMDBDatabase {
             txn,
             self.jmt_node_data.clone(),
             self.jmt_value_data.clone(),
-            self.metadata_db.clone()
+            self.metadata_db.clone(),
         );
 
         smt_writer
             .write_node_batch(&ops.node_batch)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
-        smt_writer.cleanup_stale(&ops.stale_node_index_batch).map_err(ChainStorageError::JellyfishMerkleTreeError)?;
-
+        smt_writer
+            .cleanup_stale(&ops.stale_node_index_batch)
+            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
         self.insert_block_accumulated_data(
             txn,
@@ -2126,7 +2127,7 @@ impl LMDBDatabase {
         output_hash: &HashOutput,
     ) -> Result<(), ChainStorageError> {
         let payref = Self::generate_payment_reference_for_output(header_hash, output_hash);
-        debug!(target: LOG_TARGET, "Pruning output from 'payref_to_output_index': key '{}'", payref.to_hex());
+        trace!(target: LOG_TARGET, "Pruning output from 'payref_to_output_index': key '{}'", payref.to_hex());
         match lmdb_delete(
             write_txn,
             &self.payref_to_output_index,
@@ -2154,7 +2155,7 @@ impl LMDBDatabase {
             let input = input_data.input;
             // From 'utxo_commitment_index::utxo_commitment_index'
             if let SpentOutput::OutputData { commitment, .. } = input.spent_output.clone() {
-                debug!(target: LOG_TARGET, "Pruning output from 'utxo_commitment_index': key '{}'", commitment.to_hex());
+                trace!(target: LOG_TARGET, "Pruning output from 'utxo_commitment_index': key '{}'", commitment.to_hex());
                 lmdb_delete(
                     write_txn,
                     &self.utxo_commitment_index,
@@ -2169,13 +2170,13 @@ impl LMDBDatabase {
             {
                 let header_hash = Self::header_hash_from_output_index_key(&key_bytes)?;
                 let key = OutputKey::new(&header_hash, &output_hash)?;
-                debug!(target: LOG_TARGET, "Pruning output from 'utxos_db': key '{}'", key.0);
+                trace!(target: LOG_TARGET, "Pruning output from 'utxos_db': key '{}'", key.0);
                 lmdb_delete(write_txn, &self.utxos_db, &key.convert_to_comp_key(), LMDB_DB_UTXOS)?;
 
                 self.delete_payref_index_entry(write_txn, &header_hash, &output_hash)?;
             };
             // From 'txos_hash_to_index_db::utxos_db'
-            debug!(
+            trace!(
                 target: LOG_TARGET,
                 "Pruning output from 'txos_hash_to_index_db': key '{}'",
                 output_hash.to_hex()
@@ -2201,7 +2202,7 @@ impl LMDBDatabase {
         match lmdb_get::<_, Vec<u8>>(write_txn, &self.txos_hash_to_index_db, output_hash.as_slice())? {
             Some(key_bytes) => {
                 if !matches!(output_type, OutputType::Burn) {
-                    debug!(target: LOG_TARGET, "Pruning output from 'utxo_commitment_index': key '{}'", commitment.to_hex());
+                    trace!(target: LOG_TARGET, "Pruning output from 'utxo_commitment_index': key '{}'", commitment.to_hex());
                     lmdb_delete(
                         write_txn,
                         &self.utxo_commitment_index,
@@ -2209,7 +2210,7 @@ impl LMDBDatabase {
                         "utxo_commitment_index",
                     )?;
                 }
-                debug!(target: LOG_TARGET, "Pruning output from 'txos_hash_to_index_db': key '{}'", output_hash.to_hex());
+                trace!(target: LOG_TARGET, "Pruning output from 'txos_hash_to_index_db': key '{}'", output_hash.to_hex());
                 lmdb_delete(
                     write_txn,
                     &self.txos_hash_to_index_db,
@@ -2219,9 +2220,8 @@ impl LMDBDatabase {
 
                 let header_hash = Self::header_hash_from_output_index_key(&key_bytes)?;
                 let key = OutputKey::new(&header_hash, output_hash)?;
-                debug!(target: LOG_TARGET, "Pruning output from 'utxos_db': key '{}'", key.0);
+                trace!(target: LOG_TARGET, "Pruning output from 'utxos_db': key '{}'", key.0);
                 lmdb_delete(write_txn, &self.utxos_db, &key.convert_to_comp_key(), LMDB_DB_UTXOS)?;
-
                 self.delete_payref_index_entry(write_txn, &header_hash, output_hash)?;
             },
             None => {
@@ -2251,8 +2251,6 @@ impl LMDBDatabase {
             self.metadata_db.clone(),
         );
 
-
-
         let output_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
         let batch = updates
             .iter()
@@ -2260,8 +2258,8 @@ impl LMDBDatabase {
             .collect::<Vec<_>>();
 
         let k = MetadataKey::JMTVersion;
-        let val = match lmdb_get(write_txn, &self.metadata_db, &k.as_u32())?{
-            Some(MetadataValue::JMTVersion(v)) => v+1,
+        let val = match lmdb_get(write_txn, &self.metadata_db, &k.as_u32())? {
+            Some(MetadataValue::JMTVersion(v)) => v + 1,
             _ => 0u64,
         };
         let (_root, ops) = output_smt
@@ -2271,7 +2269,9 @@ impl LMDBDatabase {
         writer
             .write_node_batch(&ops.node_batch)
             .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
-        writer.cleanup_stale(&ops.stale_node_index_batch).map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+        writer
+            .cleanup_stale(&ops.stale_node_index_batch)
+            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
 
         Ok(())
     }
@@ -2596,12 +2596,11 @@ impl BlockchainBackend for LMDBDatabase {
     fn create_smt_reader(&self) -> Result<(OwnedLmdbTreeReader<'_>, u64), ChainStorageError> {
         let read_tx = self.read_transaction()?;
         let k = MetadataKey::JMTVersion;
-        let val = match lmdb_get(&read_tx, &self.metadata_db, &k.as_u32())?{
+        let val = match lmdb_get(&read_tx, &self.metadata_db, &k.as_u32())? {
             Some(MetadataValue::JMTVersion(v)) => v,
             _ => 0u64,
         };
-        let smt_reader =
-            OwnedLmdbTreeReader::new(read_tx, self.jmt_node_data.clone(), self.jmt_value_data.clone());
+        let smt_reader = OwnedLmdbTreeReader::new(read_tx, self.jmt_node_data.clone(), self.jmt_value_data.clone());
 
         Ok((smt_reader, val))
     }
@@ -3483,14 +3482,11 @@ impl BlockchainBackend for LMDBDatabase {
         }
     }
 
-    fn verify_horizon_sync_output_root(
-        &self,
-        expected_root: HashOutput,
-    ) -> Result<(), ChainStorageError> {
+    fn verify_horizon_sync_output_root(&self, expected_root: HashOutput) -> Result<(), ChainStorageError> {
         let txn = self.read_transaction()?;
         let k = MetadataKey::JMTVersion;
-        let val = match lmdb_get(&txn, &self.metadata_db, &k.as_u32())?{
-            Some(MetadataValue::JMTVersion(v)) => v+1,
+        let val = match lmdb_get(&txn, &self.metadata_db, &k.as_u32())? {
+            Some(MetadataValue::JMTVersion(v)) => v,
             _ => 0u64,
         };
 
@@ -4953,7 +4949,7 @@ fn verify_metadata_keys(db: &LMDBDatabase) -> Result<(), ChainStorageError> {
                 Some(MetadataKey::AccumulatedDataCheckStatus) |
                 Some(MetadataKey::BlockchainConsistencyCheckStatus) |
                 Some(MetadataKey::HorizonSyncOutputCheckpoint) |
-                Some(MetadataKey::JMTVersion)=> {
+                Some(MetadataKey::JMTVersion) => {
                     warn!(
                         target: LOG_TARGET,
                         "Removed corrupt metadata entry {metadata_key:?} with key bytes: 0x{hex_key}",

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -161,7 +161,7 @@ use super::{
     lmdb::lmdb_get_prefix_cursor,
     lmdb_tree_reader::{LmdbTreeReader, OwnedLmdbTreeReader},
     lmdb_tree_writer::LmdbTreeWriter,
-    stats_collector::{DatabaseStats, LMDBStatsCollector},
+    stats_collector::{DatabaseStats, LMDBStatsCollector, MigrationPhase},
 };
 use crate::{
     PrunedKernelMmr,
@@ -500,6 +500,10 @@ fn compact_and_reopen_lmdb_database(
         "[MIGRATIONS] Compacting LMDB env at {} to reclaim space freed by JMT v1 → v2 migration",
         env_path.display()
     );
+
+    // Emit a phase=LmdbCompact update through the readiness channel before the long-running
+    // env.copy call so clients can show "Compacting LMDB" instead of a stuck progress bar.
+    publish_compaction_progress(stats_sender.as_ref(), MigrationPhase::LmdbCompact, 0, 0);
     println!("Compacting LMDB env at {} to reclaim space freed by JMT v1 → v2 migration",env_path.display());
 
     let original_data = env_path.join("data.mdb");
@@ -554,6 +558,16 @@ fn compact_and_reopen_lmdb_database(
         target: LOG_TARGET,
         "[MIGRATIONS] Compacted data.mdb size: {post_size_mb} MB (reclaimed {} MB)",
         pre_size_mb.saturating_sub(post_size_mb)
+    );
+    // The env.copy call is monolithic, so once it returns we report 100% for the
+    // LMDB-compact phase. `current_height` and `total_height` use MB as units, which
+    // matches the progress bar shown for the JMT rebuild phase (entries, not MB) - the
+    // `phase` field tells the client which unit to render.
+    publish_compaction_progress(
+        stats_sender.as_ref(),
+        MigrationPhase::LmdbCompact,
+        pre_size_mb,
+        pre_size_mb,
     );
     println!("[MIGRATIONS] Compacted data.mdb size: {post_size_mb} MB (reclaimed {} MB)",pre_size_mb.saturating_sub(post_size_mb));
 
@@ -630,6 +644,41 @@ fn compact_and_reopen_lmdb_database(
     println!("[MIGRATIONS] LMDB compaction complete: {pre_size_mb} MB -> {post_size_mb} MB");
     Ok(new_db)
 }
+
+/// Push a single `DatabaseStats` update for the LMDB-compaction phase through the readiness
+/// `watch::Sender`. We can't use the in-process `LMDBStatsCollector` here because the
+/// `LMDBDatabase` owning it is dropped before the swap/reopen — the readiness handler's sender
+/// is the one channel that survives across the rebuild.
+fn publish_compaction_progress(
+    stats_sender: Option<&watch::Sender<DatabaseStats>>,
+    phase: MigrationPhase,
+    current: u64,
+    total: u64,
+) {
+    let Some(sender) = stats_sender else {
+        return;
+    };
+    // Preserve current_db_version / target_db_version / metadata so the gRPC consumer still
+    // sees the migration version transition alongside the phase update.
+    let mut stats = sender.borrow().clone();
+    stats.migration_stats.phase = phase;
+    stats.migration_stats.current_height = current;
+    stats.migration_stats.total_height = total;
+    stats.migration_stats.progress_percentage = if total > 0 {
+        (current as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    };
+    stats.last_updated = Instant::now();
+    stats.timestamp = chrono::Utc::now().timestamp_millis() as u64;
+    if let Err(e) = sender.send(stats) {
+        warn!(
+            target: LOG_TARGET,
+            "[MIGRATIONS] Could not publish compaction phase to readiness channel: {e}"
+        );
+    }
+}
+
 /// This is a lmdb-based blockchain database for persistent storage of the chain state.
 pub struct LMDBDatabase {
     env: Arc<Environment>,
@@ -5019,6 +5068,7 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<bool, ChainStorageError
     };
 
     let total = commitments.len();
+    db.stats_collector().set_migration_phase(MigrationPhase::JmtRebuild);
     db.set_stats_total_height(total as u64);
     info!(
         target: LOG_TARGET,

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -101,13 +101,16 @@ use jmt::{JellyfishMerkleTree, KeyHash, storage::TreeWriter};
 use lmdb_zero::{
     ConstTransaction,
     Database,
+    DatabaseOptions,
     EnvBuilder,
     Environment,
+    Error as LmdbError,
     LmdbResultExt,
     ReadTransaction,
     WriteTransaction,
+    error::NOTFOUND,
     open,
-    traits::AsLmdbBytes,
+    traits::{AsLmdbBytes, CreateCursor},
 };
 use log::*;
 use primitive_types::{U256, U512};
@@ -172,6 +175,7 @@ use crate::{
         InputMinedInfo,
         MinedInfo,
         MmrTree,
+        Optional,
         Reorg,
         TemplateRegistrationEntry,
         ValidatorNodeEntry,
@@ -283,7 +287,7 @@ const LMDB_DB_VALIDATOR_NODES_ACTIVATION: &str = "validator_nodes_activation_que
 const LMDB_DB_VALIDATOR_NODES_EXIT: &str = "validator_nodes_exit";
 const LMDB_DB_TEMPLATE_REGISTRATIONS: &str = "template_registrations";
 const LMDB_DB_UTXO_SMT: &str = "utxo_smt";
-const LMDB_DB_JMT_VALUE_DATA_v1: &str = "jmt_value_data";
+const LMDB_DB_JMT_VALUE_DATA_V1: &str = "jmt_value_data";
 const LMDB_DB_JMT_VALUE_DATA_V2: &str = "jmt_values_data";
 const LMDB_DB_JMT_NODE_DATA_V1: &str = "jmt_node_data";
 const LMDB_DB_JMT_NODE_DATA_V2: &str = "jmt_nodes_data";
@@ -327,7 +331,7 @@ pub fn get_all_database_names() -> Vec<&'static str> {
         LMDB_DB_TEMPLATE_REGISTRATIONS,
         LMDB_DB_UTXO_SMT,
         LMDB_DB_JMT_VALUE_DATA_V2,
-        LMDB_DB_JMT_NODE_DATA_V1,
+        LMDB_DB_JMT_NODE_DATA_V2,
     ]
 }
 
@@ -393,7 +397,7 @@ pub(crate) fn build_lmdb_store<P: AsRef<Path>>(
         .add_database(LMDB_DB_VALIDATOR_NODES_EXIT, flags)
         .add_database(LMDB_DB_TEMPLATE_REGISTRATIONS, flags | db::DUPSORT)
         .add_database(LMDB_DB_UTXO_SMT, flags)
-        .add_database(LMDB_DB_JMT_VALUE_DATA_V2, flags )
+        .add_database(LMDB_DB_JMT_VALUE_DATA_V2, flags)
         .add_database(LMDB_DB_JMT_NODE_DATA_V2, flags)
         .build()
         .map_err(|err| ChainStorageError::CriticalError(format!("Could not create LMDB store:{err}")))?;
@@ -4386,7 +4390,7 @@ impl fmt::Display for MetadataValue {
 fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
     let _unused = verify_metadata_keys(db);
 
-    const MIGRATION_VERSION: u64 = 6;
+    const MIGRATION_VERSION: u64 = 7;
     db.stats_collector().set_target_db_version(MIGRATION_VERSION);
     let txn = db.read_transaction()?;
     let k = MetadataKey::MigrationVersion;
@@ -4696,6 +4700,16 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             write_txn.commit()?;
         }
 
+        // MIGRATION: Rebuild the JMT on disk. The v1 layout used three databases
+        // (jmt_value_data, jmt_node_data, jmt_unique_key_data) with key encodings and stored
+        // payloads that are incompatible with v2 (which uses jmt_values_data + jmt_nodes_data).
+        // Rather than translating the old data, we re-derive the JMT from the canonical UTXO set:
+        // insert every unspent UTXO into a fresh tree, write it to the v2 tables, then drop the
+        // legacy tables entirely so their pages return to disk.
+        if migrate_from_version == 6 {
+            migrate_jmt_v1_to_v2(db)?;
+        }
+
         // Let's update the migration version
         {
             let migrated_to_version = migrate_from_version + 1;
@@ -4713,6 +4727,178 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
             txn.commit()?;
         }
     }
+    Ok(())
+}
+
+/// Rebuild the JMT from the canonical UTXO set under the new v2 layout and drop the legacy
+/// v1 databases.
+///
+/// The v1 (`jmt_value_data`, `jmt_node_data`, `jmt_unique_key_data`) and v2
+/// (`jmt_values_data`, `jmt_nodes_data`) tables differ in both key encoding *and* stored payload,
+/// so the rows cannot be copied across. Instead this migration:
+///
+/// 1. Walks `utxo_commitment_index` to enumerate every unspent UTXO commitment.
+/// 2. For each commitment, looks up the mined output and computes `output.smt_hash(mined_height)`.
+/// 3. Inserts the full set into a fresh `JellyfishMerkleTree` at version 0 and writes the
+///    resulting node/value batch into the v2 tables via `LmdbTreeWriter`.
+/// 4. Deletes the three legacy v1 tables with `Database::delete` so their pages are reclaimed.
+///
+/// On a fresh database (no v1 tables present) the function is a no-op.
+fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
+    info!(target: LOG_TARGET, "[MIGRATIONS] v6: Starting JMT v1 → v2 rebuild");
+
+    // Open the legacy v1 databases by name. We deliberately avoid registering these in
+    // `build_lmdb_store` so that fresh nodes don't create them and migrated nodes can drop them
+    // permanently.
+    let open_v1 = |name: &'static str| -> Result<Option<Database<'static>>, ChainStorageError> {
+        match Database::open(db.env.clone(), Some(name), &DatabaseOptions::defaults()) {
+            Ok(opened) => Ok(Some(opened)),
+            Err(LmdbError::Code(code)) if code == NOTFOUND => Ok(None),
+            Err(e) => Err(ChainStorageError::AccessError(format!(
+                "Could not open legacy database `{name}`: {e}"
+            ))),
+        }
+    };
+
+    let v1_value_data = open_v1(LMDB_DB_JMT_VALUE_DATA_V1)?;
+    let v1_node_data = open_v1(LMDB_DB_JMT_NODE_DATA_V1)?;
+    let v1_unique_key_data = open_v1(LMDB_DB_JMT_UNIQUE_KEY_DATA)?;
+
+    if v1_value_data.is_none() && v1_node_data.is_none() && v1_unique_key_data.is_none() {
+        info!(
+            target: LOG_TARGET,
+            "[MIGRATIONS] v6: No v1 JMT tables present, nothing to migrate"
+        );
+        return Ok(());
+    }
+
+    // Collect every unspent UTXO into a JMT batch. We do the lookups in a read transaction, then
+    // drop it before opening the write transaction.
+    let batch: Vec<(KeyHash, Option<Vec<u8>>)> = {
+        let read_txn = db.read_transaction()?;
+
+        // Commitments are the keys of `utxo_commitment_index`. Snapshot them so we can release
+        // the cursor borrow before we start doing per-key lookups.
+        let commitments: Vec<[u8; 32]> = {
+            let mut cursor = (&read_txn).cursor(db.utxo_commitment_index.clone()).map_err(|e| {
+                ChainStorageError::AccessError(format!(
+                    "Could not open cursor on utxo_commitment_index: {e}"
+                ))
+            })?;
+            let access = read_txn.access();
+            let mut out: Vec<[u8; 32]> = Vec::new();
+            let mut entry = cursor.first::<[u8], [u8]>(&access).to_opt().map_err(|e| {
+                ChainStorageError::AccessError(format!(
+                    "Failed to read first utxo_commitment_index entry: {e}"
+                ))
+            })?;
+            while let Some((commitment, _output_hash)) = entry {
+                if commitment.len() != 32 {
+                    return Err(ChainStorageError::CriticalError(format!(
+                        "utxo_commitment_index key has unexpected length {}",
+                        commitment.len()
+                    )));
+                }
+                let mut bytes = [0u8; 32];
+                bytes.copy_from_slice(commitment);
+                out.push(bytes);
+                entry = cursor.next::<[u8], [u8]>(&access).to_opt().map_err(|e| {
+                    ChainStorageError::AccessError(format!(
+                        "Failed to advance cursor on utxo_commitment_index: {e}"
+                    ))
+                })?;
+            }
+            out
+        };
+
+        info!(
+            target: LOG_TARGET,
+            "[MIGRATIONS] v6: {} unspent UTXOs will be inserted into the new JMT",
+            commitments.len()
+        );
+
+        let total = commitments.len();
+        db.set_stats_total_height(total as u64);
+        let mut batch: Vec<(KeyHash, Option<Vec<u8>>)> = Vec::with_capacity(total);
+        for (i, commitment) in commitments.into_iter().enumerate() {
+            let output_hash: HashOutput =
+                lmdb_get(&read_txn, &db.utxo_commitment_index, commitment.as_ref())?.ok_or_else(|| {
+                    ChainStorageError::ValueNotFound {
+                        entity: "utxo_commitment_index",
+                        field: "commitment",
+                        value: to_hex(commitment.as_ref()),
+                    }
+                })?;
+            let utxo_info = db
+                .fetch_output_in_txn(&read_txn, output_hash.as_slice())?
+                .ok_or_else(|| ChainStorageError::ValueNotFound {
+                    entity: "TransactionOutput",
+                    field: "output_hash",
+                    value: output_hash.to_hex(),
+                })?;
+            let smt_node = utxo_info.output.smt_hash(utxo_info.mined_height).to_vec();
+            batch.push((KeyHash(commitment), Some(smt_node)));
+
+            if (i + 1).is_multiple_of(100_000) {
+                db.update_stats_progress((i + 1) as u64);
+                info!(
+                    target: LOG_TARGET,
+                    "[MIGRATIONS] v6: Prepared {}/{total} JMT batch entries",
+                    i + 1
+                );
+            }
+        }
+        batch
+    };
+
+    // Apply the rebuilt tree to the (currently empty) v2 tables in a single write transaction.
+    {
+        let write_txn = db.write_transaction()?;
+
+        // Reset the JMTVersion counter so the new tree starts from a clean baseline.
+        lmdb_delete(
+            &write_txn,
+            &db.metadata_db,
+            &MetadataKey::JMTVersion.as_u32(),
+            "metadata",
+        )
+        .optional()?;
+
+        let reader = LmdbTreeReader::new(&write_txn, db.jmt_node_data.clone(), db.jmt_value_data.clone());
+        let new_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        let (_root, ops) = new_smt
+            .put_value_set(batch, 0u64)
+            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+
+        let writer = LmdbTreeWriter::new(
+            &write_txn,
+            db.jmt_node_data.clone(),
+            db.jmt_value_data.clone(),
+            db.metadata_db.clone(),
+        );
+        writer
+            .write_node_batch(&ops.node_batch)
+            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+
+        write_txn.commit()?;
+    }
+
+    // Drop each legacy v1 database. `Database::delete` consumes the handle and calls
+    // `mdb_drop` with the delete flag, returning the pages to the LMDB free list.
+    let delete_legacy = |name: &'static str, opt: Option<Database<'static>>| -> Result<(), ChainStorageError> {
+        if let Some(legacy) = opt {
+            legacy.delete().map_err(|e| {
+                ChainStorageError::AccessError(format!("Failed to delete legacy database `{name}`: {e}"))
+            })?;
+            info!(target: LOG_TARGET, "[MIGRATIONS] v6: Dropped legacy database `{name}`");
+        }
+        Ok(())
+    };
+    delete_legacy(LMDB_DB_JMT_VALUE_DATA_V1, v1_value_data)?;
+    delete_legacy(LMDB_DB_JMT_NODE_DATA_V1, v1_node_data)?;
+    delete_legacy(LMDB_DB_JMT_UNIQUE_KEY_DATA, v1_unique_key_data)?;
+
+    info!(target: LOG_TARGET, "[MIGRATIONS] v6: JMT v1 → v2 rebuild complete");
     Ok(())
 }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -4738,12 +4738,21 @@ fn run_migrations(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
 /// so the rows cannot be copied across. Instead this migration:
 ///
 /// 1. Walks `utxo_commitment_index` to enumerate every unspent UTXO commitment.
-/// 2. For each commitment, looks up the mined output and computes `output.smt_hash(mined_height)`.
-/// 3. Inserts the full set into a fresh `JellyfishMerkleTree` at version 0 and writes the
-///    resulting node/value batch into the v2 tables via `LmdbTreeWriter`.
-/// 4. Deletes the three legacy v1 tables with `Database::delete` so their pages are reclaimed.
+/// 2. Splits the commitments into fixed-size chunks. For each chunk we resolve the mined
+///    output, compute `output.smt_hash(mined_height)`, and apply the chunk as one JMT
+///    version in its own write transaction so the LMDB env can resize between commits.
+/// 3. The chunked write transactions are wrapped in a retry loop that reacts to
+///    `DbResizeRequired` by growing the LMDB map and reapplying the failed chunk.
+/// 4. Deletes the three legacy v1 tables with `Database::delete` so their pages are
+///    reclaimed.
 ///
 /// On a fresh database (no v1 tables present) the function is a no-op.
+///
+/// Number of UTXOs applied per JMT version / write transaction during the migration. Chosen to
+/// keep each commit small enough to bound the LMDB map growth per step while still amortising
+/// the JMT bookkeeping cost across enough entries.
+const JMT_MIGRATION_BATCH_SIZE: usize = 5_000;
+
 fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> {
     info!(target: LOG_TARGET, "[MIGRATIONS] v6: Starting JMT v1 → v2 rebuild");
 
@@ -4772,90 +4781,64 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> 
         return Ok(());
     }
 
-    // Collect every unspent UTXO into a JMT batch. We do the lookups in a read transaction, then
-    // drop it before opening the write transaction.
-    let batch: Vec<(KeyHash, Option<Vec<u8>>)> = {
+    println!("Starting JMT v1 → v2 rebuild");
+
+    // Snapshot every commitment from `utxo_commitment_index` up-front. The per-chunk write
+    // transactions later look up the mined output for each commitment on demand, keeping the
+    // resident batch small.
+    let commitments: Vec<[u8; 32]> = {
         let read_txn = db.read_transaction()?;
-
-        // Commitments are the keys of `utxo_commitment_index`. Snapshot them so we can release
-        // the cursor borrow before we start doing per-key lookups.
-        let commitments: Vec<[u8; 32]> = {
-            let mut cursor = (&read_txn).cursor(db.utxo_commitment_index.clone()).map_err(|e| {
+        let mut cursor = (&read_txn).cursor(db.utxo_commitment_index.clone()).map_err(|e| {
+            ChainStorageError::AccessError(format!("Could not open cursor on utxo_commitment_index: {e}"))
+        })?;
+        let access = read_txn.access();
+        let mut out: Vec<[u8; 32]> = Vec::new();
+        let mut entry = cursor.first::<[u8], [u8]>(&access).to_opt().map_err(|e| {
+            ChainStorageError::AccessError(format!("Failed to read first utxo_commitment_index entry: {e}"))
+        })?;
+        while let Some((commitment, _output_hash)) = entry {
+            if commitment.len() != 32 {
+                return Err(ChainStorageError::CriticalError(format!(
+                    "utxo_commitment_index key has unexpected length {}",
+                    commitment.len()
+                )));
+            }
+            let mut bytes = [0u8; 32];
+            bytes.copy_from_slice(commitment);
+            out.push(bytes);
+            entry = cursor.next::<[u8], [u8]>(&access).to_opt().map_err(|e| {
                 ChainStorageError::AccessError(format!(
-                    "Could not open cursor on utxo_commitment_index: {e}"
+                    "Failed to advance cursor on utxo_commitment_index: {e}"
                 ))
             })?;
-            let access = read_txn.access();
-            let mut out: Vec<[u8; 32]> = Vec::new();
-            let mut entry = cursor.first::<[u8], [u8]>(&access).to_opt().map_err(|e| {
-                ChainStorageError::AccessError(format!(
-                    "Failed to read first utxo_commitment_index entry: {e}"
-                ))
-            })?;
-            while let Some((commitment, _output_hash)) = entry {
-                if commitment.len() != 32 {
-                    return Err(ChainStorageError::CriticalError(format!(
-                        "utxo_commitment_index key has unexpected length {}",
-                        commitment.len()
-                    )));
-                }
-                let mut bytes = [0u8; 32];
-                bytes.copy_from_slice(commitment);
-                out.push(bytes);
-                entry = cursor.next::<[u8], [u8]>(&access).to_opt().map_err(|e| {
-                    ChainStorageError::AccessError(format!(
-                        "Failed to advance cursor on utxo_commitment_index: {e}"
-                    ))
-                })?;
-            }
-            out
-        };
-
-        info!(
-            target: LOG_TARGET,
-            "[MIGRATIONS] v6: {} unspent UTXOs will be inserted into the new JMT",
-            commitments.len()
-        );
-
-        let total = commitments.len();
-        db.set_stats_total_height(total as u64);
-        let mut batch: Vec<(KeyHash, Option<Vec<u8>>)> = Vec::with_capacity(total);
-        for (i, commitment) in commitments.into_iter().enumerate() {
-            let output_hash: HashOutput =
-                lmdb_get(&read_txn, &db.utxo_commitment_index, commitment.as_ref())?.ok_or_else(|| {
-                    ChainStorageError::ValueNotFound {
-                        entity: "utxo_commitment_index",
-                        field: "commitment",
-                        value: to_hex(commitment.as_ref()),
-                    }
-                })?;
-            let utxo_info = db
-                .fetch_output_in_txn(&read_txn, output_hash.as_slice())?
-                .ok_or_else(|| ChainStorageError::ValueNotFound {
-                    entity: "TransactionOutput",
-                    field: "output_hash",
-                    value: output_hash.to_hex(),
-                })?;
-            let smt_node = utxo_info.output.smt_hash(utxo_info.mined_height).to_vec();
-            batch.push((KeyHash(commitment), Some(smt_node)));
-
-            if (i + 1).is_multiple_of(100_000) {
-                db.update_stats_progress((i + 1) as u64);
-                info!(
-                    target: LOG_TARGET,
-                    "[MIGRATIONS] v6: Prepared {}/{total} JMT batch entries",
-                    i + 1
-                );
-            }
         }
-        batch
+        out
     };
 
-    // Apply the rebuilt tree to the (currently empty) v2 tables in a single write transaction.
+    let total = commitments.len();
+    db.set_stats_total_height(total as u64);
+    info!(
+        target: LOG_TARGET,
+        "[MIGRATIONS] v6: {total} unspent UTXOs will be inserted into the new JMT in batches of {JMT_MIGRATION_BATCH_SIZE}"
+    );
+
+    // Safety: clear the v2 JMT tables and reset the JMTVersion counter before applying any
+    // batches. This protects against a previous migration attempt that crashed partway through
+    // and left stale node/value rows behind - replaying batches over those would produce a
+    // corrupt tree or trip the duplicate-key check in `LmdbTreeWriter`. The per-batch writer
+    // reads `JMTVersion`, increments it, and persists it again, so each batch effectively
+    // becomes its own JMT version.
     {
         let write_txn = db.write_transaction()?;
-
-        // Reset the JMTVersion counter so the new tree starts from a clean baseline.
+        let cleared_nodes = lmdb_clear(&write_txn, &db.jmt_node_data)?;
+        let cleared_values = lmdb_clear(&write_txn, &db.jmt_value_data)?;
+        if cleared_nodes > 0 || cleared_values > 0 {
+            warn!(
+                target: LOG_TARGET,
+                "[MIGRATIONS] v6: Cleared {cleared_nodes} stale JMT nodes and {cleared_values} stale JMT values \
+                 from the v2 tables (likely a partially-completed prior migration)"
+            );
+        }
         lmdb_delete(
             &write_txn,
             &db.metadata_db,
@@ -4863,26 +4846,105 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> 
             "metadata",
         )
         .optional()?;
-
-        let reader = LmdbTreeReader::new(&write_txn, db.jmt_node_data.clone(), db.jmt_value_data.clone());
-        let new_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
-        let (_root, ops) = new_smt
-            .put_value_set(batch, 0u64)
-            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
-
-        let writer = LmdbTreeWriter::new(
-            &write_txn,
-            db.jmt_node_data.clone(),
-            db.jmt_value_data.clone(),
-            db.metadata_db.clone(),
-        );
-        writer
-            .write_node_batch(&ops.node_batch)
-            .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
-
         write_txn.commit()?;
     }
 
+    // Resize this many times across the whole migration before giving up.
+    let max_resizes = max(8, 1024 * BYTES_PER_MB / db.env_config.grow_size_bytes());
+    let mut resize_attempts = 0usize;
+    let mut processed = 0usize;
+    let mut batch_version = 0u64;
+
+    for chunk in commitments.chunks(JMT_MIGRATION_BATCH_SIZE) {
+        // Resolve each commitment to its smt_hash payload in a fresh read transaction.
+        let batch_entries: Vec<(KeyHash, Vec<u8>)> = {
+            let read_txn = db.read_transaction()?;
+            let mut entries = Vec::with_capacity(chunk.len());
+            for commitment in chunk {
+                let output_hash: HashOutput =
+                    lmdb_get(&read_txn, &db.utxo_commitment_index, commitment.as_ref())?.ok_or_else(|| {
+                        ChainStorageError::ValueNotFound {
+                            entity: "utxo_commitment_index",
+                            field: "commitment",
+                            value: to_hex(commitment.as_ref()),
+                        }
+                    })?;
+                let utxo_info = db
+                    .fetch_output_in_txn(&read_txn, output_hash.as_slice())?
+                    .ok_or_else(|| ChainStorageError::ValueNotFound {
+                        entity: "TransactionOutput",
+                        field: "output_hash",
+                        value: output_hash.to_hex(),
+                    })?;
+                let smt_node = utxo_info.output.smt_hash(utxo_info.mined_height).to_vec();
+                entries.push((KeyHash(*commitment), smt_node));
+            }
+            entries
+        };
+
+        // Apply this batch with resize-on-MapFull retry. Each retry rebuilds the JMT for the
+        // batch from scratch, which is safe because no part of a previous attempt has been
+        // committed - `WriteTransaction::commit` is atomic.
+        loop {
+            // SAFETY: this migration runs single-threaded on startup, before any other
+            // BlockchainBackend traffic, so there are no concurrent write transactions.
+            unsafe {
+                LMDBStore::resize_if_required(
+                    &db.env,
+                    &db.env_config,
+                    Some(max(db.env_config.grow_size_bytes(), 128 * BYTES_PER_MB)),
+                )?;
+            }
+
+            match apply_jmt_migration_batch(db, &batch_entries, batch_version) {
+                Ok(()) => break,
+                Err(ChainStorageError::DbResizeRequired(size_hint)) => {
+                    resize_attempts += 1;
+                    if resize_attempts >= max_resizes {
+                        return Err(ChainStorageError::DbTransactionTooLarge(batch_entries.len()));
+                    }
+                    info!(
+                        target: LOG_TARGET,
+                        "[MIGRATIONS] v6: LMDB map full while writing batch {} ({} entries), resizing (attempt {})",
+                        batch_version, batch_entries.len(), resize_attempts
+                    );
+                    // SAFETY: see note above; the failed write_txn has already been dropped.
+                    unsafe {
+                        LMDBStore::resize(&db.env, &db.env_config, size_hint)?;
+                    }
+                },
+                Err(ChainStorageError::JellyfishMerkleTreeError(jmt_err)) => {
+                    if let Some(ChainStorageError::DbResizeRequired(size_hint)) = jmt_err.downcast_ref::<ChainStorageError>() {
+                        resize_attempts += 1;
+                        if resize_attempts >= max_resizes {
+                            return Err(ChainStorageError::DbTransactionTooLarge(batch_entries.len()));
+                        }
+                        info!(
+                            target: LOG_TARGET,
+                            "[MIGRATIONS] v6: LMDB map full inside JMT writer for batch {} ({} entries), resizing (attempt {})",
+                            batch_version, batch_entries.len(), resize_attempts
+                        );
+                        unsafe {
+                            LMDBStore::resize(&db.env, &db.env_config, *size_hint)?;
+                        }
+                    } else {
+                        return Err(ChainStorageError::JellyfishMerkleTreeError(jmt_err));
+                    }
+                },
+                Err(e) => return Err(e),
+            }
+        }
+
+        processed += batch_entries.len();
+        batch_version += 1;
+        db.update_stats_progress(processed as u64);
+        info!(
+            target: LOG_TARGET,
+            "[MIGRATIONS] v6: Wrote {processed}/{total} UTXOs into the JMT ({batch_version} batches committed)"
+        );
+        println!("Processed {processed}/{total} UTXOs into the JMT ({batch_version} batches committed)");
+    }
+    println!("deleting old jmt database tables");
     // Drop each legacy v1 database. `Database::delete` consumes the handle and calls
     // `mdb_drop` with the delete flag, returning the pages to the LMDB free list.
     let delete_legacy = |name: &'static str, opt: Option<Database<'static>>| -> Result<(), ChainStorageError> {
@@ -4895,10 +4957,54 @@ fn migrate_jmt_v1_to_v2(db: &mut LMDBDatabase) -> Result<(), ChainStorageError> 
         Ok(())
     };
     delete_legacy(LMDB_DB_JMT_VALUE_DATA_V1, v1_value_data)?;
+    println!("deleted old jmt value data");
     delete_legacy(LMDB_DB_JMT_NODE_DATA_V1, v1_node_data)?;
+    println!("deleted old jmt node data");
     delete_legacy(LMDB_DB_JMT_UNIQUE_KEY_DATA, v1_unique_key_data)?;
+    println!("deleted old jmt unique key data");
+    println!("JMT rebuild complete");
 
     info!(target: LOG_TARGET, "[MIGRATIONS] v6: JMT v1 → v2 rebuild complete");
+    Ok(())
+}
+
+/// Apply a single chunk of commitments to the v2 JMT tables in its own write transaction.
+///
+/// The JMT version supplied here is the version *at* which `put_value_set` is invoked. The
+/// underlying [`LmdbTreeWriter`] reads the current `JMTVersion` from metadata and stores
+/// `version + 1`, so subsequent calls must pass strictly increasing versions starting at 0.
+fn apply_jmt_migration_batch(
+    db: &LMDBDatabase,
+    batch: &[(KeyHash, Vec<u8>)],
+    version: u64,
+) -> Result<(), ChainStorageError> {
+    let write_txn = db.write_transaction()?;
+    let reader = LmdbTreeReader::new(&write_txn, db.jmt_node_data.clone(), db.jmt_value_data.clone());
+    let new_smt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+    let value_set: Vec<(KeyHash, Option<Vec<u8>>)> = batch
+        .iter()
+        .map(|(k, v)| (*k, Some(v.clone())))
+        .collect();
+    let (_root, ops) = new_smt
+        .put_value_set(value_set, version)
+        .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+
+    let writer = LmdbTreeWriter::new(
+        &write_txn,
+        db.jmt_node_data.clone(),
+        db.jmt_value_data.clone(),
+        db.metadata_db.clone(),
+    );
+    writer
+        .write_node_batch(&ops.node_batch)
+        .map_err(ChainStorageError::JellyfishMerkleTreeError)?;
+
+    write_txn.commit().map_err(|e| match e {
+        lmdb_zero::Error::Code(code) if code == lmdb_zero::error::MAP_FULL => {
+            ChainStorageError::DbResizeRequired(None)
+        },
+        other => ChainStorageError::AccessError(format!("Failed to commit JMT migration batch: {other}")),
+    })?;
     Ok(())
 }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_reader.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_reader.rs
@@ -25,29 +25,27 @@ use std::ops::Deref;
 use borsh::BorshSerialize;
 use jmt::storage::TreeReader;
 use lmdb_zero::{ConstTransaction, ReadTransaction};
-use log::warn;
 use tari_storage::lmdb_store::DatabaseRef;
 
-use crate::chain_storage::lmdb_db::lmdb::{lmdb_fetch_matching_after, lmdb_get};
+use crate::chain_storage::lmdb_db::lmdb::{lmdb_get};
 
-pub const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb_db";
 
 pub struct LmdbTreeReader<'a> {
     txn: &'a ConstTransaction<'a>,
     node_db: DatabaseRef,
-    unique_key_db: DatabaseRef,
+    value_db: DatabaseRef,
 }
 
 impl<'a> LmdbTreeReader<'a> {
     pub fn new<T: Deref<Target = ConstTransaction<'a>>>(
         txn: &'a T,
         node_db: DatabaseRef,
-        unique_key_db: DatabaseRef,
+        value_db: DatabaseRef,
     ) -> Self {
         Self {
             txn: txn.deref(),
             node_db,
-            unique_key_db,
+            value_db,
         }
     }
 }
@@ -55,8 +53,8 @@ impl<'a> LmdbTreeReader<'a> {
 impl TreeReader for LmdbTreeReader<'_> {
     fn get_node_option(&self, node_key: &jmt::storage::NodeKey) -> anyhow::Result<Option<jmt::storage::Node>> {
         let mut lmdb_key: Vec<u8> = vec![];
-        lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
-        BorshSerialize::serialize(&node_key.nibble_path(), &mut lmdb_key)?;
+       //lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
+        BorshSerialize::serialize(node_key, &mut lmdb_key)?;
         let node = lmdb_get(self.txn, &self.node_db, &lmdb_key)?;
         Ok(node)
     }
@@ -66,21 +64,12 @@ impl TreeReader for LmdbTreeReader<'_> {
         _max_version: jmt::Version,
         key_hash: jmt::KeyHash,
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
-        // see if there are any values already.
-        let existing_values: Vec<(Vec<u8>, Option<Vec<u8>>)> =
-            lmdb_fetch_matching_after(self.txn, &self.unique_key_db, &key_hash.0)?;
-        let mut existing_history = vec![];
-        for (key, x) in existing_values {
-            let version = u64::from_be_bytes(key.get(32..).ok_or(anyhow::anyhow!("invalid bytes"))?.try_into()?);
-            existing_history.push((version, x));
-            warn!(target: LOG_TARGET, "found version {version} for key {key:?}");
-        }
-        // sort by version
-        existing_history.sort_by_key(|a| a.0);
+        let mut lmdb_key: Vec<u8> = vec![];
+        //lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
+        lmdb_key.extend_from_slice(&key_hash.0);
+        let existing = lmdb_get(self.txn, &self.value_db, &lmdb_key)?;
 
-        let latest_value = existing_history.last().and_then(|x| x.1.clone());
-
-        Ok(latest_value)
+        Ok(existing)
     }
 
     fn get_rightmost_leaf(&self) -> anyhow::Result<Option<(jmt::storage::NodeKey, jmt::storage::LeafNode)>> {
@@ -92,22 +81,22 @@ impl TreeReader for LmdbTreeReader<'_> {
 pub struct OwnedLmdbTreeReader<'a> {
     txn: ReadTransaction<'a>,
     node_db: DatabaseRef,
-    unique_key_db: DatabaseRef,
+    value_db: DatabaseRef,
 }
 
 impl<'a> OwnedLmdbTreeReader<'a> {
-    pub fn new(txn: ReadTransaction<'a>, node_db: DatabaseRef, unique_key_db: DatabaseRef) -> Self {
+    pub fn new(txn: ReadTransaction<'a>, node_db: DatabaseRef, value_db: DatabaseRef) -> Self {
         Self {
             txn,
             node_db,
-            unique_key_db,
+            value_db,
         }
     }
 }
 
 impl TreeReader for OwnedLmdbTreeReader<'_> {
     fn get_node_option(&self, node_key: &jmt::storage::NodeKey) -> anyhow::Result<Option<jmt::storage::Node>> {
-        let inner = LmdbTreeReader::new(&self.txn, self.node_db.clone(), self.unique_key_db.clone());
+        let inner = LmdbTreeReader::new(&self.txn, self.node_db.clone(), self.value_db.clone());
         inner.get_node_option(node_key)
     }
 
@@ -116,7 +105,7 @@ impl TreeReader for OwnedLmdbTreeReader<'_> {
         max_version: jmt::Version,
         key_hash: jmt::KeyHash,
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
-        let inner = LmdbTreeReader::new(&self.txn, self.node_db.clone(), self.unique_key_db.clone());
+        let inner = LmdbTreeReader::new(&self.txn, self.node_db.clone(), self.value_db.clone());
         inner.get_value_option(max_version, key_hash)
     }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_reader.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_reader.rs
@@ -52,7 +52,6 @@ impl<'a> LmdbTreeReader<'a> {
 impl TreeReader for LmdbTreeReader<'_> {
     fn get_node_option(&self, node_key: &jmt::storage::NodeKey) -> anyhow::Result<Option<jmt::storage::Node>> {
         let mut lmdb_key: Vec<u8> = vec![];
-        // lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
         BorshSerialize::serialize(node_key, &mut lmdb_key)?;
         let node = lmdb_get(self.txn, &self.node_db, &lmdb_key)?;
         Ok(node)
@@ -64,7 +63,6 @@ impl TreeReader for LmdbTreeReader<'_> {
         key_hash: jmt::KeyHash,
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
         let mut lmdb_key: Vec<u8> = vec![];
-        // lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
         lmdb_key.extend_from_slice(&key_hash.0);
         let existing = lmdb_get(self.txn, &self.value_db, &lmdb_key)?;
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_reader.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_reader.rs
@@ -27,8 +27,7 @@ use jmt::storage::TreeReader;
 use lmdb_zero::{ConstTransaction, ReadTransaction};
 use tari_storage::lmdb_store::DatabaseRef;
 
-use crate::chain_storage::lmdb_db::lmdb::{lmdb_get};
-
+use crate::chain_storage::lmdb_db::lmdb::lmdb_get;
 
 pub struct LmdbTreeReader<'a> {
     txn: &'a ConstTransaction<'a>,
@@ -53,7 +52,7 @@ impl<'a> LmdbTreeReader<'a> {
 impl TreeReader for LmdbTreeReader<'_> {
     fn get_node_option(&self, node_key: &jmt::storage::NodeKey) -> anyhow::Result<Option<jmt::storage::Node>> {
         let mut lmdb_key: Vec<u8> = vec![];
-       //lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
+        // lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
         BorshSerialize::serialize(node_key, &mut lmdb_key)?;
         let node = lmdb_get(self.txn, &self.node_db, &lmdb_key)?;
         Ok(node)
@@ -65,7 +64,7 @@ impl TreeReader for LmdbTreeReader<'_> {
         key_hash: jmt::KeyHash,
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
         let mut lmdb_key: Vec<u8> = vec![];
-        //lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
+        // lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
         lmdb_key.extend_from_slice(&key_hash.0);
         let existing = lmdb_get(self.txn, &self.value_db, &lmdb_key)?;
 
@@ -86,11 +85,7 @@ pub struct OwnedLmdbTreeReader<'a> {
 
 impl<'a> OwnedLmdbTreeReader<'a> {
     pub fn new(txn: ReadTransaction<'a>, node_db: DatabaseRef, value_db: DatabaseRef) -> Self {
-        Self {
-            txn,
-            node_db,
-            value_db,
-        }
+        Self { txn, node_db, value_db }
     }
 }
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -20,21 +20,24 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use jmt::storage::{Node, TreeWriter};
+use jmt::storage::{StaleNodeIndexBatch, TreeWriter};
 use lmdb_zero::WriteTransaction;
 use log::*;
 use tari_storage::lmdb_store::DatabaseRef;
 use tari_utilities::hex::Hex;
 
-use super::lmdb::lmdb_insert;
-use crate::chain_storage::lmdb_db::lmdb::{lmdb_delete, lmdb_delete_keys_starting_with, lmdb_fetch_matching_after};
+use super::lmdb::{lmdb_get, lmdb_insert, lmdb_replace};
+use crate::chain_storage::Optional;
+use crate::chain_storage::lmdb_db::lmdb::{lmdb_delete};
+use crate::chain_storage::lmdb_db::lmdb_db::{MetadataKey, MetadataValue};
+
 pub const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb_tree_writer";
 
 pub(crate) struct LmdbTreeWriter<'a> {
     txn: &'a WriteTransaction<'a>,
     node_db: DatabaseRef,
     value_db: DatabaseRef,
-    unique_key_db: DatabaseRef,
+    metabase_db: DatabaseRef,
 }
 
 impl<'a> LmdbTreeWriter<'a> {
@@ -42,46 +45,66 @@ impl<'a> LmdbTreeWriter<'a> {
         txn: &'a WriteTransaction<'a>,
         node_db: DatabaseRef,
         value_db: DatabaseRef,
-        unique_key_db: DatabaseRef,
+        metabase_db: DatabaseRef,
     ) -> Self {
         Self {
             txn,
             node_db,
             value_db,
-            unique_key_db,
+            metabase_db,
         }
     }
 
-    pub fn delete_all_for_version(&self, version: u64) -> anyhow::Result<()> {
-        let key = version.to_be_bytes();
-        let nodes = lmdb_delete_keys_starting_with::<Node>(self.txn, &self.node_db, &key)?;
-        warn!(target: LOG_TARGET, "Deleted {} nodes for version {}", nodes.len(), version);
-        let values = lmdb_delete_keys_starting_with::<Vec<u8>>(self.txn, &self.value_db, &key)?;
-        warn!(target: LOG_TARGET, "Deleted {} values for version {}", values.len(), version);
-
-        for (value_key, _) in values {
-            let mut lmdb_key: Vec<u8> = vec![];
-            lmdb_key.extend_from_slice(value_key.get(8..).ok_or(anyhow::anyhow!("Value key is too short"))?);
-            lmdb_key.extend_from_slice(value_key.get(0..8).ok_or(anyhow::anyhow!("Value key is too short"))?);
-            match lmdb_delete(self.txn, &self.unique_key_db, &lmdb_key, "jmt_unique_key_table") {
-                Ok(_) => {
-                    debug!(target: LOG_TARGET, "Deleted unique key {} for version {}", lmdb_key.to_hex(), version);
-                },
-                Err(e) => {
-                    debug!(target: LOG_TARGET, "Failed to delete unique key {} for version {}: {}", lmdb_key.to_hex(), version, e);
-                },
-            }
-        }
-
-        Ok(())
-    }
+    // pub fn delete_all_for_version(&self, version: u64) -> anyhow::Result<()> {
+    //     let key = version.to_be_bytes();
+    //     let nodes = lmdb_delete_keys_starting_with::<Node>(self.txn, &self.node_db, &key)?;
+    //     warn!(target: LOG_TARGET, "Deleted {} nodes for version {}", nodes.len(), version);
+    //     let values = lmdb_delete_keys_starting_with::<Vec<u8>>(self.txn, &self.value_db, &key)?;
+    //     warn!(target: LOG_TARGET, "Deleted {} values for version {}", values.len(), version);
+    //
+    //     for (value_key, _) in values {
+    //         let mut lmdb_key: Vec<u8> = vec![];
+    //         lmdb_key.extend_from_slice(value_key.get(8..).ok_or(anyhow::anyhow!("Value key is too short"))?);
+    //         lmdb_key.extend_from_slice(value_key.get(0..8).ok_or(anyhow::anyhow!("Value key is too short"))?);
+    //         match lmdb_delete(self.txn, &self.unique_key_db, &lmdb_key, "jmt_unique_key_table") {
+    //             Ok(_) => {
+    //                 debug!(target: LOG_TARGET, "Deleted unique key {} for version {}", lmdb_key.to_hex(), version);
+    //             },
+    //             Err(e) => {
+    //                 debug!(target: LOG_TARGET, "Failed to delete unique key {} for version {}: {}", lmdb_key.to_hex(), version, e);
+    //             },
+    //         }
+    //     }
+    //
+    //     Ok(())
+    // }
 
     pub fn put_node(&self, node_key: &jmt::storage::NodeKey, node: &jmt::storage::Node) -> anyhow::Result<()> {
         let mut lmdb_key: Vec<u8> = vec![];
-        lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
-        borsh::BorshSerialize::serialize(&node_key.nibble_path(), &mut lmdb_key)?;
+        //lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
+        borsh::BorshSerialize::serialize(node_key, &mut lmdb_key)?;
+        match node{
+            jmt::storage::Node::Null => {
+                trace!(target: LOG_TARGET, "Deleting node with key {}", lmdb_key.to_hex());
+                lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
+            },
+            _ => {
+                lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, "jmt_node_table")?;
+            }
 
-        lmdb_insert(self.txn, &self.node_db, &lmdb_key, node, "jmt_node_table")?;
+        }
+        let k = MetadataKey::JMTVersion;
+        lmdb_replace(self.txn, &self.metabase_db, &k.as_u32(), &MetadataValue::JMTVersion(node_key.version()), None)?;
+        Ok(())
+    }
+
+    pub fn cleanup_stale(&self, stale: &StaleNodeIndexBatch) -> anyhow::Result<()> {
+        for index in stale{
+            let mut lmdb_key: Vec<u8> = vec![];
+            // lmdb_key.extend_from_slice(&index.node_key.version().to_be_bytes());
+            borsh::BorshSerialize::serialize(&index.node_key, &mut lmdb_key)?;
+            lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
+        }
         Ok(())
     }
 }
@@ -90,52 +113,50 @@ impl TreeWriter for LmdbTreeWriter<'_> {
     fn write_node_batch(&self, node_batch: &jmt::storage::NodeBatch) -> anyhow::Result<()> {
         for (node_key, node) in node_batch.nodes() {
             let mut lmdb_key: Vec<u8> = vec![];
-            lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
-            borsh::BorshSerialize::serialize(&node_key.nibble_path(), &mut lmdb_key)?;
-            lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, "jmt_node_table")?;
+            // lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
+            borsh::BorshSerialize::serialize(node_key, &mut lmdb_key)?;
+            match node {
+                jmt::storage::Node::Null => {
+                    trace!(target: LOG_TARGET, "Deleting node with key {}", lmdb_key.to_hex());
+                    lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
+                },
+                _ => {
+                    //dbg!(&node);
+                    lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
+                    lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, "jmt_node_table")?;
+                }
+            }
         }
         // let mut duplicates = HashMap::new();
         for (value_key, value) in node_batch.values() {
             let mut lmdb_key: Vec<u8> = vec![];
-            lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
+            //lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
             lmdb_key.extend_from_slice(&value_key.1.0);
-            let val_bytes = bincode::serialize(value)?;
-            lmdb_insert(self.txn, &self.value_db, &lmdb_key, &val_bytes, "jmt_value_table")?;
-
-            // see if there are any values already.
-            let existing_values: Vec<(Vec<u8>, Option<Vec<u8>>)> =
-                lmdb_fetch_matching_after(self.txn, &self.unique_key_db, &value_key.1.0)?;
-            let mut existing_history = vec![];
-            for (key, x) in existing_values {
-                let version = u64::from_be_bytes(key.get(32..).ok_or(anyhow::anyhow!("invalid bytes"))?.try_into()?);
-                existing_history.push((version, x));
-            }
-            // sort by version
-            existing_history.sort_by_key(|a| a.0);
-
-            let latest_value = existing_history.last().and_then(|x| x.1.clone());
-            match (value, &latest_value) {
-                (None, _) => {
-                    if latest_value.is_none() {
-                        trace!(target: LOG_TARGET, "Found no existing JMT unique key for version {}, creating it as None", value_key.0);
+            match value{
+                Some(_v) => {
+                    let existing:Option<Vec<u8>> = lmdb_get(self.txn, &self.value_db, &lmdb_key)?;
+                    if existing.is_some() {
+                        trace!(target: LOG_TARGET, "Found existing unique key {} for version {}", value_key.1 .0.to_hex(), value_key.0);
+                        return Err(anyhow::anyhow!("Duplicate value key found in batch"));
                     }
-                    let mut lmdb_key: Vec<u8> = vec![];
-                    lmdb_key.extend_from_slice(value_key.1.0.as_slice());
-                    lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
-                    lmdb_insert(self.txn, &self.unique_key_db, &lmdb_key, value, "jmt_unique_key_table")?;
-                },
-                (Some(_v), Some(_x)) => {
-                    trace!(target: LOG_TARGET, "Found existing unique key {} for version {}", value_key.1 .0.to_hex(), value_key.0);
-                    return Err(anyhow::anyhow!("Duplicate value key found in batch"));
-                },
-                (Some(_v), None) => {
-                    let mut lmdb_key: Vec<u8> = vec![];
-                    lmdb_key.extend_from_slice(value_key.1.0.as_slice());
-                    lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
-                    lmdb_insert(self.txn, &self.unique_key_db, &lmdb_key, value, "jmt_unique_key_table")?;
-                },
-            };
+                    let val_bytes = bincode::serialize(value)?;
+
+                    lmdb_insert(self.txn, &self.value_db, &lmdb_key, &val_bytes, "jmt_value_table")?;
+                }
+                None => {
+
+                    lmdb_delete(self.txn, &self.value_db, &lmdb_key, "jmt_value_table").optional()?;
+                }
+            }
         }
+        let k = MetadataKey::JMTVersion;
+        let val = match lmdb_get(self.txn, &self.metabase_db, &k.as_u32())?{
+            Some(MetadataValue::JMTVersion(v)) => v+1,
+            _ => 0u64,
+        };
+        lmdb_replace(self.txn, &self.metabase_db, &k.as_u32(), &MetadataValue::JMTVersion(val), None)?;
+
+
         trace!(target: LOG_TARGET, "Wrote JMT batch of {} nodes and {} values", node_batch.nodes().len(), node_batch.values().len());
         Ok(())
     }
@@ -158,7 +179,7 @@ mod test {
         let db = TempDatabase::new();
         let txn = db.db().create_write_txn();
         let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        let reader = db.db().create_smt_reader().unwrap();
+        let (reader, _current_version) = db.db().create_smt_reader().unwrap();
 
         let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
         let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut rand::rng());
@@ -171,7 +192,7 @@ mod test {
         // Try again for new version.
         let txn = db.db().create_write_txn();
         let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        let reader = db.db().create_smt_reader().unwrap();
+        let reader = db.db().create_smt_reader().unwrap().0;
 
         let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
 
@@ -182,13 +203,92 @@ mod test {
         );
     }
 
+
+    #[test]
+    fn test_jmt_insert_delete() {
+        let db = TempDatabase::new();
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap().0;
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        let smt_key_0 = KeyHash(vec![0; 32].try_into().expect("Key hash is always 32 bytes"));
+        let value_0 = smt_key_0.0.to_vec();
+        let smt_key_1 = KeyHash(vec![1; 32].try_into().expect("Key hash is always 32 bytes"));
+        let value_1 = smt_key_1.0.to_vec();
+        let smt_key_2 = KeyHash(vec![2; 32].try_into().expect("Key hash is always 32 bytes"));
+        let value_2 = smt_key_2.0.to_vec();
+
+        let (_root, updates) = jmt.put_value_set(vec![(smt_key_0, Some(value_0.clone()))], 0).unwrap();
+        tree_writer.write_node_batch(&updates.node_batch).unwrap();
+        txn.commit().unwrap();
+        // Try again for new version.
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap().0;
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+
+        let (root1, updates) = jmt.put_value_set(vec![(smt_key_1, Some(value_1.clone()))], 1).unwrap();
+        tree_writer.write_node_batch(&updates.node_batch).unwrap();
+        tree_writer.cleanup_stale(&updates.stale_node_index_batch).unwrap();
+        txn.commit().unwrap();
+
+
+        // // Try again for new version.
+        let reader = db.db().create_smt_reader().unwrap().0;
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        assert_eq!(jmt.get_leaf_count(1).unwrap(), 2);
+        assert!(jmt.get(smt_key_0, 1).unwrap().is_some());
+        assert!(jmt.get(smt_key_1, 1).unwrap().is_some());
+         // Try again for new version.
+         let txn = db.db().create_write_txn();
+         let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+         let reader = db.db().create_smt_reader().unwrap().0;
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+
+         let (_root, updates) = jmt.put_value_set(vec![(smt_key_2, Some(value_2.clone())), (smt_key_0, None)], 2).unwrap();
+        tree_writer.write_node_batch(&updates.node_batch).unwrap();
+        tree_writer.cleanup_stale(&updates.stale_node_index_batch).unwrap();
+        txn.commit().unwrap();
+
+        let reader = db.db().create_smt_reader().unwrap().0;
+
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        assert_eq!(jmt.get_leaf_count(2).unwrap(), 2);
+        assert!(jmt.get(smt_key_0, 5).unwrap().is_none());
+        assert!(jmt.get(smt_key_1, 5).unwrap().is_some());
+        assert!(jmt.get(smt_key_2, 5).unwrap().is_some());
+
+            // Try again for new version.
+            let txn = db.db().create_write_txn();
+            let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+            let reader = db.db().create_smt_reader().unwrap().0;
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+
+        let (root2, updates) = jmt.put_value_set(vec![(smt_key_2, None), (smt_key_0, Some(value_0))], 3).unwrap();
+        tree_writer.write_node_batch(&updates.node_batch).unwrap();
+        tree_writer.cleanup_stale(&updates.stale_node_index_batch).unwrap();
+        txn.commit().unwrap();
+
+        let reader = db.db().create_smt_reader().unwrap().0;
+        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
+        assert!(jmt.get(smt_key_0, 3).unwrap().is_some());
+        assert!(jmt.get(smt_key_1, 3).unwrap().is_some());
+        assert!(jmt.get(smt_key_2, 3).unwrap().is_none());
+        assert_eq!(jmt.get_leaf_count(3).unwrap(), 2);
+        assert_eq!(root1, root2);
+    }
+
     #[test]
     fn test_jmt_does_accept_duplicate_if_deleted() {
         // If a key in the jmt is deleted, it can be added later.
         let db = TempDatabase::new();
         let txn = db.db().create_write_txn();
         let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        let reader = db.db().create_smt_reader().unwrap();
+        let reader = db.db().create_smt_reader().unwrap().0;
 
         let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
         let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut rand::rng());
@@ -201,7 +301,7 @@ mod test {
         // Try again for new version.
         let txn = db.db().create_write_txn();
         let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        let reader = db.db().create_smt_reader().unwrap();
+        let reader = db.db().create_smt_reader().unwrap().0;
 
         let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
 
@@ -213,7 +313,7 @@ mod test {
         // Try again for version 2.
         let txn = db.db().create_write_txn();
         let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        let reader = db.db().create_smt_reader().unwrap();
+        let reader = db.db().create_smt_reader().unwrap().0;
 
         let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
 
@@ -221,56 +321,5 @@ mod test {
         tree_writer.write_node_batch(&update2.node_batch).unwrap();
 
         txn.commit().unwrap();
-    }
-
-    #[test]
-    fn test_jmt_deletes_block_on_reorg() {
-        let db = TempDatabase::new();
-        let txn = db.db().create_write_txn();
-        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        let reader = db.db().create_smt_reader().unwrap();
-
-        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
-        let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut rand::rng());
-        let smt_key = KeyHash(commitment.as_bytes().try_into().expect("Key hash is always 32 bytes"));
-        let value = b"test_value".to_vec();
-        let (root, updates) = jmt.put_value_set(vec![(smt_key, Some(value.clone()))], 0).unwrap();
-        tree_writer.write_node_batch(&updates.node_batch).unwrap();
-
-        txn.commit().unwrap();
-        // Try again for new version.
-        let txn = db.db().create_write_txn();
-        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        let reader = db.db().create_smt_reader().unwrap();
-        let (_sk, commitment) = RistrettoPublicKey::random_keypair(&mut rand::rng());
-        let smt_key2 = KeyHash(commitment.as_bytes().try_into().expect("Key hash is always 32 bytes"));
-        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
-
-        let (root1, update2) = jmt.put_value_set(vec![(smt_key2, Some(value.clone()))], 1).unwrap();
-        tree_writer.write_node_batch(&update2.node_batch).unwrap();
-        txn.commit().unwrap();
-
-        let txn = db.db().create_write_txn();
-        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        tree_writer.delete_all_for_version(1).unwrap();
-        txn.commit().unwrap();
-
-        let reader = db.db().create_smt_reader().unwrap();
-        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
-        let root2 = jmt.get_root_hash(0).unwrap();
-
-        assert_eq!(root, root2);
-
-        // Test that you can add it back again.
-        let txn = db.db().create_write_txn();
-        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-        let reader = db.db().create_smt_reader().unwrap();
-
-        let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
-        let (root1_v2, update2) = jmt.put_value_set(vec![(smt_key2, Some(value))], 1).unwrap();
-        tree_writer.write_node_batch(&update2.node_batch).unwrap();
-        txn.commit().unwrap();
-
-        assert_eq!(root1, root1_v2);
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -27,9 +27,13 @@ use tari_storage::lmdb_store::DatabaseRef;
 use tari_utilities::hex::Hex;
 
 use super::lmdb::{lmdb_get, lmdb_insert, lmdb_replace};
-use crate::chain_storage::Optional;
-use crate::chain_storage::lmdb_db::lmdb::{lmdb_delete};
-use crate::chain_storage::lmdb_db::lmdb_db::{MetadataKey, MetadataValue};
+use crate::chain_storage::{
+    Optional,
+    lmdb_db::{
+        lmdb::lmdb_delete,
+        lmdb_db::{MetadataKey, MetadataValue},
+    },
+};
 
 pub const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb_tree_writer";
 
@@ -55,51 +59,32 @@ impl<'a> LmdbTreeWriter<'a> {
         }
     }
 
-    // pub fn delete_all_for_version(&self, version: u64) -> anyhow::Result<()> {
-    //     let key = version.to_be_bytes();
-    //     let nodes = lmdb_delete_keys_starting_with::<Node>(self.txn, &self.node_db, &key)?;
-    //     warn!(target: LOG_TARGET, "Deleted {} nodes for version {}", nodes.len(), version);
-    //     let values = lmdb_delete_keys_starting_with::<Vec<u8>>(self.txn, &self.value_db, &key)?;
-    //     warn!(target: LOG_TARGET, "Deleted {} values for version {}", values.len(), version);
-    //
-    //     for (value_key, _) in values {
-    //         let mut lmdb_key: Vec<u8> = vec![];
-    //         lmdb_key.extend_from_slice(value_key.get(8..).ok_or(anyhow::anyhow!("Value key is too short"))?);
-    //         lmdb_key.extend_from_slice(value_key.get(0..8).ok_or(anyhow::anyhow!("Value key is too short"))?);
-    //         match lmdb_delete(self.txn, &self.unique_key_db, &lmdb_key, "jmt_unique_key_table") {
-    //             Ok(_) => {
-    //                 debug!(target: LOG_TARGET, "Deleted unique key {} for version {}", lmdb_key.to_hex(), version);
-    //             },
-    //             Err(e) => {
-    //                 debug!(target: LOG_TARGET, "Failed to delete unique key {} for version {}: {}", lmdb_key.to_hex(), version, e);
-    //             },
-    //         }
-    //     }
-    //
-    //     Ok(())
-    // }
-
     pub fn put_node(&self, node_key: &jmt::storage::NodeKey, node: &jmt::storage::Node) -> anyhow::Result<()> {
         let mut lmdb_key: Vec<u8> = vec![];
-        //lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
+        // lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
         borsh::BorshSerialize::serialize(node_key, &mut lmdb_key)?;
-        match node{
+        match node {
             jmt::storage::Node::Null => {
                 trace!(target: LOG_TARGET, "Deleting node with key {}", lmdb_key.to_hex());
                 lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
             },
             _ => {
                 lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, "jmt_node_table")?;
-            }
-
+            },
         }
         let k = MetadataKey::JMTVersion;
-        lmdb_replace(self.txn, &self.metabase_db, &k.as_u32(), &MetadataValue::JMTVersion(node_key.version()), None)?;
+        lmdb_replace(
+            self.txn,
+            &self.metabase_db,
+            &k.as_u32(),
+            &MetadataValue::JMTVersion(node_key.version()),
+            None,
+        )?;
         Ok(())
     }
 
     pub fn cleanup_stale(&self, stale: &StaleNodeIndexBatch) -> anyhow::Result<()> {
-        for index in stale{
+        for index in stale {
             let mut lmdb_key: Vec<u8> = vec![];
             // lmdb_key.extend_from_slice(&index.node_key.version().to_be_bytes());
             borsh::BorshSerialize::serialize(&index.node_key, &mut lmdb_key)?;
@@ -121,41 +106,44 @@ impl TreeWriter for LmdbTreeWriter<'_> {
                     lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
                 },
                 _ => {
-                    //dbg!(&node);
                     lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
                     lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, "jmt_node_table")?;
-                }
+                },
             }
         }
         // let mut duplicates = HashMap::new();
         for (value_key, value) in node_batch.values() {
             let mut lmdb_key: Vec<u8> = vec![];
-            //lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
+            // lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
             lmdb_key.extend_from_slice(&value_key.1.0);
-            match value{
+            match value {
                 Some(_v) => {
-                    let existing:Option<Vec<u8>> = lmdb_get(self.txn, &self.value_db, &lmdb_key)?;
+                    let existing: Option<Vec<u8>> = lmdb_get(self.txn, &self.value_db, &lmdb_key)?;
                     if existing.is_some() {
-                        trace!(target: LOG_TARGET, "Found existing unique key {} for version {}", value_key.1 .0.to_hex(), value_key.0);
+                        warn!(target: LOG_TARGET, "Found existing unique key {} for version {}", value_key.1 .0.to_hex(), value_key.0);
                         return Err(anyhow::anyhow!("Duplicate value key found in batch"));
                     }
                     let val_bytes = bincode::serialize(value)?;
 
                     lmdb_insert(self.txn, &self.value_db, &lmdb_key, &val_bytes, "jmt_value_table")?;
-                }
+                },
                 None => {
-
                     lmdb_delete(self.txn, &self.value_db, &lmdb_key, "jmt_value_table").optional()?;
-                }
+                },
             }
         }
         let k = MetadataKey::JMTVersion;
-        let val = match lmdb_get(self.txn, &self.metabase_db, &k.as_u32())?{
-            Some(MetadataValue::JMTVersion(v)) => v+1,
+        let val = match lmdb_get(self.txn, &self.metabase_db, &k.as_u32())? {
+            Some(MetadataValue::JMTVersion(v)) => v + 1,
             _ => 0u64,
         };
-        lmdb_replace(self.txn, &self.metabase_db, &k.as_u32(), &MetadataValue::JMTVersion(val), None)?;
-
+        lmdb_replace(
+            self.txn,
+            &self.metabase_db,
+            &k.as_u32(),
+            &MetadataValue::JMTVersion(val),
+            None,
+        )?;
 
         trace!(target: LOG_TARGET, "Wrote JMT batch of {} nodes and {} values", node_batch.nodes().len(), node_batch.values().len());
         Ok(())
@@ -203,7 +191,6 @@ mod test {
         );
     }
 
-
     #[test]
     fn test_jmt_insert_delete() {
         let db = TempDatabase::new();
@@ -234,7 +221,6 @@ mod test {
         tree_writer.cleanup_stale(&updates.stale_node_index_batch).unwrap();
         txn.commit().unwrap();
 
-
         // // Try again for new version.
         let reader = db.db().create_smt_reader().unwrap().0;
 
@@ -242,14 +228,16 @@ mod test {
         assert_eq!(jmt.get_leaf_count(1).unwrap(), 2);
         assert!(jmt.get(smt_key_0, 1).unwrap().is_some());
         assert!(jmt.get(smt_key_1, 1).unwrap().is_some());
-         // Try again for new version.
-         let txn = db.db().create_write_txn();
-         let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-         let reader = db.db().create_smt_reader().unwrap().0;
+        // Try again for new version.
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap().0;
 
         let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
 
-         let (_root, updates) = jmt.put_value_set(vec![(smt_key_2, Some(value_2.clone())), (smt_key_0, None)], 2).unwrap();
+        let (_root, updates) = jmt
+            .put_value_set(vec![(smt_key_2, Some(value_2.clone())), (smt_key_0, None)], 2)
+            .unwrap();
         tree_writer.write_node_batch(&updates.node_batch).unwrap();
         tree_writer.cleanup_stale(&updates.stale_node_index_batch).unwrap();
         txn.commit().unwrap();
@@ -262,13 +250,15 @@ mod test {
         assert!(jmt.get(smt_key_1, 5).unwrap().is_some());
         assert!(jmt.get(smt_key_2, 5).unwrap().is_some());
 
-            // Try again for new version.
-            let txn = db.db().create_write_txn();
-            let tree_writer = db.db().create_lmdb_tree_writer(&txn);
-            let reader = db.db().create_smt_reader().unwrap().0;
+        // Try again for new version.
+        let txn = db.db().create_write_txn();
+        let tree_writer = db.db().create_lmdb_tree_writer(&txn);
+        let reader = db.db().create_smt_reader().unwrap().0;
         let jmt = JellyfishMerkleTree::<_, SmtHasher>::new(&reader);
 
-        let (root2, updates) = jmt.put_value_set(vec![(smt_key_2, None), (smt_key_0, Some(value_0))], 3).unwrap();
+        let (root2, updates) = jmt
+            .put_value_set(vec![(smt_key_2, None), (smt_key_0, Some(value_0))], 3)
+            .unwrap();
         tree_writer.write_node_batch(&updates.node_batch).unwrap();
         tree_writer.cleanup_stale(&updates.stale_node_index_batch).unwrap();
         txn.commit().unwrap();

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_tree_writer.rs
@@ -59,34 +59,9 @@ impl<'a> LmdbTreeWriter<'a> {
         }
     }
 
-    pub fn put_node(&self, node_key: &jmt::storage::NodeKey, node: &jmt::storage::Node) -> anyhow::Result<()> {
-        let mut lmdb_key: Vec<u8> = vec![];
-        // lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
-        borsh::BorshSerialize::serialize(node_key, &mut lmdb_key)?;
-        match node {
-            jmt::storage::Node::Null => {
-                trace!(target: LOG_TARGET, "Deleting node with key {}", lmdb_key.to_hex());
-                lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
-            },
-            _ => {
-                lmdb_insert(self.txn, &self.node_db, &lmdb_key, &node, "jmt_node_table")?;
-            },
-        }
-        let k = MetadataKey::JMTVersion;
-        lmdb_replace(
-            self.txn,
-            &self.metabase_db,
-            &k.as_u32(),
-            &MetadataValue::JMTVersion(node_key.version()),
-            None,
-        )?;
-        Ok(())
-    }
-
     pub fn cleanup_stale(&self, stale: &StaleNodeIndexBatch) -> anyhow::Result<()> {
         for index in stale {
             let mut lmdb_key: Vec<u8> = vec![];
-            // lmdb_key.extend_from_slice(&index.node_key.version().to_be_bytes());
             borsh::BorshSerialize::serialize(&index.node_key, &mut lmdb_key)?;
             lmdb_delete(self.txn, &self.node_db, &lmdb_key, "jmt_node_table").optional()?;
         }
@@ -98,7 +73,6 @@ impl TreeWriter for LmdbTreeWriter<'_> {
     fn write_node_batch(&self, node_batch: &jmt::storage::NodeBatch) -> anyhow::Result<()> {
         for (node_key, node) in node_batch.nodes() {
             let mut lmdb_key: Vec<u8> = vec![];
-            // lmdb_key.extend_from_slice(&node_key.version().to_be_bytes());
             borsh::BorshSerialize::serialize(node_key, &mut lmdb_key)?;
             match node {
                 jmt::storage::Node::Null => {
@@ -111,10 +85,8 @@ impl TreeWriter for LmdbTreeWriter<'_> {
                 },
             }
         }
-        // let mut duplicates = HashMap::new();
         for (value_key, value) in node_batch.values() {
             let mut lmdb_key: Vec<u8> = vec![];
-            // lmdb_key.extend_from_slice(&value_key.0.to_be_bytes());
             lmdb_key.extend_from_slice(&value_key.1.0);
             match value {
                 Some(_v) => {

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -33,7 +33,7 @@ pub use lmdb_db::{
     get_all_database_names,
 };
 use serde::{Deserialize, Serialize};
-pub use stats_collector::DatabaseStats;
+pub use stats_collector::{DatabaseStats, MigrationPhase};
 use tari_common_types::types::HashOutput;
 use tari_crypto::hash_domain;
 use tari_transaction_components::transaction_components::{TransactionInput, TransactionKernel, TransactionOutput};

--- a/base_layer/core/src/chain_storage/lmdb_db/stats_collector.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/stats_collector.rs
@@ -83,6 +83,21 @@ use tokio::sync::watch;
 
 use super::lmdb_db::{MetadataKey, MetadataValue};
 
+/// Which sub-step of the migration is currently running. Surfaced via the readiness gRPC so
+/// clients can show a meaningful label in addition to the numeric `current_height/total_height`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MigrationPhase {
+    /// No migration phase has been set yet, or the migration is not currently running.
+    #[default]
+    Unspecified,
+    /// Walking the UTXO set and inserting entries into the v2 JMT tables. Per-batch progress
+    /// is reported via `update_migration_progress`.
+    JmtRebuild,
+    /// Running `mdb_env_copy2(MDB_CP_COMPACT)` to reclaim disk space freed by the migration.
+    /// LMDB does not expose intermediate progress for this operation.
+    LmdbCompact,
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct MigrationStats {
     pub current_height: u64,
@@ -90,6 +105,7 @@ pub struct MigrationStats {
     pub progress_percentage: f64,
     pub current_db_version: u64,
     pub target_db_version: u64,
+    pub phase: MigrationPhase,
 }
 
 /// Statistics data for database operations
@@ -124,6 +140,7 @@ impl DatabaseStats {
                 progress_percentage,
                 current_db_version: 0,
                 target_db_version: 0,
+                phase: MigrationPhase::default(),
             },
             last_updated: Instant::now(),
             metadata: HashMap::new(),
@@ -255,6 +272,18 @@ impl LMDBStatsCollector {
     pub fn set_current_db_version(&self, current_version: u64) {
         let mut stats = self.receiver.borrow().clone();
         stats.migration_stats.current_db_version = current_version;
+        self.update_db_stats(stats);
+    }
+
+    /// Set the migration phase. The phase resets `current_height` and the progress percentage so
+    /// that per-phase counters start clean; callers should follow with `set_total_height` and
+    /// `update_migration_progress` as the phase makes progress.
+    pub fn set_migration_phase(&self, phase: MigrationPhase) {
+        let mut stats = self.receiver.borrow().clone();
+        stats.migration_stats.phase = phase;
+        stats.migration_stats.current_height = 0;
+        stats.migration_stats.progress_percentage = 0.0;
+        stats.timestamp = self.get_current_timestamp();
         self.update_db_stats(stats);
     }
 

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -77,6 +77,7 @@ pub use lmdb_db::{
     CheckFailure,
     DatabaseStats,
     LMDBDatabase,
+    MigrationPhase,
     PayrefRebuildStatus,
     create_lmdb_database,
     create_lmdb_database_with_stats_channel,

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -546,13 +546,12 @@ impl BlockchainBackend for TempDatabase {
 
     fn verify_horizon_sync_output_root(
         &self,
-        version: u64,
         expected_root: HashOutput,
     ) -> Result<(), ChainStorageError> {
         self.db
             .as_ref()
             .unwrap()
-            .verify_horizon_sync_output_root(version, expected_root)
+            .verify_horizon_sync_output_root(expected_root)
     }
 
     fn get_stats(&self) -> Result<DbBasicStats, ChainStorageError> {
@@ -681,7 +680,7 @@ impl BlockchainBackend for TempDatabase {
             .fetch_template_registrations(start_height, end_height)
     }
 
-    fn create_smt_reader(&self) -> Result<OwnedLmdbTreeReader<'_>, ChainStorageError> {
+    fn create_smt_reader(&self) -> Result<(OwnedLmdbTreeReader<'_>, u64), ChainStorageError> {
         self.db.as_ref().unwrap().create_smt_reader()
     }
 

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -544,14 +544,8 @@ impl BlockchainBackend for TempDatabase {
         self.db.as_ref().unwrap().fetch_horizon_sync_output_checkpoint()
     }
 
-    fn verify_horizon_sync_output_root(
-        &self,
-        expected_root: HashOutput,
-    ) -> Result<(), ChainStorageError> {
-        self.db
-            .as_ref()
-            .unwrap()
-            .verify_horizon_sync_output_root(expected_root)
+    fn verify_horizon_sync_output_root(&self, expected_root: HashOutput) -> Result<(), ChainStorageError> {
+        self.db.as_ref().unwrap().verify_horizon_sync_output_root(expected_root)
     }
 
     fn get_stats(&self) -> Result<DbBasicStats, ChainStorageError> {

--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -151,7 +151,11 @@ pub async fn create_network_with_multiple_nodes(
         panic!("Must have at least 2 nodes");
     }
     let network = Network::LocalNet;
-    let temp_dir = tempdir().unwrap();
+    // Leak the temp dir so it outlives this function. The nodes hold open SQLite connections to
+    // `peers.db` under this path; if the `TempDir` drops when this function returns, SQLite's
+    // background journal/WAL writes fail with "no such table: peers" / "disk I/O error" and the
+    // entire sync stack collapses with `NoMoreSyncPeers`. The OS cleans `/tmp` between runs.
+    let temp_dir = tempdir().unwrap().into_path();
     let key_manager = KeyManager::new_random().unwrap();
     let consensus_constants = sample_blockchains::consensus_constants(network).build();
     let (initial_block, coinbase_wallet_output) = create_genesis_block(&consensus_constants, &key_manager);
@@ -172,7 +176,7 @@ pub async fn create_network_with_multiple_nodes(
         blockchain_db_configs,
         vec![P2pConfig::default(); num_nodes],
         consensus_manager,
-        temp_dir.path().to_str().unwrap(),
+        temp_dir.to_str().unwrap(),
         network,
     )
     .await;

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -276,8 +276,10 @@ async fn inputs_are_not_malleable() {
             .difficulty(1)
             .with_transactions(txs),
     );
+
     let spent_output = output;
     let mut block = blockchain.get_block("A2").cloned().unwrap().block.block().clone();
+
     blockchain.store().rewind_to_height(block.header.height - 1).unwrap();
 
     let mut malicious_test_params = TestParams::new(&blockchain.key_manager);

--- a/base_layer/core/tests/tests/horizon_sync.rs
+++ b/base_layer/core/tests/tests/horizon_sync.rs
@@ -23,9 +23,10 @@
 #![allow(clippy::indexing_slicing)]
 use std::cmp::min;
 
+use tari_common_types::types::FixedHash;
 use tari_core::{
-    base_node::state_machine_service::states::{HorizonStateSync, StateEvent},
-    chain_storage::BlockchainDatabaseConfig,
+    base_node::state_machine_service::states::{BlockSync, HorizonStateSync, StateEvent},
+    chain_storage::{BlockchainDatabaseConfig, DbTransaction, HorizonSyncOutputCheckpoint},
 };
 
 use crate::helpers::{
@@ -34,7 +35,6 @@ use crate::helpers::{
 };
 
 #[allow(clippy::too_many_lines)]
-#[ignore = "prune mode not yet working"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_initial_horizon_sync_from_archival_node_happy_path() {
     //` cargo test --release --test core_integration_tests
@@ -146,26 +146,16 @@ async fn test_initial_horizon_sync_from_archival_node_happy_path() {
     // Bob will not be banned
     assert!(!sync::wait_for_is_peer_banned(&alice_node, bob_node.node_identity.node_id(), 1).await);
 
-    // 4. Alice attempts horizon sync again without any change in the blockchain
-    println!("\n4. Alice attempts horizon sync again without any change in the blockchain\n");
+    // 4. Alice re-runs the sync decision without any change in the blockchain. Her tip already
+    // covers the new horizon (5 == 10 - 5) so `decide_next_sync` chooses block sync + prune
+    // instead of replaying the horizon snapshot — same end state, cheaper path.
+    println!("\n4. Alice re-decides the next sync (already at horizon \u{2192} block sync)\n");
 
     let event = decide_horizon_sync(&mut alice_state_machine, header_sync).await;
-    let mut horizon_sync = match event {
-        StateEvent::ProceedToHorizonSync(sync_peers) => HorizonStateSync::from(sync_peers),
-        _ => panic!("4. Alice should proceed to horizon sync"),
-    };
-    let event = sync::horizon_sync_execute(&mut alice_state_machine, &mut horizon_sync).await;
-
-    println!(
-        "Event: {} to block {}",
-        state_event(&event),
-        alice_node.blockchain_db.get_height().unwrap()
-    );
-    assert_eq!(event, StateEvent::HorizonStateSynchronized);
-    assert_eq!(
-        alice_node.blockchain_db.get_height().unwrap(),
-        alice_node.blockchain_db.fetch_last_header().unwrap().height - pruning_horizon
-    );
+    match event {
+        StateEvent::ProceedToBlockSync(_) => {},
+        _ => panic!("4. Alice should proceed to block sync, got {event:?}"),
+    }
     // Bob will not be banned
     assert!(!sync::wait_for_is_peer_banned(&alice_node, bob_node.node_identity.node_id(), 1).await);
 
@@ -294,7 +284,6 @@ async fn test_initial_horizon_sync_from_archival_node_happy_path() {
 }
 
 #[allow(clippy::too_many_lines)]
-#[ignore = "prune mode not yet working"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_consecutive_horizon_sync_from_prune_node_happy_path() {
     //` cargo test --release --test core_integration_tests
@@ -648,8 +637,11 @@ async fn test_consecutive_horizon_sync_from_prune_node_happy_path() {
     // Bob will not be banned
     assert!(!sync::wait_for_is_peer_banned(&carol_node, bob_node.node_identity.node_id(), 1).await);
 
-    // 12. Alice attempts horizon sync from Carol with adequate pruning horizon (to height 18)
-    println!("\n12. Alice attempts horizon sync from Carol with adequate pruning horizon (to height 18)\n");
+    // 12. Alice header-syncs from Carol then chooses a sync path. Alice's tip is already at 18
+    // (the new horizon = 22 - 4) from the block sync in step 8, so `decide_next_sync` takes the
+    // "local tip already covers new horizon" branch and routes to block sync + prune instead of
+    // re-downloading the aggregate horizon snapshot from genesis.
+    println!("\n12. Alice header-syncs from Carol then proceeds to block sync (already at horizon)\n");
 
     let mut header_sync_alice_from_carol = sync::initialize_sync_headers_with_ping_pong_data(&alice_node, &carol_node);
     let event = sync::sync_headers_execute(&mut alice_state_machine, &mut header_sync_alice_from_carol).await;
@@ -657,28 +649,24 @@ async fn test_consecutive_horizon_sync_from_prune_node_happy_path() {
     println!("Event: {} to header {}", state_event(&event), alice_header_height);
     assert_eq!(alice_header_height, 22);
     let event = decide_horizon_sync(&mut alice_state_machine, header_sync_alice_from_carol).await;
-    let mut horizon_sync = match event {
-        StateEvent::ProceedToHorizonSync(sync_peers) => HorizonStateSync::from(sync_peers),
-        _ => panic!("12. Alice should proceed to horizon sync"),
+    let mut block_sync = match event {
+        StateEvent::ProceedToBlockSync(sync_peers) => BlockSync::from(sync_peers),
+        _ => panic!("12. Alice should proceed to block sync, got {event:?}"),
     };
-    let event = sync::horizon_sync_execute(&mut alice_state_machine, &mut horizon_sync).await;
+    let event = sync::sync_blocks_execute(&mut alice_state_machine, &mut block_sync).await;
 
     println!(
         "Event: {} to block {}",
         state_event(&event),
         alice_node.blockchain_db.get_height().unwrap()
     );
-    assert_eq!(event, StateEvent::HorizonStateSynchronized);
-    assert_eq!(
-        alice_node.blockchain_db.get_height().unwrap(),
-        alice_header_height - pruning_horizon_alice
-    );
+    assert_eq!(event, StateEvent::BlocksSynchronized);
+    assert_eq!(alice_node.blockchain_db.get_height().unwrap(), alice_header_height);
     // Carol will not be banned
     assert!(!sync::wait_for_is_peer_banned(&alice_node, carol_node.node_identity.node_id(), 1).await);
 }
 
 #[allow(clippy::too_many_lines)]
-#[ignore = "prune mode not yet working"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_initial_horizon_sync_from_prune_node_happy_path() {
     //` cargo test --release --test core_integration_tests
@@ -864,4 +852,155 @@ async fn test_initial_horizon_sync_from_prune_node_happy_path() {
     );
     // Carol will not be banned
     assert!(!sync::wait_for_is_peer_banned(&alice_node, carol_node.node_identity.node_id(), 1).await);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_horizon_sync_discards_mismatched_checkpoint() {
+    // Exercises the full sync state machine through a horizon sync where Alice's database already
+    // contains a `HorizonSyncOutputCheckpoint` whose `sync_target_hash` does NOT match the new
+    // sync target. The synchronizer must discard the stale checkpoint and complete a fresh sync.
+    let pruning_horizon = 5;
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+        sync::create_network_with_multiple_nodes(vec![
+            BlockchainDatabaseConfig {
+                orphan_storage_capacity: 5,
+                pruning_horizon,
+                pruning_interval: 5,
+                track_reorgs: false,
+                cleanup_orphans_at_startup: false,
+                ..Default::default()
+            },
+            BlockchainDatabaseConfig::default(),
+        ])
+        .await;
+    let mut alice_state_machine = state_machines.remove(0);
+    let alice_node = peer_nodes.remove(0);
+    let bob_node = peer_nodes.remove(0);
+
+    // Use the same chain construction the other tests in this file rely on so this test exercises
+    // the same code path through `create_block_chain_with_transactions` (genesys spend at block 3,
+    // follow-up spends at block 16). Rewind Bob to height 10 — same anchor as the other tests.
+    let (blocks, _coinbases) = sync::create_block_chain_with_transactions(
+        &bob_node,
+        &initial_block,
+        &initial_coinbase,
+        &consensus_manager,
+        &key_manager,
+        pruning_horizon,
+        30,
+        3,
+        16,
+        15,
+    );
+    sync::delete_some_blocks_and_headers(&blocks[10..=30], WhatToDelete::BlocksAndHeaders, &bob_node);
+    assert_eq!(bob_node.blockchain_db.get_height().unwrap(), 10);
+
+    // The state machine sync stack needs to dial Bob before header sync will succeed. The
+    // existing happy-path tests do this by running an initial no-op horizon sync first.
+    let mut warmup = sync::initialize_horizon_sync_without_header_sync(&bob_node);
+    let event = sync::horizon_sync_execute(&mut alice_state_machine, &mut warmup).await;
+    assert_eq!(event, StateEvent::HorizonStateSynchronized);
+
+    // Alice header-syncs to Bob's tip
+    let mut header_sync = sync::initialize_sync_headers_with_ping_pong_data(&alice_node, &bob_node);
+    let _event = sync::sync_headers_execute(&mut alice_state_machine, &mut header_sync).await;
+    assert_eq!(alice_node.blockchain_db.fetch_last_header().unwrap().height, 10);
+
+    // Inject a checkpoint whose target doesn't match the upcoming horizon target. The
+    // synchronizer's `calculate_output_sync_start_stop` must discard this and start from height 1.
+    let mut txn = DbTransaction::new();
+    txn.set_horizon_sync_output_checkpoint(HorizonSyncOutputCheckpoint {
+        checkpoint_height: 99,
+        checkpoint_hash: FixedHash::zero(),
+        sync_target_height: 99,
+        sync_target_hash: FixedHash::zero(),
+    });
+    alice_node.blockchain_db.write(txn).unwrap();
+    assert!(
+        alice_node
+            .blockchain_db
+            .fetch_horizon_sync_output_checkpoint()
+            .unwrap()
+            .is_some()
+    );
+
+    let event = decide_horizon_sync(&mut alice_state_machine, header_sync).await;
+    let mut horizon_sync = match event {
+        StateEvent::ProceedToHorizonSync(sync_peers) => HorizonStateSync::from(sync_peers),
+        _ => panic!("Alice should proceed to horizon sync, got {event:?}"),
+    };
+    let event = sync::horizon_sync_execute(&mut alice_state_machine, &mut horizon_sync).await;
+
+    assert_eq!(event, StateEvent::HorizonStateSynchronized, "{}", state_event(&event));
+    assert_eq!(
+        alice_node.blockchain_db.get_height().unwrap(),
+        alice_node.blockchain_db.fetch_last_header().unwrap().height - pruning_horizon
+    );
+    // Finalization clears the checkpoint
+    assert!(
+        alice_node
+            .blockchain_db
+            .fetch_horizon_sync_output_checkpoint()
+            .unwrap()
+            .is_none(),
+        "checkpoint should be cleared after successful sync"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_horizon_sync_clears_checkpoint_on_completion() {
+    // Verifies the end-to-end resume contract: after a horizon sync runs to completion the
+    // checkpoint is cleared, so a subsequent sync starts from height 1 (verified via the resume
+    // path's no-checkpoint branch).
+    let pruning_horizon = 5;
+    let (mut state_machines, mut peer_nodes, initial_block, consensus_manager, key_manager, initial_coinbase) =
+        sync::create_network_with_multiple_nodes(vec![
+            BlockchainDatabaseConfig {
+                orphan_storage_capacity: 5,
+                pruning_horizon,
+                pruning_interval: 5,
+                track_reorgs: false,
+                cleanup_orphans_at_startup: false,
+                ..Default::default()
+            },
+            BlockchainDatabaseConfig::default(),
+        ])
+        .await;
+    let mut alice_state_machine = state_machines.remove(0);
+    let alice_node = peer_nodes.remove(0);
+    let bob_node = peer_nodes.remove(0);
+
+    let (blocks, _coinbases) = sync::create_block_chain_with_transactions(
+        &bob_node,
+        &initial_block,
+        &initial_coinbase,
+        &consensus_manager,
+        &key_manager,
+        pruning_horizon,
+        30,
+        3,
+        16,
+        15,
+    );
+    sync::delete_some_blocks_and_headers(&blocks[15..=30], WhatToDelete::BlocksAndHeaders, &bob_node);
+
+    let mut header_sync = sync::initialize_sync_headers_with_ping_pong_data(&alice_node, &bob_node);
+    let _event = sync::sync_headers_execute(&mut alice_state_machine, &mut header_sync).await;
+
+    let event = decide_horizon_sync(&mut alice_state_machine, header_sync).await;
+    let mut horizon_sync = match event {
+        StateEvent::ProceedToHorizonSync(sync_peers) => HorizonStateSync::from(sync_peers),
+        _ => panic!("Alice should proceed to horizon sync, got {event:?}"),
+    };
+    let event = sync::horizon_sync_execute(&mut alice_state_machine, &mut horizon_sync).await;
+
+    assert_eq!(event, StateEvent::HorizonStateSynchronized);
+    assert!(
+        alice_node
+            .blockchain_db
+            .fetch_horizon_sync_output_checkpoint()
+            .unwrap()
+            .is_none(),
+        "checkpoint should be cleared after successful sync"
+    );
 }

--- a/base_layer/transaction_components/src/transaction_components/transaction_input.rs
+++ b/base_layer/transaction_components/src/transaction_components/transaction_input.rs
@@ -592,6 +592,17 @@ impl SpentOutput {
         }
     }
 
+    pub fn matches_output(&self, output: &TransactionOutput) -> bool {
+        match self {
+            SpentOutput::OutputHash(h) => *h == output.hash(),
+            SpentOutput::OutputData {
+                commitment,
+                metadata_signature,
+                ..
+            } => (commitment == &output.commitment) & (metadata_signature == &output.metadata_signature),
+        }
+    }
+
     pub fn create_from_output(output: TransactionOutput) -> SpentOutput {
         let rp_hash = match output.proof {
             Some(proof) => proof.hash(),


### PR DESCRIPTION
Description
---
Fixes: #7802 
Fixes: #7749 
Reduce JMT stored data
Fixes prune mode sync

Current JMT serilization is stores everything and never removes old stale data. 
This moves to only store the current unspent sent JMT. 
Current version sown from 110Gb down to 45GB, that's a 60% reduction.
And the JMT data itself is down from 66 Gb to 2Gb, that's a 97% reduction in size.
Prune mode shrinks the db to 20Gb. 