### PR TITLE
fix(base_node): reject duplicate validator node registrations within a block

### DIFF
--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
@@ -104,6 +104,7 @@ impl AggregateBodyChainLinkedValidator {
         check_inputs_are_spendable(db, constants, header.height, &body)?;
         check_outputs(db, constants, &body, header.height)?;
         verify_no_duplicated_inputs_outputs(&body)?;
+        verify_no_duplicate_validator_node_registrations(&body)?;
         check_total_burned(&body)?;
         verify_timelocks(&body, header.height)?;
 
@@ -267,6 +268,40 @@ pub fn verify_no_duplicated_inputs_outputs(body: &AggregateBody) -> Result<(), V
     Ok(())
 }
 
+/// Ensures the body does not contain more than one validator node registration for the same validator node (scoped by
+/// sidechain id).
+///
+/// `check_validator_node_registration` only rejects a registration that duplicates one already in the validator node
+/// set as of the *parent* block. It cannot see other registrations in the same body. Without this check, a single block
+/// carrying two registrations for the same validator node would pass validation and then fail when the second
+/// registration is applied to the validator node set (the set is keyed by sidechain id + public key and inserted with
+/// `NO_OVERWRITE`), aborting the block at commit time rather than rejecting it cleanly during validation.
+// The `mutable_key_type` lint fires because `CompressedPublicKey` caches its decompressed form in a `OnceLock`. That
+// interior mutability does not affect the `Hash`/`Eq` used here, so the set behaves correctly.
+#[allow(clippy::mutable_key_type)]
+pub fn verify_no_duplicate_validator_node_registrations(body: &AggregateBody) -> Result<(), ValidationError> {
+    let mut seen = HashSet::new();
+    for output in body.outputs() {
+        let Some(sidechain_features) = output.features.sidechain_feature.as_ref() else {
+            continue;
+        };
+        let Some(vn_reg) = sidechain_features.validator_node_registration() else {
+            continue;
+        };
+        if !seen.insert((sidechain_features.sidechain_public_key().cloned(), vn_reg.public_key().clone())) {
+            warn!(
+                target: LOG_TARGET,
+                "AggregateBody validation failed due to duplicate validator node registration for {}",
+                vn_reg.public_key()
+            );
+            return Err(ValidationError::DuplicateValidatorNodeRegistration {
+                public_key: vn_reg.public_key().to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// This function checks the total burned sum in the header ensuring that every burned output is counted in the total
 /// sum.
 #[allow(clippy::mutable_key_type)]
@@ -386,4 +421,49 @@ fn check_validator_node_registration_spend<B: BlockchainBackend>(
         });
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use tari_common_types::types::{CompressedPublicKey, PrivateKey};
+    use tari_crypto::keys::SecretKey;
+    use tari_transaction_components::transaction_components::{
+        OutputFeatures,
+        TransactionOutput,
+        ValidatorNodeSignature,
+    };
+
+    use super::*;
+
+    fn registration_output(vn_secret_key: &PrivateKey) -> TransactionOutput {
+        let claim_public_key = CompressedPublicKey::from_secret_key(vn_secret_key);
+        let max_epoch = VnEpoch(10);
+        let signature = ValidatorNodeSignature::sign_for_registration(vn_secret_key, None, &claim_public_key, max_epoch);
+        let mut output = TransactionOutput::default();
+        output.features = OutputFeatures::for_validator_node_registration(signature, claim_public_key, None, max_epoch);
+        output
+    }
+
+    #[test]
+    fn it_allows_distinct_validator_node_registrations() {
+        let outputs = vec![
+            registration_output(&PrivateKey::random(&mut rand::rng())),
+            registration_output(&PrivateKey::random(&mut rand::rng())),
+            // A non-registration output should be ignored.
+            TransactionOutput::default(),
+        ];
+        let body = AggregateBody::new(vec![], outputs, vec![]);
+        assert!(verify_no_duplicate_validator_node_registrations(&body).is_ok());
+    }
+
+    #[test]
+    fn it_rejects_two_registrations_for_the_same_validator_node() {
+        // Two distinct outputs (different commitments) registering the same validator node public key. Each passes the
+        // chain-state check individually but they collide when applied to the validator node set.
+        let vn_secret_key = PrivateKey::random(&mut rand::rng());
+        let outputs = vec![registration_output(&vn_secret_key), registration_output(&vn_secret_key)];
+        let body = AggregateBody::new(vec![], outputs, vec![]);
+        let err = verify_no_duplicate_validator_node_registrations(&body).unwrap_err();
+        assert!(matches!(err, ValidationError::DuplicateValidatorNodeRegistration { .. }));
+    }
 }

--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
@@ -288,7 +288,7 @@ pub fn verify_no_duplicate_validator_node_registrations(body: &AggregateBody) ->
         let Some(vn_reg) = sidechain_features.validator_node_registration() else {
             continue;
         };
-        if !seen.insert((sidechain_features.sidechain_public_key().cloned(), vn_reg.public_key().clone())) {
+        if !seen.insert((sidechain_features.sidechain_public_key(), vn_reg.public_key())) {
             warn!(
                 target: LOG_TARGET,
                 "AggregateBody validation failed due to duplicate validator node registration for {}",

--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
@@ -438,10 +438,12 @@ mod test {
     fn registration_output(vn_secret_key: &PrivateKey) -> TransactionOutput {
         let claim_public_key = CompressedPublicKey::from_secret_key(vn_secret_key);
         let max_epoch = VnEpoch(10);
-        let signature = ValidatorNodeSignature::sign_for_registration(vn_secret_key, None, &claim_public_key, max_epoch);
-        let mut output = TransactionOutput::default();
-        output.features = OutputFeatures::for_validator_node_registration(signature, claim_public_key, None, max_epoch);
-        output
+        let signature =
+            ValidatorNodeSignature::sign_for_registration(vn_secret_key, None, &claim_public_key, max_epoch);
+        TransactionOutput {
+            features: OutputFeatures::for_validator_node_registration(signature, claim_public_key, None, max_epoch),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -464,6 +466,9 @@ mod test {
         let outputs = vec![registration_output(&vn_secret_key), registration_output(&vn_secret_key)];
         let body = AggregateBody::new(vec![], outputs, vec![]);
         let err = verify_no_duplicate_validator_node_registrations(&body).unwrap_err();
-        assert!(matches!(err, ValidationError::DuplicateValidatorNodeRegistration { .. }));
+        assert!(matches!(
+            err,
+            ValidationError::DuplicateValidatorNodeRegistration { .. }
+        ));
     }
 }

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -124,6 +124,8 @@ pub enum ValidationError {
     SidechainEvictionProofInvalidEpoch { epoch: VnEpoch, tip_height: u64 },
     #[error("Validator node already registered: {public_key}")]
     ValidatorNodeAlreadyRegistered { public_key: String },
+    #[error("Block body contains more than one validator node registration for the same validator node: {public_key}")]
+    DuplicateValidatorNodeRegistration { public_key: String },
     #[error("Validator node {public_key} not registered: {details}")]
     ValidatorNodeNotRegistered { public_key: String, details: String },
     #[error("Validator registration {public_key} invalid: max epoch {max_epoch} < current epoch {current_epoch}")]
@@ -191,6 +193,7 @@ impl ValidationError {
             err @ ValidationError::SidechainProofInvalid(_) |
             err @ ValidationError::SidechainEvictionProofInvalidEpoch { .. } |
             err @ ValidationError::ValidatorNodeAlreadyRegistered { .. } |
+            err @ ValidationError::DuplicateValidatorNodeRegistration { .. } |
             err @ ValidationError::ValidatorNodeNotRegistered { .. } |
             err @ ValidationError::ValidatorNodeRegistrationMaxEpoch { .. } |
             err @ ValidationError::OutputTypeNotMatchSidechainData { .. } |


### PR DESCRIPTION
Description
---
Adds a chain-linked validation rule (`verify_no_duplicate_validator_node_registrations`) that rejects a block body containing more than one validator node registration for the same `(sidechain id, validator node public key)`, with a new `DuplicateValidatorNodeRegistration` validation error.

Motivation and Context
---
A validator node registration UTXO is only checked against the validator node set as of the **parent** block (`check_validator_node_registration` → `validator_node_exists`). That check cannot see other registrations in the **same** block body, and `contains_duplicated_outputs` only compares whole-output equality. So two outputs registering the same validator node public key (with different commitments) both pass validation.

They then collide at commit time: the validator node set is keyed by sidechain id + public key and inserted with LMDB `NO_OVERWRITE` (`ValidatorNodeStore::insert`), so the second insert returns `KeyExists` and the block is aborted during the DB write (`reorganize_chain` restores the chain and returns an error — see the "this should typically never happen unless there is a bug in the validator" comment there) instead of being rejected cleanly during validation.

This makes the invariant ("at most one active registration per validator node") an explicit validation rule rather than an accidental side effect of the storage layer. The new error is classified as a long ban, so an offending block is recorded as bad rather than silently retried. The check runs before commit on both the block path (`BlockBodyFullValidator::validate`) and the mempool transaction path (`TransactionChainLinkedValidator`).

Note: this does not change the canonical chain — such blocks were already uncommittable; it converts a commit-time abort into a clean validation rejection.

How Has This Been Tested?
---
- New unit tests: distinct registrations pass; two registrations for the same validator node are rejected with `DuplicateValidatorNodeRegistration`.
- `cargo test -p tari_core --lib validation::` — 47 passed, 0 failed.
- `cargo clippy -p tari_core --lib` — no new warnings.

What process can a PR reviewer use to test or verify this change?
---
Run `cargo test -p tari_core --lib validation::aggregate_body::aggregate_body_chain_validator`. To verify the gap manually, construct an `AggregateBody` with two `OutputType::ValidatorNodeRegistration` outputs that share a validator node public key but have different commitments, and confirm `verify_no_duplicate_validator_node_registrations` returns `DuplicateValidatorNodeRegistration`.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

🤖 Generated with [Claude Code](https://claude.com/claude-code)