### PR TITLE
feat: add peer transport preference modes

### DIFF
--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -212,7 +212,7 @@ where B: BlockchainBackend + 'static
         )
         .await;
 
-        let comms = if p2p_config.transport.transport_type == TransportType::Tor {
+        let comms = if p2p_config.transport.transport_type.uses_tor_hidden_service() {
             let tor_id_path = base_node_config.tor_identity_file.clone();
             let node_id_path = base_node_config.identity_file.clone();
             let node_id = comms.node_identity();

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -66,10 +66,8 @@ use tari_comms::{
     transports::{
         HiddenServiceTransport,
         MemoryTransport,
-        SocksConfig,
         SocksTransport,
         TcpWithTorTransport,
-        predicate::FalsePredicate,
     },
     utils::cidr::parse_cidrs,
 };
@@ -233,16 +231,8 @@ pub async fn spawn_comms_using_transport<F: Fn(TorIdentity) + Send + Sync + Unpi
             let config = transport_config.tcp;
             debug!(target: LOG_TARGET, "Building TCP comms stack");
             let mut transport = TcpWithTorTransport::new();
-            if let Some(addr) = config.tor_socks_address {
-                transport.set_tor_socks_proxy(SocksConfig {
-                    proxy_address: addr,
-                    authentication: config.tor_socks_auth.into(),
-                    proxy_bypass_predicate: Arc::new(FalsePredicate::new()),
-                });
-            }
-            // Keep the explicit TCP mode limited to TCP peer addresses even when a legacy
-            // tor_socks_address is configured. Mixed TCP/Tor modes use the Tor hidden-service
-            // transport variants below.
+            // Keep the explicit TCP mode limited to TCP peer addresses. Mixed TCP/Tor modes
+            // use the Tor hidden-service transport variants below.
             transport.set_supported_protocols(TransportType::Tcp.get_supported_protocols());
             comms
                 .with_listener_address(config.listener_address)

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -63,12 +63,7 @@ use tari_comms::{
         rpc::RpcServer,
     },
     tor::{self, HiddenServiceControllerError, TorIdentity},
-    transports::{
-        HiddenServiceTransport,
-        MemoryTransport,
-        SocksTransport,
-        TcpWithTorTransport,
-    },
+    transports::{HiddenServiceTransport, MemoryTransport, SocksTransport, TcpWithTorTransport},
     utils::cidr::parse_cidrs,
 };
 use tari_comms_dht::{Dht, DhtInitializationError};

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -231,15 +231,7 @@ pub async fn spawn_comms_using_transport<F: Fn(TorIdentity) + Send + Sync + Unpi
         },
         TransportType::Tcp => {
             let config = transport_config.tcp;
-            debug!(
-                target: LOG_TARGET,
-                "Building TCP comms stack{}",
-                config
-                    .tor_socks_address
-                    .as_ref()
-                    .map(|_| " with Tor support")
-                    .unwrap_or("")
-            );
+            debug!(target: LOG_TARGET, "Building TCP comms stack");
             let mut transport = TcpWithTorTransport::new();
             if let Some(addr) = config.tor_socks_address {
                 transport.set_tor_socks_proxy(SocksConfig {
@@ -248,19 +240,25 @@ pub async fn spawn_comms_using_transport<F: Fn(TorIdentity) + Send + Sync + Unpi
                     proxy_bypass_predicate: Arc::new(FalsePredicate::new()),
                 });
             }
+            // Keep the explicit TCP mode limited to TCP peer addresses even when a legacy
+            // tor_socks_address is configured. Mixed TCP/Tor modes use the Tor hidden-service
+            // transport variants below.
+            transport.set_supported_protocols(TransportType::Tcp.get_supported_protocols());
             comms
                 .with_listener_address(config.listener_address)
                 .spawn_with_transport(transport)
                 .await?
         },
