### PR TITLE
fix(wallet): migrate legacy output key ids on startup

### DIFF
--- a/base_layer/transaction_components/src/key_manager/key_id.rs
+++ b/base_layer/transaction_components/src/key_manager/key_id.rs
@@ -190,7 +190,7 @@ impl FromStr for TariKeyId {
             Some(val) => match *val {
                 ZERO_KEY_BRANCH => Ok(TariKeyId::Zero),
                 DERIVED_KEY_BRANCH => {
-                    if parts.len() < 3 {
+                    if parts.len() < 2 {
                         return Err("Wrong derived format".to_string());
                     };
 
@@ -382,6 +382,14 @@ mod tests {
     #[test]
     fn roundtrip_derived_with_dots() {
         let s = "derived.ledger_key.MetadataEphemeralNonce.0";
+        let parsed = TariKeyId::from_str(s).unwrap();
+        assert!(matches!(parsed, TariKeyId::Derived { .. }));
+        assert_eq!(parsed.to_string(), s);
+    }
+
+    #[test]
+    fn roundtrip_derived_with_simple_current_key() {
+        let s = "derived.spend_key";
         let parsed = TariKeyId::from_str(s).unwrap();
         assert!(matches!(parsed, TariKeyId::Derived { .. }));
         assert_eq!(parsed.to_string(), s);

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -218,6 +218,7 @@ where
         debug!(target: LOG_TARGET, "Output Manager Service started");
         // Outputs marked as shorttermencumbered are not yet stored as transactions in the TMS, so lets clear them
         self.resources.db.clear_short_term_encumberances()?;
+        self.spawn_legacy_output_key_id_migration();
         loop {
             tokio::select! {
                 event = base_node_service_event_stream.recv() => {
@@ -249,6 +250,21 @@ where
         }
         info!(target: LOG_TARGET, "Output Manager Service ended");
         Ok(())
+    }
+
+    fn spawn_legacy_output_key_id_migration(&self) {
+        let db = self.resources.db.clone();
+        let key_manager = self.resources.key_manager.clone();
+
+        tokio::task::spawn_blocking(move || match db.migrate_legacy_output_key_ids(&key_manager) {
+            Ok(0) => {},
+            Ok(migrated_count) => {
+                info!(target: LOG_TARGET, "Migrated {migrated_count} legacy output key id(s)");
+            },
+            Err(e) => {
+                warn!(target: LOG_TARGET, "Legacy output key id migration failed: {e}");
+            },
+        });
     }
 
     /// This handler is called when the Service executor loops receives an API request

--- a/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/backend.rs
@@ -196,4 +196,15 @@ pub trait OutputManagerBackend: Send + Sync + Clone {
         q: OutputBackendQuery,
         key_manager: &KM,
     ) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError>;
+    fn fetch_outputs_with_legacy_key_ids(
+        &self,
+        last_seen_id: i32,
+        batch_size: i64,
+    ) -> Result<Vec<(i32, String, String)>, OutputManagerStorageError>;
+    fn update_output_key_ids(
+        &self,
+        output_id: i32,
+        spending_key: String,
+        script_private_key: String,
+    ) -> Result<(), OutputManagerStorageError>;
 }

--- a/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database/mod.rs
@@ -24,7 +24,10 @@ mod backend;
 use std::{
     fmt::{Debug, Display, Error, Formatter},
     ops::Range,
+    str::FromStr,
     sync::Arc,
+    thread,
+    time::Duration,
 };
 
 pub use backend::OutputManagerBackend;
@@ -35,9 +38,10 @@ use tari_common_types::{
 };
 use tari_transaction_components::{
     MicroMinotari,
+    key_manager::TariKeyId,
     transaction_components::{OutputType, TransactionOutput},
 };
-use tari_transaction_key_manager::legacy_key_manager::LegacyTransactionKeyManagerInterface;
+use tari_transaction_key_manager::legacy_key_manager::{LegacyTariKeyId, LegacyTransactionKeyManagerInterface};
 use tari_utilities::hex::Hex;
 
 use crate::output_manager_service::{
@@ -52,6 +56,8 @@ use crate::output_manager_service::{
 };
 
 const LOG_TARGET: &str = "wallet::output_manager_service::database";
+const LEGACY_KEY_ID_MIGRATION_BATCH_SIZE: i64 = 100;
+const LEGACY_KEY_ID_MIGRATION_BATCH_DELAY_MS: u64 = 50;
 
 #[derive(Debug, Copy, Clone)]
 pub enum SortDirection {
@@ -578,6 +584,105 @@ where T: OutputManagerBackend + 'static
         key_manager: &KM,
     ) -> Result<Vec<DbWalletOutput>, OutputManagerStorageError> {
         self.db.fetch_outputs_by_query(q, key_manager)
+    }
+
+    pub fn fetch_outputs_with_legacy_key_ids(
+        &self,
+        last_seen_id: i32,
+        batch_size: i64,
+    ) -> Result<Vec<(i32, String, String)>, OutputManagerStorageError> {
+        self.db.fetch_outputs_with_legacy_key_ids(last_seen_id, batch_size)
+    }
+
+    pub fn update_output_key_ids(
+        &self,
+        output_id: i32,
+        spending_key: String,
+        script_private_key: String,
+    ) -> Result<(), OutputManagerStorageError> {
+        self.db
+            .update_output_key_ids(output_id, spending_key, script_private_key)
+    }
+
+    pub fn migrate_legacy_output_key_ids<KM: LegacyTransactionKeyManagerInterface>(
+        &self,
+        key_manager: &KM,
+    ) -> Result<usize, OutputManagerStorageError> {
+        let mut last_seen_id = 0;
+        let mut total_migrated = 0;
+
+        loop {
+            let batch = self.fetch_outputs_with_legacy_key_ids(last_seen_id, LEGACY_KEY_ID_MIGRATION_BATCH_SIZE)?;
+            if batch.is_empty() {
+                break;
+            }
+
+            let full_batch = batch.len() == LEGACY_KEY_ID_MIGRATION_BATCH_SIZE as usize;
+            for (output_id, spending_key, script_private_key) in batch {
+                last_seen_id = output_id;
+                let migrated_spending_key =
+                    migrate_legacy_key_id_string(output_id, "spending_key", &spending_key, key_manager);
+                let migrated_script_private_key =
+                    migrate_legacy_key_id_string(output_id, "script_private_key", &script_private_key, key_manager);
+
+                if migrated_spending_key.is_none() && migrated_script_private_key.is_none() {
+                    continue;
+                }
+
+                if let Err(e) = self.update_output_key_ids(
+                    output_id,
+                    migrated_spending_key.unwrap_or(spending_key),
+                    migrated_script_private_key.unwrap_or(script_private_key),
+                ) {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Legacy output key id migration could not update output id {output_id}: {e}"
+                    );
+                    continue;
+                }
+
+                total_migrated += 1;
+            }
+
+            if full_batch {
+                thread::sleep(Duration::from_millis(LEGACY_KEY_ID_MIGRATION_BATCH_DELAY_MS));
+            }
+        }
+
+        Ok(total_migrated)
+    }
+}
+
+fn migrate_legacy_key_id_string<KM: LegacyTransactionKeyManagerInterface>(
+    output_id: i32,
+    column_name: &str,
+    key_id: &str,
+    key_manager: &KM,
+) -> Option<String> {
+    if TariKeyId::from_str(key_id).is_ok() {
+        return None;
+    }
+
+    let legacy_key_id = match LegacyTariKeyId::from_str(key_id) {
+        Ok(key_id) => key_id,
+        Err(e) => {
+            warn!(
+                target: LOG_TARGET,
+                "Legacy output key id migration could not parse {column_name} for output id {output_id}: {e}"
+            );
+            return None;
+        },
+    };
+
+    match key_manager.convert_legacy_tari_key_id_to_current(&legacy_key_id) {
+        Ok(key_id) => Some(key_id.to_string()),
+        Err(e) => {
+            warn!(
+                target: LOG_TARGET,
+                "Legacy output key id migration could not convert {column_name} for output id {output_id}: {e}"
+            );
+            None
+        },
     }
 }
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/mod.rs
@@ -1462,6 +1462,25 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             })
             .collect())
     }
+
+    fn fetch_outputs_with_legacy_key_ids(
+        &self,
+        last_seen_id: i32,
+        batch_size: i64,
+    ) -> Result<Vec<(i32, String, String)>, OutputManagerStorageError> {
+        let mut conn = self.database_connection.get_pooled_connection()?;
+        OutputSql::find_outputs_with_legacy_key_ids(last_seen_id, batch_size, &mut conn)
+    }
+
+    fn update_output_key_ids(
+        &self,
+        output_id: i32,
+        spending_key: String,
+        script_private_key: String,
+    ) -> Result<(), OutputManagerStorageError> {
+        let mut conn = self.database_connection.get_pooled_connection()?;
+        OutputSql::update_key_ids(output_id, spending_key, script_private_key, &mut conn)
+    }
 }
 
 fn replace_tx_id(

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db/output_sql.rs
@@ -1065,6 +1065,44 @@ impl OutputSql {
         OutputSql::find(&self.spending_key, conn)
     }
 
+    pub fn find_outputs_with_legacy_key_ids(
+        last_seen_id: i32,
+        batch_size: i64,
+        conn: &mut SqliteConnection,
+    ) -> Result<Vec<(i32, String, String)>, OutputManagerStorageError> {
+        outputs::table
+            .select((outputs::id, outputs::spending_key, outputs::script_private_key))
+            .filter(outputs::id.gt(last_seen_id))
+            .filter(
+                outputs::spending_key
+                    .like("%managed.%")
+                    .or(outputs::spending_key.like("%imported.%"))
+                    .or(outputs::script_private_key.like("%managed.%"))
+                    .or(outputs::script_private_key.like("%imported.%")),
+            )
+            .order(outputs::id.asc())
+            .limit(batch_size)
+            .load::<(i32, String, String)>(conn)
+            .map_err(OutputManagerStorageError::DieselError)
+    }
+
+    pub fn update_key_ids(
+        output_id: i32,
+        spending_key: String,
+        script_private_key: String,
+        conn: &mut SqliteConnection,
+    ) -> Result<(), OutputManagerStorageError> {
+        diesel::update(outputs::table.filter(outputs::id.eq(output_id)))
+            .set((
+                outputs::spending_key.eq(spending_key),
+                outputs::script_private_key.eq(script_private_key),
+            ))
+            .execute(conn)
+            .num_rows_affected_or_not_found(1)?;
+
+        Ok(())
+    }
+
     #[allow(clippy::too_many_lines)]
     pub fn to_db_wallet_output<KM: LegacyTransactionKeyManagerInterface>(
         self,

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -24,6 +24,7 @@
 use std::sync::Arc;
 
 use chrono::Utc;
+use diesel::prelude::*;
 use minotari_wallet::{
     base_node_service::handle::{BaseNodeEvent, BaseNodeServiceHandle},
     connectivity_service::WalletConnectivityHandle,
@@ -34,12 +35,14 @@ use minotari_wallet::{
         handle::OutputManagerHandle,
         service::OutputManagerService,
         storage::{
+            OutputSource,
             OutputStatus,
             database::{OutputManagerBackend, OutputManagerDatabase},
-            models::SpendingPriority,
+            models::{DbWalletOutput, SpendingPriority},
             sqlite_db::OutputManagerSqliteDatabase,
         },
     },
+    schema::outputs,
     test_utils::create_consensus_constants,
     transaction_service::handle::TransactionServiceHandle,
     util::watch::Watch,
@@ -47,6 +50,7 @@ use minotari_wallet::{
 };
 use rand::Rng;
 use tari_common::configuration::Network;
+use tari_common_sqlite::sqlite_connection_pool::PooledDbConnection;
 use tari_common_types::{
     tari_address::TariAddress,
     transaction::TxId,
@@ -77,9 +81,11 @@ use tari_transaction_key_manager::legacy_key_manager::{
     MemoryKeyManager,
     create_new_random_key_manager,
 };
+use tari_utilities::ByteArray;
 use tokio::{
     sync::{broadcast, broadcast::channel},
     task,
+    time::{Duration, sleep, timeout},
 };
 
 use crate::support::{
@@ -237,6 +243,84 @@ pub async fn setup_oms_with_bn_state<T: OutputManagerBackend + 'static>(
         event_publisher_bns,
         key_manager,
     )
+}
+
+#[tokio::test]
+async fn test_startup_migrates_legacy_output_key_ids() {
+    let mut shutdown = Shutdown::new();
+    let factories = CryptoFactories::default();
+
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection.clone());
+    let db = OutputManagerDatabase::new(backend.clone());
+    let key_manager = create_new_random_key_manager().await.unwrap();
+
+    let output = make_input(
+        &mut rand::rng(),
+        MicroMinotari::from(5000),
+        &OutputFeatures::default(),
+        key_manager.key_manager(),
+    );
+    let output = DbWalletOutput::from_wallet_output(output, None, OutputSource::Standard, None, None);
+    db.add_unspent_output(output.clone(), &key_manager).unwrap();
+    db.mark_outputs_as_unspent(vec![(output.hash, true)]).unwrap();
+    {
+        let mut conn = connection.get_pooled_connection().unwrap();
+        diesel::update(outputs::table.filter(outputs::commitment.eq(output.commitment.to_vec())))
+            .set(outputs::spending_key.eq("managed.comms.0"))
+            .execute(&mut conn)
+            .unwrap();
+    }
+
+    let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
+    let (oms_event_publisher, _) = broadcast::channel(200);
+    let (sender, _receiver_bns) = reply_channel::unbounded();
+    let (event_publisher_bns, _) = broadcast::channel(100);
+    let base_node_service_handle = BaseNodeServiceHandle::new(sender, event_publisher_bns);
+    let connectivity = WalletConnectivityHandle::new(MockHttpClientFactory::default());
+    let (event_sender, _) = broadcast::channel(200);
+    let recovery_message_watch = Watch::new("unset".to_string());
+    let one_sided_message_watch = Watch::new("unset".to_string());
+    let scanner_handle = UtxoScannerHandle::new(event_sender, one_sided_message_watch, recovery_message_watch);
+
+    let output_manager_service = OutputManagerService::new(
+        OutputManagerServiceConfig { ..Default::default() },
+        oms_request_receiver,
+        db.clone(),
+        oms_event_publisher.clone(),
+        factories,
+        create_consensus_constants(0),
+        shutdown.to_signal(),
+        base_node_service_handle,
+        Network::LocalNet,
+        connectivity,
+        key_manager.clone(),
+        scanner_handle,
+    )
+    .await
+    .unwrap();
+    let mut output_manager_handle = OutputManagerHandle::new(oms_request_sender, oms_event_publisher);
+    task::spawn(async move { output_manager_service.start().await.unwrap() });
+
+    let balance = timeout(Duration::from_secs(2), output_manager_handle.get_balance())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(balance.available_balance, MicroMinotari::from(5000));
+
+    for _ in 0..50 {
+        if db.fetch_outputs_with_legacy_key_ids(0, 100).unwrap().is_empty() {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(db.fetch_outputs_with_legacy_key_ids(0, 100).unwrap().is_empty());
+    let outputs = output_manager_handle.get_unspent_outputs().await.unwrap();
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(outputs[0].wallet_output.commitment_mask_key_id(), &TariKeyId::SpendKey);
+
+    shutdown.trigger();
 }
 
 #[tokio::test]

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -21,35 +21,101 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![allow(clippy::indexing_slicing)]
-use std::convert::TryFrom;
+use std::{convert::TryFrom, mem::size_of, str::FromStr, sync::Arc};
 
-use minotari_wallet::output_manager_service::{
-    RangeLimit,
-    UtxoSelectionCriteria,
-    error::OutputManagerStorageError,
-    service::Balance,
-    storage::{
-        OutputSource,
-        OutputStatus,
-        database::{OutputManagerBackend, OutputManagerDatabase},
-        models::DbWalletOutput,
-        sqlite_db::{OutputManagerSqliteDatabase, ReceivedOutputInfoForBatch, SpentOutputInfoForBatch},
+use chacha20poly1305::{Key, XChaCha20Poly1305, aead::KeyInit};
+use diesel::prelude::*;
+use minotari_wallet::{
+    output_manager_service::{
+        RangeLimit,
+        UtxoSelectionCriteria,
+        error::OutputManagerStorageError,
+        service::Balance,
+        storage::{
+            OutputSource,
+            OutputStatus,
+            database::{OutputManagerBackend, OutputManagerDatabase},
+            models::DbWalletOutput,
+            sqlite_db::{OutputManagerSqliteDatabase, ReceivedOutputInfoForBatch, SpentOutputInfoForBatch},
+        },
     },
+    schema::outputs,
+    storage::sqlite_utilities::WalletDbConnection,
 };
 use rand::Rng;
+use tari_common_sqlite::{
+    connection::{DbConnection, DbConnectionUrl},
+    sqlite_connection_pool::PooledDbConnection,
+};
 use tari_common_types::{
+    seeds::cipher_seed::CipherSeed,
     transaction::TxId,
-    types::{FixedHash, HashOutput, PrivateKey},
+    types::{CompressedPublicKey, FixedHash, HashOutput, PrivateKey},
 };
 use tari_crypto::keys::SecretKey;
-use tari_transaction_components::{MicroMinotari, transaction_components::OutputFeatures};
-use tari_transaction_key_manager::legacy_key_manager::{
-    LegacyTransactionKeyManagerInterface,
-    create_new_random_key_manager,
+use tari_test_utils::random;
+use tari_transaction_components::{
+    MicroMinotari,
+    crypto_factories::CryptoFactories,
+    key_manager::{SecretTransactionKeyManagerInterface, TariKeyId},
+    transaction_components::OutputFeatures,
+};
+use tari_transaction_key_manager::{
+    legacy_key_manager::{
+        LegacyTariKeyId,
+        LegacyTransactionKeyManagerInterface,
+        LegacyTransactionKeyManagerWrapper,
+        TransactionKeyManagerBackend,
+        create_new_random_key_manager,
+        wallet_types::LegacyWalletType,
+    },
+    storage::sqlite_db::TransactionKeyManagerSqliteDatabase,
 };
 use tari_utilities::{ByteArray, hex::Hex};
 
 use crate::support::{data::get_temp_sqlite_database_connection, utils::make_input};
+
+fn add_test_output<KM: LegacyTransactionKeyManagerInterface>(
+    db: &OutputManagerDatabase<OutputManagerSqliteDatabase>,
+    key_manager: &KM,
+    value: MicroMinotari,
+) -> DbWalletOutput {
+    let output = make_input(
+        &mut rand::rng(),
+        value,
+        &OutputFeatures::default(),
+        key_manager.key_manager(),
+    );
+    let output = DbWalletOutput::from_wallet_output(output, None, OutputSource::Standard, None, None);
+    db.add_unspent_output(output.clone(), key_manager).unwrap();
+    db.mark_outputs_as_unspent(vec![(output.hash, true)]).unwrap();
+    output
+}
+
+fn set_output_key_ids(
+    connection: &WalletDbConnection,
+    output: &DbWalletOutput,
+    spending_key: &str,
+    script_private_key: &str,
+) {
+    let mut conn = connection.get_pooled_connection().unwrap();
+    diesel::update(outputs::table.filter(outputs::commitment.eq(output.commitment.to_vec())))
+        .set((
+            outputs::spending_key.eq(spending_key),
+            outputs::script_private_key.eq(script_private_key),
+        ))
+        .execute(&mut conn)
+        .unwrap();
+}
+
+fn get_output_key_ids(connection: &WalletDbConnection, output: &DbWalletOutput) -> (String, String) {
+    let mut conn = connection.get_pooled_connection().unwrap();
+    outputs::table
+        .select((outputs::spending_key, outputs::script_private_key))
+        .filter(outputs::commitment.eq(output.commitment.to_vec()))
+        .first::<(String, String)>(&mut conn)
+        .unwrap()
+}
 
 #[allow(clippy::too_many_lines)]
 pub async fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
@@ -988,4 +1054,169 @@ pub async fn test_mark_as_unmined() {
         }
     }
     assert_eq!(batch_invalid_count, batch_count);
+}
+
+#[tokio::test]
+async fn test_legacy_key_filter_catches_nested_key_ids() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection.clone());
+    let db = OutputManagerDatabase::new(backend);
+    let key_manager = create_new_random_key_manager().await.unwrap();
+
+    let legacy_key_ids = [
+        "managed.comms.0",
+        "derived.managed.comms.0",
+        "imported.not-a-public-key",
+        "derived.imported.not-a-public-key",
+    ];
+
+    for (i, legacy_key_id) in legacy_key_ids.iter().enumerate() {
+        let output = add_test_output(&db, &key_manager, MicroMinotari::from(1000 + i as u64));
+        let script_key_id = output.wallet_output.script_key_id().to_string();
+        set_output_key_ids(&connection, &output, legacy_key_id, &script_key_id);
+    }
+
+    let found = db.fetch_outputs_with_legacy_key_ids(0, 100).unwrap();
+    let found_spending_keys = found
+        .into_iter()
+        .map(|(_, spending_key, _)| spending_key)
+        .collect::<Vec<_>>();
+    assert_eq!(found_spending_keys, legacy_key_ids.map(String::from));
+}
+
+#[tokio::test]
+async fn test_migrate_legacy_output_key_ids() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection.clone());
+    let db = OutputManagerDatabase::new(backend);
+    let key_manager = create_new_random_key_manager().await.unwrap();
+
+    let direct_legacy_output = add_test_output(&db, &key_manager, MicroMinotari::from(2000));
+    let nested_legacy_output = add_test_output(&db, &key_manager, MicroMinotari::from(3000));
+
+    let direct_script_key_id = direct_legacy_output.wallet_output.script_key_id().to_string();
+    let nested_script_key_id = nested_legacy_output.wallet_output.script_key_id().to_string();
+    set_output_key_ids(
+        &connection,
+        &direct_legacy_output,
+        "managed.comms.0",
+        &direct_script_key_id,
+    );
+    set_output_key_ids(
+        &connection,
+        &nested_legacy_output,
+        "derived.managed.comms.0",
+        &nested_script_key_id,
+    );
+
+    let migrated_count = db.migrate_legacy_output_key_ids(&key_manager).unwrap();
+    assert_eq!(migrated_count, 2);
+
+    let (direct_spending_key, _) = get_output_key_ids(&connection, &direct_legacy_output);
+    assert_eq!(direct_spending_key, TariKeyId::SpendKey.to_string());
+
+    let (nested_spending_key, _) = get_output_key_ids(&connection, &nested_legacy_output);
+    assert_eq!(
+        TariKeyId::from_str(&nested_spending_key).unwrap(),
+        TariKeyId::from_str("derived.spend_key").unwrap()
+    );
+
+    let remaining_legacy_key_ids = db.fetch_outputs_with_legacy_key_ids(0, 100).unwrap();
+    assert!(remaining_legacy_key_ids.is_empty());
+    assert_eq!(db.migrate_legacy_output_key_ids(&key_manager).unwrap(), 0);
+
+    let outputs = db.fetch_sorted_unspent_outputs(&key_manager).unwrap();
+    assert_eq!(outputs.len(), 2);
+}
+
+#[tokio::test]
+async fn test_migrate_imported_legacy_output_key_id() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection.clone());
+    let db = OutputManagerDatabase::new(backend);
+
+    let key_manager_connection =
+        DbConnection::connect_url(&DbConnectionUrl::MemoryShared(random::string(8)), Some(5)).unwrap();
+    let mut key = [0u8; size_of::<Key>()];
+    rand::rng().fill_bytes(&mut key);
+    let db_cipher = XChaCha20Poly1305::new(Key::from_slice(&key));
+    let kms_backend = TransactionKeyManagerSqliteDatabase::init(key_manager_connection, db_cipher);
+
+    let imported_private_key = PrivateKey::random(&mut rand::rng());
+    let imported_public_key = CompressedPublicKey::from_secret_key(&imported_private_key);
+    kms_backend
+        .insert_imported_key(imported_public_key.clone(), imported_private_key.clone())
+        .await
+        .unwrap();
+
+    let key_manager = LegacyTransactionKeyManagerWrapper::new_with_legacy_storage(
+        CipherSeed::random(),
+        kms_backend,
+        CryptoFactories::default(),
+        Arc::new(LegacyWalletType::default()),
+    )
+    .await
+    .unwrap();
+
+    let output = add_test_output(&db, &key_manager, MicroMinotari::from(2000));
+    let imported_legacy_key_id = LegacyTariKeyId::Imported {
+        key: imported_public_key,
+    }
+    .to_string();
+    let script_key_id = output.wallet_output.script_key_id().to_string();
+    set_output_key_ids(&connection, &output, &imported_legacy_key_id, &script_key_id);
+
+    let migrated_count = db.migrate_legacy_output_key_ids(&key_manager).unwrap();
+    assert_eq!(migrated_count, 1);
+
+    let (spending_key, _) = get_output_key_ids(&connection, &output);
+    assert_ne!(spending_key, imported_legacy_key_id);
+    assert_eq!(
+        key_manager
+            .get_private_key(&TariKeyId::from_str(&spending_key).unwrap())
+            .unwrap(),
+        imported_private_key
+    );
+}
+
+#[tokio::test]
+async fn test_legacy_key_migration_keyset_pagination_skips_bad_rows() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection.clone());
+    let db = OutputManagerDatabase::new(backend);
+    let key_manager = create_new_random_key_manager().await.unwrap();
+
+    let bad_output = add_test_output(&db, &key_manager, MicroMinotari::from(1000));
+    let bad_script_key_id = bad_output.wallet_output.script_key_id().to_string();
+    set_output_key_ids(
+        &connection,
+        &bad_output,
+        "not-legacy.managed.unparseable",
+        &bad_script_key_id,
+    );
+
+    let first_page = db.fetch_outputs_with_legacy_key_ids(0, 1).unwrap();
+    assert_eq!(first_page.len(), 1);
+
+    let valid_output = add_test_output(&db, &key_manager, MicroMinotari::from(2000));
+    let valid_script_key_id = valid_output.wallet_output.script_key_id().to_string();
+    set_output_key_ids(&connection, &valid_output, "managed.comms.0", &valid_script_key_id);
+
+    let second_page = db.fetch_outputs_with_legacy_key_ids(first_page[0].0, 1).unwrap();
+    assert_eq!(second_page.len(), 1);
+    assert_eq!(second_page[0].1, "managed.comms.0");
+
+    let migrated_count = db.migrate_legacy_output_key_ids(&key_manager).unwrap();
+    assert_eq!(migrated_count, 1);
+
+    let (bad_spending_key, _) = get_output_key_ids(&connection, &bad_output);
+    assert_eq!(bad_spending_key, "not-legacy.managed.unparseable");
+
+    let (valid_spending_key, _) = get_output_key_ids(&connection, &valid_output);
+    assert_eq!(valid_spending_key, TariKeyId::SpendKey.to_string());
+
+    let remaining = db.fetch_outputs_with_legacy_key_ids(0, 100).unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].1, "not-legacy.managed.unparseable");
+    assert_eq!(db.migrate_legacy_output_key_ids(&key_manager).unwrap(), 0);
 }


### PR DESCRIPTION
Fixes #7829

## Summary
- Run a nonblocking startup migration for legacy console-wallet output key ids.
- Fetch output rows in small keyset-paginated batches, selecting only `id`, `spending_key`, and `script_private_key`.
- Convert legacy key ids through the existing legacy key-manager path and leave rows unchanged if an individual conversion or update fails.
- Add coverage for direct, nested, imported, malformed-row, idempotency, and startup behavior.

## Correctness Note
The nested-key test exposed one small parser wrinkle: `derived.managed.comms.0` converts to the current key id `derived.spend_key`. That persisted current key id must parse cleanly when wallet outputs are loaded again, so this also allows one-segment derived current key ids such as `derived.spend_key`.

## Testing
- `cargo test -p minotari_wallet --test wallet_integration_tests legacy_key`
- `cargo test -p minotari_wallet --test wallet_integration_tests legacy_output_key`
- `cargo test -p minotari_wallet --test wallet_integration_tests legacy`
- `cargo test -p tari_transaction_components roundtrip_derived_with_simple_current_key`
