### PR TITLE
feat: unified cross-platform Ledger installer with USB HID auto-detection

### DIFF
--- a/applications/minotari_ledger_wallet/wallet/INSTALLER_README.md
+++ b/applications/minotari_ledger_wallet/wallet/INSTALLER_README.md
@@ -1,0 +1,19 @@
+# Minotari Ledger Wallet - Unified Installer
+
+Replaces per-OS/per-model scripts with a single cross-platform installer.
+
+## Usage
+
+```bash
+pip install requests ledgerwallet ledgerblue hidapi
+python3 minotari_ledger_install.py          # auto-detect, latest release
+python3 minotari_ledger_install.py --tag v5.2.0
+python3 minotari_ledger_install.py --model nanosplus
+```
+
+Models: `nanos` | `nanosplus` | `nanox` | `flex` | `stax`
+
+## Prerequisites
+
+Python 3.10+, Ledger connected via USB, unlocked, Developer Mode on.
+Works on macOS, Linux, and Windows.

--- a/applications/minotari_ledger_wallet/wallet/minotari_ledger_install.py
+++ b/applications/minotari_ledger_wallet/wallet/minotari_ledger_install.py
@@ -10,86 +10,168 @@ Usage:
     python3 minotari_ledger_install.py [--tag v5.2.0] [--model nanosplus]
 
 Requirements:
-    pip install requests ledgerwallet ledgerblue hidapi
+    pip install requests ledgerwallet ledgerblue hidapi ledgerctl
 """
 from __future__ import annotations
-import argparse,platform,subprocess,sys,tempfile,zipfile
+import argparse, platform, re, subprocess, sys, tempfile, zipfile
 from pathlib import Path
 try: import requests
-except ImportError: sys.exit("pip install requests ledgerwallet ledgerblue hidapi")
+except ImportError: sys.exit("pip install requests ledgerwallet ledgerblue hidapi ledgerctl")
 
-MODELS={"nanos":{"target_id":"0x31100004","asset":"nanos","display":"Nano S"},
-        "nanosplus":{"target_id":"0x33100004","asset":"nanosplus","display":"Nano S Plus"},
-        "nanox":{"target_id":"0x33000004","asset":"nanox","display":"Nano X"},
-        "stax":{"target_id":"0x33200004","asset":"stax","display":"Stax"},
-        "flex":{"target_id":"0x33300004","asset":"flex","display":"Flex"}}
-HID_PID={0x0011:"nanos",0x4011:"nanosplus",0x0015:"nanosplus",
-         0x5011:"nanox",0x0040:"nanox",0x6011:"stax",0x0060:"stax",
-         0x7011:"flex",0x0070:"flex"}
-VENDOR=0x2C97
-REPO="tari-project/tari"
-APP="MinoTari Wallet"
+MODELS = {
+    "nanos":     {"target_id": "0x31100004", "asset": "nanos",     "display": "Nano S"},
+    "nanosplus": {"target_id": "0x33100004", "asset": "nanosplus", "display": "Nano S Plus"},
+    "nanox":     {"target_id": "0x33000004", "asset": "nanox",     "display": "Nano X"},
+    "stax":      {"target_id": "0x33200004", "asset": "stax",      "display": "Stax"},
+    "flex":      {"target_id": "0x33300004", "asset": "flex",      "display": "Flex"},
+}
+HID_PID = {
+    0x0011: "nanos",    0x4011: "nanosplus", 0x0015: "nanosplus",
+    0x5011: "nanox",    0x0040: "nanox",
+    0x6011: "stax",     0x0060: "stax",
+    0x7011: "flex",     0x0070: "flex",
+}
+VENDOR = 0x2C97
+REPO   = "tari-project/tari"
+APP    = "MinoTari Wallet"
 
-def detect()->str|None:
+
+def detect() -> str | None:
+    # USB HID detection (most reliable)
     try:
         import hid
-        for d in hid.enumerate(VENDOR,0):
-            m=HID_PID.get(d.get("product_id",0))
-            if m: return m
-    except ImportError: pass
+        for d in hid.enumerate(VENDOR, 0):
+            m = HID_PID.get(d.get("product_id", 0))
+            if m:
+                return m
+    except Exception:
+        # Catches ImportError AND OSError/AttributeError when libusb is missing
+        pass
+    # Fallback: ledgerctl
     try:
-        out=subprocess.check_output(["ledgerctl","get-target-id"],text=True,timeout=10).strip().lower()
-        for k,v in MODELS.items():
-            if v["target_id"].lower()==out: return k
-    except Exception: pass
+        out = subprocess.check_output(
+            ["ledgerctl", "get-target-id"], text=True, timeout=10
+        ).strip().lower()
+        for k, v in MODELS.items():
+            if v["target_id"].lower() == out:
+                return k
+    except Exception:
+        pass
     return None
 
-def asset_url(model:str,tag:str|None)->str:
-    base=f"https://api.github.com/repos/{REPO}/releases"
-    url=f"{base}/tags/{tag}" if tag else f"{base}/latest"
-    r=requests.get(url,timeout=30); r.raise_for_status()
-    pat=MODELS[model]["asset"]
-    for a in r.json().get("assets",[]):
-        n=a["name"].lower()
-        if pat in n and n.endswith(".zip"): return a["browser_download_url"]
-    raise RuntimeError(f"No asset for {model!r}")
 
-def install(model:str,apdu:Path)->None:
-    tid=MODELS[model]["target_id"]
-    subprocess.run(["ledgerctl","delete",APP],capture_output=True)
-    rc=subprocess.run([sys.executable,"-m","ledgerblue.runScript",
-        "--targetId",tid,"--fileName",str(apdu),"--apdu","--scp"]).returncode
-    if rc!=0: raise RuntimeError("ledgerblue failed")
+def asset_url(model: str, tag: str | None) -> str:
+    """Return firmware download URL using word-boundary matching.
 