-        TransportType::Tor => {
+        TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor => {
+            let transport_type = transport_config.transport_type;
             let tor_config = transport_config.tor;
-            debug!(target: LOG_TARGET, "Building TOR comms stack ({tor_config:?})");
+            debug!(target: LOG_TARGET, "Building {transport_type:?} comms stack ({tor_config:?})");
             let listener_address_override = tor_config.listener_address_override.clone();
             let hidden_service_ctl = initialize_hidden_service(tor_config)?;
             // Set the listener address to be the address (usually local) to which tor will forward all traffic
             let instant = Instant::now();
-            let transport = HiddenServiceTransport::new(hidden_service_ctl, after_comms);
+            let transport = HiddenServiceTransport::new(hidden_service_ctl, after_comms)
+                .with_supported_protocols(transport_type.get_supported_protocols());
             debug!(target: LOG_TARGET, "TOR transport initialized in {:.0?}", instant.elapsed());
 
             comms

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -145,19 +145,23 @@ mod test {
 
     #[test]
     fn transport_modes_expose_expected_protocol_availability_and_order() {
-        assert_eq!(TransportType::Tor.get_supported_protocols(), vec![TransportProtocol::Onion]);
-        assert_eq!(
-            TransportType::Tcp.get_supported_protocols(),
-            vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6]
-        );
-        assert_eq!(
-            TransportType::TorTcp.get_supported_protocols(),
-            vec![TransportProtocol::Onion, TransportProtocol::Ipv4, TransportProtocol::Ipv6]
-        );
-        assert_eq!(
-            TransportType::TcpTor.get_supported_protocols(),
-            vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6, TransportProtocol::Onion]
-        );
+        assert_eq!(TransportType::Tor.get_supported_protocols(), vec![
+            TransportProtocol::Onion
+        ]);
+        assert_eq!(TransportType::Tcp.get_supported_protocols(), vec![
+            TransportProtocol::Ipv4,
+            TransportProtocol::Ipv6
+        ]);
+        assert_eq!(TransportType::TorTcp.get_supported_protocols(), vec![
+            TransportProtocol::Onion,
+            TransportProtocol::Ipv4,
+            TransportProtocol::Ipv6
+        ]);
+        assert_eq!(TransportType::TcpTor.get_supported_protocols(), vec![
+            TransportProtocol::Ipv4,
+            TransportProtocol::Ipv6,
+            TransportProtocol::Onion
+        ]);
     }
 
     #[test]

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -83,7 +83,7 @@ impl TransportConfig {
     }
 
     pub fn is_tor(&self) -> bool {
-        matches!(self.transport_type, TransportType::Tor)
+        self.transport_type.uses_tor_hidden_service()
     }
 }
 
