### PR TITLE
fix(wallet): bind target sidechain into burn claim ownership proof

### DIFF
--- a/base_layer/transaction_components/src/key_manager/interface.rs
+++ b/base_layer/transaction_components/src/key_manager/interface.rs
@@ -261,11 +261,16 @@ pub trait TransactionKeyManagerInterface: Clone + Send + Sync + 'static {
         metadata_signature_message: &[u8; 32],
     ) -> Result<ComAndPubSignature, KeyManagerError>;
 
+    /// Sign the burn claim ownership proof. `sidechain_id` is the public key of the target
+    /// sidechain (`None` for the default L2 chain that has no deployment key); it is bound into the
+    /// signature challenge so the proof cannot be replayed to claim the burn on a different
+    /// sidechain/application that shares this claim mechanism (see tari-ootle#445).
     fn generate_burn_claim_signature(
         &self,
         commitment_mask_key_id: &TariKeyId,
         amount: u64,
         claim_public_key: &CompressedPublicKey,
+        sidechain_id: Option<&CompressedPublicKey>,
     ) -> Result<CompressedSignature, KeyManagerError>;
 
     /// Derive a deterministic sender-offset key for an L2-targeted burn, bound to the burn's

--- a/base_layer/transaction_components/src/key_manager/manager.rs
+++ b/base_layer/transaction_components/src/key_manager/manager.rs
@@ -1296,14 +1296,21 @@ impl TransactionKeyManagerInterface for KeyManager {
         commitment_mask_key_id: &TariKeyId,
         amount: u64,
         claim_public_key: &CompressedPublicKey,
+        sidechain_id: Option<&CompressedPublicKey>,
     ) -> Result<CompressedSignature, KeyManagerError> {
         let mask = self.get_private_key(commitment_mask_key_id)?;
         let commitment =
             CompressedCommitment::from_commitment(self.crypto_factories.commitment.commit(&mask, &amount.into()));
 
+        // Bind the proof to the target sidechain so it cannot be replayed to claim the burn on a
+        // different sidechain/application that shares this claim mechanism (tari-ootle#445). The
+        // Tari network is already mixed into the hash domain by ConfidentialOutputHasher, and the
+        // Option encoding distinguishes "no sidechain" from a specific one.
+        let sidechain_id = sidechain_id.cloned();
         let message = ConfidentialOutputHasher::new("commitment_signature")
             .chain(&commitment)
             .chain(claim_public_key)
+            .chain(&sidechain_id)
             .finalize();
 
         let s = UncompressedSignature::sign(&mask, message, &mut rand::rng())

--- a/base_layer/transaction_key_manager/src/legacy_key_manager/inner.rs
+++ b/base_layer/transaction_key_manager/src/legacy_key_manager/inner.rs
@@ -365,9 +365,10 @@ where TBackend: TransactionKeyManagerBackend + 'static
         commitment_mask_key_id: &TariKeyId,
         value: u64,
         claim_public_key: &CompressedPublicKey,
+        sidechain_id: Option<&CompressedPublicKey>,
     ) -> Result<CompressedSignature, KeyManagerError> {
         self.key_manager
-            .generate_burn_claim_signature(commitment_mask_key_id, value, claim_public_key)
+            .generate_burn_claim_signature(commitment_mask_key_id, value, claim_public_key, sidechain_id)
     }
 
     pub fn derive_burn_sender_offset_key(

--- a/base_layer/transaction_key_manager/src/legacy_key_manager/wrapper.rs
+++ b/base_layer/transaction_key_manager/src/legacy_key_manager/wrapper.rs
@@ -502,11 +502,13 @@ where TBackend: TransactionKeyManagerBackend + 'static
         commitment_mask_key_id: &TariKeyId,
         value: u64,
         claim_public_key: &CompressedPublicKey,
+        sidechain_id: Option<&CompressedPublicKey>,
     ) -> Result<CompressedSignature, KeyManagerError> {
         self.transaction_key_manager_inner.generate_burn_claim_signature(
             commitment_mask_key_id,
             value,
             claim_public_key,
+            sidechain_id,
         )
     }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -3283,6 +3283,13 @@ where
             // derive the spend secret s = H(R·p) + p against C. C is not carried in the proof:
             // both ends recompute it from (R, P, p) and the on-chain ConfidentialOutputData
             // echoes it for the wallets that want chain-side discoverability.
+            //
+            // The proof is also bound to the target sidechain (the deployment key's public key,
+            // which is what `SideChainId::sign` records on-chain) so it cannot be replayed to claim
+            // the burn on a different sidechain/application (tari-ootle#445).
+            let sidechain_id = sidechain_deployment_key
+                .as_ref()
+                .map(CompressedPublicKey::from_secret_key);
             let ownership_proof = self
                 .resources
                 .transaction_key_manager_service