-def main()->None:
-    ap=argparse.ArgumentParser(description=__doc__,formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("-t","--tag",help="Release tag (default: latest)")
-    ap.add_argument("-m","--model",choices=list(MODELS),help="Override auto-detect")
-    a=ap.parse_args()
+    'nanos' must NOT match inside 'nanosplus-...' filenames.
+    We use a regex word-boundary so only exact model tokens match.
+    """
+    base = f"https://api.github.com/repos/{REPO}/releases"
+    url  = f"{base}/tags/{tag}" if tag else f"{base}/latest"
+    try:
+        r = requests.get(url, timeout=30)
+        r.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Failed to fetch release metadata: {exc}") from exc
+
+    pat    = re.compile(r'(?<![a-z])' + re.escape(MODELS[model]["asset"]) + r'(?![a-z])')
+    assets = r.json().get("assets", [])
+    # Sort descending by name length so longer/more-specific names (nanosplus)
+    # are checked before shorter ones (nanos) as an extra safeguard.
+    for a in sorted(assets, key=lambda x: len(x["name"]), reverse=True):
+        n = a["name"].lower()
+        if n.endswith(".zip") and pat.search(n[:-4]):
+            return a["browser_download_url"]
+    raise RuntimeError(
+        f"No firmware asset found for {model!r} in release {tag or 'latest'}. "
+        f"Assets: {[a['name'] for a in assets]}"
+    )
+
+
+def install(model: str, apdu: Path) -> None:
+    tid = MODELS[model]["target_id"]
+    # Best-effort removal of existing app; missing ledgerctl is not fatal
+    try:
+        subprocess.run(["ledgerctl", "delete", APP],
+                       capture_output=True, timeout=30)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    try:
+        rc = subprocess.run(
+            [sys.executable, "-m", "ledgerblue.runScript",
+             "--targetId", tid, "--fileName", str(apdu), "--apdu", "--scp"],
+            timeout=120,
+        ).returncode
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "ledgerblue not found. Install with: pip install ledgerblue"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("Installation timed out after 120 s") from exc
+    if rc != 0:
+        raise RuntimeError(
+            f"ledgerblue exited with code {rc}. "
+            "Ensure the device is unlocked and on the home screen."
+        )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("-t", "--tag",   help="Release tag (default: latest)")
+    ap.add_argument("-m", "--model", choices=list(MODELS), help="Override auto-detect")
+    a = ap.parse_args()
+
     print(f"Minotari Ledger Installer  [{platform.system()} {platform.machine()}]\n")
-    model=a.model
+
+    model = a.model
     if not model:
         print("Step 1: Detecting Ledger...")
-        model=detect()
+        model = detect()
         if not model:
-            print("  ERROR: No Ledger found. Check USB, PIN, Developer Mode.\n  Or pass --model nanosplus|nanox|flex|stax")
+            print(
+                "  ERROR: No Ledger found.\n"
+                "  - Check USB connection, unlock the device, enable Developer Mode.\n"
+                "  - Or pass --model nanos|nanosplus|nanox|stax|flex"
+            )
             sys.exit(1)
     print(f"  Model: {MODELS[model]['display']}\n")
+
     print(f"Step 2: Fetching release (tag={a.tag or 'latest'})...")
-    url=asset_url(model,a.tag); print(f"  {url}")
+    try:
+        url = asset_url(model, a.tag)
+    except RuntimeError as exc:
+        print(f"  ERROR: {exc}"); sys.exit(1)
+    print(f"  {url}")
+
     with tempfile.TemporaryDirectory() as tmp:
-        zp=Path(tmp)/"fw.zip"
-        with requests.get(url,stream=True,timeout=120) as r:
-            r.raise_for_status()
-            with open(zp,"wb") as f:
-                for chunk in r.iter_content(8192): f.write(chunk)
-        print(f"  Downloaded {zp.stat().st_size//1024} KB")
-        with zipfile.ZipFile(zp) as z: z.extractall(tmp)
-        hits=list(Path(tmp).rglob("*.apdu"))
-        if not hits: sys.exit("  ERROR: no .apdu in archive")
-        apdu=hits[0]; print(f"  Firmware: {apdu.name}\n")
+        zp = Path(tmp) / "fw.zip"
+        try:
+            with requests.get(url, stream=True, timeout=120) as r:
+                r.raise_for_status()
+                with open(zp, "wb") as f:
+                    for chunk in r.iter_content(8192):
+                        f.write(chunk)
+        except requests.RequestException as exc:
+            print(f"  ERROR: Download failed: {exc}"); sys.exit(1)
+        print(f"  Downloaded {zp.stat().st_size // 1024} KB")
+        try:
+            with zipfile.ZipFile(zp) as z: z.extractall(tmp)
+        except zipfile.BadZipFile as exc:
+            print(f"  ERROR: Bad zip file: {exc}"); sys.exit(1)
+        hits = list(Path(tmp).rglob("*.apdu"))
+        if not hits: print("  ERROR: no .apdu firmware file in archive"); sys.exit(1)
+        apdu = hits[0]; print(f"  Firmware: {apdu.name}\n")
         print("Step 3: Installing - device must be unlocked and on home screen...")
-        install(model,apdu)
+        try:
+            install(model, apdu)
+        except RuntimeError as exc:
+            print(f"  ERROR: {exc}"); sys.exit(1)
+
     print(f"\nDone! {MODELS[model]['display']} - MinoTari Wallet installed.")
 
-if __name__=="__main__": main()
+
+if __name__ == "__main__":
+    main()

--- a/applications/minotari_ledger_wallet/wallet/minotari_ledger_install.py
+++ b/applications/minotari_ledger_wallet/wallet/minotari_ledger_install.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Minotari Ledger Wallet - Unified Cross-Platform Installer.
+
+Replaces per-OS/per-model shell scripts with one installer that:
+  1. Auto-detects the connected Ledger model via USB HID
+  2. Downloads the correct firmware from GitHub Releases
+  3. Installs it - all in one step
+
+Usage:
+    python3 minotari_ledger_install.py [--tag v5.2.0] [--model nanosplus]
+
+Requirements:
+    pip install requests ledgerwallet ledgerblue hidapi
+"""
+from __future__ import annotations
+import argparse,platform,subprocess,sys,tempfile,zipfile
+from pathlib import Path
+try: import requests
+except ImportError: sys.exit("pip install requests ledgerwallet ledgerblue hidapi")
+
+MODELS={"nanos":{"target_id":"0x31100004","asset":"nanos","display":"Nano S"},
+        "nanosplus":{"target_id":"0x33100004","asset":"nanosplus","display":"Nano S Plus"},
+        "nanox":{"target_id":"0x33000004","asset":"nanox","display":"Nano X"},
+        "stax":{"target_id":"0x33200004","asset":"stax","display":"Stax"},
+        "flex":{"target_id":"0x33300004","asset":"flex","display":"Flex"}}
+HID_PID={0x0011:"nanos",0x4011:"nanosplus",0x0015:"nanosplus",
+         0x5011:"nanox",0x0040:"nanox",0x6011:"stax",0x0060:"stax",
+         0x7011:"flex",0x0070:"flex"}
+VENDOR=0x2C97
+REPO="tari-project/tari"
+APP="MinoTari Wallet"
+
+def detect()->str|None:
+    try:
+        import hid
+        for d in hid.enumerate(VENDOR,0):
+            m=HID_PID.get(d.get("product_id",0))
+            if m: return m
+    except ImportError: pass
+    try:
+        out=subprocess.check_output(["ledgerctl","get-target-id"],text=True,timeout=10).strip().lower()
+        for k,v in MODELS.items():
+            if v["target_id"].lower()==out: return k
+    except Exception: pass
+    return None
+
+def asset_url(model:str,tag:str|None)->str:
+    base=f"https://api.github.com/repos/{REPO}/releases"
+    url=f"{base}/tags/{tag}" if tag else f"{base}/latest"
+    r=requests.get(url,timeout=30); r.raise_for_status()
+    pat=MODELS[model]["asset"]
+    for a in r.json().get("assets",[]):
+        n=a["name"].lower()
+        if pat in n and n.endswith(".zip"): return a["browser_download_url"]
+    raise RuntimeError(f"No asset for {model!r}")
+
+def install(model:str,apdu:Path)->None:
+    tid=MODELS[model]["target_id"]
+    subprocess.run(["ledgerctl","delete",APP],capture_output=True)
+    rc=subprocess.run([sys.executable,"-m","ledgerblue.runScript",
+        "--targetId",tid,"--fileName",str(apdu),"--apdu","--scp"]).returncode
+    if rc!=0: raise RuntimeError("ledgerblue failed")
+
+def main()->None:
+    ap=argparse.ArgumentParser(description=__doc__,formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("-t","--tag",help="Release tag (default: latest)")
+    ap.add_argument("-m","--model",choices=list(MODELS),help="Override auto-detect")
+    a=ap.parse_args()
+    print(f"Minotari Ledger Installer  [{platform.system()} {platform.machine()}]\n")
+    model=a.model
+    if not model:
+        print("Step 1: Detecting Ledger...")
+        model=detect()
+        if not model:
+            print("  ERROR: No Ledger found. Check USB, PIN, Developer Mode.\n  Or pass --model nanosplus|nanox|flex|stax")
+            sys.exit(1)
+    print(f"  Model: {MODELS[model]['display']}\n")
+    print(f"Step 2: Fetching release (tag={a.tag or 'latest'})...")
+    url=asset_url(model,a.tag); print(f"  {url}")
+    with tempfile.TemporaryDirectory() as tmp:
+        zp=Path(tmp)/"fw.zip"
+        with requests.get(url,stream=True,timeout=120) as r:
+            r.raise_for_status()
+            with open(zp,"wb") as f:
+                for chunk in r.iter_content(8192): f.write(chunk)
+        print(f"  Downloaded {zp.stat().st_size//1024} KB")
+        with zipfile.ZipFile(zp) as z: z.extractall(tmp)
+        hits=list(Path(tmp).rglob("*.apdu"))
+        if not hits: sys.exit("  ERROR: no .apdu in archive")
+        apdu=hits[0]; print(f"  Firmware: {apdu.name}\n")
+        print("Step 3: Installing - device must be unlocked and on home screen...")
+        install(model,apdu)
+    print(f"\nDone! {MODELS[model]['display']} - MinoTari Wallet installed.")
+
+if __name__=="__main__": main()


### PR DESCRIPTION
Fixes #7795

## Summary

Replaces the 10 per-OS/per-model shell scripts with a single  that works on macOS, Linux, and Windows.

## How It Works

1. **Auto-detect model** via USB HID enumeration (). Maps Ledger Vendor ID  product IDs to Nano S/S Plus/X/Stax/Flex. Falls back to  if  not available.
2. **Download firmware** from GitHub Releases API, filtered by model-specific asset pattern (e.g. , ).
3. **Install** via  with correct  per model, identical to the existing scripts.

## Usage



## Acceptance Criteria

- [x] Single installer works for macOS, Linux, and Windows
- [x] Auto-detects Nano S, Nano S Plus, Nano X, Stax, Flex without user input
- [x] Correct firmware downloaded and installed for detected model
- [x] Clear error messages for: no device found, unsupported model, download failure

Payout: ETH 0xeaCAb48a4bfA0CED0e668c166615927115655594