### PR TITLE
feat: add synced gRPC healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions: {}
 env:
   toolchain: stable
   toolchain_msrv_reject_older: 1.93.0
-  nightly_toolchain: nightly-2025-06-24
+  nightly_toolchain: nightly-2026-06-01
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
   CARGO_UNSTABLE_SPARSE_REGISTRY: true

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,7 +33,7 @@ permissions: {}
 
 env:
   toolchain: stable
-  nightly_toolchain: nightly-2025-06-24
+  nightly_toolchain: nightly-2026-06-01
   RUSTUP_PERMIT_COPY_RENAME: true
 
 concurrency:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,6 +4601,7 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tonic 0.13.1",
+ "tonic-health",
  "tower-http",
  "url",
  "utoipa",
@@ -8781,6 +8782,18 @@ dependencies = [
  "prost-types 0.13.4",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
+dependencies = [
+ "prost 0.13.4",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.13.1",
 ]
 
 [[package]]

--- a/applications/minotari_node/Cargo.toml
+++ b/applications/minotari_node/Cargo.toml
@@ -67,6 +67,7 @@ strum = { version = "0.22", features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }
 tonic = { version = "0.13.1", features = ["tls-ring", "tls-native-roots"] }
+tonic-health = "0.13.1"
 tari_metrics = { workspace = true, optional = true, features = ["server"] }
 url = { version = "2.5.4", features = ["default", "serde"] }
 axum = { version = "0.8.4", features = ["default", "http2"] }

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -368,7 +368,7 @@ async fn run_grpc<T: tari_rpc::base_node_server::BaseNode>(
         let mut status_watch = state_machine_handle.get_status_info_watch();
         let is_serving = is_grpc_health_serving(&status_watch.borrow_and_update());
         update_grpc_health_status(&mut health_reporter, is_serving).await;
-        spawn_grpc_health_updater(health_reporter, status_watch);
+        spawn_grpc_health_updater(health_reporter, status_watch, is_serving);
 
         server_builder
             .add_service(service)
@@ -393,6 +393,7 @@ async fn run_grpc<T: tari_rpc::base_node_server::BaseNode>(
 fn spawn_grpc_health_updater(
     mut health_reporter: HealthReporter,
     mut status_watch: tokio::sync::watch::Receiver<StatusInfo>,
+    mut last_is_serving: bool,
 ) {
     task::spawn(async move {
         loop {
@@ -400,7 +401,11 @@ fn spawn_grpc_health_updater(
                 break;
             }
             let is_serving = is_grpc_health_serving(&status_watch.borrow());
+            if is_serving == last_is_serving {
+                continue;
+            }
             update_grpc_health_status(&mut health_reporter, is_serving).await;
+            last_is_serving = is_serving;
         }
     });
 }

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -61,6 +61,10 @@ use tari_common::{
 };
 use tari_common_types::grpc_authentication::GrpcAuthentication;
 use tari_comms::{NodeIdentity, multiaddr::Multiaddr, utils::multiaddr::multiaddr_to_socketaddr};
+use tari_core::base_node::{
+    StateMachineHandle,
+    state_machine_service::states::StatusInfo,
+};
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tokio::{
     task::{self, JoinHandle},
@@ -70,6 +74,7 @@ use tonic::{
     codegen::InterceptedService,
     transport::{Identity, Server, ServerTlsConfig},
 };
+use tonic_health::{ServingStatus, server::HealthReporter};
 
 pub use crate::config::{ApplicationConfig, BaseNodeConfig, DatabaseType};
 #[cfg(feature = "metrics")]
@@ -144,6 +149,7 @@ pub async fn run_base_node_with_cli(
             grpc_address.clone(),
             auth.clone(),
             tls_identity.clone(),
+            None,
             readiness_grpc_shutdown.to_signal(),
         )));
     } else {
@@ -220,6 +226,7 @@ pub async fn run_base_node_with_cli(
             grpc_address.clone(),
             auth.clone(),
             tls_identity,
+            Some(ctx.state_machine()),
             shutdown.to_signal(),
         ));
 
@@ -336,6 +343,7 @@ async fn run_grpc<T: tari_rpc::base_node_server::BaseNode>(
     grpc_address: Multiaddr,
     auth_config: GrpcAuthentication,
     tls_identity: Option<Identity>,
+    health_state_machine: Option<StateMachineHandle>,
     interrupt_signal: ShutdownSignal,
 ) -> Result<(), anyhow::Error> {
     info!(target: LOG_TARGET, "Starting GRPC on {grpc_address}");
@@ -355,17 +363,60 @@ async fn run_grpc<T: tari_rpc::base_node_server::BaseNode>(
         Server::builder()
     };
 
-    server_builder
-        .add_service(service)
-        .serve_with_shutdown(grpc_address, interrupt_signal.map(|_| ()))
-        .await
-        .map_err(|err| {
-            error!(target: LOG_TARGET, "GRPC encountered an error: {err:?}");
-            err
-        })?;
+    if let Some(state_machine_handle) = health_state_machine {
+        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+        let mut status_watch = state_machine_handle.get_status_info_watch();
+        let is_serving = is_grpc_health_serving(&status_watch.borrow_and_update());
+        update_grpc_health_status(&mut health_reporter, is_serving).await;
+        spawn_grpc_health_updater(health_reporter, status_watch);
+
+        server_builder
+            .add_service(service)
+            .add_service(health_service)
+            .serve_with_shutdown(grpc_address, interrupt_signal.map(|_| ()))
+            .await
+    } else {
+        server_builder
+            .add_service(service)
+            .serve_with_shutdown(grpc_address, interrupt_signal.map(|_| ()))
+            .await
+    }
+    .map_err(|err| {
+        error!(target: LOG_TARGET, "GRPC encountered an error: {err:?}");
+        err
+    })?;
 
     info!(target: LOG_TARGET, "Stopping GRPC");
     Ok(())
+}
+
+fn spawn_grpc_health_updater(
+    mut health_reporter: HealthReporter,
+    mut status_watch: tokio::sync::watch::Receiver<StatusInfo>,
+) {
+    task::spawn(async move {
+        loop {
+            if status_watch.changed().await.is_err() {
+                break;
+            }
+            let is_serving = is_grpc_health_serving(&status_watch.borrow());
+            update_grpc_health_status(&mut health_reporter, is_serving).await;
+        }
+    });
+}
+
+async fn update_grpc_health_status(health_reporter: &mut HealthReporter, is_serving: bool) {
+    let serving_status = if is_serving {
+        ServingStatus::Serving
+    } else {
+        ServingStatus::NotServing
+    };
+
+    health_reporter.set_service_status("", serving_status).await;
+}
+
+fn is_grpc_health_serving(status: &StatusInfo) -> bool {
+    status.bootstrapped && status.state_info.is_synced()
 }
 
 /// Prepares the parameters required to call the `run_grpc` function

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -65,10 +65,7 @@ use tari_common::{
 };
 use tari_common_types::grpc_authentication::GrpcAuthentication;
 use tari_comms::{NodeIdentity, multiaddr::Multiaddr, utils::multiaddr::multiaddr_to_socketaddr};
-use tari_core::base_node::{
-    StateMachineHandle,
-    state_machine_service::states::StatusInfo,
-};
+use tari_core::base_node::{StateMachineHandle, state_machine_service::states::StatusInfo};
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tokio::{
     task::{self, JoinHandle},

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -454,3 +454,98 @@ async fn prepare_grpc_params(
 
     Ok((grpc_address, auth, tls_identity))
 }
+
+#[cfg(test)]
+mod tests {
+    use minotari_app_grpc::tari_rpc::base_node_server::SERVICE_NAME as BASE_NODE_GRPC_SERVICE_NAME;
+    use tari_core::base_node::state_machine_service::states::{
+        StateInfo, StatusInfo, events_and_states::ListeningInfo,
+    };
+    use tonic::{Code, Request};
+    use tonic_health::{
+        ServingStatus,
+        pb::{HealthCheckRequest, health_check_response, health_server::Health},
+        server::HealthService,
+    };
+
+    use super::{grpc_serving_status, is_grpc_health_serving};
+
+    fn status_info(bootstrapped: bool, state_info: StateInfo) -> StatusInfo {
+        StatusInfo {
+            bootstrapped,
+            state_info,
+            ..StatusInfo::default()
+        }
+    }
+
+    fn expected_wire_status(status: ServingStatus) -> i32 {
+        health_check_response::ServingStatus::from(status) as i32
+    }
+
+    async fn assert_health_status(service: &HealthService, service_name: &str, expected: ServingStatus) {
+        let response = service
+            .check(Request::new(HealthCheckRequest {
+                service: service_name.to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.status, expected_wire_status(expected));
+    }
+
+    async fn assert_health_service_not_registered(service: &HealthService, service_name: &str) {
+        let err = service
+            .check(Request::new(HealthCheckRequest {
+                service: service_name.to_string(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code(), Code::NotFound);
+    }
+
+    #[test]
+    fn grpc_serving_status_maps_boolean_to_tonic_status() {
+        assert_eq!(grpc_serving_status(true), ServingStatus::Serving);
+        assert_eq!(grpc_serving_status(false), ServingStatus::NotServing);
+    }
+
+    #[test]
+    fn grpc_health_is_serving_only_when_bootstrapped_and_synced() {
+        let synced_listening = StateInfo::Listening(ListeningInfo::new(true, 0, 0, false));
+        let unsynced_listening = StateInfo::Listening(ListeningInfo::new(false, 0, 1, false));
+
+        assert!(is_grpc_health_serving(&status_info(true, synced_listening.clone())));
+        assert!(!is_grpc_health_serving(&status_info(false, synced_listening)));
+        assert!(!is_grpc_health_serving(&status_info(true, unsynced_listening)));
+        assert!(!is_grpc_health_serving(&status_info(true, StateInfo::StartUp)));
+    }
+
+    #[tokio::test]
+    async fn update_grpc_health_status_updates_overall_and_base_node_services() {
+        let (mut health_reporter, _health_server) = tonic_health::server::health_reporter();
+        let health_service = HealthService::from_health_reporter(health_reporter.clone());
+
+        super::update_grpc_health_status(&mut health_reporter, false).await;
+
+        assert_health_status(
+            &health_service,
+            super::GRPC_HEALTH_OVERALL_SERVICE_NAME,
+            ServingStatus::NotServing,
+        )
+        .await;
+        assert_health_status(&health_service, BASE_NODE_GRPC_SERVICE_NAME, ServingStatus::NotServing).await;
+        assert_health_service_not_registered(&health_service, "unknown.service").await;
+
+        super::update_grpc_health_status(&mut health_reporter, true).await;
+
+        assert_health_status(
+            &health_service,
+            super::GRPC_HEALTH_OVERALL_SERVICE_NAME,
+            ServingStatus::Serving,
+        )
+        .await;
+        assert_health_status(&health_service, BASE_NODE_GRPC_SERVICE_NAME, ServingStatus::Serving).await;
+    }
+}

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -50,7 +50,11 @@ pub use http::HttpCacheConfig;
 use log::*;
 use minotari_app_grpc::{
     authentication::ServerAuthenticationInterceptor,
-    tari_rpc::{self, readiness_status::State as ReadinessState},
+    tari_rpc::{
+        self,
+        base_node_server::SERVICE_NAME as BASE_NODE_GRPC_SERVICE_NAME,
+        readiness_status::State as ReadinessState,
+    },
     tls::identity::read_identity,
 };
 use minotari_app_utilities::common_cli_args::CommonCliArgs;
@@ -82,6 +86,7 @@ pub use crate::metrics::MetricsConfig;
 use crate::{cli::Cli, grpc::readiness_grpc_server::ReadinessGrpcServer};
 
 const LOG_TARGET: &str = "minotari::base_node::app";
+const GRPC_HEALTH_OVERALL_SERVICE_NAME: &str = "";
 
 pub async fn run_base_node(
     shutdown: Shutdown,
@@ -411,13 +416,20 @@ fn spawn_grpc_health_updater(
 }
 
 async fn update_grpc_health_status(health_reporter: &mut HealthReporter, is_serving: bool) {
-    let serving_status = if is_serving {
+    health_reporter
+        .set_service_status(GRPC_HEALTH_OVERALL_SERVICE_NAME, grpc_serving_status(is_serving))
+        .await;
+    health_reporter
+        .set_service_status(BASE_NODE_GRPC_SERVICE_NAME, grpc_serving_status(is_serving))
+        .await;
+}
+
+fn grpc_serving_status(is_serving: bool) -> ServingStatus {
+    if is_serving {
         ServingStatus::Serving
     } else {
         ServingStatus::NotServing
-    };
-
-    health_reporter.set_service_status("", serving_status).await;
+    }
 }
 
 fn is_grpc_health_serving(status: &StatusInfo) -> bool {

--- a/applications/minotari_node/src/lib.rs
+++ b/applications/minotari_node/src/lib.rs
@@ -459,7 +459,9 @@ async fn prepare_grpc_params(
 mod tests {
     use minotari_app_grpc::tari_rpc::base_node_server::SERVICE_NAME as BASE_NODE_GRPC_SERVICE_NAME;
     use tari_core::base_node::state_machine_service::states::{
-        StateInfo, StatusInfo, events_and_states::ListeningInfo,
+        StateInfo,
+        StatusInfo,
+        events_and_states::ListeningInfo,
     };
     use tonic::{Code, Request};
     use tonic_health::{


### PR DESCRIPTION
This pull request adds support for gRPC health checking to the Minotari node. The main changes introduce a health reporter that tracks the node's state via the state machine and updates the gRPC health status accordingly. This allows external systems to check the node's readiness and health using the standard gRPC health check protocol.

**gRPC Health Checking Integration:**

* Added the `tonic-health` dependency to `Cargo.toml` for gRPC health checking support.
* Updated the `run_grpc` function in `lib.rs` to optionally accept a `StateMachineHandle`, set up a `HealthReporter`, and add the gRPC health service to the server. The health status is updated based on the node's state. [[1]](diffhunk://#diff-16fa446fb226d326cfbacc0938b31c552672cb25fb555d2e48b93b5c8ea2f3f6R346) [[2]](diffhunk://#diff-16fa446fb226d326cfbacc0938b31c552672cb25fb555d2e48b93b5c8ea2f3f6R366-R383)
