### PR TITLE
fix(common): make StaticApplicationInfo work for crates.io consumers

### DIFF
--- a/common/src/build/application.rs
+++ b/common/src/build/application.rs
@@ -52,50 +52,80 @@ impl StaticApplicationInfo {
         let out_dir = env::var_os("OUT_DIR").unwrap();
         let out_path = Path::new(&out_dir).join(filename);
         let mut file = fs::File::create(&out_path)?;
+        let full_version = self.get_full_version()?;
+        let version_number = self.get_version_number()?;
+        let authors = get_authors(&self.manifest).join(",");
         writeln!(
             file,
-            r#"#[allow(dead_code)] pub const APP_VERSION: &str = "{}";"#,
-            self.get_full_version()
+            r#"#[allow(dead_code)] pub const APP_VERSION: &str = "{full_version}";"#,
         )?;
         writeln!(
             file,
-            r#"#[allow(dead_code)] pub const APP_VERSION_NUMBER: &str = "{}";"#,
-            self.get_version_number()
+            r#"#[allow(dead_code)] pub const APP_VERSION_NUMBER: &str = "{version_number}";"#,
         )?;
         writeln!(
             file,
-            r#"#[allow(dead_code)] pub const APP_AUTHORS: &str = "{}";"#,
-            self.manifest
-                .workspace
-                .as_ref()
-                .and_then(|w| w.package.as_ref())
-                .and_then(|p| p.authors.as_ref())
-                .map(|a| a.join(","))
-                .unwrap_or_default()
+            r#"#[allow(dead_code)] pub const APP_AUTHORS: &str = "{authors}";"#
         )?;
         Ok(out_path)
     }
 
     /// Add the git version commit and built type to the version number
     /// The final output looks like 0.1.2-fc435c-release
