### PR TITLE
[codex] Add transport peer selection modes

### DIFF
--- a/applications/minotari_app_utilities/src/identity_management.rs
+++ b/applications/minotari_app_utilities/src/identity_management.rs
@@ -141,29 +141,9 @@ fn load_node_identity<P: AsRef<Path>>(path: P, transport_type: TransportType) ->
     let id_str = fs::read_to_string(path.as_ref())?;
     let id = json5::from_str::<NodeIdentity>(&id_str)?;
 
-    let id = if transport_type == TransportType::Tcp {
-        let current_addresses = id.public_addresses();
-        debug!(
-            target: LOG_TARGET,
-            "Filtering addresses for TCP transport. Current addresses: {:?}",
-            current_addresses
-        );
-        // For TCP transport remove all onion addresses
-        let filtered_addresses: Vec<Multiaddr> = current_addresses
-            .into_iter()
-            .filter(|addr| !addr.iter().any(|p| matches!(p, Protocol::Onion3(_))))
-            .collect();
-        debug!(
-            target: LOG_TARGET,
-            "After filtering for TCP transport, {} addresses remain: {:?}",
-            filtered_addresses.len(),
-            filtered_addresses
-        );
-        id.set_public_addresses(filtered_addresses);
-        id
-    } else {
-        id
-    };
+    let current_addresses = id.public_addresses();
+    let filtered_addresses = filter_addresses_for_transport(current_addresses, transport_type);
+    id.set_public_addresses(filtered_addresses);
 
     // Check whether the previous version has a signature and sign if necessary
     if !id.is_signed() {
@@ -181,27 +161,24 @@ fn load_node_identity<P: AsRef<Path>>(path: P, transport_type: TransportType) ->
 
 /// Filter addresses based on transport type
 fn filter_addresses_for_transport(addresses: Vec<Multiaddr>, transport_type: TransportType) -> Vec<Multiaddr> {
-    if transport_type == TransportType::Tcp {
-        // Filter out onion addresses for TCP transport
-        let filtered: Vec<Multiaddr> = addresses
-            .into_iter()
-            .filter(|addr| !addr.iter().any(|p| matches!(p, Protocol::Onion3(_))))
-            .collect();
-        debug!(
-            target: LOG_TARGET,
-            "Filtered addresses for TCP transport: {:?}",
-            filtered
-        );
+    let filtered: Vec<Multiaddr> = match transport_type {
+        TransportType::Tor => addresses.into_iter().filter(is_onion_address).collect(),
+        TransportType::Tcp => addresses.into_iter().filter(|addr| !is_onion_address(addr)).collect(),
+        TransportType::TorTcp | TransportType::TcpTor => addresses,
+    };
+    debug!(
+        target: LOG_TARGET,
+        "Filtered addresses for {:?} transport: {:?}",
+        transport_type,
         filtered
-    } else {
-        debug!(
-            target: LOG_TARGET,
-            "No filtering for {:?} transport, keeping all {} addresses",
-            transport_type,
-            addresses.len()
-        );
-        addresses
-    }
+    );
+    filtered
+}
+
+fn is_onion_address(address: &Multiaddr) -> bool {
+    address
+        .iter()
+        .any(|protocol| matches!(protocol, Protocol::Onion(_, _) | Protocol::Onion3(_)))
 }
 
 /// Create a new node id and save it to disk

--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -212,7 +212,7 @@ where B: BlockchainBackend + 'static
         )
         .await;
 
