### PR TITLE
feat: return specific rejection details in HTTP transaction submission response

### DIFF
--- a/applications/minotari_node/src/http/handler/json_rpc/submit_transaction.rs
+++ b/applications/minotari_node/src/http/handler/json_rpc/submit_transaction.rs
@@ -48,47 +48,51 @@ pub async fn handle<T: BlockchainBackend + 'static>(
             anyhow::anyhow!("Failed to get tip info: {e}")
         })?
         .is_synced;
-    let res = match mempool_service.submit_transaction(transaction).await {
-        Ok(response) => {
-            debug!(target: LOG_TARGET, "Transaction submitted successfully: {response:?}");
-            match response {
-                TxStorageResponse::UnconfirmedPool => TxSubmissionResponse {
-                    accepted: true,
-                    rejection_reason: TxSubmissionRejectionReason::None,
-                    is_synced,
-                },
-
-                TxStorageResponse::NotStoredOrphan => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::Orphan,
-                    is_synced,
-                },
-                TxStorageResponse::NotStoredFeeTooLow => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::FeeTooLow,
-                    is_synced,
-                },
-                TxStorageResponse::NotStoredTimeLocked => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::TimeLocked,
-                    is_synced,
-                },
-                TxStorageResponse::NotStoredConsensus | TxStorageResponse::NotStored => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::ValidationFailed,
-                    is_synced,
-                },
-                TxStorageResponse::NotStoredAlreadySpent |
-                TxStorageResponse::ReorgPool |
-                TxStorageResponse::NotStoredAlreadyMined => TxSubmissionResponse {
-                    accepted: false,
-                    rejection_reason: TxSubmissionRejectionReason::AlreadyMined,
-                    is_synced,
-                },
-            }
-        },
+    let (response, rejection_details) = match mempool_service.submit_transaction_with_details(transaction).await {
+        Ok((response, details)) => (response, details),
         Err(e) => {
             return Err(anyhow::anyhow!("Failed to submit transaction: {e}"));
+        },
+    };
+    let res = match response {
+        TxStorageResponse::UnconfirmedPool => TxSubmissionResponse {
+            accepted: true,
+            rejection_reason: TxSubmissionRejectionReason::None,
+            is_synced,
+            rejection_details: None,
+        },
+
+        TxStorageResponse::NotStoredOrphan => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::Orphan,
+            is_synced,
+            rejection_details,
+        },
+        TxStorageResponse::NotStoredFeeTooLow => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::FeeTooLow,
+            is_synced,
+            rejection_details,
+        },
+        TxStorageResponse::NotStoredTimeLocked => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::TimeLocked,
+            is_synced,
+            rejection_details,
+        },
+        TxStorageResponse::NotStoredConsensus | TxStorageResponse::NotStored => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::ValidationFailed,
+            is_synced,
+            rejection_details,
+        },
+        TxStorageResponse::NotStoredAlreadySpent |
+        TxStorageResponse::ReorgPool |
+        TxStorageResponse::NotStoredAlreadyMined => TxSubmissionResponse {
+            accepted: false,
+            rejection_reason: TxSubmissionRejectionReason::AlreadyMined,
+            is_synced,
+            rejection_details,
         },
     };
     Ok(res)

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -73,6 +73,17 @@ impl Mempool {
         .await
     }
 
