### PR TITLE
feat(sidechain)!: carry next-epoch hash in EndEpoch command

### DIFF
--- a/base_layer/sidechain/src/command.rs
+++ b/base_layer/sidechain/src/command.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
 use tari_hashing::layer2::command_hasher;
 
-use crate::eviction_proof::EvictNodeAtom;
+use crate::{eviction_proof::EvictNodeAtom, serde::hex_or_bytes};
 
 pub trait ToCommand {
     fn to_command(&self) -> Command;
@@ -21,7 +21,7 @@ pub enum Command {
     SomeAccept,
     ForeignProposal,
     EvictNode(EvictNodeAtom),
-    EndEpoch,
+    EndEpoch(EndEpochAtom),
 }
 
 impl Command {
@@ -32,7 +32,45 @@ impl Command {
         }
     }
 
+    pub fn end_epoch(&self) -> Option<&EndEpochAtom> {
+        match self {
+            Self::EndEpoch(end_epoch_atom) => Some(end_epoch_atom),
+            _ => None,
+        }
+    }
+
     pub fn hash(&self) -> FixedHash {
         command_hasher().chain(self).finalize().into()
+    }
+}
+
+/// The atom committed by an `EndEpoch` command.
+///
+/// It carries the base-layer boundary-block hash of the *next* epoch so that the value is ratified
+/// by the committee: a validator only votes for the end-of-epoch block if `next_epoch_hash` matches
+/// its own (lagged, reorg-stable) view of the next epoch's boundary block. Because this hash is part
+/// of the command, it is committed in the block's command merkle root and attested by the quorum
+/// that commits the block — a node can no longer unilaterally lock an epoch hash the committee never
+/// agreed on (which is what wedges consensus when a base-layer reorg deeper than the confirmation
+/// depth straddles the epoch boundary).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
+pub struct EndEpochAtom {
+    #[serde(with = "hex_or_bytes")]
+    next_epoch_hash: FixedHash,
+}
+
+impl EndEpochAtom {
+    pub fn new(next_epoch_hash: FixedHash) -> Self {
+        Self { next_epoch_hash }
+    }
+
+    pub fn next_epoch_hash(&self) -> FixedHash {
+        self.next_epoch_hash
+    }
+}
+
+impl ToCommand for EndEpochAtom {
+    fn to_command(&self) -> Command {
+        Command::EndEpoch(self.clone())
     }
 }


### PR DESCRIPTION
## Description

Adds `EndEpochAtom { next_epoch_hash }` and changes `Command::EndEpoch` to `Command::EndEpoch(EndEpochAtom)`.

The next epoch's base-layer boundary-block hash is now carried inside the `EndEpoch` command, so it becomes part of the block's command merkle root and is attested by the quorum that commits the end-of-epoch block.

## Motivation

Today each validator derives the next epoch's boundary hash from its own base-layer oracle and locks it unilaterally when it stamps the next epoch's genesis. When a base-layer reorg deeper than the confirmation depth straddles an epoch boundary, the committee can split across two different boundary-block hashes, after which nodes reject each other's proposals (`InvalidEpochHash`) and consensus wedges with no automatic recovery.

Carrying the hash in the command lets the committee **ratify the next epoch's hash by quorum** instead: a validator only votes for the EOE block if `next_epoch_hash` matches its own (lagged, reorg-stable) view, so a hash can no longer be locked without agreement. The layer-2 consensus changes that consume this live in the tari-ootle repo.

## Notes

- The command still hashes via `command_hasher().chain(self)` (Borsh), keeping the layer-2 command hash consistent with the consensus block's command merkle root. The matching tari-ootle `Command` change preserves byte-identical hashing so L1 inclusion-proof verification is unaffected.
- `EndEpoch` stays the last enum variant (Borsh index unchanged).

## How Has This Been Tested?

`cargo build` and `cargo test` for `tari_sidechain` pass.