@@ -3290,6 +3297,7 @@ where
                     &commitment_mask_key.key_id,
                     amount.as_u64(),
                     &stealth_claim_public_key,
+                    sidechain_id.as_ref(),
                 )?;
             let proof = PartialBurnClaimProof {
                 claim_public_key,

--- a/base_layer/wallet/tests/transaction_service_tests/service.rs
+++ b/base_layer/wallet/tests/transaction_service_tests/service.rs
@@ -552,6 +552,8 @@ async fn single_transaction_burn_tari() {
         .unwrap();
     let burn_value = 10000.into();
     let (claim_private_key, claim_public_key) = CompressedPublicKey::random_keypair(&mut rand::rng());
+    // Burn towards a specific sidechain so the ownership proof is bound to it (tari-ootle#445).
+    let sidechain_deployment_key = PrivateKey::random(&mut rand::rng());
     let (tx_id, burn_proof) = alice_ts
         .burn_tari(
             burn_value,
@@ -559,7 +561,7 @@ async fn single_transaction_burn_tari() {
             20.into(),
             MemoField::new_empty(),
             Some(claim_public_key.clone()),
-            None,
+            Some(sidechain_deployment_key.clone()),
         )
         .await
         .expect("Alice sending burn tx");
@@ -612,9 +614,13 @@ async fn single_transaction_burn_tari() {
         CompressedPublicKey::from_secret_key(&scalar).to_public_key().unwrap() +
             &claim_public_key.to_public_key().unwrap(),
     );
+    // The challenge is also bound to the target sidechain's public key (= the deployment key's
+    // public key, as recorded on-chain by SideChainId::sign).
+    let sidechain_id = Some(CompressedPublicKey::from_secret_key(&sidechain_deployment_key));
     let challenge_bytes = ConfidentialOutputHasher::new("commitment_signature")
         .chain(&burn_proof.commitment)
         .chain(&stealth_claim_public_key)
+        .chain(&sidechain_id)
         .finalize();
     let ownership_proof = burn_proof.ownership_proof.to_schnorr_signature().unwrap();
     let commit_value = factories


### PR DESCRIPTION
## Description

The L1→L2 burn claim ownership signature (`generate_burn_claim_signature`) builds its challenge from only:

```rust
ConfidentialOutputHasher::new("commitment_signature")
    .chain(&commitment)
    .chain(claim_public_key)
    .finalize()
```

There is **no chain/application identifier** in the challenge. `ConfidentialOutputHasher` already mixes the **Tari network** byte into its hash domain, so cross-*network* replay is prevented — but another sidechain or application that reuses this same claim mechanism **on the same network** could replay the proof to claim the burn on their chain.

This PR binds the **target sidechain's public key** into the challenge. That key is the deployment key's public key — exactly what `SideChainId::sign` already records on-chain in `SideChainFeature.sidechain_id`, so the L2 verifier can reconstruct the same challenge from on-chain data. The value is threaded as `Option<&CompressedPublicKey>`; the `Option` encoding distinguishes "no sidechain" (default L2 chain, no deployment key) from a specific one.

## Why this is safe on L1

The burn claim `ownership_proof` is **not** part of any base-layer consensus rule — it is a payload carried for L2 (Ootle) to consume. Confirmed by tracing every reference:

- `ownership_proof` is never read in `base_layer/core/src/validation/`, mempool, block, kernel, or output validation.
- The challenge label `"commitment_signature"` appears only in the signer and the wallet test.
- The only consensus-validated burn fields are the output commitment ↔ kernel `burn_commitment` match and the separate `sidechain_id` knowledge-proof over `claim_public_key` — neither is touched here.

So changing the challenge cannot affect L1 consensus.

## Changes

- `TransactionKeyManagerInterface::generate_burn_claim_signature` gains a `sidechain_id: Option<&CompressedPublicKey>` parameter (+ legacy key-manager delegates).
- The wallet burn flow derives the id from the `sidechain_deployment_key` and passes it.
- `single_transaction_burn_tari` now burns towards a specific sidechain and verifies the proof against a challenge that includes the sidechain id.

## ⚠️ Breaking / coordination required

This changes the burn claim ownership proof challenge. The **L2 (Ootle) claim verification must be updated in lockstep** to reconstruct the challenge with the sidechain id, otherwise valid claims will be rejected. This PR is the L1 half only — see tari-project/tari-ootle#445.

## Testing

- `cargo check` / `cargo clippy` clean on `tari_transaction_components`, `tari_transaction_key_manager`, `minotari_wallet`.
- `cargo +nightly fmt --check` clean.
- `single_transaction_burn_tari` passes (binding verified end-to-end).

Addresses tari-project/tari-ootle#445

🤖 Generated with [Claude Code](https://claude.com/claude-code)