### PR TITLE
fix: increase buffer

### DIFF
--- a/comms/core/src/builder/consts.rs
+++ b/comms/core/src/builder/consts.rs
@@ -24,9 +24,10 @@
 pub const CONNECTIVITY_MANAGER_REQUEST_BUFFER_SIZE: usize = 10;
 /// Buffer size for connectivity events
 pub const CONNECTIVITY_MANAGER_EVENTS_BUFFER_SIZE: usize = 500;
-/// Buffer size for actor requests to connection manager. A lower value is ok because the connection manager shouldn't
-/// need to handle a ton of requests concurrently.
-pub const CONNECTION_MANAGER_REQUEST_BUFFER_SIZE: usize = 10;
+/// Buffer size for actor requests to connection manager. Must be large enough to absorb a burst of proactive dial
+/// requests (see `comms::connectivity::proactive_dialer::MAX_CONCURRENT_DIALS`) without back-pressuring senders inside
+/// the connectivity refresh timeout.
+pub const CONNECTION_MANAGER_REQUEST_BUFFER_SIZE: usize = 60;
 /// Connection manager events buffer size. The size should allow more than enough "time" for slow subscribers to read
 /// the events while not being wasteful.
 pub const CONNECTION_MANAGER_EVENTS_BUFFER_SIZE: usize = 30;

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -62,7 +62,7 @@ use crate::{
 const LOG_TARGET: &str = "comms::connection_manager::manager";
 
 const EVENT_CHANNEL_SIZE: usize = 32;
-const DIALER_REQUEST_CHANNEL_SIZE: usize = 32;
+const DIALER_REQUEST_CHANNEL_SIZE: usize = 60;
 
 /// Connection events
 #[derive(Debug)]

--- a/comms/core/src/connectivity/proactive_dialer.rs
+++ b/comms/core/src/connectivity/proactive_dialer.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "comms::connectivity::proactive_dialer";
-const MAX_CONCURRENT_DIALS: usize = 30;
+pub const MAX_CONCURRENT_DIALS: usize = 30;
 
 /// Proactive peer dialing logic for maintaining target connection counts
 pub struct ProactiveDialer {


### PR DESCRIPTION
Description
---
Proactive dailing can flood the small buffer, which would in turn block the sender. 