### PR TITLE
fix(minotari-utils): fix three dbstats bugs affecting Windows and legacy chains

### DIFF
--- a/applications/minotari_utils/Cargo.toml
+++ b/applications/minotari_utils/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 tari_core = { workspace = true }
 
 lmdb-zero = "0.4.4"
-rusqlite = "0.32"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 clap = { version = "4.0", features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive"] }

--- a/applications/minotari_utils/src/commands/dbstats.rs
+++ b/applications/minotari_utils/src/commands/dbstats.rs
@@ -471,9 +471,11 @@ fn get_directory_size(dir: &Path) -> Result<u64> {
 }
 
 fn find_base_node_lmdb_database(databases: &[ComponentDatabaseInfo]) -> Option<&ComponentDatabaseInfo> {
-    databases
-        .iter()
-        .find(|db| db.component == "Base Node" && db.db_type == "LMDB" && db.path.contains("data/base_node/db"))
+    databases.iter().find(|db| {
+        db.component == "Base Node" &&
+            db.db_type == "LMDB" &&
+            (db.path.contains("data/base_node/db") || db.path.contains("data\\base_node\\db"))
+    })
 }
 
 fn collect_database_stats(db_path: &Path) -> Result<DbStatsOutput> {
@@ -496,29 +498,37 @@ fn collect_database_stats(db_path: &Path) -> Result<DbStatsOutput> {
     let mut databases = Vec::new();
     let page_size = env_stat.psize as usize;
 
-    // Get the authoritative list of database names from Tari core
-    let db_names = get_all_database_names();
+    // Get the authoritative list of database names from Tari core, plus a few V1/legacy names
+    // so we can inspect older databases that have not yet been migrated to the V2 schema.
+    let mut db_names = get_all_database_names();
+    for legacy in ["jmt_node_data", "jmt_value_data", "jmt_unique_key_data"] {
+        db_names.push(legacy);
+    }
 
     // Get statistics for each database
     for db_name in db_names {
-        if let Ok(database) = Database::open(&*env, Some(db_name), &DatabaseOptions::defaults()) &&
-            let Ok(db_stat) = ReadTransaction::new(env.clone()).and_then(|txn| txn.db_stat(&database))
-        {
-            let total_pages = db_stat.leaf_pages + db_stat.branch_pages + db_stat.overflow_pages;
-            let total_size = total_pages * page_size;
-            let avg_size = total_size.checked_div(db_stat.entries).unwrap_or(0);
+        match Database::open(&*env, Some(db_name), &DatabaseOptions::defaults()) {
+            Ok(database) => match ReadTransaction::new(env.clone()).and_then(|txn| txn.db_stat(&database)) {
+                Ok(db_stat) => {
+                    let total_pages = db_stat.leaf_pages + db_stat.branch_pages + db_stat.overflow_pages;
+                    let total_size = total_pages * page_size;
+                    let avg_size = total_size.checked_div(db_stat.entries).unwrap_or(0);
 
-            databases.push(DatabaseStats {
-                name: db_name.to_string(),
-                entries: db_stat.entries,
-                total_size,
-                avg_size,
-                depth: db_stat.depth,
-                total_pages,
-                leaf_pages: db_stat.leaf_pages,
-                branch_pages: db_stat.branch_pages,
-                overflow_pages: db_stat.overflow_pages,
-            });
+                    databases.push(DatabaseStats {
+                        name: db_name.to_string(),
+                        entries: db_stat.entries,
+                        total_size,
+                        avg_size,
+                        depth: db_stat.depth,
+                        total_pages,
+                        leaf_pages: db_stat.leaf_pages,
+                        branch_pages: db_stat.branch_pages,
+                        overflow_pages: db_stat.overflow_pages,
+                    });
+                },
+                Err(e) => eprintln!("  [warn] db_stat failed for '{db_name}': {e}"),
+            },
+            Err(e) => eprintln!("  [warn] Database::open failed for '{db_name}': {e}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Three bugs in `minotari-utils dbstats` discovered while running the tool against a local node on Windows. None affect chain consensus or wallet logic - these are all diagnostic tooling issues.

## Root cause

1. **Windows path separator**: `find_base_node_lmdb_database` filtered on `"data/base_node/db"` (forward slash). On Windows the paths use backslashes, so the base node LMDB was never matched and the detailed analysis block was silently skipped.
2. **V1/legacy JMT table names absent**: `get_all_database_names()` returns only V2 table names. Nodes that have not yet completed the V2 migration show zero JMT entries because the V1 tables (`jmt_node_data`, `jmt_value_data`, `jmt_unique_key_data`) are not in the list.
3. **Silent error suppression**: The `if let Ok(...) && let Ok(...)` chain discards all `Database::open` and `db_stat` failures without any output, making it impossible to tell whether a table is missing or failed to open.

## Fix

- `find_base_node_lmdb_database`: OR condition accepts both `/` and `\` path separators.
- `collect_database_stats`: append the three V1 JMT names after `get_all_database_names()`. They appear as missing on fully migrated nodes (expected), but are present and correctly sized on pre-migration nodes.
- `collect_database_stats`: replace `if let` chain with nested `match`; each error arm emits `eprintln!("[warn] ...")` so the caller sees what failed.
- `Cargo.toml`: add `features = ["bundled"]` to `rusqlite`. The system `sqlite3.lib` is not present on Windows; without `bundled` the binary fails to link.

## Changes

- `applications/minotari_utils/Cargo.toml`: add `bundled` feature to rusqlite
- `applications/minotari_utils/src/commands/dbstats.rs`: Windows path fix, V1 table names, error surfacing

## Breaking change

None. Output format is unchanged; the only visible difference is additional `[warn]` lines when a named table does not exist in the LMDB (which is normal for tables that were never populated on a given node).

## Bounty payment

`123JbAxCZ4Vrh4jCjFLXTu4z8sLeggUR87fejwNunsB55NMBSH9RpkjNiw1WL2GkKr8JhqRZhbrsSREchGanchw2Nhb`