### PR TITLE
Migrate legacy wallet output key ids on startup

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -216,6 +216,7 @@ where
         let mut utxo_scanner_events = self.resources.utxo_scanner_handle.get_event_receiver();
 
         debug!(target: LOG_TARGET, "Output Manager Service started");
+        self.spawn_legacy_output_key_id_migration();
         // Outputs marked as shorttermencumbered are not yet stored as transactions in the TMS, so lets clear them
         self.resources.db.clear_short_term_encumberances()?;
         loop {
@@ -249,6 +250,28 @@ where
         }
         info!(target: LOG_TARGET, "Output Manager Service ended");
         Ok(())
+    }
+
+    fn spawn_legacy_output_key_id_migration(&self) {
+        let db = self.resources.db.clone();
+        let key_manager = self.resources.key_manager.clone();
+
+        tokio::task::spawn_blocking(move || {
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                db.migrate_legacy_output_key_ids(&key_manager)
+            })) {
+                Ok(Ok(0)) => {},
+                Ok(Ok(migrated_count)) => {
+                    info!(target: LOG_TARGET, "Migrated {migrated_count} legacy output key id(s)");
+                },
+                Ok(Err(e)) => {
+                    error!(target: LOG_TARGET, "Error migrating legacy output key ids: {e}");
+                },
+                Err(_) => {
+                    error!(target: LOG_TARGET, "Panic occurred during legacy output key id migration");
+                },
+            }
+        });
     }
 
     /// This handler is called when the Service executor loops receives an API request

--- a/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
@@ -74,6 +74,11 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
         op: WriteOperation,
         key_manager: &KM,
     ) -> Result<Option<DbValue>, OutputManagerStorageError>;
+    /// Persist any legacy key id strings in the outputs table as current TariKeyId strings.
+    fn migrate_legacy_output_key_ids<KM: LegacyTransactionKeyManagerInterface>(
+        &self,
+        key_manager: &KM,
+    ) -> Result<usize, OutputManagerStorageError>;
     fn fetch_pending_incoming_outputs<KM: LegacyTransactionKeyManagerInterface>(
         &self,
         key_manager: &KM,

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -249,6 +249,13 @@ where T: OutputManagerBackend + 'static
         self.db.clear_short_term_encumberances()
     }
 
+    pub fn migrate_legacy_output_key_ids<KM: LegacyTransactionKeyManagerInterface>(
+        &self,
+        key_manager: &KM,
+    ) -> Result<usize, OutputManagerStorageError> {
+        self.db.migrate_legacy_output_key_ids(key_manager)
+    }
+
     /// When a pending transaction is cancelled the encumbered outputs are moved back to the `unspent_outputs`
     /// collection.
     pub fn cancel_pending_transaction_outputs(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -441,6 +441,30 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         result
     }
 
