### PR TITLE
docs: fix minotari docker volume path

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ services:
     image: quay.io/tarilabs/minotari_node:latest-nextnet
     restart: unless-stopped
     volumes:
-      - ./data:/root/.tari
+      - ./data:/var/tari
 # These 2 params are required for an interactive docker-compose session
     stdin_open: true
     tty: true
@@ -248,6 +248,9 @@ services:
     ports:
       - "18142:18142"
 ```
+
+The Docker image runs with `/var/tari` as the Tari home directory. Mounting the host `./data` directory there persists
+the node base path (`/var/tari/node`) and config path (`/var/tari/config/config.toml`).
 
 Then run `docker-compose up -d` to start your docker service.
 


### PR DESCRIPTION
Description
---
Updates the Docker compose example in the root README to mount persistent data at `/var/tari`, matching the Minotari Docker image runtime defaults.

The Docker entrypoint uses `/var/tari/node` as the base path for the node image and `/var/tari/config/config.toml` for config, so mounting `/var/tari` persists both.

Motivation and Context
---
Fixes #7686.

The previous example mounted `./data` to `/root/.tari`, but the Docker image creates the `tari` user with `/var/tari` as its home directory and `start_tari_app.sh` defaults to paths under `/var/tari`.

How Has This Been Tested?
---
- `git diff --check`

What process can a PR reviewer use to test or verify this change?
---
Review `buildtools/docker_rig/tarilabs.Dockerfile` and `buildtools/docker_rig/start_tari_app.sh` to confirm the container paths used by the Docker image.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify