### PR TITLE
[codex] Implement transport peer selection modes

### DIFF
--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -212,7 +212,7 @@ where B: BlockchainBackend + 'static
         )
         .await;
 
-        let comms = if p2p_config.transport.transport_type == TransportType::Tor {
+        let comms = if p2p_config.transport.transport_type.uses_tor_transport() {
             let tor_id_path = base_node_config.tor_identity_file.clone();
             let node_id_path = base_node_config.identity_file.clone();
             let node_id = comms.node_identity();

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -253,7 +253,7 @@ pub async fn spawn_comms_using_transport<F: Fn(TorIdentity) + Send + Sync + Unpi
                 .spawn_with_transport(transport)
                 .await?
         },
-        TransportType::Tor => {
+        TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor => {
             let tor_config = transport_config.tor;
             debug!(target: LOG_TARGET, "Building TOR comms stack ({tor_config:?})");
             let listener_address_override = tor_config.listener_address_override.clone();

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -83,7 +83,7 @@ impl TransportConfig {
     }
 
     pub fn is_tor(&self) -> bool {
-        matches!(self.transport_type, TransportType::Tor)
+        self.transport_type.uses_tor_transport()
     }
 }
 
@@ -92,26 +92,38 @@ impl TransportConfig {
 pub enum TransportType {
     /// Memory transport. Supports a single address type in the form '/memory/x' and can only communicate in-process.
     Memory,
-    /// Use TCP to join the Tari network. By default, this transport can only contact TCP/IP nodes, however it can be
-    /// configured to allow communication with peers using the tor transport.
+    /// Use TCP only to join the Tari network.
     Tcp,
-    /// Configures the node to run over a tor hidden service using the Tor proxy. This transport can connect to TCP/IP,
-    /// onion v3 and DNS addresses.
-    #[default]
+    /// Configures the node to run over a Tor hidden service and select Tor peers only.
     Tor,
+    /// Enables Tor and TCP peer selection, preferring Tor peers and Tor dial addresses.
+    TorTcp,
+    /// Enables TCP and Tor peer selection, preferring TCP peers and TCP dial addresses.
+    #[default]
+    TcpTor,
     /// Use a SOCKS5 proxy transport. This transport allows any addresses supported by the proxy.
     Socks5,
 }
 
 impl TransportType {
+    pub fn uses_tor_transport(&self) -> bool {
+        matches!(self, TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor)
+    }
+
     pub fn get_supported_protocols(&self) -> Vec<TransportProtocol> {
         match self {
             TransportType::Memory => vec![TransportProtocol::Memory],
             TransportType::Tcp => vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6],
-            TransportType::Tor => vec![
+            TransportType::Tor => vec![TransportProtocol::Onion],
+            TransportType::TorTcp => vec![
                 TransportProtocol::Onion,
                 TransportProtocol::Ipv4,
                 TransportProtocol::Ipv6,
+            ],
+            TransportType::TcpTor => vec![
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+                TransportProtocol::Onion,
             ],
             TransportType::Socks5 => vec![
                 TransportProtocol::Onion,
@@ -254,5 +266,58 @@ impl Default for MemoryTransportConfig {
         Self {
             listener_address: "/memory/0".parse().unwrap(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tari_comms::types::TransportProtocol;
+
+    #[test]
+    fn transport_type_defines_peer_selection_modes_and_default() {
+        assert_eq!(TransportType::default(), TransportType::TcpTor);
+        assert_eq!(
+            TransportType::Tor.get_supported_protocols(),
+            vec![TransportProtocol::Onion]
+        );
+        assert_eq!(
+            TransportType::Tcp.get_supported_protocols(),
+            vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6]
+        );
+        assert_eq!(
+            TransportType::TorTcp.get_supported_protocols(),
+            vec![
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6
+            ]
+        );
+        assert_eq!(
+            TransportType::TcpTor.get_supported_protocols(),
+            vec![
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+                TransportProtocol::Onion
+            ]
+        );
+    }
+
+    #[test]
+    fn transport_type_deserializes_new_peer_selection_modes() {
+        #[derive(Deserialize)]
+        struct Config {
+            #[serde(rename = "type")]
+            transport_type: TransportType,
+        }
+
+        assert_eq!(
+            toml::from_str::<Config>("type = \"tor_tcp\"").unwrap().transport_type,
+            TransportType::TorTcp
+        );
+        assert_eq!(
+            toml::from_str::<Config>("type = \"tcp_tor\"").unwrap().transport_type,
+            TransportType::TcpTor
+        );
     }
 }

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -185,9 +185,8 @@ listener_self_liveness_check_interval = 15
 
 [base_node.p2p.transport]
 # -------------- Transport configuration --------------
-# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
-# e.g. tor onion addresses will not be contactable. (default = "tor")
-#type = "tor"
+# Peer selection mode. Options are "tor", "tcp", "tor_tcp" and "tcp_tor". (default = "tcp_tor")
+#type = "tcp_tor"
 
 # The address and port to listen for peer connections over TCP. (use: type = "tcp")
 #tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"
@@ -441,4 +440,3 @@ excluded_dial_addresses = []
 # Range proof type for coinbase outputs produced by the XMRig proxy.
 # Valid values: "RevealedValue", "BulletProofPlus". (default = "RevealedValue")
 #xmrig_proxy_range_proof_type = "RevealedValue"
-

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -229,9 +229,8 @@ event_channel_size = 3500
 
 [wallet.p2p.transport]
 # -------------- Transport configuration --------------
-# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
-# e.g. tor onion addresses will not be contactable. (default = "tor")
-#type = "tor"
+# Peer selection mode. Options are "tor", "tcp", "tor_tcp" and "tcp_tor". (default = "tcp_tor")
+#type = "tcp_tor"
 
 # The address and port to listen for peer connections over TCP. (use: type = "tcp")
 #tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -323,6 +323,7 @@ impl CommsBuilder {
     /// Set the transport protocols to use for communication
     /// if not provided defaults to IP4, IP6, TOR and memory address
     pub fn with_transport_protocols(mut self, protocols: Vec<TransportProtocol>) -> Self {
+        self.connection_manager_config.transport_protocols = protocols.clone();
         self.transport_protocols = protocols;
         self
     }

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -64,7 +64,7 @@ use crate::{
     peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
     protocol::ProtocolId,
     transports::Transport,
-    types::CommsPublicKey,
+    types::{CommsPublicKey, TransportProtocol},
 };
 
 const LOG_TARGET: &str = "comms::connection_manager::dialer";
@@ -535,6 +535,7 @@ where
                         &noise_config,
                         &current_transport,
                         config.network_info.network_wire_byte,
+                        config.transport_protocols.clone(),
                         config.excluded_dial_addresses.clone(),
                     )
                     .await
@@ -597,6 +598,7 @@ where
         noise_config: &NoiseConfig,
         transport: &TTransport,
         network_byte: u8,
+        transport_protocols: Vec<TransportProtocol>,
         excluded_dial_addresses: Vec<MultiaddrRange>,
     ) -> (
         DialState,
@@ -605,18 +607,12 @@ where
         let supported_transport_protocols = transport.supported_protocols();
         trace!(target: LOG_TARGET, "Supported transport protocols: {:?}", supported_transport_protocols);
 
-        let addresses = dial_state
-            .peer()
-            .addresses
-            .clone()
-            .into_vec()
-            .iter()
-            .filter(|&a| {
-                !excluded_dial_addresses.iter().any(|excluded| excluded.contains(a)) &&
-                    supported_transport_protocols.contains(a.into())
-            })
-            .cloned()
-            .collect::<Vec<_>>();
+        let addresses = Self::select_dial_addresses(
+            dial_state.peer(),
+            &supported_transport_protocols,
+            &transport_protocols,
+            &excluded_dial_addresses,
+        );
 
         if addresses.is_empty() {
             let node_id_hex = dial_state.peer().node_id.clone().to_hex();
@@ -757,5 +753,135 @@ where
         }
 
         (dial_state, Err(ConnectionManagerError::DialConnectFailedAllAddresses))
+    }
+
+    fn select_dial_addresses(
+        peer: &Peer,
+        supported_transport_protocols: &[TransportProtocol],
+        preferred_transport_protocols: &[TransportProtocol],
+        excluded_dial_addresses: &[MultiaddrRange],
+    ) -> Vec<Multiaddr> {
+        let preferred_transport_protocols =
+            Self::effective_transport_protocols(supported_transport_protocols, preferred_transport_protocols);
+        let addresses = peer
+            .addresses
+            .addresses()
+            .iter()
+            .filter_map(|address| {
+                let address = address.address();
+                let protocol = TransportProtocol::from(address);
+                if !excluded_dial_addresses
+                    .iter()
+                    .any(|excluded| excluded.contains(address))
+                    && preferred_transport_protocols.contains(&protocol)
+                {
+                    Some(address.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        TransportProtocol::sort_multiaddrs_by_preference(addresses, &preferred_transport_protocols)
+    }
+
+    fn effective_transport_protocols(
+        supported_transport_protocols: &[TransportProtocol],
+        preferred_transport_protocols: &[TransportProtocol],
+    ) -> Vec<TransportProtocol> {
+        let protocols = preferred_transport_protocols
+            .iter()
+            .copied()
+            .filter(|protocol| supported_transport_protocols.contains(protocol))
+            .collect::<Vec<_>>();
+
+        if protocols.is_empty() {
+            supported_transport_protocols.to_vec()
+        } else {
+            protocols
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        backoff::ConstantBackoff,
+        connection_manager::tests::create_test_peer,
+        net_address::{MultiaddressesWithStats, PeerAddressSource},
+        transports::MemoryTransport,
+    };
+
+    #[test]
+    fn select_dial_addresses_applies_transport_protocol_preference() {
+        let onion = format!("/onion3/{}:18141", "d".repeat(56))
+            .parse::<Multiaddr>()
+            .unwrap();
+        let ipv4 = "/ip4/8.8.8.8/tcp/18189".parse::<Multiaddr>().unwrap();
+        let ipv6 = "/ip6/::1/tcp/18189".parse::<Multiaddr>().unwrap();
+
+        let mut peer = create_test_peer();
+        peer.addresses = MultiaddressesWithStats::from_addresses_with_source(
+            vec![ipv4.clone(), onion.clone(), ipv6.clone()],
+            &PeerAddressSource::Config,
+        );
+
+        let tor_preferred = Dialer::<MemoryTransport, ConstantBackoff>::select_dial_addresses(
+            &peer,
+            &[
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+            ],
+            &[
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+            ],
+            &[],
+        );
+        assert_eq!(tor_preferred, vec![onion.clone(), ipv4.clone(), ipv6.clone()]);
+
+        let tcp_preferred = Dialer::<MemoryTransport, ConstantBackoff>::select_dial_addresses(
+            &peer,
+            &[
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+            ],
+            &[
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+                TransportProtocol::Onion,
+            ],
+            &[],
+        );
+
+        let tor_only = Dialer::<MemoryTransport, ConstantBackoff>::select_dial_addresses(
+            &peer,
+            &[
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+            ],
+            &[TransportProtocol::Onion],
+            &[],
+        );
+        assert_eq!(tor_only, vec![onion.clone()]);
+
+        let tcp_only = Dialer::<MemoryTransport, ConstantBackoff>::select_dial_addresses(
+            &peer,
+            &[
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+            ],
+            &[TransportProtocol::Ipv4, TransportProtocol::Ipv6],
+            &[],
+        );
+        assert_eq!(tcp_only, vec![ipv4.clone(), ipv6.clone()]);
+
+        assert_eq!(tcp_preferred, vec![ipv4, ipv6, onion]);
     }
 }

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -57,6 +57,7 @@ use crate::{
     peer_validator::PeerValidatorConfig,
     protocol::{NodeNetworkInfo, ProtocolEvent, ProtocolId, Protocols},
     transports::{TcpTransport, Transport},
+    types::TransportProtocol,
 };
 
 const LOG_TARGET: &str = "comms::connection_manager::manager";
@@ -139,6 +140,8 @@ pub struct ConnectionManagerConfig {
     pub peer_validation_config: PeerValidatorConfig,
     /// Addresses that should never be dialed
     pub excluded_dial_addresses: Vec<MultiaddrRange>,
+    /// Transport protocols allowed for peer dialing, ordered by selection preference.
+    pub transport_protocols: Vec<TransportProtocol>,
 }
 
 impl Default for ConnectionManagerConfig {
@@ -162,6 +165,7 @@ impl Default for ConnectionManagerConfig {
             noise_handshake_recv_timeout: Duration::from_secs(6),
             noise_dial_timeout: Duration::from_secs(60),
             excluded_dial_addresses: vec![],
+            transport_protocols: TransportProtocol::get_all(),
         }
     }
 }

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -20,7 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{cmp::min, collections::HashMap, str::FromStr, time::Duration};
+use std::{
+    cmp::min,
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    time::Duration,
+};
 
 use bytes::Bytes;
 use chrono::{NaiveDateTime, TimeDelta};
@@ -59,6 +64,7 @@ use crate::{
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./src/peer_manager/storage/migrations");
 const LOG_TARGET: &str = "comms::peer_manager::storage::db";
+const MAX_MULTIADDRESSES_PER_PEER: usize = 10;
 
 /// This peer's identity information
 #[derive(Clone)]
@@ -875,14 +881,18 @@ impl PeerDatabaseSql {
                 PeerFeatures::COMMUNICATION_NODE.to_i32()
             )))
             .select(peers::node_id)
-            .distinct()
             .into_boxed();
 
         if exclude_failed {
             query = query.filter(multi_addresses::last_failed_reason.is_null());
         }
 
-        if randomize {
+        if let Some(order_sql) = Self::build_addr_preference_order_sql(transport_protocols) {
+            query = query.order_by(diesel::dsl::sql::<diesel::sql_types::Integer>(&order_sql));
+            if randomize {
+                query = query.then_order_by(diesel::dsl::sql::<diesel::sql_types::Integer>("RANDOM()"));
+            }
+        } else if randomize {
             query = query.order_by(diesel::dsl::sql::<diesel::sql_types::Integer>("RANDOM()"));
         }
 
@@ -896,14 +906,11 @@ impl PeerDatabaseSql {
             query = query.filter(peers::node_id.ne_all(excluded_hex_ids));
         }
 
-        // Apply limit if specified
-        if let Some(limit) = n {
-            // Safely convert usize to i64, using try_into with fallback to i64::MAX
-            let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
-            query = query.limit(limit_i64);
+        if let Some(limit) = Self::unique_node_id_row_limit(n) {
+            query = query.limit(limit);
         }
 
-        let node_ids = query.load::<String>(&mut conn)?;
+        let node_ids = Self::unique_node_ids_preserving_order(query.load::<String>(&mut conn)?, n);
 
         if node_ids.is_empty() {
             return Ok(Vec::new());
@@ -912,7 +919,13 @@ impl PeerDatabaseSql {
         // A peer can have more than one valid address, so that if the join-limit-load query is not returning node IDs,
         // it will give the requested number of unique peer-adress combinations, which will result in less peer records
         // than what was required. For that reason, we need a 2nd query to fetch the peers by node IDs.
-        self.get_peers_by_node_ids_str(&node_ids, false, &mut conn)
+        let mut peers = self.get_peers_by_node_ids_str(&node_ids, false, &mut conn)?;
+        Self::order_peers_by_node_id_order(&mut peers, &node_ids);
+        Self::sort_peers_by_transport_preference(&mut peers, transport_protocols);
+        if let Some(limit) = n {
+            peers.truncate(limit);
+        }
+        Ok(peers)
     }
 
     /// Get a peer by its node ID
@@ -1218,12 +1231,16 @@ impl PeerDatabaseSql {
                     PeerFeatures::COMMUNICATION_NODE.to_i32()
                 )))
                 .filter(peers::node_id.ne_all(exclude_node_ids))
-                .order_by(diesel::dsl::sql::<diesel::sql_types::Integer>("RANDOM()"))
-                .limit(i64::try_from(n).unwrap_or(i64::MAX))
                 .select(peers::node_id)
-                .distinct()
                 .into_boxed();
 
+            if let Some(order_sql) = Self::build_addr_preference_order_sql(transport_protocols) {
+                query = query
+                    .order_by(diesel::dsl::sql::<diesel::sql_types::Integer>(&order_sql))
+                    .then_order_by(diesel::dsl::sql::<diesel::sql_types::Integer>("RANDOM()"));
+            } else {
+                query = query.order_by(diesel::dsl::sql::<diesel::sql_types::Integer>("RANDOM()"));
+            }
             if known_good {
                 query = query.filter(multi_addresses::last_seen.is_not_null());
             }
@@ -1235,14 +1252,22 @@ impl PeerDatabaseSql {
                 query = query.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(&filter_sql));
             }
 
-            let node_ids: Vec<String> = query.load::<String>(conn)?;
+            if let Some(limit) = Self::unique_node_id_row_limit(Some(n)) {
+                query = query.limit(limit);
+            }
+
+            let node_ids = Self::unique_node_ids_preserving_order(query.load::<String>(conn)?, Some(n));
 
             if node_ids.is_empty() {
                 return Ok(Vec::new());
             }
 
             // Step 2: Load full peer + addresses only for selected node_ids
-            self.get_peers_by_node_ids_str(&node_ids, true, conn)
+            let mut peers = self.get_peers_by_node_ids_str(&node_ids, true, conn)?;
+            Self::order_peers_by_node_id_order(&mut peers, &node_ids);
+            Self::sort_peers_by_transport_preference(&mut peers, transport_protocols);
+            peers.truncate(n);
+            Ok(peers)
         })
     }
 
@@ -1290,6 +1315,76 @@ impl PeerDatabaseSql {
             .collect();
 
         Some(format!("({})", conditions.join(" OR ")))
+    }
+
+    fn build_addr_preference_order_sql(transport_protocols: &[TransportProtocol]) -> Option<String> {
+        if transport_protocols.is_empty() {
+            return None;
+        }
+
+        let conditions = transport_protocols
+            .iter()
+            .enumerate()
+            .map(|(index, protocol)| {
+                format!(
+                    "WHEN multi_addresses.address LIKE '{}%' THEN {}",
+                    sql_escape(protocol.get_prefix()),
+                    index
+                )
+            })
+            .collect::<Vec<_>>();
+
+        Some(format!("CASE {} ELSE {} END", conditions.join(" "), transport_protocols.len()))
+    }
+
+    fn order_peers_by_node_id_order(peers: &mut [Peer], node_ids: &[String]) {
+        let node_id_positions = node_ids
+            .iter()
+            .enumerate()
+            .map(|(index, node_id)| (node_id.clone(), index))
+            .collect::<HashMap<_, _>>();
+
+        peers.sort_by_cached_key(|peer| {
+            node_id_positions
+                .get(&peer.node_id.to_hex())
+                .copied()
+                .unwrap_or(usize::MAX)
+        });
+    }
+
+    fn unique_node_ids_preserving_order(node_ids: Vec<String>, limit: Option<usize>) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut unique_node_ids = Vec::new();
+
+        for node_id in node_ids {
+            if seen.insert(node_id.clone()) {
+                unique_node_ids.push(node_id);
+                if limit.is_some_and(|limit| unique_node_ids.len() >= limit) {
+                    break;
+                }
+            }
+        }
+
+        unique_node_ids
+    }
+
+    fn unique_node_id_row_limit(limit: Option<usize>) -> Option<i64> {
+        limit
+            .map(|limit| limit.saturating_mul(MAX_MULTIADDRESSES_PER_PEER))
+            .map(|limit| i64::try_from(limit).unwrap_or(i64::MAX))
+    }
+
+    fn sort_peers_by_transport_preference(peers: &mut [Peer], transport_protocols: &[TransportProtocol]) {
+        peers.sort_by_key(|peer| Self::peer_transport_preference_rank(peer, transport_protocols));
+    }
+
+    fn peer_transport_preference_rank(peer: &Peer, transport_protocols: &[TransportProtocol]) -> usize {
+        peer.addresses
+            .addresses()
+            .iter()
+            .filter_map(|address| TransportProtocol::preference_index(address.address(), transport_protocols))
+            .min()
+            .unwrap_or(usize::MAX)
     }
 }
 
@@ -1587,6 +1682,16 @@ mod tests {
         types::{CommsPublicKey, TransportProtocol},
     };
 
+    fn create_test_peer_with_addresses(addresses: Vec<&str>) -> Peer {
+        let mut peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let addresses = addresses
+            .into_iter()
+            .map(|address| address.parse::<Multiaddr>().unwrap())
+            .collect::<Vec<_>>();
+        peer.addresses = MultiaddressesWithStats::from_addresses_with_source(addresses, &PeerAddressSource::Config);
+        peer
+    }
+
     #[test]
     fn test_add_update_peer_with_addresses() {
         let db_connection = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
@@ -1727,6 +1832,67 @@ mod tests {
             .get_n_random_active_peers(100, &[], None, None, None, false, &[TransportProtocol::Onion])
             .unwrap();
         assert_eq!(node_with_onion_addresses.len(), 1);
+    }
+
+    #[test]
+    fn test_dial_candidate_selection_applies_transport_protocol_preference() {
+        let db_connection = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
+        let peers_db = PeerDatabaseSql::new(
+            db_connection,
+            &create_test_peer(false, PeerFeatures::COMMUNICATION_NODE),
+        )
+        .unwrap();
+
+        let tcp_peer = create_test_peer_with_addresses(vec!["/ip4/8.8.8.8/tcp/18189"]);
+        let onion_peer = create_test_peer_with_addresses(vec![&format!("/onion3/{}:18141", "b".repeat(56))]);
+        peers_db.add_or_update_peer(tcp_peer.clone()).unwrap();
+        peers_db.add_or_update_peer(onion_peer.clone()).unwrap();
+
+        let tor_only = peers_db
+            .get_available_dial_candidates(&[], Some(1), &[TransportProtocol::Onion], true, false)
+            .unwrap();
+        assert_eq!(tor_only.first().unwrap().node_id, onion_peer.node_id);
+
+        let tcp_only = peers_db
+            .get_available_dial_candidates(
+                &[],
+                Some(1),
+                &[TransportProtocol::Ipv4, TransportProtocol::Ipv6],
+                true,
+                false,
+            )
+            .unwrap();
+        assert_eq!(tcp_only.first().unwrap().node_id, tcp_peer.node_id);
+
+        let tor_preferred = peers_db
+            .get_available_dial_candidates(
+                &[],
+                Some(1),
+                &[
+                    TransportProtocol::Onion,
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6,
+                ],
+                true,
+                false,
+            )
+            .unwrap();
+        assert_eq!(tor_preferred.first().unwrap().node_id, onion_peer.node_id);
+
+        let tcp_preferred = peers_db
+            .get_available_dial_candidates(
+                &[],
+                Some(1),
+                &[
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6,
+                    TransportProtocol::Onion,
+                ],
+                true,
+                false,
+            )
+            .unwrap();
+        assert_eq!(tcp_preferred.first().unwrap().node_id, tcp_peer.node_id);
     }
 
     #[ignore]

--- a/comms/core/src/types.rs
+++ b/comms/core/src/types.rs
@@ -83,6 +83,21 @@ impl TransportProtocol {
             TransportProtocol::Memory => "/memory",
         }
     }
+
+    pub fn preference_index(address: &Multiaddr, preferred_protocols: &[TransportProtocol]) -> Option<usize> {
+        let protocol = TransportProtocol::from(address);
+        preferred_protocols
+            .iter()
+            .position(|preferred_protocol| preferred_protocol == &protocol)
+    }
+
+    pub fn sort_multiaddrs_by_preference(
+        mut addresses: Vec<Multiaddr>,
+        preferred_protocols: &[TransportProtocol],
+    ) -> Vec<Multiaddr> {
+        addresses.sort_by_key(|address| Self::preference_index(address, preferred_protocols).unwrap_or(usize::MAX));
+        addresses
+    }
 }
 
 impl From<Multiaddr> for TransportProtocol {
@@ -125,3 +140,41 @@ impl From<&Multiaddr> for &TransportProtocol {
 }
 
 hash_domain!(CommsCoreHashDomain, "com.tari.comms.core", 0);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn sorts_multiaddrs_by_transport_protocol_preference() {
+        let onion_host = "a".repeat(56);
+        let onion = format!("/onion3/{onion_host}:18141").parse::<Multiaddr>().unwrap();
+        let ipv4 = "/ip4/8.8.8.8/tcp/18189".parse::<Multiaddr>().unwrap();
+        let ipv6 = "/ip6/::1/tcp/18189".parse::<Multiaddr>().unwrap();
+
+        let addresses = vec![ipv4.clone(), onion.clone(), ipv6.clone()];
+
+        assert_eq!(
+            TransportProtocol::sort_multiaddrs_by_preference(
+                addresses.clone(),
+                &[
+                    TransportProtocol::Onion,
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6
+                ],
+            ),
+            vec![onion.clone(), ipv4.clone(), ipv6.clone()]
+        );
+        assert_eq!(
+            TransportProtocol::sort_multiaddrs_by_preference(
+                addresses,
+                &[
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6,
+                    TransportProtocol::Onion
+                ],
+            ),
+            vec![ipv4, ipv6, onion]
+        );
+    }
+}

--- a/infrastructure/libtor/src/tor.rs
+++ b/infrastructure/libtor/src/tor.rs
@@ -125,7 +125,7 @@ impl Tor {
     /// Override a given Tor comms transport with the control address and auth from this instance
     pub fn update_comms_transport(&self, transport: &mut TransportConfig) -> Result<(), ExitError> {
         match transport.transport_type {
-            TransportType::Tor => {
+            TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor => {
                 if let Some(ref passphrase) = self.passphrase.0 {
                     transport.tor.control_auth = TorControlAuthentication::Password(passphrase.to_owned());
                 }

--- a/integration_tests/tests/features/TransportPeerSelection.feature
+++ b/integration_tests/tests/features/TransportPeerSelection.feature
@@ -1,0 +1,11 @@
+Feature: Transport peer selection
+
+  Scenario Outline: transport mode selects peer protocols and dial address order
+    Then transport mode "<mode>" selects peer protocols "<protocols>" and orders dial addresses "<addresses>"
+
+    Examples:
+      | mode   | protocols       | addresses       |
+      | Tor    | onion           | onion           |
+      | Tcp    | ipv4,ipv6       | ipv4,ipv6       |
+      | TorTcp | onion,ipv4,ipv6 | onion,ipv4,ipv6 |
+      | TcpTor | ipv4,ipv6,onion | ipv4,ipv6,onion |

--- a/integration_tests/tests/steps/mod.rs
+++ b/integration_tests/tests/steps/mod.rs
@@ -29,7 +29,9 @@ use std::{
 
 use chrono::Local;
 use cucumber::{then, when};
+use tari_comms::{multiaddr::Multiaddr, types::TransportProtocol};
 use tari_integration_tests::TariWorld;
+use tari_p2p::TransportType;
 
 pub mod merge_mining_steps;
 pub mod mining_steps;
@@ -91,4 +93,53 @@ pub fn get_saved_seed_words(world: &mut TariWorld, wallet_name: &str) -> Vec<Str
         .into_iter()
         .map(|v| v.to_string())
         .collect::<Vec<_>>()
+}
+
+#[then(
+    regex = r#"transport mode "(Tor|Tcp|TorTcp|TcpTor)" selects peer protocols "(.*)" and orders dial addresses "(.*)""#
+)]
+async fn transport_mode_selects_peer_protocols_and_orders_dial_addresses(
+    _world: &mut TariWorld,
+    mode: String,
+    expected_protocols: String,
+    expected_addresses: String,
+) {
+    let mode = match mode.as_str() {
+        "Tor" => TransportType::Tor,
+        "Tcp" => TransportType::Tcp,
+        "TorTcp" => TransportType::TorTcp,
+        "TcpTor" => TransportType::TcpTor,
+        other => panic!("Unknown transport mode {other}"),
+    };
+    let mode_protocols = mode.get_supported_protocols();
+    let expected_protocols = parse_transport_protocols(&expected_protocols);
+    assert_eq!(mode_protocols, expected_protocols);
+
+    let onion_host = "c".repeat(56);
+    let addresses = vec![
+        "/ip4/8.8.8.8/tcp/18189".parse::<Multiaddr>().unwrap(),
+        format!("/onion3/{onion_host}:18141").parse::<Multiaddr>().unwrap(),
+        "/ip6/::1/tcp/18189".parse::<Multiaddr>().unwrap(),
+    ]
+    .into_iter()
+    .filter(|address| mode_protocols.contains(&TransportProtocol::from(address)))
+    .collect::<Vec<_>>();
+    let ordered = TransportProtocol::sort_multiaddrs_by_preference(addresses, &mode_protocols)
+        .into_iter()
+        .map(|address| TransportProtocol::from(&address))
+        .collect::<Vec<_>>();
+
+    assert_eq!(ordered, parse_transport_protocols(&expected_addresses));
+}
+
+fn parse_transport_protocols(protocols: &str) -> Vec<TransportProtocol> {
+    protocols
+        .split(',')
+        .map(|protocol| match protocol.trim() {
+            "ipv4" => TransportProtocol::Ipv4,
+            "ipv6" => TransportProtocol::Ipv6,
+            "onion" => TransportProtocol::Onion,
+            other => panic!("Unknown transport protocol {other}"),
+        })
+        .collect()
 }


### PR DESCRIPTION
Fixes #7830

## Summary
- Add the requested public peer-selection transport modes: `Tor`, `Tcp`, `TorTcp`, and `TcpTor`, with `TcpTor` as the new default.
- Propagate the configured transport protocol order into both peer candidate selection and dial address selection.
- Sort and filter peer candidates and dial addresses by the configured protocol preference, while retaining the existing `Memory` and `Socks5` transport variants for compatibility.
- Add unit coverage for protocol ordering/filtering and a cucumber feature covering all four requested modes.

## Validation
- `cargo test -p tari_p2p --no-default-features`
- `cargo test -p tari_comms transport_protocol_preference --no-default-features`
- `cargo test -p tari_integration_tests --test cucumber --no-run`
- `git diff --check`

## Notes
- I also attempted the full `cargo test -p tari_comms --no-default-features` suite locally. The transport-focused tests passed, but the full package run hit local baseline failures in temp SQLite/DNS-related tests outside this change.
- `cargo fmt --check` is not usable in my local stable toolchain for this repo because `rustfmt.toml` enables nightly-only rustfmt options and stable reports broad baseline diffs. No source files were modified by that check.