-    fn get_full_version(&self) -> String {
+    fn get_full_version(&self) -> Result<String, anyhow::Error> {
         let build = env::var("PROFILE").unwrap_or_else(|e| {
             emit_cargo_warn(e);
             "Unknown".to_string()
         });
-        format!("{}-{}-{}", self.get_version_number(), self.commit, build)
+        Ok(format!("{}-{}-{}", self.get_version_number()?, self.commit, build))
     }
 
     /// Get the version number only
     /// The final output looks like 0.1.2
-    fn get_version_number(&self) -> String {
-        self.manifest
-            .workspace
-            .as_ref()
-            .and_then(|w| w.package.as_ref())
-            .and_then(|p| p.version.clone())
-            .unwrap_or_default()
+    fn get_version_number(&self) -> Result<String, anyhow::Error> {
+        get_version_number(&self.manifest)
     }
+}
+
+/// Resolve the package version from a parsed manifest.
+///
+/// When called from a git checkout, `find_git_root` lands on the workspace root and the version
+/// lives under `[workspace.package]`. When called from an unpacked registry crate (e.g. as a
+/// build-dep of a consumer pulling tari from crates.io) there is no `.git` and no workspace
+/// table — cargo strips workspace inheritance on publish and substitutes the literal value into
+/// `[package].version`. Try both, in that order.
+fn get_version_number(manifest: &Manifest) -> Result<String, anyhow::Error> {
+    if let Some(version) = manifest
+        .workspace
+        .as_ref()
+        .and_then(|w| w.package.as_ref())
+        .and_then(|p| p.version.clone())
+    {
+        return Ok(version);
+    }
+    if let Some(version) = manifest.package.as_ref().and_then(|p| p.version.get().ok()) {
+        return Ok(version.clone());
+    }
+    Err(anyhow::anyhow!(
+        "Could not determine package version: neither [workspace.package].version nor [package].version is set"
+    ))
+}
+
+/// Resolve package authors from a parsed manifest, applying the same workspace → package
+/// fallback as [`get_version_number`].
+fn get_authors(manifest: &Manifest) -> Vec<String> {
+    if let Some(authors) = manifest
+        .workspace
+        .as_ref()
+        .and_then(|w| w.package.as_ref())
+        .and_then(|p| p.authors.as_ref())
+    {
+        return authors.clone();
+    }
+    if let Some(authors) = manifest.package.as_ref().and_then(|p| p.authors.get().ok().cloned()) {
+        return authors;
+    }
+    Vec::new()
 }
 
 fn extract_manifest<P: AsRef<Path>>(git_root: P) -> Result<Manifest, anyhow::Error> {
@@ -109,19 +139,20 @@ fn extract_manifest<P: AsRef<Path>>(git_root: P) -> Result<Manifest, anyhow::Err
 fn find_git_root() -> Result<PathBuf, anyhow::Error> {
     let manifest = env::var("CARGO_MANIFEST_DIR")?;
     let manifest_path = PathBuf::from(&manifest);
-    let mut path = manifest_path.clone();
 
-    let mut loop_count = 0;
-    while !path.join(".git").exists() {
-        path = path.join("..");
-        if loop_count == 10 {
-            emit_cargo_warn("Not a git repository or CARGO_MANIFEST_DIR nested deeper than 10 from the root");
-            return Ok(manifest_path);
+    let mut current = manifest_path.as_path();
+    loop {
+        if current.join(".git").exists() {
+            return Ok(current.to_path_buf());
         }
-        loop_count += 1;
+        match current.parent() {
+            Some(parent) => current = parent,
+            None => {
+                emit_cargo_warn("Not a git repository — no ancestor of CARGO_MANIFEST_DIR contains a .git directory");
+                return Ok(manifest_path);
+            },
+        }
     }
-
-    Ok(path)
 }
 
 fn get_commit<P: AsRef<Path>>(git_root: P) -> Result<String, anyhow::Error> {
@@ -138,4 +169,70 @@ fn get_commit<P: AsRef<Path>>(git_root: P) -> Result<String, anyhow::Error> {
 
 fn emit_cargo_warn<T: fmt::Display>(e: T) {
     println!("cargo:warning=Could not open repo: {e}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(toml_str: &str) -> Manifest {
+        toml::from_str(toml_str).expect("test manifest parses")
+    }
+
+    // Mirrors the workspace root Cargo.toml seen during an in-tree git checkout build.
+    const WORKSPACE_MANIFEST: &str = r#"
+[workspace.package]
+version = "1.2.3"
+authors = ["alice", "bob"]
+
+[workspace]
+members = []
+"#;
+
+    // Mirrors a published crate's Cargo.toml as unpacked into the cargo registry: cargo strips
+    // workspace inheritance on publish and substitutes the literal values into [package].
+    const REGISTRY_MANIFEST: &str = r#"
+[package]
+name = "demo"
+version = "1.2.3"
+authors = ["alice", "bob"]
+edition = "2021"
+"#;
+
+    #[test]
+    fn reads_version_from_workspace_package() {
+        assert_eq!(get_version_number(&parse(WORKSPACE_MANIFEST)).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn falls_back_to_package_version_when_workspace_table_missing() {
+        assert_eq!(get_version_number(&parse(REGISTRY_MANIFEST)).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn errors_when_no_version_is_set_anywhere() {
+        let manifest: Manifest = parse(
+            r#"
+[workspace]
+members = []
+"#,
+        );
+        assert!(get_version_number(&manifest).is_err());
+    }
+
+    #[test]
+    fn reads_authors_from_workspace_package() {
+        assert_eq!(get_authors(&parse(WORKSPACE_MANIFEST)), vec![
+            "alice".to_string(),
+            "bob".to_string()
+        ]);
+    }
+
+    #[test]
+    fn falls_back_to_package_authors_when_workspace_table_missing() {
+        assert_eq!(get_authors(&parse(REGISTRY_MANIFEST)), vec![
+            "alice".to_string(),
+            "bob".to_string()
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary

TL;DR for Humans: the  StaticApplicationInfo assumes you're in a git repo, which isnt the case on crates.io, meaning compilation fails. This PR handles this by reading the version filled in by crates.io in the CARGO_MANIFEST_DIR Cargo.toml

Fixes `tari_common`'s `StaticApplicationInfo` build helper so that crates depending on tari/minotari **via crates.io** (rather than as in-tree workspace members or git pins) actually get a usable `APP_VERSION_NUMBER`. Today the helper returns `""` for registry consumers, which downstream gets baked into `consts::APP_VERSION_NUMBER` and causes `minotari_node` to panic at startup parsing `""` as semver.

This unblocks moving downstream consumers (e.g. tari-ootle) off git pins onto published crates.io versions.

## Why it's broken on crates.io today

`StaticApplicationInfo::initialize()` calls `find_git_root()`, which walks up from `CARGO_MANIFEST_DIR` looking for a `.git` directory, then reads the `Cargo.toml` at that location and pulls the version from `[workspace.package].version`.

When the helper runs from `~/.cargo/registry/src/index.crates.io-XXX/<crate>-X.Y.Z/`:

1. **No `.git` anywhere up the registry source tree.** The walk had a hardcoded 10-iteration cap on `..` joins (not on real ancestors), bailed, and returned `CARGO_MANIFEST_DIR` — the unpacked crate's own dir.
2. **The crate's own `Cargo.toml` is the published one.** Cargo strips workspace inheritance on publish and substitutes literals into `[package].version`, so `[workspace.package]` doesn't exist in the published manifest.
3. The helper only read `[workspace.package].version`, so it returned `""`.
4. That empty string ended up as `consts::APP_VERSION_NUMBER`, and `minotari_node/src/bootstrap.rs` does `APP_VERSION_NUMBER.parse::<Version>().expect("Unable to parse application version. Not valid semver")` → panic on startup.

## Fix

In `common/src/build/application.rs`:

- **`find_git_root`** now walks via `Path::parent()` and terminates naturally at the filesystem root, instead of bailing after N `..` joins.
- **`get_version_number` / `get_authors`** fall back to `[package].*` when `[workspace.package].*` is absent. In a git checkout the workspace lookup still wins (unchanged); in a registry-unpacked crate the package lookup picks up the literal value cargo substituted on publish.
- **`get_version_number` / `get_full_version`** now return `Result`. A missing version surfaces as a build-time error rather than as a downstream runtime semver-parse panic.
- Five unit tests cover workspace-style and registry-style manifests for both version and authors, plus the "no version anywhere" error case.

## Follow-up (not in this PR)

This fix needs to ship in the next L1 release. Every crate whose `build.rs` (or any transitive build dep) consumes the helper must be republished — at minimum `tari_common`, `minotari_app_utilities`, `minotari_node`, `minotari_console_wallet`, `minotari_wallet`.

## Test plan

- [x] `cargo test -p tari_common --features static-application-info --lib build::application` (5/5 pass)
- [x] `cargo check -p minotari_app_utilities -p minotari_wallet -p minotari_wallet_ffi` (the three `StaticApplicationInfo` callers, compiles clean)
- [ ] After republish: a downstream consumer importing tari from crates.io builds and starts without the semver-parse panic