+    fn migrate_legacy_output_key_ids<KM: LegacyTransactionKeyManagerInterface>(
+        &self,
+        key_manager: &KM,
+    ) -> Result<usize, OutputManagerStorageError> {
+        let start = Instant::now();
+        let mut conn = self.database_connection.get_pooled_connection()?;
+        let acquire_lock = start.elapsed();
+        let migrated = retry_db("migrate_legacy_output_key_ids", || {
+            OutputSql::migrate_legacy_key_ids(&mut conn, key_manager)
+        })?;
+
+        if start.elapsed().as_millis() > 0 {
+            trace!(
+                target: LOG_TARGET,
+                "sqlite profile - migrate_legacy_output_key_ids: lock {} + db_op {} = {} ms",
+                acquire_lock.as_millis(),
+                (start.elapsed() - acquire_lock).as_millis(),
+                start.elapsed().as_millis()
+            );
+        }
+
+        Ok(migrated)
+    }
+
     fn fetch_pending_incoming_outputs<KM: LegacyTransactionKeyManagerInterface>(
         &self,
         key_manager: &KM,

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -86,6 +86,7 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "wallet::output_manager_service::database::wallet";
+const LEGACY_KEY_ID_MIGRATION_BATCH_SIZE: i64 = 500;
 
 #[derive(Clone, Derivative, Debug, Queryable, Identifiable, PartialEq, QueryableByName)]
 #[diesel(table_name = outputs)]
@@ -962,6 +963,95 @@ impl OutputSql {
                 .set(UpdateOutputSql::from(updated_output))
                 .execute(conn)?,
         )
+    }
+
+    pub fn migrate_legacy_key_ids<KM: LegacyTransactionKeyManagerInterface>(
+        conn: &mut SqliteConnection,
+        key_manager: &KM,
+    ) -> Result<usize, OutputManagerStorageError> {
+        let mut last_seen_id = 0;
+        let mut total_migrated = 0;
+
+        loop {
+            let (last_batch_id, batch_size, migrated) =
+                Self::migrate_legacy_key_id_batch(conn, key_manager, last_seen_id)?;
+            total_migrated += migrated;
+
+            if batch_size < LEGACY_KEY_ID_MIGRATION_BATCH_SIZE as usize {
+                break;
+            }
+
+            last_seen_id = last_batch_id;
+        }
+
+        Ok(total_migrated)
+    }
+
+    fn migrate_legacy_key_id_batch<KM: LegacyTransactionKeyManagerInterface>(
+        conn: &mut SqliteConnection,
+        key_manager: &KM,
+        after_id: i32,
+    ) -> Result<(i32, usize, usize), OutputManagerStorageError> {
+        conn.transaction::<_, OutputManagerStorageError, _>(|conn| {
+            let outputs_to_check = outputs::table
+                .select((outputs::id, outputs::spending_key, outputs::script_private_key))
+                .filter(outputs::id.gt(after_id))
+                .order(outputs::id.asc())
+                .limit(LEGACY_KEY_ID_MIGRATION_BATCH_SIZE)
+                .load::<(i32, String, String)>(conn)?;
+            let batch_size = outputs_to_check.len();
+            let mut last_batch_id = after_id;
+            let mut migrated = 0;
+
+            for (id, spending_key, script_private_key) in outputs_to_check {
+                last_batch_id = id;
+                let migrated_spending_key =
+                    Self::migrate_key_id_string(&spending_key, key_manager, "spending key id")?;
+                let migrated_script_private_key =
+                    Self::migrate_key_id_string(&script_private_key, key_manager, "script private key id")?;
+
+                if migrated_spending_key.is_none() && migrated_script_private_key.is_none() {
+                    continue;
+                }
+
+                diesel::update(outputs::table.filter(outputs::id.eq(id)))
+                    .set((
+                        outputs::spending_key.eq(migrated_spending_key.unwrap_or(spending_key)),
+                        outputs::script_private_key.eq(migrated_script_private_key.unwrap_or(script_private_key)),
+                    ))
+                    .execute(conn)
+                    .num_rows_affected_or_not_found(1)?;
+                migrated += 1;
+            }
+
+            Ok((last_batch_id, batch_size, migrated))
+        })
+    }
+
+    fn migrate_key_id_string<KM: LegacyTransactionKeyManagerInterface>(
+        stored_key_id: &str,
+        key_manager: &KM,
+        key_role: &str,
+    ) -> Result<Option<String>, OutputManagerStorageError> {
+        if TariKeyId::from_str(stored_key_id).is_ok() {
+            return Ok(None);
+        }
+
+        let legacy = LegacyTariKeyId::from_str(stored_key_id).map_err(|e| {
+            error!(
+                target: LOG_TARGET,
+                "Could not create {key_role}({stored_key_id}) from stored string ({e})"
+            );
+            OutputManagerStorageError::ConversionError {
+                reason: format!("{key_role}({stored_key_id}) could not be converted from string ({e})"),
+            }
+        })?;
+
+        Ok(Some(
+            key_manager
+                .convert_legacy_tari_key_id_to_current(&legacy)?
+                .to_string(),
+        ))
     }
 
     pub fn find_by_commitment_and_cancelled(

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -21,8 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![allow(clippy::indexing_slicing)]
-use std::convert::TryFrom;
+use std::{convert::TryFrom, str::FromStr};
 
+use diesel::prelude::*;
 use minotari_wallet::output_manager_service::{
     RangeLimit,
     UtxoSelectionCriteria,
@@ -33,16 +34,18 @@ use minotari_wallet::output_manager_service::{
         OutputStatus,
         database::{OutputManagerBackend, OutputManagerDatabase},
         models::DbWalletOutput,
-        sqlite_db::{OutputManagerSqliteDatabase, ReceivedOutputInfoForBatch, SpentOutputInfoForBatch},
+        sqlite_db::{OutputManagerSqliteDatabase, OutputSql, ReceivedOutputInfoForBatch, SpentOutputInfoForBatch},
     },
 };
+use minotari_wallet::schema::outputs;
 use rand::Rng;
+use tari_common_sqlite::sqlite_connection_pool::PooledDbConnection;
 use tari_common_types::{
     transaction::TxId,
     types::{FixedHash, HashOutput, PrivateKey},
 };
 use tari_crypto::keys::SecretKey;
-use tari_transaction_components::{MicroMinotari, transaction_components::OutputFeatures};
+use tari_transaction_components::{MicroMinotari, key_manager::TariKeyId, transaction_components::OutputFeatures};
 use tari_transaction_key_manager::legacy_key_manager::{
     LegacyTransactionKeyManagerInterface,
     create_new_random_key_manager,
@@ -386,6 +389,65 @@ pub async fn test_output_manager_sqlite_db() {
     let (connection, _tempdir) = get_temp_sqlite_database_connection();
 
     test_db_backend(OutputManagerSqliteDatabase::new(connection)).await;
+}
+
+#[tokio::test]
+pub async fn test_migrate_legacy_output_key_ids_persists_current_key_ids() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection.clone());
+    let db = OutputManagerDatabase::new(backend);
+    let key_manager = create_new_random_key_manager().await.unwrap();
+
+    let uo = make_input(
+        &mut rand::rng(),
+        MicroMinotari::from(100),
+        &OutputFeatures::default(),
+        key_manager.key_manager(),
+    );
+    let output = DbWalletOutput::from_wallet_output(uo, None, OutputSource::Standard, None, None);
+    let current_spending_key = output.wallet_output.commitment_mask_key_id().to_string();
+    let current_script_private_key = output.wallet_output.script_key_id().to_string();
+    let legacy_spending_key = key_manager
+        .convert_key_id_to_legacy_key_id(output.wallet_output.commitment_mask_key_id())
+        .to_string();
+    let legacy_script_private_key = key_manager
+        .convert_key_id_to_legacy_key_id(output.wallet_output.script_key_id())
+        .to_string();
+
+    db.add_unspent_output(output.clone(), &key_manager).unwrap();
+    db.mark_outputs_as_unspent(vec![(output.hash.clone(), true)]).unwrap();
+    {
+        let mut conn = connection.get_pooled_connection().unwrap();
+        diesel::update(outputs::table.filter(outputs::hash.eq(output.hash.to_vec())))
+            .set((
+                outputs::spending_key.eq(legacy_spending_key.clone()),
+                outputs::script_private_key.eq(legacy_script_private_key.clone()),
+            ))
+            .execute(&mut conn)
+            .unwrap();
+
+        let stored_output = OutputSql::find_by_hash(output.hash.as_slice(), OutputStatus::Unspent, &mut conn).unwrap();
+        assert_eq!(stored_output.spending_key, legacy_spending_key);
+        assert_eq!(stored_output.script_private_key, legacy_script_private_key);
+    }
+
+    let migrated_count = db.migrate_legacy_output_key_ids(&key_manager).unwrap();
+    assert_eq!(migrated_count, 1);
+
+    {
+        let mut conn = connection.get_pooled_connection().unwrap();
+        let stored_output = OutputSql::find_by_hash(output.hash.as_slice(), OutputStatus::Unspent, &mut conn).unwrap();
+        assert_eq!(stored_output.spending_key, current_spending_key);
+        assert_eq!(stored_output.script_private_key, current_script_private_key);
+        assert!(TariKeyId::from_str(&stored_output.spending_key).is_ok());
+        assert!(TariKeyId::from_str(&stored_output.script_private_key).is_ok());
+    }
+
+    let migrated_again_count = db.migrate_legacy_output_key_ids(&key_manager).unwrap();
+    assert_eq!(migrated_again_count, 0);
+
+    let fetched_output = db.fetch_by_commitment(output.commitment.clone(), &key_manager).unwrap();
+    assert_eq!(fetched_output.hash, output.hash);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #7829 by adding a startup migration path for legacy wallet output key ids.

This change:
- adds an output-manager startup hook that schedules legacy key migration without blocking wallet startup
- adds database methods for finding and updating legacy output key ids in batches
- converts legacy private keys through the existing key manager path before storing the current key id
- covers the sqlite migration path with an output manager storage test

## Verification

- `git diff --check origin/development...HEAD`

I could not run the Rust integration test suite locally in this Windows environment because `cargo`/`rustc` are not installed here. The PR includes a focused storage test for the migration behavior.

## Bounty

Submitting for the $70 bounty on #7829.