### PR TITLE
feat: add transport protocol preference modes

### DIFF
--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -212,7 +212,7 @@ where B: BlockchainBackend + 'static
         )
         .await;
 
-        let comms = if p2p_config.transport.transport_type == TransportType::Tor {
+        let comms = if p2p_config.transport.transport_type.uses_tor() {
             let tor_id_path = base_node_config.tor_identity_file.clone();
             let node_id_path = base_node_config.identity_file.clone();
             let node_id = comms.node_identity();

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -253,14 +253,19 @@ pub async fn spawn_comms_using_transport<F: Fn(TorIdentity) + Send + Sync + Unpi
                 .spawn_with_transport(transport)
                 .await?
         },
-        TransportType::Tor => {
+        TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor => {
             let tor_config = transport_config.tor;
             debug!(target: LOG_TARGET, "Building TOR comms stack ({tor_config:?})");
             let listener_address_override = tor_config.listener_address_override.clone();
+            let supported_protocols = transport_config.transport_type.get_supported_protocols();
             let hidden_service_ctl = initialize_hidden_service(tor_config)?;
             // Set the listener address to be the address (usually local) to which tor will forward all traffic
             let instant = Instant::now();
-            let transport = HiddenServiceTransport::new(hidden_service_ctl, after_comms);
+            let transport = HiddenServiceTransport::new_with_supported_protocols(
+                hidden_service_ctl,
+                after_comms,
+                supported_protocols,
+            );
             debug!(target: LOG_TARGET, "TOR transport initialized in {:.0?}", instant.elapsed());
 
             comms

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -83,7 +83,7 @@ impl TransportConfig {
     }
 
     pub fn is_tor(&self) -> bool {
-        matches!(self.transport_type, TransportType::Tor)
+        self.transport_type.uses_tor()
     }
 }
 
@@ -95,28 +95,42 @@ pub enum TransportType {
     /// Use TCP to join the Tari network. By default, this transport can only contact TCP/IP nodes, however it can be
     /// configured to allow communication with peers using the tor transport.
     Tcp,
-    /// Configures the node to run over a tor hidden service using the Tor proxy. This transport can connect to TCP/IP,
-    /// onion v3 and DNS addresses.
-    #[default]
+    /// Configures the node to run over a tor hidden service using the Tor proxy. This transport only contacts onion
+    /// addresses during peer selection.
     Tor,
+    /// Enables TCP and Tor peer addresses and prefers Tor addresses when both are available.
+    TorTcp,
+    /// Enables TCP and Tor peer addresses and prefers TCP addresses when both are available.
+    #[default]
+    TcpTor,
     /// Use a SOCKS5 proxy transport. This transport allows any addresses supported by the proxy.
     Socks5,
 }
 
 impl TransportType {
+    pub fn uses_tor(&self) -> bool {
+        matches!(self, TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor)
+    }
+
     pub fn get_supported_protocols(&self) -> Vec<TransportProtocol> {
         match self {
             TransportType::Memory => vec![TransportProtocol::Memory],
             TransportType::Tcp => vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6],
-            TransportType::Tor => vec![
+            TransportType::Tor => vec![TransportProtocol::Onion],
+            TransportType::TorTcp => vec![
                 TransportProtocol::Onion,
                 TransportProtocol::Ipv4,
                 TransportProtocol::Ipv6,
             ],
-            TransportType::Socks5 => vec![
-                TransportProtocol::Onion,
+            TransportType::TcpTor => vec![
                 TransportProtocol::Ipv4,
                 TransportProtocol::Ipv6,
+                TransportProtocol::Onion,
+            ],
+            TransportType::Socks5 => vec![
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+                TransportProtocol::Onion,
             ],
         }
     }
@@ -253,6 +267,48 @@ impl Default for MemoryTransportConfig {
     fn default() -> Self {
         Self {
             listener_address: "/memory/0".parse().unwrap(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tari_comms::types::TransportProtocol;
+
+    #[test]
+    fn default_transport_type_prefers_tcp_then_tor() {
+        assert_eq!(TransportType::default(), TransportType::TcpTor);
+    }
+
+    #[test]
+    fn transport_type_protocols_match_peer_selection_modes() {
+        let cases = [
+            (TransportType::Tor, vec![TransportProtocol::Onion]),
+            (
+                TransportType::Tcp,
+                vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6],
+            ),
+            (
+                TransportType::TorTcp,
+                vec![
+                    TransportProtocol::Onion,
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6,
+                ],
+            ),
+            (
+                TransportType::TcpTor,
+                vec![
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6,
+                    TransportProtocol::Onion,
+                ],
+            ),
+        ];
+
+        for (transport_type, expected_protocols) in cases {
+            assert_eq!(transport_type.get_supported_protocols(), expected_protocols);
         }
     }
 }

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -185,9 +185,10 @@ listener_self_liveness_check_interval = 15
 
 [base_node.p2p.transport]
 # -------------- Transport configuration --------------
-# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
-# e.g. tor onion addresses will not be contactable. (default = "tor")
-#type = "tor"
+# Select which peer address protocols are eligible and their preference order:
+# "tor" = onion only, "tcp" = TCP/IP only, "tor_tcp" = both preferring onion,
+# "tcp_tor" = both preferring TCP/IP. (default = "tcp_tor")
+#type = "tcp_tor"
 
 # The address and port to listen for peer connections over TCP. (use: type = "tcp")
 #tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"
@@ -198,8 +199,7 @@ listener_self_liveness_check_interval = 15
 # Optional tor SOCKS proxy authentication (default = "none")
 #tcp.tor_socks_auth = "none"
 
-# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
-# onion v2, onion v3 and dns addresses. (use: type = "tor")
+# Configures the node to run over a tor hidden service using the Tor proxy. Used by "tor", "tor_tcp" and "tcp_tor".
 # Address of the tor control server
 #tor.control_address = "/ip4/127.0.0.1/tcp/9051"
 # SOCKS proxy auth (default = "none")
@@ -441,4 +441,3 @@ excluded_dial_addresses = []
 # Range proof type for coinbase outputs produced by the XMRig proxy.
 # Valid values: "RevealedValue", "BulletProofPlus". (default = "RevealedValue")
 #xmrig_proxy_range_proof_type = "RevealedValue"
-

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -229,9 +229,10 @@ event_channel_size = 3500
 
 [wallet.p2p.transport]
 # -------------- Transport configuration --------------
-# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
-# e.g. tor onion addresses will not be contactable. (default = "tor")
-#type = "tor"
+# Select which peer address protocols are eligible and their preference order:
+# "tor" = onion only, "tcp" = TCP/IP only, "tor_tcp" = both preferring onion,
+# "tcp_tor" = both preferring TCP/IP. (default = "tcp_tor")
+#type = "tcp_tor"
 
 # The address and port to listen for peer connections over TCP. (use: type = "tcp")
 #tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"
@@ -242,8 +243,7 @@ event_channel_size = 3500
 # Optional tor SOCKS proxy authentication (default = "none")
 #tcp.tor_socks_auth = "none"
 
-# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
-# onion v2, onion v3 and dns addresses. (use: type = "tor")
+# Configures the node to run over a tor hidden service using the Tor proxy. Used by "tor", "tor_tcp" and "tcp_tor".
 # Address of the tor control server
 #tor.control_address = "/ip4/127.0.0.1/tcp/9051"
 # SOCKS proxy auth (default = "none")

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -64,7 +64,7 @@ use crate::{
     peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
     protocol::ProtocolId,
     transports::Transport,
-    types::CommsPublicKey,
+    types::{CommsPublicKey, TransportProtocol},
 };
 
 const LOG_TARGET: &str = "comms::connection_manager::dialer";
@@ -79,6 +79,27 @@ type DialFuturesUnordered = FuturesUnordered<
         ),
     >,
 >;
+
+fn select_dial_addresses(
+    peer_addresses: &[Multiaddr],
+    supported_transport_protocols: &[TransportProtocol],
+    excluded_dial_addresses: &[MultiaddrRange],
+) -> Vec<Multiaddr> {
+    supported_transport_protocols
+        .iter()
+        .flat_map(|protocol| {
+            peer_addresses
+                .iter()
+                .filter(move |address| {
+                    TransportProtocol::from(*address) == *protocol &&
+                        !excluded_dial_addresses
+                            .iter()
+                            .any(|excluded| excluded.contains(address))
+                })
+                .cloned()
+        })
+        .collect()
+}
 
 #[derive(Debug)]
 pub(crate) enum DialerRequest {
@@ -605,18 +626,12 @@ where
         let supported_transport_protocols = transport.supported_protocols();
         trace!(target: LOG_TARGET, "Supported transport protocols: {:?}", supported_transport_protocols);
 
-        let addresses = dial_state
-            .peer()
-            .addresses
-            .clone()
-            .into_vec()
-            .iter()
-            .filter(|&a| {
-                !excluded_dial_addresses.iter().any(|excluded| excluded.contains(a)) &&
-                    supported_transport_protocols.contains(a.into())
-            })
-            .cloned()
-            .collect::<Vec<_>>();
+        let peer_addresses = dial_state.peer().addresses.clone().into_vec();
+        let addresses = select_dial_addresses(
+            &peer_addresses,
+            &supported_transport_protocols,
+            &excluded_dial_addresses,
+        );
 
         if addresses.is_empty() {
             let node_id_hex = dial_state.peer().node_id.clone().to_hex();
@@ -757,5 +772,53 @@ where
         }
 
         (dial_state, Err(ConnectionManagerError::DialConnectFailedAllAddresses))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::types::TransportProtocol;
+
+    fn addr(value: &str) -> Multiaddr {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn select_dial_addresses_follows_transport_protocol_preference() {
+        let tcp = addr("/ip4/127.0.0.1/tcp/18189");
+        let ipv6 = addr("/ip6/::1/tcp/18189");
+        let onion = addr("/onion3/b5zgqd6emm6p2zmj7gdniysbxvmtvltrwshsyfxjoq26xqfjoicge5id:18141");
+        let peer_addresses = vec![tcp.clone(), onion.clone(), ipv6.clone()];
+        let excluded = vec![];
+
+        assert_eq!(
+            select_dial_addresses(
+                &peer_addresses,
+                &[
+                    TransportProtocol::Onion,
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6,
+                ],
+                &excluded,
+            ),
+            vec![onion.clone(), tcp.clone(), ipv6.clone()],
+        );
+        assert_eq!(
+            select_dial_addresses(
+                &peer_addresses,
+                &[
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6,
+                    TransportProtocol::Onion,
+                ],
+                &excluded,
+            ),
+            vec![tcp.clone(), ipv6.clone(), onion.clone()],
+        );
+        assert_eq!(
+            select_dial_addresses(&peer_addresses, &[TransportProtocol::Onion], &excluded),
+            vec![onion],
+        );
     }
 }

--- a/comms/core/src/transports/hidden_service_transport.rs
+++ b/comms/core/src/transports/hidden_service_transport.rs
@@ -53,6 +53,17 @@ impl<F: Fn(TorIdentity)> HiddenServiceTransport<F> {
         if supports_ipv6() {
             supported_protocols.push(TransportProtocol::Ipv6);
         }
+        Self::new_with_supported_protocols(hidden_service_ctl, after_init, supported_protocols)
+    }
+
+    pub fn new_with_supported_protocols(
+        hidden_service_ctl: HiddenServiceController,
+        after_init: F,
+        mut supported_protocols: Vec<TransportProtocol>,
+    ) -> Self {
+        if !supports_ipv6() {
+            supported_protocols.retain(|protocol| protocol != &TransportProtocol::Ipv6);
+        }
         Self {
             inner: Arc::new(RwLock::new(HiddenServiceTransportInner {
                 socks_transport: None,

--- a/infrastructure/libtor/src/tor.rs
+++ b/infrastructure/libtor/src/tor.rs
@@ -125,7 +125,7 @@ impl Tor {
     /// Override a given Tor comms transport with the control address and auth from this instance
     pub fn update_comms_transport(&self, transport: &mut TransportConfig) -> Result<(), ExitError> {
         match transport.transport_type {
-            TransportType::Tor => {
+            TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor => {
                 if let Some(ref passphrase) = self.passphrase.0 {
                     transport.tor.control_auth = TorControlAuthentication::Password(passphrase.to_owned());
                 }

--- a/integration_tests/tests/features/TransportSelection.feature
+++ b/integration_tests/tests/features/TransportSelection.feature
@@ -1,0 +1,17 @@
+# Copyright 2026 The Tari Project
+# SPDX-License-Identifier: BSD-3-Clause
+
+Feature: Transport peer selection
+
+    Scenario Outline: Transport mode controls peer protocol preference
+        Then peer selection for transport mode <mode> prefers protocols "<protocols>"
+
+        Examples:
+            | mode    | protocols    |
+            | tor     | onion        |
+            | tcp     | ip4,ip6      |
+            | tor_tcp | onion,ip4,ip6 |
+            | tcp_tor | ip4,ip6,onion |
+
+    Scenario: Default peer transport prefers TCP then Tor
+        Then default peer transport mode is tcp_tor

--- a/integration_tests/tests/steps/mod.rs
+++ b/integration_tests/tests/steps/mod.rs
@@ -29,7 +29,9 @@ use std::{
 
 use chrono::Local;
 use cucumber::{then, when};
+use tari_comms::types::TransportProtocol;
 use tari_integration_tests::TariWorld;
+use tari_p2p::TransportType;
 
 pub mod merge_mining_steps;
 pub mod mining_steps;
@@ -71,6 +73,42 @@ pub fn cucumber_steps_log<S: AsRef<str>>(log_message: S) {
     let mut file = OpenOptions::new().create(true).append(true).open(log_file).unwrap();
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
     writeln!(file, "[{}] {}", timestamp, log_message.as_ref()).unwrap();
+}
+
+fn parse_transport_type(value: &str) -> TransportType {
+    match value {
+        "tor" => TransportType::Tor,
+        "tcp" => TransportType::Tcp,
+        "tor_tcp" => TransportType::TorTcp,
+        "tcp_tor" => TransportType::TcpTor,
+        other => panic!("Unsupported transport mode '{other}'"),
+    }
+}
+
+fn parse_transport_protocols(value: &str) -> Vec<TransportProtocol> {
+    value
+        .split(',')
+        .map(|protocol| protocol.trim())
+        .map(|protocol| match protocol {
+            "ip4" => TransportProtocol::Ipv4,
+            "ip6" => TransportProtocol::Ipv6,
+            "onion" => TransportProtocol::Onion,
+            other => panic!("Unsupported transport protocol '{other}'"),
+        })
+        .collect()
+}
+
+#[then(expr = "peer selection for transport mode {word} prefers protocols {string}")]
+async fn peer_selection_for_transport_mode_prefers_protocols(_world: &mut TariWorld, mode: String, protocols: String) {
+    let transport_type = parse_transport_type(&mode);
+    let expected_protocols = parse_transport_protocols(&protocols);
+
+    assert_eq!(transport_type.get_supported_protocols(), expected_protocols);
+}
+
+#[then(expr = "default peer transport mode is {word}")]
+async fn default_peer_transport_mode_is(_world: &mut TariWorld, mode: String) {
+    assert_eq!(TransportType::default(), parse_transport_type(&mode));
 }
 
 pub fn get_saved_seed_words(world: &mut TariWorld, wallet_name: &str) -> Vec<String> {


### PR DESCRIPTION
Fixes #7830.

## Summary

- Add `tor_tcp` and `tcp_tor` transport modes alongside `tor` and `tcp`.
- Make `tcp_tor` the default transport mode.
- Use the transport protocol list as the dial preference order when selecting peer addresses.
- Pass the selected protocol order into the hidden service transport so Tor-only, Tor-preferred and TCP-preferred modes are reflected in peer selection.
- Add unit and Cucumber coverage for the four public peer selection modes.

## Notes

`memory` and `socks5` are left in place for existing in-process test transport and proxy transport support. The four public peer selection modes requested by the bounty are covered by `tor`, `tcp`, `tor_tcp`, and `tcp_tor`.

Payout details can be provided on acceptance.

## Validation

- `cargo +1.93.0 test -p tari_p2p transport_type -- --nocapture`
- `cargo +1.93.0 test -p tari_comms select_dial_addresses -- --nocapture`
- `cargo +1.93.0 check -p tari_p2p -p tari_comms`
- `cargo +1.93.0 check -p tari_integration_tests --test cucumber`
- `git diff --check`