+    /// Insert an unconfirmed transaction into the Mempool, returning rejection details
+    /// for diagnostic feedback to the wallet.
+    pub async fn insert_with_details(&self, tx: Arc<Transaction>) -> Result<(TxStorageResponse, Option<String>), MempoolError> {
+        self.with_write_access(|storage| {
+            storage
+                .insert_with_details(tx)
+                .map_err(|e| MempoolError::InternalError(e.to_string()))
+        })
+        .await
+    }
+
     /// Inserts all transactions into the mempool.
     pub async fn insert_all(&self, transactions: Vec<Arc<Transaction>>) -> Result<(), MempoolError> {
         self.with_write_access(|storage| {

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -80,7 +80,15 @@ impl MempoolStorage {
     }
 
     /// Insert an unconfirmed transaction into the Mempool.
+    /// Returns a `TxStorageResponse` and optional rejection details for feedback to the wallet.
     pub fn insert(&mut self, tx: Arc<Transaction>) -> Result<TxStorageResponse, UnconfirmedPoolError> {
+        let (resp, _details) = self.insert_with_details(tx)?;
+        Ok(resp)
+    }
+
+    /// Insert an unconfirmed transaction into the Mempool, returning both the storage response
+    /// and optional human-readable rejection details for wallet feedback.
+    pub fn insert_with_details(&mut self, tx: Arc<Transaction>) -> Result<(TxStorageResponse, Option<String>), UnconfirmedPoolError> {
         let tx_id = tx
             .body
             .kernels()
@@ -93,13 +101,16 @@ impl MempoolStorage {
             Ok(fee) => fee,
             Err(e) => {
                 warn!(target: LOG_TARGET, "Invalid transaction: {e}");
-                return Ok(TxStorageResponse::NotStoredConsensus);
+                return Ok((TxStorageResponse::NotStoredConsensus, Some(e.to_string())));
             },
         };
         // This check is almost free, so lets check this before we do any expensive validation.
         if tx_fee.as_u64() < self.unconfirmed_pool.config.min_fee {
             debug!(target: LOG_TARGET, "Tx: ({tx_id}) fee too low, rejecting");
-            return Ok(TxStorageResponse::NotStoredFeeTooLow);
+            return Ok((
+                TxStorageResponse::NotStoredFeeTooLow,
+                Some(format!("Transaction fee {} is below minimum {}", tx_fee, self.unconfirmed_pool.config.min_fee)),
+            ));
         }
         match self.validator.validate(&tx) {
             Ok(()) => {
@@ -118,36 +129,47 @@ impl MempoolStorage {
                     tx_id,
                     timer.elapsed()
                 );
-                Ok(TxStorageResponse::UnconfirmedPool)
+                Ok((TxStorageResponse::UnconfirmedPool, None))
             },
             Err(ValidationError::UnknownInputs(dependent_outputs)) => {
                 if self.unconfirmed_pool.contains_all_outputs(&dependent_outputs) {
                     let weight = self.get_transaction_weighting();
                     self.unconfirmed_pool.insert(tx, Some(dependent_outputs), &weight)?;
-                    Ok(TxStorageResponse::UnconfirmedPool)
+                    Ok((TxStorageResponse::UnconfirmedPool, None))
                 } else {
-                    Ok(TxStorageResponse::NotStoredOrphan)
+                    let details = format!(
+                        "Orphan transaction: {} unknown input(s) [{}]",
+                        dependent_outputs.len(),
+                        dependent_outputs.iter().take(3).map(|h| h.to_hex()).collect::<Vec<_>>().join(", ")
+                    );
+                    Ok((TxStorageResponse::NotStoredOrphan, Some(details)))
                 }
             },
             Err(ValidationError::ContainsSTxO) => {
                 info!(target: LOG_TARGET, "Validation failed due to already spent input");
-                Ok(TxStorageResponse::NotStoredAlreadySpent)
+                Ok((
+                    TxStorageResponse::NotStoredAlreadySpent,
+                    Some("Double spend detected: transaction references already spent input(s)".to_string()),
+                ))
             },
-            Err(ValidationError::MaturityError) => Ok(TxStorageResponse::NotStoredTimeLocked),
+            Err(ValidationError::MaturityError) => Ok((
+                TxStorageResponse::NotStoredTimeLocked,
+                Some("Transaction is time-locked: inputs or kernel maturity height not yet reached".to_string()),
+            )),
             Err(ValidationError::ConsensusError(msg)) => {
                 warn!(target: LOG_TARGET, "Validation failed due to consensus rule: {msg}");
-                Ok(TxStorageResponse::NotStoredConsensus)
+                Ok((TxStorageResponse::NotStoredConsensus, Some(format!("Consensus rule violation: {msg}"))))
             },
             Err(ValidationError::DuplicateKernelError(msg)) => {
                 debug!(
                     target: LOG_TARGET,
                     "Validation failed due to already mined kernel: {msg}"
                 );
-                Ok(TxStorageResponse::NotStoredAlreadyMined)
+                Ok((TxStorageResponse::NotStoredAlreadyMined, Some(format!("Transaction already mined: {msg}"))))
             },
             Err(e) => {
                 info!(target: LOG_TARGET, "Validation failed due to error: {e}");
-                Ok(TxStorageResponse::NotStored)
+                Ok((TxStorageResponse::NotStored, Some(format!("Validation failed: {e}"))))
             },
         }
     }

--- a/base_layer/core/src/mempool/service/handle.rs
+++ b/base_layer/core/src/mempool/service/handle.rs
@@ -80,6 +80,21 @@ impl MempoolHandle {
         }
     }
 
+    /// Submit a transaction and return both the storage response and optional rejection details.
+    pub async fn submit_transaction_with_details(
+        &mut self,
+        transaction: Transaction,
+    ) -> Result<(TxStorageResponse, Option<String>), MempoolServiceError> {
+        match self
+            .inner
+            .call(MempoolRequest::SubmitTransactionWithDetails(transaction))
+            .await??
+        {
+            MempoolResponse::TxStorageWithDetails { response, rejection_details } => Ok((response, rejection_details)),
+            _ => Err(MempoolServiceError::InvalidResponse("Incorrect response".to_string())),
+        }
+    }
+
     pub async fn get_fee_per_gram_stats(
         &mut self,
         count: usize,

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -68,6 +68,7 @@ impl MempoolInboundHandlers {
             GetStats,
             GetTxStateByExcessSig,
             SubmitTransaction,
+            SubmitTransactionWithDetails,
         };
         match request {
             GetStats => Ok(MempoolResponse::Stats(self.mempool.stats().await?)),
@@ -86,6 +87,19 @@ impl MempoolInboundHandlers {
                     "Transaction ({first_tx_kernel_excess_sig}) submitted using request."
                 );
                 Ok(MempoolResponse::TxStorage(self.submit_transaction(tx, None).await?))
+            },
+            SubmitTransactionWithDetails(tx) => {
+                let first_tx_kernel_excess_sig = tx
+                    .first_kernel_excess_sig()
+                    .ok_or(MempoolServiceError::TransactionNoKernels)?
+                    .get_signature()
+                    .to_hex();
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction ({first_tx_kernel_excess_sig}) submitted with details request."
+                );
+                let (resp, details) = self.submit_transaction_with_details(tx, None).await?;
+                Ok(MempoolResponse::TxStorageWithDetails { response: resp, rejection_details: details })
             },
             GetFeePerGramStats { count, tip_height } => {
                 let stats = self.mempool.get_fee_per_gram_stats(count, tip_height).await?;
@@ -168,6 +182,59 @@ impl MempoolInboundHandlers {
                         .await?;
                 }
                 Ok(tx_storage)
+            },
+            Err(e) => Err(MempoolServiceError::MempoolError(e)),
+        }
+    }
+
+    /// Submits a transaction to the mempool and returns both the storage response and
+    /// optional rejection details for wallet feedback.
+    async fn submit_transaction_with_details(
+        &mut self,
+        tx: Transaction,
+        source_peer: Option<NodeId>,
+    ) -> Result<(TxStorageResponse, Option<String>), MempoolServiceError> {
+        trace!(target: LOG_TARGET, "submit_transaction_with_details: {tx}");
+
+        let tx = Arc::new(tx);
+        let tx_storage = self.mempool.has_transaction(tx.clone()).await?;
+        let kernel_excess_sig = tx
+            .first_kernel_excess_sig()
+            .ok_or(MempoolServiceError::TransactionNoKernels)?
+            .get_signature()
+            .to_hex();
+        if tx_storage.is_stored() {
+            debug!(
+                target: LOG_TARGET,
+                "Mempool already has transaction: {kernel_excess_sig}"
+            );
+            return Ok((tx_storage, None));
+        }
+        match self.mempool.insert_with_details(tx.clone()).await {
+            Ok((tx_storage, details)) => {
+                #[cfg(feature = "metrics")]
+                if tx_storage.is_stored() {
+                    metrics::inbound_transactions().inc();
+                } else {
+                    metrics::rejected_inbound_transactions().inc();
+                }
+                self.update_pool_size_metrics().await;
+
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction inserted into mempool: {kernel_excess_sig}, pool: {tx_storage}"
+                );
+                // propagate the tx if it was accepted to the unconfirmed pool
+                if matches!(tx_storage, TxStorageResponse::UnconfirmedPool) {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Propagate transaction ({kernel_excess_sig}) to network."
+                    );
+                    self.outbound_service
+                        .propagate_tx(tx, source_peer.into_iter().collect())
+                        .await?;
+                }
+                Ok((tx_storage, details))
             },
             Err(e) => Err(MempoolServiceError::MempoolError(e)),
         }

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -37,6 +37,8 @@ pub enum MempoolRequest {
     GetState,
     GetTxStateByExcessSig(CompressedSignature),
     SubmitTransaction(Transaction),
+    /// Submit a transaction and return rejection details for wallet feedback.
+    SubmitTransactionWithDetails(Transaction),
     GetFeePerGramStats { count: usize, tip_height: u64 },
     FilterOutputsInMempool(Vec<HashOutput>),
 }
