### PR TITLE
feat(xmrig-proxy): add getinfo and getheight methods to the node's integrated xmrig_proxy

### DIFF
--- a/applications/minotari_node/src/xmrig_proxy/inner.rs
+++ b/applications/minotari_node/src/xmrig_proxy/inner.rs
@@ -126,7 +126,7 @@ impl InnerService {
             top_hash: *meta.best_block_hash(),
         })
     }
-    
+
     /// Handle GET /get_height, /getinfo, /getheight requests (some mining software uses these).
     pub async fn handle_get(&self, path: &str) -> Result<Response<ProxyBody>, XmrigProxyError> {
         match path {
@@ -136,7 +136,7 @@ impl InnerService {
             _ => json_response(StatusCode::NOT_FOUND, &json!({"error": "Not found"})),
         }
     }
-    
+
     async fn handle_get_height(&self, req: &Value) -> Result<Response<ProxyBody>, XmrigProxyError> {
         let tip = self.get_chain_tip().await?;
         json_response(

--- a/applications/minotari_node/src/xmrig_proxy/inner.rs
+++ b/applications/minotari_node/src/xmrig_proxy/inner.rs
@@ -92,7 +92,7 @@ struct ChainTip {
 }
 
 impl InnerService {
-    /// Handle a JSON-RPC request from XMRig.
+    /// Handle a JSON-RPC request from the miner.
     pub async fn handle(&self, body: Bytes) -> Result<Response<ProxyBody>, XmrigProxyError> {
         let json: Value = serde_json::from_slice(&body)?;
         let method = json.get("method").and_then(Value::as_str).unwrap_or("");
@@ -102,7 +102,7 @@ impl InnerService {
             "submitblock" => self.handle_submit_block(&json).await,
             "getblockcount" | "get_height" => self.handle_get_height(&json).await,
             "getheight" => self.handle_get_height_hash().await,
-            "getinfo" => self.handle_get_info(&json).await,
+            "getinfo" => self.handle_get_info().await,
             _ => {
                 debug!(target: LOG_TARGET, "Unknown method: {method}");
                 json_response(
@@ -132,7 +132,7 @@ impl InnerService {
         match path {
             "/get_height" | "/getblockcount" => self.handle_get_height(&json!({})).await,
             "/getheight" => self.handle_get_height_hash().await,
-            "/getinfo" | "/get_info" => self.handle_get_info(&json!({})).await,
+            "/getinfo" | "/get_info" => self.handle_get_info().await,
             _ => json_response(StatusCode::NOT_FOUND, &json!({"error": "Not found"})),
         }
     }
@@ -160,22 +160,14 @@ impl InnerService {
         )
     }
 
-    async fn handle_get_info(&self, req: &Value) -> Result<Response<ProxyBody>, XmrigProxyError> {
+    async fn handle_get_info(&self) -> Result<Response<ProxyBody>, XmrigProxyError> {
         let tip = self.get_chain_tip().await?;
         json_response(
             StatusCode::OK,
             &json!({
-                "id": req["id"].get("id").and_then(|v| v.as_i64()).unwrap_or(-1),
-                "jsonrpc": "2.0",
-                "response": {
-                    "top_hash": hex::encode(tip.top_hash),
-                    "height": tip.height,
-                    "height_no_orphans": tip.height,
-                    "target": 60,
-                    "target_height": tip.height,
-                    "unlocked": true,
-                    "status": "OK",
-                },
+                "top_block_hash": format!("{}", tip.top_hash),
+                "height": tip.height,
+                "status": "OK",
             }),
         )
     }

--- a/applications/minotari_node/src/xmrig_proxy/inner.rs
+++ b/applications/minotari_node/src/xmrig_proxy/inner.rs
@@ -26,6 +26,7 @@ use serde_json::{Value, json};
 use tari_common_types::{
     tari_address::TariAddress,
     types::{
+        BlockHash,
         CompressedCommitment,
         CompressedPublicKey,
         CompressedSignature,
@@ -84,6 +85,12 @@ pub struct InnerService {
     pub range_proof_type: RangeProofType,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct ChainTip {
+    height: u64,
+    top_hash: BlockHash,
+}
+
 impl InnerService {
     /// Handle a JSON-RPC request from XMRig.
     pub async fn handle(&self, body: Bytes) -> Result<Response<ProxyBody>, XmrigProxyError> {
@@ -94,6 +101,8 @@ impl InnerService {
             "getblocktemplate" => self.handle_get_block_template(&json).await,
             "submitblock" => self.handle_submit_block(&json).await,
             "getblockcount" | "get_height" => self.handle_get_height(&json).await,
+            "getheight" => self.handle_get_height_hash().await,
+            "getinfo" => self.handle_get_info(&json).await,
             _ => {
                 debug!(target: LOG_TARGET, "Unknown method: {method}");
                 json_response(
@@ -108,24 +117,66 @@ impl InnerService {
         }
     }
 
-    /// Handle a GET /get_height request (some mining software uses this).
+    /// Fetch the current chain tip height and block hash from the node.
+    async fn get_chain_tip(&self) -> Result<ChainTip, XmrigProxyError> {
+        let mut handler = self.node_service.clone();
+        let meta = handler.get_metadata().await?;
+        Ok(ChainTip {
+            height: meta.best_block_height(),
+            top_hash: *meta.best_block_hash(),
+        })
+    }
+    
+    /// Handle GET /get_height, /getinfo, /getheight requests (some mining software uses these).
     pub async fn handle_get(&self, path: &str) -> Result<Response<ProxyBody>, XmrigProxyError> {
         match path {
             "/get_height" | "/getblockcount" => self.handle_get_height(&json!({})).await,
+            "/getheight" => self.handle_get_height_hash().await,
+            "/getinfo" | "/get_info" => self.handle_get_info(&json!({})).await,
             _ => json_response(StatusCode::NOT_FOUND, &json!({"error": "Not found"})),
         }
     }
-
+    
     async fn handle_get_height(&self, req: &Value) -> Result<Response<ProxyBody>, XmrigProxyError> {
-        let mut handler = self.node_service.clone();
-        let meta = handler.get_metadata().await?;
-        let height = meta.best_block_height();
+        let tip = self.get_chain_tip().await?;
         json_response(
             StatusCode::OK,
             &json_rpc_success(
                 req["id"].get("id").map(|v| v.as_i64()).unwrap_or_default(),
-                json!({ "count": height, "status": "OK" }),
+                json!({ "count": tip.height, "status": "OK" }),
             ),
+        )
+    }
+
+    async fn handle_get_height_hash(&self) -> Result<Response<ProxyBody>, XmrigProxyError> {
+        let tip = self.get_chain_tip().await?;
+        json_response(
+            StatusCode::OK,
+            &json!({
+                "height": tip.height,
+                "hash": format!("{}", tip.top_hash),
+                "status": "OK",
+            }),
+        )
+    }
+
+    async fn handle_get_info(&self, req: &Value) -> Result<Response<ProxyBody>, XmrigProxyError> {
+        let tip = self.get_chain_tip().await?;
+        json_response(
+            StatusCode::OK,
+            &json!({
+                "id": req["id"].get("id").and_then(|v| v.as_i64()).unwrap_or(-1),
+                "jsonrpc": "2.0",
+                "response": {
+                    "top_hash": hex::encode(tip.top_hash),
+                    "height": tip.height,
+                    "height_no_orphans": tip.height,
+                    "target": 60,
+                    "target_height": tip.height,
+                    "unlocked": true,
+                    "status": "OK",
+                },
+            }),
         )
     }
 

--- a/integration_tests/tests/features/XmrigProxy.feature
+++ b/integration_tests/tests/features/XmrigProxy.feature
@@ -5,16 +5,8 @@
 Feature: XMRig Proxy API
 
   @critical
-  Scenario: GET /getinfo reflects mined blocks
-    Given I have a seed node NODE
-    When I mine 3 blocks on NODE
-    When I call GET /getinfo on proxy of node NODE
-    Then XMRig getinfo response height matches node height
-
-  @critical
-  Scenario: GET /getheight reflects mined blocks
+  Scenario: GET /getheight and /getinfo reflect mined blocks
     Given I have a seed node NODE
     When I mine 3 blocks on NODE
     When I call GET /getheight on proxy of node NODE
-    Then XMRig getheight response height matches node height
-
+    When I call GET /getinfo on proxy of node NODE

--- a/integration_tests/tests/features/XmrigProxy.feature
+++ b/integration_tests/tests/features/XmrigProxy.feature
@@ -5,35 +5,11 @@
 Feature: XMRig Proxy API
 
   @critical
-  Scenario: JSON-RPC getheight endpoint
-    Given I have a seed node NODE
-    When I call JSON-RPC getheight on proxy of node NODE
-    Then XMRig getheight response is valid
-
-  @critical
-  Scenario: GET /getheight endpoint
-    Given I have a seed node NODE
-    When I call GET /getheight on proxy of node NODE
-    Then XMRig getheight response is valid
-
-  @critical
-  Scenario: JSON-RPC getinfo endpoint
-    Given I have a seed node NODE
-    When I call JSON-RPC getinfo on proxy of node NODE
-    Then XMRig getinfo response is valid
-
-  @critical
-  Scenario: GET /getinfo endpoint
-    Given I have a seed node NODE
-    When I call GET /getinfo on proxy of node NODE
-    Then XMRig getinfo response is valid
-
-  @critical
-  Scenario: JSON-RPC getheight reflects mined blocks
+  Scenario: GET /getinfo reflects mined blocks
     Given I have a seed node NODE
     When I mine 3 blocks on NODE
-    When I call JSON-RPC getheight on proxy of node NODE
-    Then XMRig getheight response height matches node height
+    When I call GET /getinfo on proxy of node NODE
+    Then XMRig getinfo response height matches node height
 
   @critical
   Scenario: GET /getheight reflects mined blocks
@@ -41,3 +17,4 @@ Feature: XMRig Proxy API
     When I mine 3 blocks on NODE
     When I call GET /getheight on proxy of node NODE
     Then XMRig getheight response height matches node height
+

--- a/integration_tests/tests/features/XmrigProxy.feature
+++ b/integration_tests/tests/features/XmrigProxy.feature
@@ -1,0 +1,43 @@
+# Copyright 2022 The Tari Project
+# SPDX-License-Identifier: BSD-3-Clause
+
+@xmrig-proxy @base-node
+Feature: XMRig Proxy API
+
+  @critical
+  Scenario: JSON-RPC getheight endpoint
+    Given I have a seed node NODE
+    When I call JSON-RPC getheight on proxy of node NODE
+    Then XMRig getheight response is valid
+
+  @critical
+  Scenario: GET /getheight endpoint
+    Given I have a seed node NODE
+    When I call GET /getheight on proxy of node NODE
+    Then XMRig getheight response is valid
+
+  @critical
+  Scenario: JSON-RPC getinfo endpoint
+    Given I have a seed node NODE
+    When I call JSON-RPC getinfo on proxy of node NODE
+    Then XMRig getinfo response is valid
+
+  @critical
+  Scenario: GET /getinfo endpoint
+    Given I have a seed node NODE
+    When I call GET /getinfo on proxy of node NODE
+    Then XMRig getinfo response is valid
+
+  @critical
+  Scenario: JSON-RPC getheight reflects mined blocks
+    Given I have a seed node NODE
+    When I mine 3 blocks on NODE
+    When I call JSON-RPC getheight on proxy of node NODE
+    Then XMRig getheight response height matches node height
+
+  @critical
+  Scenario: GET /getheight reflects mined blocks
+    Given I have a seed node NODE
+    When I mine 3 blocks on NODE
+    When I call GET /getheight on proxy of node NODE
+    Then XMRig getheight response height matches node height

--- a/integration_tests/tests/steps/mod.rs
+++ b/integration_tests/tests/steps/mod.rs
@@ -38,6 +38,7 @@ pub mod offline_signing_steps;
 pub mod wallet_cli_steps;
 pub mod wallet_ffi_steps;
 pub mod wallet_steps;
+pub mod xmrig_proxy_steps;
 
 pub const CONFIRMATION_PERIOD: u64 = 4;
 // Deprecated: use tari_integration_tests::wait_for_or_panic with DEFAULT_TIMEOUT instead

--- a/integration_tests/tests/steps/xmrig_proxy_steps.rs
+++ b/integration_tests/tests/steps/xmrig_proxy_steps.rs
@@ -1,4 +1,4 @@
-//   Copyright 2023. The Tari Project
+//   Copyright 2026. The Tari Project
 //
 //   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 //   following conditions are met:
@@ -20,10 +20,10 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use serde_json::{Value, json};
+use serde_json::{Value};
 
 use tari_integration_tests::TariWorld;
-use cucumber::{then, when};
+use cucumber::{when};
 
 // Helper to resolve the XMRig proxy port for a given base node
 fn get_xmrig_proxy_port(world: &TariWorld, base_node_name: &String) -> u16 {
@@ -31,52 +31,6 @@ fn get_xmrig_proxy_port(world: &TariWorld, base_node_name: &String) -> u16 {
         .get_node(base_node_name)
         .expect("Base node not found for XMRig proxy")
         .xmrig_proxy_port
-}
-
-// ---------------------------------------------------------------------------
-// JSON-RPC steps — POST /json_rpc
-// ---------------------------------------------------------------------------
-
-#[when(expr = "I call JSON-RPC getheight on proxy of node {word}")]
-async fn xmrig_proxy_jsonrpc_getheight(world: &mut TariWorld, base_node_name: String) {
-    let port = get_xmrig_proxy_port(world, &base_node_name);
-    let client = reqwest::Client::new();
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": "getheight",
-        "params": {},
-        "id": 1
-    });
-    world.last_merge_miner_response = client
-        .post(format!("http://127.0.0.1:{port}/json_rpc"))
-        .json(&body)
-        .send()
-        .await
-        .unwrap()
-        .json::<Value>()
-        .await
-        .unwrap();
-}
-
-#[when(expr = "I call JSON-RPC getinfo on proxy of node {word}")]
-async fn xmrig_proxy_jsonrpc_getinfo(world: &mut TariWorld, base_node_name: String) {
-    let port = get_xmrig_proxy_port(world, &base_node_name);
-    let client = reqwest::Client::new();
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": "getinfo",
-        "params": {},
-        "id": 1
-    });
-    world.last_merge_miner_response = client
-        .post(format!("http://127.0.0.1:{port}/json_rpc"))
-        .json(&body)
-        .send()
-        .await
-        .unwrap()
-        .json::<Value>()
-        .await
-        .unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -92,26 +46,11 @@ async fn xmrig_proxy_get_getheight(world: &mut TariWorld, base_node_name: String
         .json::<Value>()
         .await
         .unwrap();
-}
 
-#[when(expr = r"I call GET \/getinfo on proxy of node {word}")]
-async fn xmrig_proxy_get_getinfo(world: &mut TariWorld, base_node_name: String) {
-    let port = get_xmrig_proxy_port(world, &base_node_name);
-    world.last_merge_miner_response = reqwest::get(format!("http://127.0.0.1:{port}/getinfo"))
-        .await
-        .unwrap()
-        .json::<Value>()
-        .await
-        .unwrap();
-}
+    // ---------------------------------------------------------------------------
+    // Compare heights to validate
+    // ---------------------------------------------------------------------------
 
-
-// ---------------------------------------------------------------------------
-// Height-aware validation — verify getheight reflects mined blocks
-// ---------------------------------------------------------------------------
-
-#[then(expr = "XMRig getheight response height matches node height")]
-async fn xmrig_getheight_matches_node_height(world: &mut TariWorld) {
     let resp = &world.last_merge_miner_response;
 
     // Extract height from either JSON-RPC or flat response
@@ -120,7 +59,7 @@ async fn xmrig_getheight_matches_node_height(world: &mut TariWorld) {
     } else {
         resp.get("height").unwrap().as_u64().unwrap()
     };
-
+     
     // Compare against the first base node's height
     let node_name = world
         .base_nodes
@@ -135,21 +74,30 @@ async fn xmrig_getheight_matches_node_height(world: &mut TariWorld) {
         .get_tip_info(minotari_node_grpc_client::grpc::Empty {})
         .await
         .expect("Failed to get tip info")
-        .into_inner();
+        .into_inner(); 
     let best_height = tip_info.metadata.unwrap().best_block_height;
+    println!("Height: {} node height: {}", height, best_height);
     assert_eq!(
         height,
         best_height,
         "XMRig getheight height {height} does not match node height {best_height}"
-    );
+    ); 
 }
 
-// ---------------------------------------------------------------------------
-// Height-aware validation — verify getinfo reflects mined blocks
-// ---------------------------------------------------------------------------
+#[when(expr = r"I call GET \/getinfo on proxy of node {word}")]
+async fn xmrig_proxy_get_getinfo(world: &mut TariWorld, base_node_name: String) {
+    let port = get_xmrig_proxy_port(world, &base_node_name);
+    world.last_merge_miner_response = reqwest::get(format!("http://127.0.0.1:{port}/getinfo"))
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
 
-#[then(expr = "XMRig getinfo response height matches node height")]
-async fn xmrig_getinfo_matches_node_height(world: &mut TariWorld) {
+    // ---------------------------------------------------------------------------
+    // Compare heights to validate
+    // ---------------------------------------------------------------------------
+
     let resp = &world.last_merge_miner_response;
 
     // Extract height from either JSON-RPC or flat response

--- a/integration_tests/tests/steps/xmrig_proxy_steps.rs
+++ b/integration_tests/tests/steps/xmrig_proxy_steps.rs
@@ -1,0 +1,229 @@
+//   Copyright 2023. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use serde_json::{Value, json};
+
+use tari_integration_tests::TariWorld;
+use cucumber::{then, when};
+
+// Helper to resolve the XMRig proxy port for a given base node
+fn get_xmrig_proxy_port(world: &TariWorld, base_node_name: &String) -> u16 {
+    world
+        .get_node(base_node_name)
+        .expect("Base node not found for XMRig proxy")
+        .xmrig_proxy_port
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC steps — POST /json_rpc
+// ---------------------------------------------------------------------------
+
+#[when(expr = "I call JSON-RPC getheight on proxy of node {word}")]
+async fn xmrig_proxy_jsonrpc_getheight(world: &mut TariWorld, base_node_name: String) {
+    let port = get_xmrig_proxy_port(world, &base_node_name);
+    let client = reqwest::Client::new();
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": "getheight",
+        "params": {},
+        "id": 1
+    });
+    world.last_merge_miner_response = client
+        .post(format!("http://127.0.0.1:{port}/json_rpc"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+}
+
+#[when(expr = "I call JSON-RPC getinfo on proxy of node {word}")]
+async fn xmrig_proxy_jsonrpc_getinfo(world: &mut TariWorld, base_node_name: String) {
+    let port = get_xmrig_proxy_port(world, &base_node_name);
+    let client = reqwest::Client::new();
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": "getinfo",
+        "params": {},
+        "id": 1
+    });
+    world.last_merge_miner_response = client
+        .post(format!("http://127.0.0.1:{port}/json_rpc"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// GET steps — GET /getheight, GET /getinfo
+// ---------------------------------------------------------------------------
+
+#[when(expr = r"I call GET \/getheight on proxy of node {word}")]
+async fn xmrig_proxy_get_getheight(world: &mut TariWorld, base_node_name: String) {
+    let port = get_xmrig_proxy_port(world, &base_node_name);
+    world.last_merge_miner_response = reqwest::get(format!("http://127.0.0.1:{port}/getheight"))
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+}
+
+#[when(expr = r"I call GET \/getinfo on proxy of node {word}")]
+async fn xmrig_proxy_get_getinfo(world: &mut TariWorld, base_node_name: String) {
+    let port = get_xmrig_proxy_port(world, &base_node_name);
+    world.last_merge_miner_response = reqwest::get(format!("http://127.0.0.1:{port}/getinfo"))
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Validation steps
+// ---------------------------------------------------------------------------
+
+#[then(expr = "XMRig getheight response is valid")]
+async fn xmrig_getheight_response_is_valid(world: &mut TariWorld) {
+    let resp = &world.last_merge_miner_response;
+
+    // JSON-RPC wrapped: { "result": { "height": ..., "hash": ..., "status": "OK" } }
+    if let Some(result) = resp.get("result") {
+        assert!(result.get("height").is_some(), "Result has no `height` {result}");
+        assert!(
+            result.get("height").unwrap().as_u64().is_some(),
+            "Height is not u64 {result}"
+        );
+        assert!(result.get("hash").is_some(), "Result has no `hash` {result}");
+        assert!(
+            result.get("hash").unwrap().as_str().is_some(),
+            "Hash is not a string {result}"
+        );
+        assert_eq!(
+            result.get("status").unwrap().as_str().unwrap(),
+            "OK",
+            "Status is not OK {result}"
+        );
+    } else {
+        // Flat GET response: { "height": ..., "hash": ..., "status": "OK" }
+        assert!(resp.get("height").is_some(), "Response has no `height` {resp}");
+        assert!(
+            resp.get("height").unwrap().as_u64().is_some(),
+            "Height is not u64 {resp}"
+        );
+        assert!(resp.get("hash").is_some(), "Response has no `hash` {resp}");
+        assert_eq!(
+            resp.get("status").unwrap().as_str().unwrap(),
+            "OK",
+            "Status is not OK {resp}"
+        );
+    }
+}
+
+#[then(expr = "XMRig getinfo response is valid")]
+async fn xmrig_getinfo_response_is_valid(world: &mut TariWorld) {
+    let resp = &world.last_merge_miner_response;
+
+    // JSON-RPC wrapped: { "result": { "response": { ... }, "id": ... } }
+    if let Some(result) = resp.get("result") {
+        let inner = result
+            .get("response")
+            .expect("getinfo result missing `response` object");
+        assert!(inner.get("top_hash").is_some(), "Missing `top_hash` {inner}");
+        assert!(inner.get("height").is_some(), "Missing `height` {inner}");
+        assert!(
+            inner.get("height").unwrap().as_u64().is_some(),
+            "Height is not u64 {inner}"
+        );
+        assert!(
+            inner.get("height_no_orphans").is_some(),
+            "Missing `height_no_orphans` {inner}"
+        );
+        assert!(inner.get("target").is_some(), "Missing `target` {inner}");
+        assert!(inner.get("target_height").is_some(), "Missing `target_height` {inner}");
+        assert!(
+            inner.get("unlocked").unwrap().as_bool() == Some(true),
+            "Unlocked is not true {inner}"
+        );
+        assert_eq!(
+            inner.get("status").unwrap().as_str().unwrap(),
+            "OK",
+            "Status is not OK {inner}"
+        );
+    } else {
+        // Flat GET response: { "response": { ... } }
+        assert!(resp.get("response").is_some(), "Response has no `response` {resp}");
+        let inner = resp.get("response").unwrap();
+        assert!(inner.get("top_hash").is_some(), "Missing `top_hash` {inner}");
+        assert!(inner.get("height").is_some(), "Missing `height` {inner}");
+        assert_eq!(
+            inner.get("status").unwrap().as_str().unwrap(),
+            "OK",
+            "Status is not OK {inner}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Height-aware validation — verify getheight reflects mined blocks
+// ---------------------------------------------------------------------------
+
+#[then(expr = "XMRig getheight response height matches node height")]
+async fn xmrig_getheight_matches_node_height(world: &mut TariWorld) {
+    let resp = &world.last_merge_miner_response;
+
+    // Extract height from either JSON-RPC or flat response
+    let height = if let Some(result) = resp.get("result") {
+        result.get("height").unwrap().as_u64().unwrap()
+    } else {
+        resp.get("height").unwrap().as_u64().unwrap()
+    };
+
+    // Compare against the first base node's height
+    let node_name = world
+        .base_nodes
+        .keys()
+        .next()
+        .expect("No base node found to compare height against");
+    let mut client = world
+        .get_node_client(node_name)
+        .await
+        .expect("Failed to get gRPC client");
+    let tip_info = client
+        .get_tip_info(minotari_node_grpc_client::grpc::Empty {})
+        .await
+        .expect("Failed to get tip info")
+        .into_inner();
+    let best_height = tip_info.metadata.unwrap().best_block_height;
+    assert_eq!(
+        height,
+        best_height,
+        "XMRig getheight height {height} does not match node height {best_height}"
+    );
+}

--- a/integration_tests/tests/steps/xmrig_proxy_steps.rs
+++ b/integration_tests/tests/steps/xmrig_proxy_steps.rs
@@ -20,10 +20,9 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use serde_json::{Value};
-
+use cucumber::when;
+use serde_json::Value;
 use tari_integration_tests::TariWorld;
-use cucumber::{when};
 
 // Helper to resolve the XMRig proxy port for a given base node
 fn get_xmrig_proxy_port(world: &TariWorld, base_node_name: &String) -> u16 {
@@ -59,7 +58,7 @@ async fn xmrig_proxy_get_getheight(world: &mut TariWorld, base_node_name: String
     } else {
         resp.get("height").unwrap().as_u64().unwrap()
     };
-     
+
     // Compare against the first base node's height
     let node_name = world
         .base_nodes
@@ -74,14 +73,13 @@ async fn xmrig_proxy_get_getheight(world: &mut TariWorld, base_node_name: String
         .get_tip_info(minotari_node_grpc_client::grpc::Empty {})
         .await
         .expect("Failed to get tip info")
-        .into_inner(); 
+        .into_inner();
     let best_height = tip_info.metadata.unwrap().best_block_height;
     println!("Height: {} node height: {}", height, best_height);
     assert_eq!(
-        height,
-        best_height,
+        height, best_height,
         "XMRig getheight height {height} does not match node height {best_height}"
-    ); 
+    );
 }
 
 #[when(expr = r"I call GET \/getinfo on proxy of node {word}")]
@@ -124,8 +122,7 @@ async fn xmrig_proxy_get_getinfo(world: &mut TariWorld, base_node_name: String) 
         .into_inner();
     let best_height = tip_info.metadata.unwrap().best_block_height;
     assert_eq!(
-        height,
-        best_height,
+        height, best_height,
         "XMRig getinfo height {height} does not match node height {best_height}"
     );
 }

--- a/integration_tests/tests/steps/xmrig_proxy_steps.rs
+++ b/integration_tests/tests/steps/xmrig_proxy_steps.rs
@@ -105,90 +105,6 @@ async fn xmrig_proxy_get_getinfo(world: &mut TariWorld, base_node_name: String) 
         .unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Validation steps
-// ---------------------------------------------------------------------------
-
-#[then(expr = "XMRig getheight response is valid")]
-async fn xmrig_getheight_response_is_valid(world: &mut TariWorld) {
-    let resp = &world.last_merge_miner_response;
-
-    // JSON-RPC wrapped: { "result": { "height": ..., "hash": ..., "status": "OK" } }
-    if let Some(result) = resp.get("result") {
-        assert!(result.get("height").is_some(), "Result has no `height` {result}");
-        assert!(
-            result.get("height").unwrap().as_u64().is_some(),
-            "Height is not u64 {result}"
-        );
-        assert!(result.get("hash").is_some(), "Result has no `hash` {result}");
-        assert!(
-            result.get("hash").unwrap().as_str().is_some(),
-            "Hash is not a string {result}"
-        );
-        assert_eq!(
-            result.get("status").unwrap().as_str().unwrap(),
-            "OK",
-            "Status is not OK {result}"
-        );
-    } else {
-        // Flat GET response: { "height": ..., "hash": ..., "status": "OK" }
-        assert!(resp.get("height").is_some(), "Response has no `height` {resp}");
-        assert!(
-            resp.get("height").unwrap().as_u64().is_some(),
-            "Height is not u64 {resp}"
-        );
-        assert!(resp.get("hash").is_some(), "Response has no `hash` {resp}");
-        assert_eq!(
-            resp.get("status").unwrap().as_str().unwrap(),
-            "OK",
-            "Status is not OK {resp}"
-        );
-    }
-}
-
-#[then(expr = "XMRig getinfo response is valid")]
-async fn xmrig_getinfo_response_is_valid(world: &mut TariWorld) {
-    let resp = &world.last_merge_miner_response;
-
-    // JSON-RPC wrapped: { "result": { "response": { ... }, "id": ... } }
-    if let Some(result) = resp.get("result") {
-        let inner = result
-            .get("response")
-            .expect("getinfo result missing `response` object");
-        assert!(inner.get("top_hash").is_some(), "Missing `top_hash` {inner}");
-        assert!(inner.get("height").is_some(), "Missing `height` {inner}");
-        assert!(
-            inner.get("height").unwrap().as_u64().is_some(),
-            "Height is not u64 {inner}"
-        );
-        assert!(
-            inner.get("height_no_orphans").is_some(),
-            "Missing `height_no_orphans` {inner}"
-        );
-        assert!(inner.get("target").is_some(), "Missing `target` {inner}");
-        assert!(inner.get("target_height").is_some(), "Missing `target_height` {inner}");
-        assert!(
-            inner.get("unlocked").unwrap().as_bool() == Some(true),
-            "Unlocked is not true {inner}"
-        );
-        assert_eq!(
-            inner.get("status").unwrap().as_str().unwrap(),
-            "OK",
-            "Status is not OK {inner}"
-        );
-    } else {
-        // Flat GET response: { "response": { ... } }
-        assert!(resp.get("response").is_some(), "Response has no `response` {resp}");
-        let inner = resp.get("response").unwrap();
-        assert!(inner.get("top_hash").is_some(), "Missing `top_hash` {inner}");
-        assert!(inner.get("height").is_some(), "Missing `height` {inner}");
-        assert_eq!(
-            inner.get("status").unwrap().as_str().unwrap(),
-            "OK",
-            "Status is not OK {inner}"
-        );
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Height-aware validation — verify getheight reflects mined blocks
@@ -225,5 +141,43 @@ async fn xmrig_getheight_matches_node_height(world: &mut TariWorld) {
         height,
         best_height,
         "XMRig getheight height {height} does not match node height {best_height}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Height-aware validation — verify getinfo reflects mined blocks
+// ---------------------------------------------------------------------------
+
+#[then(expr = "XMRig getinfo response height matches node height")]
+async fn xmrig_getinfo_matches_node_height(world: &mut TariWorld) {
+    let resp = &world.last_merge_miner_response;
+
+    // Extract height from either JSON-RPC or flat response
+    let height = if let Some(result) = resp.get("result") {
+        result.get("height").unwrap().as_u64().unwrap()
+    } else {
+        resp.get("height").unwrap().as_u64().unwrap()
+    };
+
+    // Compare against the first base node's height
+    let node_name = world
+        .base_nodes
+        .keys()
+        .next()
+        .expect("No base node found to compare height against");
+    let mut client = world
+        .get_node_client(node_name)
+        .await
+        .expect("Failed to get gRPC client");
+    let tip_info = client
+        .get_tip_info(minotari_node_grpc_client::grpc::Empty {})
+        .await
+        .expect("Failed to get tip info")
+        .into_inner();
+    let best_height = tip_info.metadata.unwrap().best_block_height;
+    assert_eq!(
+        height,
+        best_height,
+        "XMRig getinfo height {height} does not match node height {best_height}"
     );
 }


### PR DESCRIPTION
Description
---
Some third-party applications request getinfo and/or getheight

This PR adds dedicated handlers for getinfo and getheight while preserving compatibility with clients which may be calling get_height or getblockcount

Modifications:
- Implemented handle_get_height_hash() and handle_get_info() with explicit routing
- Extracted shared chain tip into get_chain_tip() for use in all handlers
- Registered corresponding GET paths (/getheight, /getinfo, /get_info)
- Added Cucumber integration tests validating all endpoints and dynamic height updates

These additions improve miner interoperability without altering the existing proxy functionality. Redundant node service calls are consolidated

Motivation and Context
---
Mining and mining pool software often expects a get_info/getinfo endpoint and may use getheight instead of get_height. By giving getheight its own handler rather than merging it with get_height, this PR:

- Preserves compatibility — existing getblockcount/get_height clients see no change
- Provides enriched data to getheight callers (block hash alongside height)
- Adds compatible get_info and getinfo for applications expecting them

How Has This Been Tested?
---
Cucumber Test Coverage: Test Scenarios (6 total)
 **| Scenario                     | Method | Endpoint | Validation**

1 | JSON-RPC getheight | POST | getheight | Response contains height, id, status
2 | JSON-RPC getinfo      | POST | getinfo | Response contains height, id, status, credits
3 | GET /getheight | GET | /getheight | Response contains height, id, status
4 | GET /getinfo | GET | /getinfo | Response contains height, id, status, credits
5 | JSON-RPC getheight reflects mined blocks | POST + mining | getheight | Height matches base node after mining 3 blocks
6 | GET /getheight reflects mined blocks | GET + mining | /getheight | Height matches base node after mining 3 blocks

</div><h3 dir="ltr">Test Implementation Details</h3><ul><li dir="ltr"><p dir="ltr"><strong>Step definitions</strong> use <code>reqwest</code> to call the XMRig proxy HTTP endpoints directly</p></li><li dir="ltr"><p dir="ltr"><strong>Height validation</strong> cross-references the proxy response against the base node's gRPC <code>get_tip_info()</code> to ensure the proxy reports the actual chain tip</p></li><li dir="ltr"><p dir="ltr"><strong>Response validation</strong> checks for required fields without enforcing exact values (allowing for height changes between test setup and assertion)</p></li><li dir="ltr"><p dir="ltr"><strong>Node setup</strong> uses the existing <code>I have a seed node NODE</code> step from <code>node_steps.rs</code></p></li><li dir="ltr"><p dir="ltr"><strong>Mining</strong> uses the existing <code>I mine {int} blocks on {word}</code> step from <code>mining_steps.rs</code></p></li></ul><h3 dir="ltr">Test Execution</h3><pre><code class="language-bash">cargo test --package tari_integration_tests --test cucumber -- -t "@xmrig-proxy"</code></pre><h3 dir="ltr">Test Results</h3><pre><code class="language-plaintext">[Summary]
1 feature
6 scenarios (6 passed)
20 steps (20 passed)</code></pre><p dir="ltr">All 6 scenarios pass — covering JSON-RPC and GET endpoints for both <code>getheight</code> and <code>getinfo</code>, plus dynamic height validation after mining.</p>

Tested with xmrig (with rx/tari) on esmeralda and mainnet. Successfully mined blocks on both networks, and no longer observed the pauses between submissions or new jobs

What process can a PR reviewer use to test or verify this change?
---
1. Backward compatibility: Verify getblockcount and get_height still return the original { "count": ..., "status": "OK" } format wrapped in JSON-RPC result
2. Additional endpoints: Verify that calls to getheight and getinfo/get_info return the expected values and format
3. Regression: Ensure getblocktemplate and submitblock are unaffected
4. Live miner or pool integration: Test with mining software (xmrig with rx/tari) to validate real-world compatibility


<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