-        let comms = if p2p_config.transport.transport_type == TransportType::Tor {
+        let comms = if p2p_config.transport.uses_tor_hidden_service() {
             let tor_id_path = base_node_config.tor_identity_file.clone();
             let node_id_path = base_node_config.identity_file.clone();
             let node_id = comms.node_identity();

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -66,10 +66,8 @@ use tari_comms::{
     transports::{
         HiddenServiceTransport,
         MemoryTransport,
-        SocksConfig,
         SocksTransport,
         TcpWithTorTransport,
-        predicate::FalsePredicate,
     },
     utils::cidr::parse_cidrs,
 };
@@ -221,63 +219,52 @@ pub async fn spawn_comms_using_transport<F: Fn(TorIdentity) + Send + Sync + Unpi
     transport_config: TransportConfig,
     after_comms: F,
 ) -> Result<CommsNode, CommsInitializationError> {
-    let comms = match transport_config.transport_type {
-        TransportType::Memory => {
-            debug!(target: LOG_TARGET, "Building in-memory comms stack");
-            comms
-                .with_listener_address(transport_config.memory.listener_address.clone())
-                .spawn_with_transport(MemoryTransport)
-                .await?
-        },
-        TransportType::Tcp => {
-            let config = transport_config.tcp;
-            debug!(
-                target: LOG_TARGET,
-                "Building TCP comms stack{}",
-                config
-                    .tor_socks_address
-                    .as_ref()
-                    .map(|_| " with Tor support")
-                    .unwrap_or("")
-            );
-            let mut transport = TcpWithTorTransport::new();
-            if let Some(addr) = config.tor_socks_address {
-                transport.set_tor_socks_proxy(SocksConfig {
-                    proxy_address: addr,
-                    authentication: config.tor_socks_auth.into(),
-                    proxy_bypass_predicate: Arc::new(FalsePredicate::new()),
-                });
-            }
-            comms
-                .with_listener_address(config.listener_address)
-                .spawn_with_transport(transport)
-                .await?
-        },
-        TransportType::Tor => {
-            let tor_config = transport_config.tor;
-            debug!(target: LOG_TARGET, "Building TOR comms stack ({tor_config:?})");
-            let listener_address_override = tor_config.listener_address_override.clone();
-            let hidden_service_ctl = initialize_hidden_service(tor_config)?;
-            // Set the listener address to be the address (usually local) to which tor will forward all traffic
-            let instant = Instant::now();
-            let transport = HiddenServiceTransport::new(hidden_service_ctl, after_comms);
-            debug!(target: LOG_TARGET, "TOR transport initialized in {:.0?}", instant.elapsed());
+    let comms = if transport_config.is_memory_transport() {
+        debug!(target: LOG_TARGET, "Building in-memory comms stack");
+        comms
+            .with_listener_address(transport_config.memory.listener_address.clone())
+            .spawn_with_transport(MemoryTransport)
+            .await?
+    } else if transport_config.is_socks5_transport() {
+        debug!(target: LOG_TARGET, "Building SOCKS5 comms stack");
+        let transport = SocksTransport::new(transport_config.socks.into());
+        comms
+            .with_listener_address(transport_config.tcp.listener_address)
+            .spawn_with_transport(transport)
+            .await?
+    } else {
+        match transport_config.transport_type {
+            TransportType::Tcp => {
+                let config = transport_config.tcp;
+                debug!(target: LOG_TARGET, "Building TCP comms stack");
+                comms
+                    .with_listener_address(config.listener_address)
+                    .spawn_with_transport(TcpWithTorTransport::new())
+                    .await?
+            },
+            TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor => {
+                let supported_protocols = transport_config.transport_type.get_supported_protocols();
+                let tor_config = transport_config.tor;
+                debug!(target: LOG_TARGET, "Building TOR comms stack ({tor_config:?})");
+                let listener_address_override = tor_config.listener_address_override.clone();
+                let hidden_service_ctl = initialize_hidden_service(tor_config)?;
+                // Set the listener address to be the address (usually local) to which tor will forward all traffic
+                let instant = Instant::now();
+                let transport = HiddenServiceTransport::with_supported_protocols(
+                    hidden_service_ctl,
+                    after_comms,
+                    supported_protocols,
+                );
+                debug!(target: LOG_TARGET, "TOR transport initialized in {:.0?}", instant.elapsed());
 
-            comms
-                .with_listener_address(
-                    listener_address_override.unwrap_or_else(|| multiaddr![Ip4([127, 0, 0, 1]), Tcp(0u16)]),
-                )
-                .spawn_with_transport(transport)
-                .await?
-        },
-        TransportType::Socks5 => {
-            debug!(target: LOG_TARGET, "Building SOCKS5 comms stack");
-            let transport = SocksTransport::new(transport_config.socks.into());
-            comms
-                .with_listener_address(transport_config.tcp.listener_address)
-                .spawn_with_transport(transport)
-                .await?
-        },
+                comms
+                    .with_listener_address(
+                        listener_address_override.unwrap_or_else(|| multiaddr![Ip4([127, 0, 0, 1]), Tcp(0u16)]),
+                    )
+                    .spawn_with_transport(transport)
+                    .await?
+            },
+        }
     };
 
     Ok(comms)
@@ -331,7 +318,7 @@ async fn configure_comms_and_dht(
         .with_listener_liveness_max_sessions(config.listener_liveness_max_sessions)
         .with_listener_liveness_allowlist_cidrs(listener_liveness_allowlist_cidrs)
         .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(500)))
-        .with_transport_protocols(config.transport.transport_type.get_supported_protocols())
+        .with_transport_protocols(config.transport.get_supported_protocols())
         .with_peer_storage(peer_database)
         .with_excluded_dial_addresses(config.dht.excluded_dial_addresses.clone().into_vec());
 

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use std::{num::NonZeroU16, sync::Arc};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tari_common::configuration::MultiaddrList;
 use tari_comms::{
     multiaddr::Multiaddr,
@@ -34,21 +34,20 @@ use tari_comms::{
 
 use crate::{SocksAuthentication, TorControlAuthentication, initialization::CommsInitializationError};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Default)]
 pub struct TransportConfig {
-    #[serde(rename = "type")]
     pub transport_type: TransportType,
     pub tcp: TcpTransportConfig,
     pub tor: TorTransportConfig,
     pub socks: Socks5TransportConfig,
     pub memory: MemoryTransportConfig,
+    transport_override: TransportOverride,
 }
 
 impl TransportConfig {
     pub fn new_memory(config: MemoryTransportConfig) -> Self {
         Self {
-            transport_type: TransportType::Memory,
+            transport_override: TransportOverride::Memory,
             memory: config,
             ..Default::default()
         }
@@ -72,7 +71,7 @@ impl TransportConfig {
 
     pub fn new_socks5(forward_address: Multiaddr, config: Socks5TransportConfig) -> Self {
         Self {
-            transport_type: TransportType::Socks5,
+            transport_override: TransportOverride::Socks5,
             socks: config,
             tcp: TcpTransportConfig {
                 listener_address: forward_address,
@@ -83,40 +82,184 @@ impl TransportConfig {
     }
 
     pub fn is_tor(&self) -> bool {
-        matches!(self.transport_type, TransportType::Tor)
+        self.uses_tor_hidden_service()
+    }
+
+    pub fn uses_tor_hidden_service(&self) -> bool {
+        self.transport_override == TransportOverride::None && self.transport_type.uses_tor()
+    }
+
+    pub fn get_supported_protocols(&self) -> Vec<TransportProtocol> {
+        match self.transport_override {
+            TransportOverride::Memory => vec![TransportProtocol::Memory],
+            TransportOverride::Socks5 => vec![
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+            ],
+            TransportOverride::None => self.transport_type.get_supported_protocols(),
+        }
+    }
+
+    pub(crate) fn is_memory_transport(&self) -> bool {
+        self.transport_override == TransportOverride::Memory
+    }
+
+    pub(crate) fn is_socks5_transport(&self) -> bool {
+        self.transport_override == TransportOverride::Socks5
+    }
+}
+
+impl Serialize for TransportConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        TransportConfigWireRef {
+            transport_type: WireTransportType::from(self),
+            tcp: &self.tcp,
+            tor: &self.tor,
+            socks: &self.socks,
+            memory: &self.memory,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for TransportConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(TransportConfigWire::deserialize(deserializer)?.into())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+enum TransportOverride {
+    #[default]
+    None,
+    Memory,
+    Socks5,
+}
+
+#[derive(Serialize)]
+struct TransportConfigWireRef<'a> {
+    #[serde(rename = "type")]
+    transport_type: WireTransportType,
+    tcp: &'a TcpTransportConfig,
+    tor: &'a TorTransportConfig,
+    socks: &'a Socks5TransportConfig,
+    memory: &'a MemoryTransportConfig,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TransportConfigWire {
+    #[serde(rename = "type", default)]
+    transport_type: WireTransportType,
+    #[serde(default)]
+    tcp: TcpTransportConfig,
+    #[serde(default)]
+    tor: TorTransportConfig,
+    #[serde(default)]
+    socks: Socks5TransportConfig,
+    #[serde(default)]
+    memory: MemoryTransportConfig,
+}
+
+impl From<TransportConfigWire> for TransportConfig {
+    fn from(config: TransportConfigWire) -> Self {
+        let (transport_type, transport_override) = config.transport_type.into_transport_parts();
+        Self {
+            transport_type,
+            tcp: config.tcp,
+            tor: config.tor,
+            socks: config.socks,
+            memory: config.memory,
+            transport_override,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+enum WireTransportType {
+    Tor,
+    Tcp,
+    TorTcp,
+    #[default]
+    TcpTor,
+    Memory,
+    Socks5,
+}
+
+impl WireTransportType {
+    fn into_transport_parts(self) -> (TransportType, TransportOverride) {
+        match self {
+            WireTransportType::Tor => (TransportType::Tor, TransportOverride::None),
+            WireTransportType::Tcp => (TransportType::Tcp, TransportOverride::None),
+            WireTransportType::TorTcp => (TransportType::TorTcp, TransportOverride::None),
+            WireTransportType::TcpTor => (TransportType::TcpTor, TransportOverride::None),
+            WireTransportType::Memory => (TransportType::TcpTor, TransportOverride::Memory),
+            WireTransportType::Socks5 => (TransportType::TcpTor, TransportOverride::Socks5),
+        }
+    }
+}
+
+impl From<&TransportConfig> for WireTransportType {
+    fn from(config: &TransportConfig) -> Self {
+        match config.transport_override {
+            TransportOverride::Memory => WireTransportType::Memory,
+            TransportOverride::Socks5 => WireTransportType::Socks5,
+            TransportOverride::None => config.transport_type.into(),
+        }
+    }
+}
+
+impl From<TransportType> for WireTransportType {
+    fn from(transport_type: TransportType) -> Self {
+        match transport_type {
+            TransportType::Tor => WireTransportType::Tor,
+            TransportType::Tcp => WireTransportType::Tcp,
+            TransportType::TorTcp => WireTransportType::TorTcp,
+            TransportType::TcpTor => WireTransportType::TcpTor,
+        }
     }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum TransportType {
-    /// Memory transport. Supports a single address type in the form '/memory/x' and can only communicate in-process.
-    Memory,
-    /// Use TCP to join the Tari network. By default, this transport can only contact TCP/IP nodes, however it can be
-    /// configured to allow communication with peers using the tor transport.
-    Tcp,
-    /// Configures the node to run over a tor hidden service using the Tor proxy. This transport can connect to TCP/IP,
-    /// onion v3 and DNS addresses.
-    #[default]
+    /// Use Tor onion addresses only when selecting peers and dial addresses.
     Tor,
-    /// Use a SOCKS5 proxy transport. This transport allows any addresses supported by the proxy.
-    Socks5,
+    /// Use TCP/IP addresses only when selecting peers and dial addresses.
+    Tcp,
+    /// Enable Tor and TCP/IP addresses, preferring Tor onion addresses.
+    TorTcp,
+    /// Enable Tor and TCP/IP addresses, preferring TCP/IP addresses.
+    #[default]
+    TcpTor,
 }
 
 impl TransportType {
+    pub fn uses_tor(&self) -> bool {
+        matches!(self, TransportType::Tor | TransportType::TorTcp | TransportType::TcpTor)
+    }
+
     pub fn get_supported_protocols(&self) -> Vec<TransportProtocol> {
         match self {
-            TransportType::Memory => vec![TransportProtocol::Memory],
+            TransportType::Tor => vec![TransportProtocol::Onion],
             TransportType::Tcp => vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6],
-            TransportType::Tor => vec![
+            TransportType::TorTcp => vec![
                 TransportProtocol::Onion,
                 TransportProtocol::Ipv4,
                 TransportProtocol::Ipv6,
             ],
-            TransportType::Socks5 => vec![
-                TransportProtocol::Onion,
+            TransportType::TcpTor => vec![
                 TransportProtocol::Ipv4,
                 TransportProtocol::Ipv6,
+                TransportProtocol::Onion,
             ],
         }
     }
@@ -127,7 +270,8 @@ impl TransportType {
 pub struct TcpTransportConfig {
     /// Socket to bind the TCP listener
     pub listener_address: Multiaddr,
-    /// Optional socket address of the tor SOCKS proxy, enabling the node to communicate with Tor nodes
+    /// Deprecated for peer selection modes. The `Tcp` transport type is TCP-only; use `TorTcp` or `TcpTor` to select
+    /// onion addresses.
     pub tor_socks_address: Option<Multiaddr>,
     /// Optional tor SOCKS proxy authentication
     pub tor_socks_auth: SocksAuthentication,
@@ -254,5 +398,64 @@ impl Default for MemoryTransportConfig {
         Self {
             listener_address: "/memory/0".parse().unwrap(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn transport_type_default_prefers_tcp_then_tor() {
+        assert_eq!(TransportType::default(), TransportType::TcpTor);
+    }
+
+    #[test]
+    fn transport_type_protocol_order_matches_peer_selection_modes() {
+        assert_eq!(
+            TransportType::Tor.get_supported_protocols(),
+            vec![TransportProtocol::Onion]
+        );
+        assert_eq!(
+            TransportType::Tcp.get_supported_protocols(),
+            vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6]
+        );
+        assert_eq!(
+            TransportType::TorTcp.get_supported_protocols(),
+            vec![
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6
+            ]
+        );
+        assert_eq!(
+            TransportType::TcpTor.get_supported_protocols(),
+            vec![
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6,
+                TransportProtocol::Onion
+            ]
+        );
+    }
+
+    #[test]
+    fn legacy_auxiliary_transports_do_not_add_public_transport_type_modes() {
+        let memory = TransportConfig::new_memory(MemoryTransportConfig::default());
+        assert_eq!(memory.transport_type, TransportType::TcpTor);
+        assert_eq!(memory.get_supported_protocols(), vec![TransportProtocol::Memory]);
+
+        let socks = TransportConfig::new_socks5(
+            "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+            Socks5TransportConfig::default(),
+        );
+        assert_eq!(socks.transport_type, TransportType::TcpTor);
+        assert_eq!(
+            socks.get_supported_protocols(),
+            vec![
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv4,
+                TransportProtocol::Ipv6
+            ]
+        );
     }
 }

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -185,21 +185,23 @@ listener_self_liveness_check_interval = 15
 
 [base_node.p2p.transport]
 # -------------- Transport configuration --------------
-# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
-# e.g. tor onion addresses will not be contactable. (default = "tor")
-#type = "tor"
+# Peer transport modes:
+# - "tor": Tor onion addresses only
+# - "tcp": TCP/IP addresses only
+# - "tor_tcp": Tor and TCP/IP addresses, preferring Tor
+# - "tcp_tor": TCP/IP and Tor addresses, preferring TCP/IP (default)
+#type = "tcp_tor"
 
 # The address and port to listen for peer connections over TCP. (use: type = "tcp")
 #tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"
-# Configures a tor proxy used to connect to onion addresses. All other traffic uses direct TCP connections.
-# This setting is optional however, if it is not specified, this node will not be able to connect to nodes that
-# only advertise an onion address. (default = )
+# Deprecated for peer transport selection: type = "tcp" is TCP-only. Use "tor_tcp" or "tcp_tor" to enable onion
+# address selection.
 #tcp.tor_socks_address =
 # Optional tor SOCKS proxy authentication (default = "none")
 #tcp.tor_socks_auth = "none"
 
-# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
-# onion v2, onion v3 and dns addresses. (use: type = "tor")
+# Configures the node to run over a tor hidden service using the Tor proxy.
+# Used by type = "tor", type = "tor_tcp", and type = "tcp_tor".
 # Address of the tor control server
 #tor.control_address = "/ip4/127.0.0.1/tcp/9051"
 # SOCKS proxy auth (default = "none")
@@ -220,17 +222,6 @@ listener_self_liveness_check_interval = 15
 #tor.forward_address =
 # If set, the listener will bind to this address instead of the forward_address. You need to make sure that this listener is connectable from the forward_address.
 #tor.listener_address_override =
-
-# Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
-# (use: type = "socks5")
-# The address of the SOCKS5 proxy. Traffic will be forwarded to tcp.listener_address.
-# (Default = "/ip4/127.0.0.1/tcp/8080")
-#socks.proxy_address = "/ip4/127.0.0.1/tcp/9050"
-# SOCKS proxy auth (Default = "none", or assign "username_password=username:xxxxxxx")
-#socks.auth = "none"
-
-# Use a Memory proxy transport. (use: type = "memory")
-#memory.listener_address = "/memory/0"
 
 [base_node.p2p.dht]
 # The `DbConnectionUrl` for the Dht database. Default: In-memory database

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -229,21 +229,23 @@ event_channel_size = 3500
 
 [wallet.p2p.transport]
 # -------------- Transport configuration --------------
-# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
-# e.g. tor onion addresses will not be contactable. (default = "tor")
-#type = "tor"
+# Peer transport modes:
+# - "tor": Tor onion addresses only
+# - "tcp": TCP/IP addresses only
+# - "tor_tcp": Tor and TCP/IP addresses, preferring Tor
+# - "tcp_tor": TCP/IP and Tor addresses, preferring TCP/IP (default)
+#type = "tcp_tor"
 
 # The address and port to listen for peer connections over TCP. (use: type = "tcp")
 #tcp.listener_address = "/ip4/0.0.0.0/tcp/18189"
-# Configures a tor proxy used to connect to onion addresses. All other traffic uses direct TCP connections.
-# This setting is optional however, if it is not specified, this node will not be able to connect to nodes that
-# only advertise an onion address. (default = )
+# Deprecated for peer transport selection: type = "tcp" is TCP-only. Use "tor_tcp" or "tcp_tor" to enable onion
+# address selection.
 #tcp.tor_socks_address =
 # Optional tor SOCKS proxy authentication (default = "none")
 #tcp.tor_socks_auth = "none"
 
-# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
-# onion v2, onion v3 and dns addresses. (use: type = "tor")
+# Configures the node to run over a tor hidden service using the Tor proxy.
+# Used by type = "tor", type = "tor_tcp", and type = "tcp_tor".
 # Address of the tor control server
 #tor.control_address = "/ip4/127.0.0.1/tcp/9051"
 # SOCKS proxy auth (default = "none")
@@ -262,17 +264,6 @@ event_channel_size = 3500
 #tor.proxy_bypass_for_outbound_tcp = true
 # If set, instructs tor to forward traffic the provided address. (e.g. "/ip4/127.0.0.1/tcp/0") (default = )
 #tor.forward_address =
-
-# Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
-# (use: type = "socks5")
-# The address of the SOCKS5 proxy. Traffic will be forwarded to tcp.listener_address.
-# (Default = "/ip4/127.0.0.1/tcp/8080")
-#socks.proxy_address = "/ip4/127.0.0.1/tcp/9050"
-# SOCKS proxy auth (Default = "none", or assign "username_password=username:xxxxxxx")
-#socks.auth = "none"
-
-# Use a Memory proxy transport. (use: type = "memory")
-#memory.listener_address = "/memory/0"
 
 [wallet.p2p.dht]
 # The `DbConnectionUrl` for the Dht database. Default: In-memory database

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -64,7 +64,7 @@ use crate::{
     peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
     protocol::ProtocolId,
     transports::Transport,
-    types::CommsPublicKey,
+    types::{CommsPublicKey, TransportProtocol},
 };
 
 const LOG_TARGET: &str = "comms::connection_manager::dialer";
@@ -79,6 +79,31 @@ type DialFuturesUnordered = FuturesUnordered<
         ),
     >,
 >;
+
+fn filter_and_order_dial_addresses(
+    addresses: impl IntoIterator<Item = Multiaddr>,
+    supported_transport_protocols: &[TransportProtocol],
+    excluded_dial_addresses: &[MultiaddrRange],
+) -> Vec<Multiaddr> {
+    let mut addresses = addresses
+        .into_iter()
+        .filter(|address| {
+            !excluded_dial_addresses
+                .iter()
+                .any(|excluded| excluded.contains(address))
+                && supported_transport_protocols.contains(&TransportProtocol::from(address))
+        })
+        .collect::<Vec<_>>();
+
+    addresses.sort_by_key(|address| {
+        let protocol = TransportProtocol::from(address);
+        supported_transport_protocols
+            .iter()
+            .position(|supported_protocol| *supported_protocol == protocol)
+            .unwrap_or(usize::MAX)
+    });
+    addresses
+}
 
 #[derive(Debug)]
 pub(crate) enum DialerRequest {
@@ -605,18 +630,11 @@ where
         let supported_transport_protocols = transport.supported_protocols();
         trace!(target: LOG_TARGET, "Supported transport protocols: {:?}", supported_transport_protocols);
 
-        let addresses = dial_state
-            .peer()
-            .addresses
-            .clone()
-            .into_vec()
-            .iter()
-            .filter(|&a| {
-                !excluded_dial_addresses.iter().any(|excluded| excluded.contains(a)) &&
-                    supported_transport_protocols.contains(a.into())
-            })
-            .cloned()
-            .collect::<Vec<_>>();
+        let addresses = filter_and_order_dial_addresses(
+            dial_state.peer().addresses.clone().into_vec(),
+            &supported_transport_protocols,
+            &excluded_dial_addresses,
+        );
 
         if addresses.is_empty() {
             let node_id_hex = dial_state.peer().node_id.clone().to_hex();
@@ -757,5 +775,69 @@ where
         }
 
         (dial_state, Err(ConnectionManagerError::DialConnectFailedAllAddresses))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn tcp4_addr() -> Multiaddr {
+        "/ip4/127.0.0.1/tcp/18189".parse().unwrap()
+    }
+
+    fn tcp6_addr() -> Multiaddr {
+        "/ip6/::1/tcp/18189".parse().unwrap()
+    }
+
+    fn onion_addr() -> Multiaddr {
+        "/onion3/e4dsii6vc5f7frao23syonalgikd5kcd7fddrdjhab6bdo3cu47n3kyd:18141"
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn dial_address_selection_filters_and_orders_transport_modes() {
+        let tcp4 = tcp4_addr();
+        let tcp6 = tcp6_addr();
+        let onion = onion_addr();
+        let addresses = vec![tcp4.clone(), onion.clone(), tcp6.clone()];
+
+        assert_eq!(
+            filter_and_order_dial_addresses(addresses.clone(), &[TransportProtocol::Onion], &[]),
+            vec![onion.clone()]
+        );
+        assert_eq!(
+            filter_and_order_dial_addresses(
+                addresses.clone(),
+                &[TransportProtocol::Ipv4, TransportProtocol::Ipv6],
+                &[]
+            ),
+            vec![tcp4.clone(), tcp6.clone()]
+        );
+        assert_eq!(
+            filter_and_order_dial_addresses(
+                addresses.clone(),
+                &[
+                    TransportProtocol::Onion,
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6
+                ],
+                &[]
+            ),
+            vec![onion.clone(), tcp4.clone(), tcp6.clone()]
+        );
+        assert_eq!(
+            filter_and_order_dial_addresses(
+                addresses,
+                &[
+                    TransportProtocol::Ipv4,
+                    TransportProtocol::Ipv6,
+                    TransportProtocol::Onion
+                ],
+                &[]
+            ),
+            vec![tcp4, tcp6, onion]
+        );
     }
 }

--- a/comms/core/src/transports/hidden_service_transport.rs
+++ b/comms/core/src/transports/hidden_service_transport.rs
@@ -49,17 +49,29 @@ pub struct HiddenServiceTransport<F: Fn(TorIdentity)> {
 
 impl<F: Fn(TorIdentity)> HiddenServiceTransport<F> {
     pub fn new(hidden_service_ctl: HiddenServiceController, after_init: F) -> Self {
-        let mut supported_protocols = vec![TransportProtocol::Ipv4, TransportProtocol::Onion];
-        if supports_ipv6() {
-            supported_protocols.push(TransportProtocol::Ipv6);
-        }
+        Self::with_supported_protocols(
+            hidden_service_ctl,
+            after_init,
+            vec![
+                TransportProtocol::Ipv4,
+                TransportProtocol::Onion,
+                TransportProtocol::Ipv6,
+            ],
+        )
+    }
+
+    pub fn with_supported_protocols(
+        hidden_service_ctl: HiddenServiceController,
+        after_init: F,
+        supported_protocols: Vec<TransportProtocol>,
+    ) -> Self {
         Self {
             inner: Arc::new(RwLock::new(HiddenServiceTransportInner {
                 socks_transport: None,
                 hidden_service_ctl: Some(hidden_service_ctl),
             })),
             after_init,
-            supported_protocols,
+            supported_protocols: filter_supported_protocols_for_host(supported_protocols),
         }
     }
 
@@ -104,6 +116,13 @@ impl<F: Fn(TorIdentity)> HiddenServiceTransport<F> {
         (self.after_init)(hidden_service.tor_identity().clone());
         Ok((inbound, listen_addr))
     }
+}
+
+fn filter_supported_protocols_for_host(mut supported_protocols: Vec<TransportProtocol>) -> Vec<TransportProtocol> {
+    if !supports_ipv6() {
+        supported_protocols.retain(|protocol| *protocol != TransportProtocol::Ipv6);
+    }
+    supported_protocols
 }
 #[crate::async_trait]
 impl<F: Fn(TorIdentity) + Send + Sync> Transport for HiddenServiceTransport<F> {

--- a/infrastructure/libtor/src/tor.rs
+++ b/infrastructure/libtor/src/tor.rs
@@ -27,7 +27,7 @@ use libtor::{LogDestination, LogLevel, TorFlag};
 use log::*;
 use rand::{RngExt, distr::Alphanumeric};
 use tari_common::exit_codes::{ExitCode, ExitError};
-use tari_p2p::{TorControlAuthentication, TransportConfig, TransportType};
+use tari_p2p::{TorControlAuthentication, TransportConfig};
 use tor_hash_passwd::EncryptedKey;
 
 const LOG_TARGET: &str = "tari_libtor";
@@ -124,19 +124,16 @@ impl Tor {
 
     /// Override a given Tor comms transport with the control address and auth from this instance
     pub fn update_comms_transport(&self, transport: &mut TransportConfig) -> Result<(), ExitError> {
-        match transport.transport_type {
-            TransportType::Tor => {
-                if let Some(ref passphrase) = self.passphrase.0 {
-                    transport.tor.control_auth = TorControlAuthentication::Password(passphrase.to_owned());
-                }
-                transport.tor.control_address = format!("/ip4/127.0.0.1/tcp/{}", self.control_port).parse().unwrap();
-                debug!(target: LOG_TARGET, "updated comms transport: {transport:?}");
-                Ok(())
-            },
-            _ => {
-                let e = format!("Expected a TorHiddenService comms transport, received: {transport:?}");
-                Err(ExitError::new(ExitCode::ConfigError, e))
-            },
+        if transport.uses_tor_hidden_service() {
+            if let Some(ref passphrase) = self.passphrase.0 {
+                transport.tor.control_auth = TorControlAuthentication::Password(passphrase.to_owned());
+            }
+            transport.tor.control_address = format!("/ip4/127.0.0.1/tcp/{}", self.control_port).parse().unwrap();
+            debug!(target: LOG_TARGET, "updated comms transport: {transport:?}");
+            Ok(())
+        } else {
+            let e = format!("Expected a TorHiddenService comms transport, received: {transport:?}");
+            Err(ExitError::new(ExitCode::ConfigError, e))
         }
     }
 

--- a/integration_tests/tests/features/TransportSelection.feature
+++ b/integration_tests/tests/features/TransportSelection.feature
@@ -1,0 +1,12 @@
+@transport-selection
+Feature: Transport peer selection
+
+  Scenario Outline: Transport mode selects the expected dial protocol preference order
+    Then transport type <mode> selects peer protocols <protocols>
+
+    Examples:
+      | mode    | protocols   |
+      | tor     | onion       |
+      | tcp     | tcp         |
+      | tor_tcp | onion,tcp   |
+      | tcp_tor | tcp,onion   |

--- a/integration_tests/tests/steps/mod.rs
+++ b/integration_tests/tests/steps/mod.rs
@@ -29,7 +29,9 @@ use std::{
 
 use chrono::Local;
 use cucumber::{then, when};
+use tari_comms::types::TransportProtocol;
 use tari_integration_tests::TariWorld;
+use tari_p2p::TransportType;
 
 pub mod merge_mining_steps;
 pub mod mining_steps;
@@ -46,6 +48,34 @@ pub const CONFIRMATION_PERIOD: u64 = 4;
 pub const TWO_MINUTES_WITH_HALF_SECOND_SLEEP: u64 = 240;
 #[allow(dead_code)]
 pub const HALF_SECOND: u64 = 500;
+
+#[then(expr = "transport type {word} selects peer protocols {word}")]
+async fn transport_type_selects_peer_protocols(_world: &mut TariWorld, transport_type: String, protocols: String) {
+    let transport_type = match transport_type.as_str() {
+        "tor" => TransportType::Tor,
+        "tcp" => TransportType::Tcp,
+        "tor_tcp" => TransportType::TorTcp,
+        "tcp_tor" => TransportType::TcpTor,
+        other => panic!("Unknown transport type '{other}'"),
+    };
+    let expected = match protocols.as_str() {
+        "onion" => vec![TransportProtocol::Onion],
+        "tcp" => vec![TransportProtocol::Ipv4, TransportProtocol::Ipv6],
+        "onion,tcp" => vec![
+            TransportProtocol::Onion,
+            TransportProtocol::Ipv4,
+            TransportProtocol::Ipv6,
+        ],
+        "tcp,onion" => vec![
+            TransportProtocol::Ipv4,
+            TransportProtocol::Ipv6,
+            TransportProtocol::Onion,
+        ],
+        other => panic!("Unknown protocol list '{other}'"),
+    };
+
+    assert_eq!(transport_type.get_supported_protocols(), expected);
+}
 
 #[when(expr = "I wait {int} seconds")]
 async fn wait_seconds(_world: &mut TariWorld, seconds: u64) {


### PR DESCRIPTION
Fixes #7830.

## Summary
- Replace the public peer `TransportType` modes with `Tor`, `Tcp`, `TorTcp`, and `TcpTor`, with `TcpTor` as the default.
- Apply the mode protocol order when selecting dial addresses so Tor-only filters to onion, TCP-only filters to IP, and mixed modes preserve the requested preference.
- Wire Tor-backed modes through hidden-service transport protocol ordering and keep legacy memory/SOCKS transports as internal `TransportConfig` overrides for existing tests/config compatibility.
- Add unit coverage for transport mode protocol order and dial address ordering, plus a cucumber scenario outline for all four peer selection modes.

## Validation
- `cargo test -p tari_p2p transport_type --no-default-features --features tari_common_sqlite/bundled`
- `cargo test -p tari_comms dial_address_selection_filters_and_orders_transport_modes --no-default-features --features tari_common_sqlite/bundled`
- `cargo check -p minotari_app_utilities --no-default-features`
- `cargo check -p tari_libtor --no-default-features`

## Notes
- `cargo check -p minotari_node --no-default-features` and cucumber compile-only were attempted locally but stopped before checking this patch because `randomx-rs` requires `cmake`, which is not installed in this Windows environment.