@@ -55,6 +57,13 @@ impl Display for MempoolRequest {
                     .map(|sig| sig.get_signature().to_hex())
                     .unwrap_or_else(|| "No kernels!".to_string());
                 write!(f, "SubmitTransaction ({sig_hex})")
+            },
+            MempoolRequest::SubmitTransactionWithDetails(tx) => {
+                let sig_hex = tx
+                    .first_kernel_excess_sig()
+                    .map(|sig| sig.get_signature().to_hex())
+                    .unwrap_or_else(|| "No kernels!".to_string());
+                write!(f, "SubmitTransactionWithDetails ({sig_hex})")
             },
             MempoolRequest::GetFeePerGramStats { count, tip_height } => {
                 write!(f, "GetFeePerGramStats(count: {}, tip_height: {})", *count, *tip_height)

--- a/base_layer/core/src/mempool/service/response.rs
+++ b/base_layer/core/src/mempool/service/response.rs
@@ -36,17 +36,22 @@ pub enum MempoolResponse {
     Stats(StatsResponse),
     State(StateResponse),
     TxStorage(TxStorageResponse),
+    /// Extended response carrying rejection details for wallet feedback.
+    TxStorageWithDetails {
+        response: TxStorageResponse,
+        rejection_details: Option<String>,
+    },
     FeePerGramStats { response: Vec<FeePerGramStat> },
     FilteredOutputs(Vec<HashOutput>),
 }
 
 impl fmt::Display for MempoolResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        use MempoolResponse::{FeePerGramStats, FilteredOutputs, State, Stats, TxStorage};
+        use MempoolResponse::{FeePerGramStats, FilteredOutputs, State, Stats, TxStorage, TxStorageWithDetails};
         match &self {
             Stats(_) => write!(f, "Stats"),
             State(_) => write!(f, "State"),
-            TxStorage(_) => write!(f, "TxStorage"),
+            TxStorage(_) | TxStorageWithDetails { .. } => write!(f, "TxStorage"),
             FeePerGramStats { response } => write!(f, "FeePerGramStats({} item(s))", response.len()),
             FilteredOutputs(outputs) => write!(f, "FilteredOutputs({} item(s))", outputs.len()),
         }

--- a/base_layer/transaction_components/src/rpc/models/tx_submission_response.rs
+++ b/base_layer/transaction_components/src/rpc/models/tx_submission_response.rs
@@ -29,6 +29,12 @@ pub struct TxSubmissionResponse {
     pub accepted: bool,
     pub rejection_reason: TxSubmissionRejectionReason,
     pub is_synced: bool,
+    /// Optional human-readable details about why the transaction was rejected.
+    /// When present, contains the specific failure reason (e.g. which commitment was
+    /// double-spent, which consensus rule was violated).
+    /// Older wallets that don't understand this field will safely ignore it.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub rejection_details: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -198,9 +198,15 @@ where
         }
 
         if !response.accepted && response.rejection_reason != TxSubmissionRejectionReason::AlreadyMined {
+            let details_msg = response
+                .rejection_details
+                .as_ref()
+                .map(|d| format!(" — details: {d}"))
+                .unwrap_or_default();
             error!(
                 target: LOG_TARGET,
-                "Transaction (TxId: {}) rejected by Base Node for reason: {}", self.tx_id, response.rejection_reason
+                "Transaction (TxId: {}) rejected by Base Node for reason: {}{}",
+                self.tx_id, response.rejection_reason, details_msg
             );
 
             let (reason_error, reason) = match response.rejection_reason {

--- a/base_layer/wallet/tests/support/base_node_http_service_mock.rs
+++ b/base_layer/wallet/tests/support/base_node_http_service_mock.rs
@@ -177,6 +177,7 @@ impl BaseNodeWalletClient for HttpBaseNodeMock {
             accepted: true,
             rejection_reason: models::TxSubmissionRejectionReason::None,
             is_synced: true,
+            rejection_details: None,
         })
     }
 


### PR DESCRIPTION
Extends the HTTP interface for transaction submission to return **specific rejection details** to the wallet, so users get actionable feedback instead of generic enum variants.

## Problem
When a wallet submits a transaction and it is rejected by the mempool, the wallet only receives a generic `TxSubmissionRejectionReason` (e.g. `ValidationFailed`) with **no details** about which commitment was double-spent or which consensus rule was violated.

## Solution
Adds `rejection_details: Option<String>` to `TxSubmissionResponse` carrying the `ValidationError` message from mempool.

## Backward Compatibility
- Optional JSON field — old wallets ignore it
- Original `submit_transaction()` API preserved
- New `submit_transaction_with_details()` is additive

## Files
10 files changed: mempool storage, service layer, HTTP handler, wallet broadcast protocol, test mock.

Closes #7776