@@ -92,26 +92,38 @@ impl TransportConfig {
 pub enum TransportType {
     /// Memory transport. Supports a single address type in the form '/memory/x' and can only communicate in-process.
     Memory,
-    /// Use TCP to join the Tari network. By default, this transport can only contact TCP/IP nodes, however it can be
-    /// configured to allow communication with peers using the tor transport.
+    /// Use only TCP peer addresses when selecting peers and dial addresses.
     Tcp,
-    /// Configures the node to run over a tor hidden service using the Tor proxy. This transport can connect to TCP/IP,
-    /// onion v3 and DNS addresses.
-    #[default]
+    /// Use only Tor onion peer addresses when selecting peers and dial addresses.
     Tor,
+    /// Enables both Tor and TCP peer addresses, preferring Tor when selecting dial addresses.
+    TorTcp,
+    /// Enables both TCP and Tor peer addresses, preferring TCP when selecting dial addresses.
+    #[default]
+    TcpTor,
     /// Use a SOCKS5 proxy transport. This transport allows any addresses supported by the proxy.
     Socks5,
 }
 
 impl TransportType {
+    pub fn uses_tor_hidden_service(&self) -> bool {
+        matches!(self, TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor)
+    }
+
     pub fn get_supported_protocols(&self) -> Vec<TransportProtocol> {
         match self {
             TransportType::Memory => vec![TransportProtocol::Memory],
             TransportType::Tcp => vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6],
-            TransportType::Tor => vec![
+            TransportType::Tor => vec![TransportProtocol::Onion],
+            TransportType::TorTcp => vec![
                 TransportProtocol::Onion,
                 TransportProtocol::Ipv4,
                 TransportProtocol::Ipv6,
+            ],
+            TransportType::TcpTor => vec![
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+                TransportProtocol::Onion,
             ],
             TransportType::Socks5 => vec![
                 TransportProtocol::Onion,
@@ -119,6 +131,41 @@ impl TransportType {
                 TransportProtocol::Ipv6,
             ],
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{TransportProtocol, TransportType};
+
+    #[test]
+    fn tcp_tor_is_the_default_peer_transport_mode() {
+        assert_eq!(TransportType::default(), TransportType::TcpTor);
+    }
+
+    #[test]
+    fn transport_modes_expose_expected_protocol_availability_and_order() {
+        assert_eq!(TransportType::Tor.get_supported_protocols(), vec![TransportProtocol::Onion]);
+        assert_eq!(
+            TransportType::Tcp.get_supported_protocols(),
+            vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6]
+        );
+        assert_eq!(
+            TransportType::TorTcp.get_supported_protocols(),
+            vec![TransportProtocol::Onion, TransportProtocol::Ipv4, TransportProtocol::Ipv6]
+        );
+        assert_eq!(
+            TransportType::TcpTor.get_supported_protocols(),
+            vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6, TransportProtocol::Onion]
+        );
+    }
+
+    #[test]
+    fn hidden_service_modes_are_tor_backed() {
+        assert!(TransportType::Tor.uses_tor_hidden_service());
+        assert!(TransportType::TorTcp.uses_tor_hidden_service());
+        assert!(TransportType::TcpTor.uses_tor_hidden_service());
+        assert!(!TransportType::Tcp.uses_tor_hidden_service());
     }
 }
 

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -185,21 +185,21 @@ listener_self_liveness_check_interval = 15
 
 [base_node.p2p.transport]
 # -------------- Transport configuration --------------
-# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
-# e.g. tor onion addresses will not be contactable. (default = "tor")
-#type = "tor"
+# Choose which peer address types to use and in which order to prefer them.
+# Options: "tor" (Tor only), "tcp" (TCP only), "tor_tcp" (both, prefer Tor), "tcp_tor" (both, prefer TCP).
+# (default = "tcp_tor")
+#type = "tcp_tor"
 
 # The address and port to listen for peer connections over TCP. (use: type = "tcp")
 #tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"
-# Configures a tor proxy used to connect to onion addresses. All other traffic uses direct TCP connections.
-# This setting is optional however, if it is not specified, this node will not be able to connect to nodes that
-# only advertise an onion address. (default = )
+# Configures a tor proxy available to the TCP transport. Mixed TCP/Tor peer selection uses the hidden-service
+# transport modes: type = "tor", "tor_tcp" or "tcp_tor". (default = none)
 #tcp.tor_socks_address =
 # Optional tor SOCKS proxy authentication (default = "none")
 #tcp.tor_socks_auth = "none"
 
-# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
-# onion v2, onion v3 and dns addresses. (use: type = "tor")
+# Configures the node to run over a tor hidden service using the Tor proxy. This is used by the "tor", "tor_tcp",
+# and "tcp_tor" transport modes.
 # Address of the tor control server
 #tor.control_address = "/ip4/127.0.0.1/tcp/9051"
 # SOCKS proxy auth (default = "none")

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -229,21 +229,21 @@ event_channel_size = 3500
 
 [wallet.p2p.transport]
 # -------------- Transport configuration --------------
-# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
-# e.g. tor onion addresses will not be contactable. (default = "tor")
-#type = "tor"
+# Choose which peer address types to use and in which order to prefer them.
+# Options: "tor" (Tor only), "tcp" (TCP only), "tor_tcp" (both, prefer Tor), "tcp_tor" (both, prefer TCP).
+# (default = "tcp_tor")
+#type = "tcp_tor"
 
 # The address and port to listen for peer connections over TCP. (use: type = "tcp")
 #tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"
-# Configures a tor proxy used to connect to onion addresses. All other traffic uses direct TCP connections.
-# This setting is optional however, if it is not specified, this node will not be able to connect to nodes that
-# only advertise an onion address. (default = )
+# Configures a tor proxy available to the TCP transport. Mixed TCP/Tor peer selection uses the hidden-service
+# transport modes: type = "tor", "tor_tcp" or "tcp_tor". (default = none)
 #tcp.tor_socks_address =
 # Optional tor SOCKS proxy authentication (default = "none")
 #tcp.tor_socks_auth = "none"
 
-# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
-# onion v2, onion v3 and dns addresses. (use: type = "tor")
+# Configures the node to run over a tor hidden service using the Tor proxy. This is used by the "tor", "tor_tcp",
+# and "tcp_tor" transport modes.
 # Address of the tor control server
 #tor.control_address = "/ip4/127.0.0.1/tcp/9051"
 # SOCKS proxy auth (default = "none")

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -64,7 +64,7 @@ use crate::{
     peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
     protocol::ProtocolId,
     transports::Transport,
-    types::CommsPublicKey,
+    types::{CommsPublicKey, TransportProtocol},
 };
 
 const LOG_TARGET: &str = "comms::connection_manager::dialer";
@@ -605,7 +605,7 @@ where
         let supported_transport_protocols = transport.supported_protocols();
         trace!(target: LOG_TARGET, "Supported transport protocols: {:?}", supported_transport_protocols);
 
-        let addresses = dial_state
+        let mut addresses = dial_state
             .peer()
             .addresses
             .clone()
@@ -617,6 +617,7 @@ where
             })
             .cloned()
             .collect::<Vec<_>>();
+        Self::sort_addresses_by_transport_preference(&mut addresses, &supported_transport_protocols);
 
         if addresses.is_empty() {
             let node_id_hex = dial_state.peer().node_id.clone().to_hex();
@@ -757,5 +758,18 @@ where
         }
 
         (dial_state, Err(ConnectionManagerError::DialConnectFailedAllAddresses))
+    }
+
+    fn sort_addresses_by_transport_preference(
+        addresses: &mut [Multiaddr],
+        supported_transport_protocols: &[TransportProtocol],
+    ) {
+        addresses.sort_by_key(|addr| {
+            let protocol = TransportProtocol::from(addr);
+            supported_transport_protocols
+                .iter()
+                .position(|supported| supported == &protocol)
+                .unwrap_or(usize::MAX)
+        });
     }
 }

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -760,7 +760,7 @@ where
         (dial_state, Err(ConnectionManagerError::DialConnectFailedAllAddresses))
     }
 
-    fn sort_addresses_by_transport_preference(
+    pub(super) fn sort_addresses_by_transport_preference(
         addresses: &mut [Multiaddr],
         supported_transport_protocols: &[TransportProtocol],
     ) {

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -22,7 +22,7 @@
 
 use std::{error::Error, time::Duration};
 
-use multiaddr::Protocol;
+use multiaddr::{Multiaddr, Protocol};
 use tari_shutdown::Shutdown;
 use tari_test_utils::unpack_enum;
 use tokio::{
@@ -48,7 +48,33 @@ use crate::{
     protocol::ProtocolId,
     test_utils::{build_peer_manager, node_identity::build_node_identity},
     transports::MemoryTransport,
+    types::TransportProtocol,
 };
+
+#[test]
+fn dial_addresses_follow_transport_preference_order() -> Result<(), Box<dyn Error>> {
+    let ip4: Multiaddr = "/ip4/127.0.0.1/tcp/18189".parse()?;
+    let ip6: Multiaddr = "/ip6/::1/tcp/18189".parse()?;
+    let onion: Multiaddr = "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:18189".parse()?;
+    let memory: Multiaddr = "/memory/1".parse()?;
+
+    let mut tcp_tor_addresses = vec![onion.clone(), memory.clone(), ip6.clone(), ip4.clone()];
+    Dialer::<MemoryTransport, ConstantBackoff>::sort_addresses_by_transport_preference(
+        &mut tcp_tor_addresses,
+        &[TransportProtocol::Ipv4, TransportProtocol::Ipv6, TransportProtocol::Onion],
+    );
+    assert_eq!(tcp_tor_addresses, vec![ip4.clone(), ip6.clone(), onion.clone(), memory.clone()]);
+
+    let mut tor_tcp_addresses = vec![ip4.clone(), memory.clone(), ip6.clone(), onion.clone()];
+    Dialer::<MemoryTransport, ConstantBackoff>::sort_addresses_by_transport_preference(
+        &mut tor_tcp_addresses,
+        &[TransportProtocol::Onion, TransportProtocol::Ipv4, TransportProtocol::Ipv6],
+    );
+    assert_eq!(tor_tcp_addresses, vec![onion, ip4, ip6, memory]);
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn listen() -> Result<(), Box<dyn Error>> {
     let (event_tx, _) = mpsc::channel(1);

--- a/comms/core/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/core/src/connection_manager/tests/listener_dialer.rs
@@ -59,17 +59,24 @@ fn dial_addresses_follow_transport_preference_order() -> Result<(), Box<dyn Erro
     let memory: Multiaddr = "/memory/1".parse()?;
 
     let mut tcp_tor_addresses = vec![onion.clone(), memory.clone(), ip6.clone(), ip4.clone()];
-    Dialer::<MemoryTransport, ConstantBackoff>::sort_addresses_by_transport_preference(
-        &mut tcp_tor_addresses,
-        &[TransportProtocol::Ipv4, TransportProtocol::Ipv6, TransportProtocol::Onion],
-    );
-    assert_eq!(tcp_tor_addresses, vec![ip4.clone(), ip6.clone(), onion.clone(), memory.clone()]);
+    Dialer::<MemoryTransport, ConstantBackoff>::sort_addresses_by_transport_preference(&mut tcp_tor_addresses, &[
+        TransportProtocol::Ipv4,
+        TransportProtocol::Ipv6,
+        TransportProtocol::Onion,
+    ]);
+    assert_eq!(tcp_tor_addresses, vec![
+        ip4.clone(),
+        ip6.clone(),
+        onion.clone(),
+        memory.clone()
+    ]);
 
     let mut tor_tcp_addresses = vec![ip4.clone(), memory.clone(), ip6.clone(), onion.clone()];
-    Dialer::<MemoryTransport, ConstantBackoff>::sort_addresses_by_transport_preference(
-        &mut tor_tcp_addresses,
-        &[TransportProtocol::Onion, TransportProtocol::Ipv4, TransportProtocol::Ipv6],
-    );
+    Dialer::<MemoryTransport, ConstantBackoff>::sort_addresses_by_transport_preference(&mut tor_tcp_addresses, &[
+        TransportProtocol::Onion,
+        TransportProtocol::Ipv4,
+        TransportProtocol::Ipv6,
+    ]);
     assert_eq!(tor_tcp_addresses, vec![onion, ip4, ip6, memory]);
 
     Ok(())

--- a/comms/core/src/transports/hidden_service_transport.rs
+++ b/comms/core/src/transports/hidden_service_transport.rs
@@ -63,6 +63,11 @@ impl<F: Fn(TorIdentity)> HiddenServiceTransport<F> {
         }
     }
 
+    pub fn with_supported_protocols(mut self, supported_protocols: Vec<TransportProtocol>) -> Self {
+        self.supported_protocols = supported_protocols;
+        self
+    }
+
     async fn is_initialized(&self) -> bool {
         self.inner.read().await.socks_transport.is_some()
     }

--- a/comms/core/src/transports/tcp_with_tor.rs
+++ b/comms/core/src/transports/tcp_with_tor.rs
@@ -74,6 +74,11 @@ impl TcpWithTorTransport {
     pub fn tcp_transport_mut(&mut self) -> &mut TcpTransport {
         &mut self.tcp_transport
     }
+
+    pub fn set_supported_protocols(&mut self, supported_protocols: Vec<TransportProtocol>) -> &mut Self {
+        self.supported_protocols = supported_protocols;
+        self
+    }
 }
 
 #[crate::async_trait]

--- a/infrastructure/libtor/src/tor.rs
+++ b/infrastructure/libtor/src/tor.rs
@@ -27,7 +27,7 @@ use libtor::{LogDestination, LogLevel, TorFlag};
 use log::*;
 use rand::{RngExt, distr::Alphanumeric};
 use tari_common::exit_codes::{ExitCode, ExitError};
-use tari_p2p::{TorControlAuthentication, TransportConfig, TransportType};
+use tari_p2p::{TorControlAuthentication, TransportConfig};
 use tor_hash_passwd::EncryptedKey;
 
 const LOG_TARGET: &str = "tari_libtor";
@@ -124,20 +124,17 @@ impl Tor {
 
     /// Override a given Tor comms transport with the control address and auth from this instance
     pub fn update_comms_transport(&self, transport: &mut TransportConfig) -> Result<(), ExitError> {
-        match transport.transport_type {
-            TransportType::Tor => {
-                if let Some(ref passphrase) = self.passphrase.0 {
-                    transport.tor.control_auth = TorControlAuthentication::Password(passphrase.to_owned());
-                }
-                transport.tor.control_address = format!("/ip4/127.0.0.1/tcp/{}", self.control_port).parse().unwrap();
-                debug!(target: LOG_TARGET, "updated comms transport: {transport:?}");
-                Ok(())
-            },
-            _ => {
-                let e = format!("Expected a TorHiddenService comms transport, received: {transport:?}");
-                Err(ExitError::new(ExitCode::ConfigError, e))
-            },
+        if !transport.transport_type.uses_tor_hidden_service() {
+            let e = format!("Expected a TorHiddenService comms transport, received: {transport:?}");
+            return Err(ExitError::new(ExitCode::ConfigError, e));
         }
+
+        if let Some(ref passphrase) = self.passphrase.0 {
+            transport.tor.control_auth = TorControlAuthentication::Password(passphrase.to_owned());
+        }
+        transport.tor.control_address = format!("/ip4/127.0.0.1/tcp/{}", self.control_port).parse().unwrap();
+        debug!(target: LOG_TARGET, "updated comms transport: {transport:?}");
+        Ok(())
     }
 
     /// Run the Tor instance in the background and return a handle to the thread.


### PR DESCRIPTION
Fixes #7830

## Summary
- add TorTcp and TcpTor peer transport modes, with TcpTor as the default
- restrict peer protocol availability per mode and apply transport preference order before dialing addresses
- add unit coverage for mode protocol order and dial address ordering
- add a Cucumber feature covering all four peer transport modes

## Validation
- git diff --check
- cargo fmt/test not run locally because this Windows environment does not have cargo/rustfmt installed