### PR TITLE
fix: reduce listening state log spam

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -22,9 +22,11 @@
 
 use std::{
     cmp::Ordering,
+    collections::HashMap,
     convert::TryFrom,
     fmt::{Display, Formatter},
     ops::Deref,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -55,6 +57,7 @@ use crate::{
                 events_and_states,
             },
         },
+        sync::SyncPeer,
     },
     chain_storage::BlockchainBackend,
 };
@@ -166,18 +169,14 @@ impl Display for ChainStatusPeerLog {
 #[derive(Debug, Default)]
 struct ChainStatusLog {
     local_tip: Option<ChainStatusTipLog>,
-    peers: Vec<ChainStatusPeerLog>,
+    peers: HashMap<String, ChainStatusPeerLog>,
 }
 
 impl ChainStatusLog {
     fn record(&mut self, local: &ChainMetadata, peer_metadata: &PeerChainMetadata) {
         self.local_tip = Some(ChainStatusTipLog::new(local));
         let peer_log = ChainStatusPeerLog::new(peer_metadata);
-        if let Some(existing) = self.peers.iter_mut().find(|peer| peer.node_id == peer_log.node_id) {
-            *existing = peer_log;
-        } else {
-            self.peers.push(peer_log);
-        }
+        self.peers.insert(peer_log.node_id.clone(), peer_log);
     }
 
     fn summary_message(&self) -> Option<String> {
@@ -190,7 +189,7 @@ impl ChainStatusLog {
         let mut lagging_peers = Vec::new();
         let mut ahead_peers = Vec::new();
 
-        for peer in &self.peers {
+        for peer in self.peers.values() {
             match peer.tip.accumulated_difficulty.cmp(&local_tip.accumulated_difficulty) {
                 Ordering::Greater => ahead_peers.push(peer),
                 Ordering::Equal => in_sync_peers.push(peer),
@@ -220,7 +219,8 @@ impl ChainStatusLog {
         }
 
         Some(format!(
-            "We are in sync with the network ({local_tip}), we have lagging peers {{{}}}",
+            "We are in sync with the network ({local_tip}) with {} in sync peer(s), we have lagging peers {{{}}}",
+            in_sync_peers.len(),
             Self::format_peer_tips(&lagging_peers)
         ))
     }
@@ -248,6 +248,22 @@ impl ChainStatusLog {
             .collect::<Vec<_>>()
             .join(", ")
     }
+}
+
+#[derive(Debug, Default)]
+struct ListeningLoopState {
+    time_since_better_block: Option<Instant>,
+    initial_sync_counter: u64,
+    ahead_of_peers_counter: u64,
+    initial_sync_peer_list: Vec<SyncPeer>,
+    chain_status_log: ChainStatusLog,
+}
+
+#[derive(Debug)]
+enum MetadataEventAction {
+    Continue,
+    StopListening,
+    Transition(StateEvent),
 }
 
 /// This state listens for chain metadata events received from the liveness and chain metadata service. Based on the
@@ -280,6 +296,201 @@ impl Listening {
             shared.config.initial_sync_peer_count,
             self.network_silence,
         )));
+    }
+
+    async fn handle_metadata_event<B: BlockchainBackend + 'static>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+        metadata_event: Result<Arc<ChainMetadataEvent>, broadcast::error::RecvError>,
+        state: &mut ListeningLoopState,
+    ) -> MetadataEventAction {
+        match metadata_event.as_ref().map(|v| v.deref()) {
+            Ok(ChainMetadataEvent::NetworkSilence) => {
+                self.network_silence = true;
+                self.set_synced_response(shared);
+                debug!("NetworkSilence event received");
+            },
+            Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata)) => {
+                // We received a valid metadata update, so the network is not silent.
+                if self.network_silence {
+                    self.network_silence = false;
+                    self.publish_status_info(shared);
+                }
+
+                // if we are not yet synced, we wait for the initial delay of ping/pongs, so let's propagate the
+                // updated info
+                if !self.is_synced {
+                    self.publish_status_info(shared);
+                }
+                // We already ban the peer based on some previous logic, but this message was already in the
+                // pipeline before the ban went into effect.
+                match shared.peer_manager.is_peer_banned(peer_metadata.node_id()).await {
+                    Ok(true) => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Ignoring chain metadata from banned peer {}",
+                            peer_metadata.node_id()
+                        );
+                        return MetadataEventAction::Continue;
+                    },
+                    Ok(false) => {},
+                    Err(e) => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Ignoring chain metadata from peer {} due to error: {}",
+                            peer_metadata.node_id(), e
+                        );
+                        return MetadataEventAction::Continue;
+                    },
+                }
+
+                let peer_data = PeerMetadata {
+                    metadata: peer_metadata.claimed_chain_metadata().clone(),
+                    last_updated: EpochTime::now(),
+                };
+                // If this fails, its not the end of the world, we just want to keep record of the stats of
+                // the peer
+                let _old_data = shared
+                    .peer_manager
+                    .set_peer_metadata(peer_metadata.node_id(), 1, peer_data.to_bytes())
+                    .await;
+
+                let configured_sync_peers = &shared.config.blockchain_sync_config.forced_sync_peers;
+                if !configured_sync_peers.is_empty() {
+                    // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
+                    // we're out of sync
+                    if !configured_sync_peers.contains(peer_metadata.node_id()) {
+                        return MetadataEventAction::Continue;
+                    }
+                };
+
+                let local_metadata = match shared.db.get_chain_metadata().await {
+                    Ok(m) => m,
+                    Err(e) => {
+                        state.chain_status_log.log_and_clear();
+                        return MetadataEventAction::Transition(FatalError(format!(
+                            "Could not get local blockchain metadata. {e}"
+                        )));
+                    },
+                };
+
+                let mut sync_mode = determine_sync_mode(
+                    shared.config.blocks_behind_before_considered_lagging,
+                    &local_metadata,
+                    peer_metadata,
+                );
+
+                // Generally we will receive a block via incoming blocks, but something might have
+                // happened that we have not synced to them, e.g. our network could have been down.
+                // If we know about a stronger chain, but haven't synced to it, because we didn't get
+                // the blocks propagated to us, or we have a high `blocks_before_considered_lagging`
+                // then we will wait at least `time_before_considered_lagging` before we try to sync
+                // to that new chain. If you want to sync to a new chain immediately, then you can
+                // set this value to 1 second or lower.
+                if let SyncStatus::BehindButNotYetLagging {
+                    local,
+                    network,
+                    sync_peers,
+                } = &sync_mode
+                {
+                    if state.time_since_better_block.is_none() {
+                        state.time_since_better_block = Some(Instant::now());
+                    }
+                    if state
+                        .time_since_better_block
+                        .map(|t| t.elapsed() > shared.config.time_before_considered_lagging)
+                        .unwrap()
+                    // unwrap is safe because time_since_better_block is set right above
+                    {
+                        sync_mode = SyncStatus::Lagging {
+                            local: local.clone(),
+                            network: network.clone(),
+                            sync_peers: sync_peers.clone(),
+                        };
+                    }
+                } else {
+                    // We might have gotten up to date via propagation outside of this state, so reset the timer
+                    if sync_mode == SyncStatus::UpToDate {
+                        state.time_since_better_block = None;
+                    }
+                }
+
+                state.chain_status_log.record(&local_metadata, peer_metadata);
+
+                if !self.is_synced && sync_mode.is_up_to_date() {
+                    state.ahead_of_peers_counter += 1;
+                    if state.ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
+                        self.set_synced_response(shared);
+                        info!(target: LOG_TARGET, "Initial sync achieved");
+                    } else {
+                        info!(
+                            target: LOG_TARGET,
+                            "We are ahead of at least {} peers, waiting for more info",
+                            state.ahead_of_peers_counter
+                        );
+                        self.set_synced_response(shared);
+                    }
+                }
+
+                // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
+                // immediately return fallen behind with the peer that has a higher pow than us
+                if sync_mode.is_lagging() && self.is_synced {
+                    state.chain_status_log.log_and_clear();
+                    return MetadataEventAction::Transition(StateEvent::FallenBehind(sync_mode));
+                }
+                // if we are lagging and not yet reached initial sync, we delay a bit till we get
+                // INITIAL_SYNC_PEER_COUNT metadata updates from peers to ensure we make a better choice of which
+                // peer to sync from in the next stages
+                if let SyncStatus::Lagging {
+                    local,
+                    network,
+                    sync_peers,
+                } = sync_mode
+                {
+                    state.initial_sync_counter += 1;
+                    self.initial_delay_count = state.initial_sync_counter;
+                    for peer in sync_peers {
+                        let mut found = false;
+                        // lets search the list to ensure we only have unique peers in the list with the latest
+                        // up-to-date information
+                        for initial_peer in &mut state.initial_sync_peer_list {
+                            // we compare the two peers via the comparison operator on syncpeer
+                            if *initial_peer == peer {
+                                found = true;
+                                // if the peer is already in the list, we replace all the information about the peer
+                                // with the newest up-to-date information
+                                *initial_peer = peer.clone();
+                                break;
+                            }
+                        }
+                        if !found {
+                            state.initial_sync_peer_list.push(peer.clone());
+                        }
+                    }
+                    // We use a list here to ensure that we dont wait for even for INITIAL_SYNC_PEER_COUNT different
+                    // peers
+                    if state.initial_sync_counter >= shared.config.initial_sync_peer_count {
+                        state.chain_status_log.log_and_clear();
+                        // lets return now that we have enough peers to chose from
+                        return MetadataEventAction::Transition(StateEvent::FallenBehind(SyncStatus::Lagging {
+                            local,
+                            network,
+                            sync_peers: std::mem::take(&mut state.initial_sync_peer_list),
+                        }));
+                    }
+                }
+            },
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                debug!(target: LOG_TARGET, "Metadata event subscriber lagged by {n} item(s)");
+            },
+            Err(broadcast::error::RecvError::Closed) => {
+                state.chain_status_log.log_and_clear();
+                debug!(target: LOG_TARGET, "Metadata event subscriber closed");
+                return MetadataEventAction::StopListening;
+            },
+        }
+
+        MetadataEventAction::Continue
     }
 
     #[allow(clippy::too_many_lines)]
@@ -315,11 +526,7 @@ impl Listening {
             self.publish_status_info(shared);
         }
 
-        let mut time_since_better_block = None;
-        let mut initial_sync_counter = 0;
-        let mut ahead_of_peers_counter = 0;
-        let mut initial_sync_peer_list = Vec::new();
-        let mut chain_status_log = ChainStatusLog::default();
+        let mut state = ListeningLoopState::default();
         let mut chain_status_log_interval = interval(CHAIN_STATUS_LOG_INTERVAL);
         chain_status_log_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         chain_status_log_interval.tick().await;
@@ -327,186 +534,13 @@ impl Listening {
         loop {
             tokio::select! {
                 _ = chain_status_log_interval.tick() => {
-                    chain_status_log.log_and_clear();
+                    state.chain_status_log.log_and_clear();
                 },
                 metadata_event = shared.metadata_event_stream.recv() => {
-                    match metadata_event.as_ref().map(|v| v.deref()) {
-                        Ok(ChainMetadataEvent::NetworkSilence) => {
-                            self.network_silence = true;
-                            self.set_synced_response(shared);
-                            debug!("NetworkSilence event received");
-                        },
-                        Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata)) => {
-                            // We received a valid metadata update, so the network is not silent.
-                            if self.network_silence {
-                                self.network_silence = false;
-                                self.publish_status_info(shared);
-                            }
-
-                            // if we are not yet synced, we wait for the initial delay of ping/pongs, so let's propagate the
-                            // updated info
-                            if !self.is_synced {
-                                self.publish_status_info(shared);
-                            }
-                            // We already ban the peer based on some previous logic, but this message was already in the
-                            // pipeline before the ban went into effect.
-                            match shared.peer_manager.is_peer_banned(peer_metadata.node_id()).await {
-                                Ok(true) => {
-                                    warn!(
-                                        target: LOG_TARGET,
-                                        "Ignoring chain metadata from banned peer {}",
-                                        peer_metadata.node_id()
-                                    );
-                                    continue;
-                                },
-                                Ok(false) => {},
-                                Err(e) => {
-                                    warn!(
-                                        target: LOG_TARGET,
-                                        "Ignoring chain metadata from peer {} due to error: {}",
-                                        peer_metadata.node_id(), e
-                                    );
-                                    continue;
-                                },
-                            }
-
-                            let peer_data = PeerMetadata {
-                                metadata: peer_metadata.claimed_chain_metadata().clone(),
-                                last_updated: EpochTime::now(),
-                            };
-                            // If this fails, its not the end of the world, we just want to keep record of the stats of
-                            // the peer
-                            let _old_data = shared
-                                .peer_manager
-                                .set_peer_metadata(peer_metadata.node_id(), 1, peer_data.to_bytes())
-                                .await;
-
-                            let configured_sync_peers = &shared.config.blockchain_sync_config.forced_sync_peers;
-                            if !configured_sync_peers.is_empty() {
-                                // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
-                                // we're out of sync
-                                if !configured_sync_peers.contains(peer_metadata.node_id()) {
-                                    continue;
-                                }
-                            };
-
-                            let local_metadata = match shared.db.get_chain_metadata().await {
-                                Ok(m) => m,
-                                Err(e) => {
-                                    chain_status_log.log_and_clear();
-                                    return FatalError(format!("Could not get local blockchain metadata. {e}"));
-                                },
-                            };
-
-                            let mut sync_mode = determine_sync_mode(
-                                shared.config.blocks_behind_before_considered_lagging,
-                                &local_metadata,
-                                peer_metadata,
-                            );
-
-                            // Generally we will receive a block via incoming blocks, but something might have
-                            // happened that we have not synced to them, e.g. our network could have been down.
-                            // If we know about a stronger chain, but haven't synced to it, because we didn't get
-                            // the blocks propagated to us, or we have a high `blocks_before_considered_lagging`
-                            // then we will wait at least `time_before_considered_lagging` before we try to sync
-                            // to that new chain. If you want to sync to a new chain immediately, then you can
-                            // set this value to 1 second or lower.
-                            if let SyncStatus::BehindButNotYetLagging {
-                                local,
-                                network,
-                                sync_peers,
-                            } = &sync_mode
-                            {
-                                if time_since_better_block.is_none() {
-                                    time_since_better_block = Some(Instant::now());
-                                }
-                                if time_since_better_block
-                                    .map(|t| t.elapsed() > shared.config.time_before_considered_lagging)
-                                    .unwrap()
-                                // unwrap is safe because time_since_better_block is set right above
-                                {
-                                    sync_mode = SyncStatus::Lagging {
-                                        local: local.clone(),
-                                        network: network.clone(),
-                                        sync_peers: sync_peers.clone(),
-                                    };
-                                }
-                            } else {
-                                // We might have gotten up to date via propagation outside of this state, so reset the timer
-                                if sync_mode == SyncStatus::UpToDate {
-                                    time_since_better_block = None;
-                                }
-                            }
-
-                            chain_status_log.record(&local_metadata, peer_metadata);
-
-                            if !self.is_synced && sync_mode.is_up_to_date() {
-                                ahead_of_peers_counter += 1;
-                                if ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
-                                    self.set_synced_response(shared);
-                                    info!(target: LOG_TARGET, "Initial sync achieved");
-                                } else {
-                                    info!(target: LOG_TARGET, "We are ahead of at least {ahead_of_peers_counter} peers, waiting for more info");
-                                    self.set_synced_response(shared);
-                                }
-                            }
-
-                            // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
-                            // immediately return fallen behind with the peer that has a higher pow than us
-                            if sync_mode.is_lagging() && self.is_synced {
-                                chain_status_log.log_and_clear();
-                                return StateEvent::FallenBehind(sync_mode);
-                            }
-                            // if we are lagging and not yet reached initial sync, we delay a bit till we get
-                            // INITIAL_SYNC_PEER_COUNT metadata updates from peers to ensure we make a better choice of which
-                            // peer to sync from in the next stages
-                            if let SyncStatus::Lagging {
-                                local,
-                                network,
-                                sync_peers,
-                            } = sync_mode
-                            {
-                                initial_sync_counter += 1;
-                                self.initial_delay_count = initial_sync_counter;
-                                for peer in sync_peers {
-                                    let mut found = false;
-                                    // lets search the list to ensure we only have unique peers in the list with the latest
-                                    // up-to-date information
-                                    for initial_peer in &mut initial_sync_peer_list {
-                                        // we compare the two peers via the comparison operator on syncpeer
-                                        if *initial_peer == peer {
-                                            found = true;
-                                            // if the peer is already in the list, we replace all the information about the peer
-                                            // with the newest up-to-date information
-                                            *initial_peer = peer.clone();
-                                            break;
-                                        }
-                                    }
-                                    if !found {
-                                        initial_sync_peer_list.push(peer.clone());
-                                    }
-                                }
-                                // We use a list here to ensure that we dont wait for even for INITIAL_SYNC_PEER_COUNT different
-                                // peers
-                                if initial_sync_counter >= shared.config.initial_sync_peer_count {
-                                    chain_status_log.log_and_clear();
-                                    // lets return now that we have enough peers to chose from
-                                    return StateEvent::FallenBehind(SyncStatus::Lagging {
-                                        local,
-                                        network,
-                                        sync_peers: initial_sync_peer_list,
-                                    });
-                                }
-                            }
-                        },
-                        Err(broadcast::error::RecvError::Lagged(n)) => {
-                            debug!(target: LOG_TARGET, "Metadata event subscriber lagged by {n} item(s)");
-                        },
-                        Err(broadcast::error::RecvError::Closed) => {
-                            chain_status_log.log_and_clear();
-                            debug!(target: LOG_TARGET, "Metadata event subscriber closed");
-                            break;
-                        },
+                    match self.handle_metadata_event(shared, metadata_event, &mut state).await {
+                        MetadataEventAction::Continue => {},
+                        MetadataEventAction::StopListening => break,
+                        MetadataEventAction::Transition(state_event) => return state_event,
                     }
                 },
             }
@@ -745,6 +779,7 @@ mod test {
 
         let message = chain_status_log.summary_message().unwrap();
         assert!(message.contains("We are in sync with the network"));
+        assert!(message.contains("with 1 in sync peer(s)"));
         assert!(message.contains("lagging peers"));
         assert!(message.contains(&lagging_peer_id));
 

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -137,11 +137,7 @@ impl ChainStatusTipLog {
 
 impl Display for ChainStatusTipLog {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(
-            fmt,
-            "height={}, diff={}",
-            self.height, self.accumulated_difficulty
-        )
+        write!(fmt, "height={}, diff={}", self.height, self.accumulated_difficulty)
     }
 }
 
@@ -331,17 +327,63 @@ impl Listening {
         peer_metadata: &PeerChainMetadata,
         state: &mut ListeningLoopState,
     ) -> Option<StateEvent> {
+        self.mark_network_active(shared);
+
+        if !self.accepts_peer_metadata(shared, peer_metadata).await {
+            return None;
+        }
+
+        self.record_peer_metadata(shared, peer_metadata).await;
+
+        if !Self::is_configured_sync_peer(shared, peer_metadata) {
+            return None;
+        }
+
+        let local_metadata = match Self::get_local_metadata(shared, state).await {
+            Ok(metadata) => metadata,
+            Err(state_event) => return Some(state_event),
+        };
+
+        let mut sync_mode = determine_sync_mode(
+            shared.config.blocks_behind_before_considered_lagging,
+            &local_metadata,
+            peer_metadata,
+        );
+
+        Self::promote_to_lagging_after_delay(&mut sync_mode, state, shared.config.time_before_considered_lagging);
+
+        state.chain_status_log.record(&local_metadata, peer_metadata);
+
+        self.update_initial_sync_status(shared, state, &sync_mode);
+
+        // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
+        // immediately return fallen behind with the peer that has a higher pow than us
+        if sync_mode.is_lagging() && self.is_synced {
+            state.chain_status_log.log_and_clear();
+            return Some(StateEvent::FallenBehind(sync_mode));
+        }
+
+        self.collect_initial_lagging_peers(shared, state, sync_mode)
+    }
+
+    fn mark_network_active<B: BlockchainBackend + 'static>(&mut self, shared: &mut BaseNodeStateMachine<B>) {
         // We received a valid metadata update, so the network is not silent.
         if self.network_silence {
             self.network_silence = false;
             self.publish_status_info(shared);
         }
 
-        // if we are not yet synced, we wait for the initial delay of ping/pongs, so let's propagate the
-        // updated info
+        // If we are not yet synced, propagate the updated initial-delay info while waiting for ping/pongs.
         if !self.is_synced {
             self.publish_status_info(shared);
         }
+    }
+
+    async fn accepts_peer_metadata<B: BlockchainBackend + 'static>(
+        &self,
+        shared: &BaseNodeStateMachine<B>,
+        peer_metadata: &PeerChainMetadata,
+    ) -> bool {
         // We already ban the peer based on some previous logic, but this message was already in the
         // pipeline before the ban went into effect.
         match shared.peer_manager.is_peer_banned(peer_metadata.node_id()).await {
@@ -351,111 +393,119 @@ impl Listening {
                     "Ignoring chain metadata from banned peer {}",
                     peer_metadata.node_id()
                 );
-                return None;
+                false
             },
-            Ok(false) => {},
+            Ok(false) => true,
             Err(e) => {
                 warn!(
                     target: LOG_TARGET,
                     "Ignoring chain metadata from peer {} due to error: {}",
                     peer_metadata.node_id(), e
                 );
-                return None;
+                false
             },
         }
+    }
 
+    async fn record_peer_metadata<B: BlockchainBackend + 'static>(
+        &self,
+        shared: &mut BaseNodeStateMachine<B>,
+        peer_metadata: &PeerChainMetadata,
+    ) {
         let peer_data = PeerMetadata {
             metadata: peer_metadata.claimed_chain_metadata().clone(),
             last_updated: EpochTime::now(),
         };
-        // If this fails, its not the end of the world, we just want to keep record of the stats of
-        // the peer
+        // If this fails, it's not the end of the world; we just want to keep peer stats.
         let _old_data = shared
             .peer_manager
             .set_peer_metadata(peer_metadata.node_id(), 1, peer_data.to_bytes())
             .await;
+    }
 
+    fn is_configured_sync_peer<B: BlockchainBackend + 'static>(
+        shared: &BaseNodeStateMachine<B>,
+        peer_metadata: &PeerChainMetadata,
+    ) -> bool {
         let configured_sync_peers = &shared.config.blockchain_sync_config.forced_sync_peers;
-        if !configured_sync_peers.is_empty() {
-            // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
-            // we're out of sync
-            if !configured_sync_peers.contains(peer_metadata.node_id()) {
-                return None;
-            }
-        };
+        configured_sync_peers.is_empty() || configured_sync_peers.contains(peer_metadata.node_id())
+    }
 
-        let local_metadata = match shared.db.get_chain_metadata().await {
-            Ok(m) => m,
-            Err(e) => {
-                state.chain_status_log.log_and_clear();
-                return Some(FatalError(format!("Could not get local blockchain metadata. {e}")));
-            },
-        };
+    async fn get_local_metadata<B: BlockchainBackend + 'static>(
+        shared: &BaseNodeStateMachine<B>,
+        state: &mut ListeningLoopState,
+    ) -> Result<ChainMetadata, StateEvent> {
+        shared.db.get_chain_metadata().await.map_err(|e| {
+            state.chain_status_log.log_and_clear();
+            FatalError(format!("Could not get local blockchain metadata. {e}"))
+        })
+    }
 
-        let mut sync_mode = determine_sync_mode(
-            shared.config.blocks_behind_before_considered_lagging,
-            &local_metadata,
-            peer_metadata,
-        );
-
-        // Generally we will receive a block via incoming blocks, but something might have
-        // happened that we have not synced to them, e.g. our network could have been down.
-        // If we know about a stronger chain, but haven't synced to it, because we didn't get
-        // the blocks propagated to us, or we have a high `blocks_before_considered_lagging`
-        // then we will wait at least `time_before_considered_lagging` before we try to sync
-        // to that new chain. If you want to sync to a new chain immediately, then you can
-        // set this value to 1 second or lower.
-        if let SyncStatus::BehindButNotYetLagging {
+    fn promote_to_lagging_after_delay(
+        sync_mode: &mut SyncStatus,
+        state: &mut ListeningLoopState,
+        time_before_considered_lagging: Duration,
+    ) {
+        // If a stronger chain is known but blocks have not propagated yet, wait before block sync.
+        let lagging_sync_mode = if let SyncStatus::BehindButNotYetLagging {
             local,
             network,
             sync_peers,
-        } = &sync_mode
+        } = sync_mode
         {
-            if state.time_since_better_block.is_none() {
-                state.time_since_better_block = Some(Instant::now());
-            }
-            if state
-                .time_since_better_block
-                .map(|t| t.elapsed() > shared.config.time_before_considered_lagging)
-                .unwrap()
-            // unwrap is safe because time_since_better_block is set right above
-            {
-                sync_mode = SyncStatus::Lagging {
+            let time_since_better_block = state.time_since_better_block.get_or_insert_with(Instant::now);
+            if time_since_better_block.elapsed() > time_before_considered_lagging {
+                Some(SyncStatus::Lagging {
                     local: local.clone(),
                     network: network.clone(),
                     sync_peers: sync_peers.clone(),
-                };
-            }
-        } else {
-            // We might have gotten up to date via propagation outside of this state, so reset the timer
-            if sync_mode == SyncStatus::UpToDate {
-                state.time_since_better_block = None;
-            }
-        }
-
-        state.chain_status_log.record(&local_metadata, peer_metadata);
-
-        if !self.is_synced && sync_mode.is_up_to_date() {
-            state.ahead_of_peers_counter += 1;
-            if state.ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
-                self.set_synced_response(shared);
-                info!(target: LOG_TARGET, "Initial sync achieved");
+                })
             } else {
-                info!(
-                    target: LOG_TARGET,
-                    "We are ahead of at least {} peers, waiting for more info",
-                    state.ahead_of_peers_counter
-                );
-                self.set_synced_response(shared);
+                None
             }
+        } else if *sync_mode == SyncStatus::UpToDate {
+            // We might have gotten up to date via propagation outside of this state, so reset the timer.
+            state.time_since_better_block = None;
+            None
+        } else {
+            None
+        };
+
+        if let Some(sync_mode_update) = lagging_sync_mode {
+            *sync_mode = sync_mode_update;
+        }
+    }
+
+    fn update_initial_sync_status<B: BlockchainBackend + 'static>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+        state: &mut ListeningLoopState,
+        sync_mode: &SyncStatus,
+    ) {
+        if self.is_synced || !sync_mode.is_up_to_date() {
+            return;
         }
 
-        // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
-        // immediately return fallen behind with the peer that has a higher pow than us
-        if sync_mode.is_lagging() && self.is_synced {
-            state.chain_status_log.log_and_clear();
-            return Some(StateEvent::FallenBehind(sync_mode));
+        state.ahead_of_peers_counter += 1;
+        if state.ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
+            self.set_synced_response(shared);
+            info!(target: LOG_TARGET, "Initial sync achieved");
+        } else {
+            info!(
+                target: LOG_TARGET,
+                "We are ahead of at least {} peers, waiting for more info",
+                state.ahead_of_peers_counter
+            );
+            self.set_synced_response(shared);
         }
+    }
+
+    fn collect_initial_lagging_peers<B: BlockchainBackend + 'static>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+        state: &mut ListeningLoopState,
+        sync_mode: SyncStatus,
+    ) -> Option<StateEvent> {
         // if we are lagging and not yet reached initial sync, we delay a bit till we get
         // INITIAL_SYNC_PEER_COUNT metadata updates from peers to ensure we make a better choice of which
         // peer to sync from in the next stages
@@ -607,8 +657,8 @@ fn determine_sync_mode(
         // we only require some data from it, we need to ensure that they can supply the data we need, as in their
         // effective pruned horizon is greater than our local current chain tip.
         let pruned_mode = local.pruning_horizon() > 0;
-        let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0
-            && network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
+        let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0 &&
+            network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
         let pruning_height_check = network.claimed_chain_metadata().pruned_height() > local.best_block_height();
         let sync_able_peer = match (pruned_mode, pruning_horizon_check, pruning_height_check) {
             (true, true, _) => {
@@ -643,8 +693,8 @@ fn determine_sync_mode(
         if blocks_behind_before_considered_lagging > 0 {
             // Otherwise, only wait when the tip is above us, otherwise
             // chains with a lower height will never be reorged to.
-            if network_tip_height > local_tip_height
-                && local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
+            if network_tip_height > local_tip_height &&
+                local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
             {
                 trace!(
                     target: LOG_TARGET,

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -116,17 +116,13 @@ impl ListeningInfo {
 struct ChainStatusLogState {
     local_height: u64,
     local_accumulated_difficulty: U512,
-    network_height: u64,
-    network_accumulated_difficulty: U512,
 }
 
 impl ChainStatusLogState {
-    fn new(local: &ChainMetadata, network: &ChainMetadata) -> Self {
+    fn new(local: &ChainMetadata) -> Self {
         Self {
             local_height: local.best_block_height(),
             local_accumulated_difficulty: local.accumulated_difficulty(),
-            network_height: network.best_block_height(),
-            network_accumulated_difficulty: network.accumulated_difficulty(),
         }
     }
 }
@@ -164,8 +160,8 @@ impl Listening {
         )));
     }
 
-    fn should_log_chain_status_at_debug(&mut self, local: &ChainMetadata, network: &ChainMetadata) -> bool {
-        let log_state = ChainStatusLogState::new(local, network);
+    fn should_log_chain_status_at_debug(&mut self, local: &ChainMetadata) -> bool {
+        let log_state = ChainStatusLogState::new(local);
         if self.last_chain_status_log == Some(log_state) {
             return false;
         }
@@ -176,7 +172,7 @@ impl Listening {
 
     fn log_current_chain_status(&mut self, local: &ChainMetadata, network: &PeerChainMetadata) {
         let network_metadata = network.claimed_chain_metadata();
-        let level = if self.should_log_chain_status_at_debug(local, network_metadata) {
+        let level = if self.should_log_chain_status_at_debug(local) {
             Level::Debug
         } else {
             Level::Trace
@@ -634,7 +630,7 @@ mod test {
     }
 
     #[test]
-    fn test_chain_status_debug_log_is_deduplicated_by_tip() {
+    fn test_chain_status_debug_log_is_deduplicated_by_local_tip() {
         const NETWORK_TIP_HEIGHT: u64 = 5000;
         let block_hash = FixedHash::from([
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
@@ -645,8 +641,8 @@ mod test {
         let next_metadata = ChainMetadata::new(NETWORK_TIP_HEIGHT + 1, block_hash, 0, 0, U512::from(10001), 0).unwrap();
         let mut listening = Listening::new();
 
-        assert!(listening.should_log_chain_status_at_debug(&metadata, &metadata));
-        assert!(!listening.should_log_chain_status_at_debug(&metadata, &metadata));
-        assert!(listening.should_log_chain_status_at_debug(&metadata, &next_metadata));
+        assert!(listening.should_log_chain_status_at_debug(&metadata));
+        assert!(!listening.should_log_chain_status_at_debug(&metadata));
+        assert!(listening.should_log_chain_status_at_debug(&next_metadata));
     }
 }

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -206,7 +206,7 @@ impl ChainStatusLog {
 
         if in_sync_peers.is_empty() {
             return Some(format!(
-                "We are ahead ({local_tip}) with lagging peers {{{}}}",
+                "We are ahead ({local_tip}) with 0 in sync peer(s), we have lagging peers {{{}}}",
                 Self::format_peer_tips(&lagging_peers)
             ));
         }
@@ -255,7 +255,7 @@ struct ListeningLoopState {
     time_since_better_block: Option<Instant>,
     initial_sync_counter: u64,
     ahead_of_peers_counter: u64,
-    initial_sync_peer_list: Vec<SyncPeer>,
+    initial_sync_peer_list: HashMap<String, SyncPeer>,
     chain_status_log: ChainStatusLog,
 }
 
@@ -304,171 +304,8 @@ impl Listening {
                 debug!("NetworkSilence event received");
             },
             Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata)) => {
-                // We received a valid metadata update, so the network is not silent.
-                if self.network_silence {
-                    self.network_silence = false;
-                    self.publish_status_info(shared);
-                }
-
-                // if we are not yet synced, we wait for the initial delay of ping/pongs, so let's propagate the
-                // updated info
-                if !self.is_synced {
-                    self.publish_status_info(shared);
-                }
-                // We already ban the peer based on some previous logic, but this message was already in the
-                // pipeline before the ban went into effect.
-                match shared.peer_manager.is_peer_banned(peer_metadata.node_id()).await {
-                    Ok(true) => {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Ignoring chain metadata from banned peer {}",
-                            peer_metadata.node_id()
-                        );
-                        return None;
-                    },
-                    Ok(false) => {},
-                    Err(e) => {
-                        warn!(
-                            target: LOG_TARGET,
-                            "Ignoring chain metadata from peer {} due to error: {}",
-                            peer_metadata.node_id(), e
-                        );
-                        return None;
-                    },
-                }
-
-                let peer_data = PeerMetadata {
-                    metadata: peer_metadata.claimed_chain_metadata().clone(),
-                    last_updated: EpochTime::now(),
-                };
-                // If this fails, its not the end of the world, we just want to keep record of the stats of
-                // the peer
-                let _old_data = shared
-                    .peer_manager
-                    .set_peer_metadata(peer_metadata.node_id(), 1, peer_data.to_bytes())
-                    .await;
-
-                let configured_sync_peers = &shared.config.blockchain_sync_config.forced_sync_peers;
-                if !configured_sync_peers.is_empty() {
-                    // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
-                    // we're out of sync
-                    if !configured_sync_peers.contains(peer_metadata.node_id()) {
-                        return None;
-                    }
-                };
-
-                let local_metadata = match shared.db.get_chain_metadata().await {
-                    Ok(m) => m,
-                    Err(e) => {
-                        state.chain_status_log.log_and_clear();
-                        return Some(FatalError(format!("Could not get local blockchain metadata. {e}")));
-                    },
-                };
-
-                let mut sync_mode = determine_sync_mode(
-                    shared.config.blocks_behind_before_considered_lagging,
-                    &local_metadata,
-                    peer_metadata,
-                );
-
-                // Generally we will receive a block via incoming blocks, but something might have
-                // happened that we have not synced to them, e.g. our network could have been down.
-                // If we know about a stronger chain, but haven't synced to it, because we didn't get
-                // the blocks propagated to us, or we have a high `blocks_before_considered_lagging`
-                // then we will wait at least `time_before_considered_lagging` before we try to sync
-                // to that new chain. If you want to sync to a new chain immediately, then you can
-                // set this value to 1 second or lower.
-                if let SyncStatus::BehindButNotYetLagging {
-                    local,
-                    network,
-                    sync_peers,
-                } = &sync_mode
-                {
-                    if state.time_since_better_block.is_none() {
-                        state.time_since_better_block = Some(Instant::now());
-                    }
-                    if state
-                        .time_since_better_block
-                        .map(|t| t.elapsed() > shared.config.time_before_considered_lagging)
-                        .unwrap()
-                    // unwrap is safe because time_since_better_block is set right above
-                    {
-                        sync_mode = SyncStatus::Lagging {
-                            local: local.clone(),
-                            network: network.clone(),
-                            sync_peers: sync_peers.clone(),
-                        };
-                    }
-                } else {
-                    // We might have gotten up to date via propagation outside of this state, so reset the timer
-                    if sync_mode == SyncStatus::UpToDate {
-                        state.time_since_better_block = None;
-                    }
-                }
-
-                state.chain_status_log.record(&local_metadata, peer_metadata);
-
-                if !self.is_synced && sync_mode.is_up_to_date() {
-                    state.ahead_of_peers_counter += 1;
-                    if state.ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
-                        self.set_synced_response(shared);
-                        info!(target: LOG_TARGET, "Initial sync achieved");
-                    } else {
-                        info!(
-                            target: LOG_TARGET,
-                            "We are ahead of at least {} peers, waiting for more info",
-                            state.ahead_of_peers_counter
-                        );
-                        self.set_synced_response(shared);
-                    }
-                }
-
-                // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
-                // immediately return fallen behind with the peer that has a higher pow than us
-                if sync_mode.is_lagging() && self.is_synced {
-                    state.chain_status_log.log_and_clear();
-                    return Some(StateEvent::FallenBehind(sync_mode));
-                }
-                // if we are lagging and not yet reached initial sync, we delay a bit till we get
-                // INITIAL_SYNC_PEER_COUNT metadata updates from peers to ensure we make a better choice of which
-                // peer to sync from in the next stages
-                if let SyncStatus::Lagging {
-                    local,
-                    network,
-                    sync_peers,
-                } = sync_mode
-                {
-                    state.initial_sync_counter += 1;
-                    self.initial_delay_count = state.initial_sync_counter;
-                    for peer in sync_peers {
-                        let mut found = false;
-                        // lets search the list to ensure we only have unique peers in the list with the latest
-                        // up-to-date information
-                        for initial_peer in &mut state.initial_sync_peer_list {
-                            // we compare the two peers via the comparison operator on syncpeer
-                            if *initial_peer == peer {
-                                found = true;
-                                // if the peer is already in the list, we replace all the information about the peer
-                                // with the newest up-to-date information
-                                *initial_peer = peer.clone();
-                                break;
-                            }
-                        }
-                        if !found {
-                            state.initial_sync_peer_list.push(peer.clone());
-                        }
-                    }
-                    // We use a list here to ensure that we dont wait for even for INITIAL_SYNC_PEER_COUNT different
-                    // peers
-                    if state.initial_sync_counter >= shared.config.initial_sync_peer_count {
-                        state.chain_status_log.log_and_clear();
-                        // lets return now that we have enough peers to chose from
-                        return Some(StateEvent::FallenBehind(SyncStatus::Lagging {
-                            local,
-                            network,
-                            sync_peers: std::mem::take(&mut state.initial_sync_peer_list),
-                        }));
-                    }
+                if let Some(state_event) = self.handle_peer_chain_metadata(shared, peer_metadata, state).await {
+                    return Some(state_event);
                 }
             },
             Err(broadcast::error::RecvError::Lagged(n)) => {
@@ -483,6 +320,170 @@ impl Listening {
                 );
                 return Some(StateEvent::UserQuit);
             },
+        }
+
+        None
+    }
+
+    async fn handle_peer_chain_metadata<B: BlockchainBackend + 'static>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+        peer_metadata: &PeerChainMetadata,
+        state: &mut ListeningLoopState,
+    ) -> Option<StateEvent> {
+        // We received a valid metadata update, so the network is not silent.
+        if self.network_silence {
+            self.network_silence = false;
+            self.publish_status_info(shared);
+        }
+
+        // if we are not yet synced, we wait for the initial delay of ping/pongs, so let's propagate the
+        // updated info
+        if !self.is_synced {
+            self.publish_status_info(shared);
+        }
+        // We already ban the peer based on some previous logic, but this message was already in the
+        // pipeline before the ban went into effect.
+        match shared.peer_manager.is_peer_banned(peer_metadata.node_id()).await {
+            Ok(true) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Ignoring chain metadata from banned peer {}",
+                    peer_metadata.node_id()
+                );
+                return None;
+            },
+            Ok(false) => {},
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Ignoring chain metadata from peer {} due to error: {}",
+                    peer_metadata.node_id(), e
+                );
+                return None;
+            },
+        }
+
+        let peer_data = PeerMetadata {
+            metadata: peer_metadata.claimed_chain_metadata().clone(),
+            last_updated: EpochTime::now(),
+        };
+        // If this fails, its not the end of the world, we just want to keep record of the stats of
+        // the peer
+        let _old_data = shared
+            .peer_manager
+            .set_peer_metadata(peer_metadata.node_id(), 1, peer_data.to_bytes())
+            .await;
+
+        let configured_sync_peers = &shared.config.blockchain_sync_config.forced_sync_peers;
+        if !configured_sync_peers.is_empty() {
+            // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
+            // we're out of sync
+            if !configured_sync_peers.contains(peer_metadata.node_id()) {
+                return None;
+            }
+        };
+
+        let local_metadata = match shared.db.get_chain_metadata().await {
+            Ok(m) => m,
+            Err(e) => {
+                state.chain_status_log.log_and_clear();
+                return Some(FatalError(format!("Could not get local blockchain metadata. {e}")));
+            },
+        };
+
+        let mut sync_mode = determine_sync_mode(
+            shared.config.blocks_behind_before_considered_lagging,
+            &local_metadata,
+            peer_metadata,
+        );
+
+        // Generally we will receive a block via incoming blocks, but something might have
+        // happened that we have not synced to them, e.g. our network could have been down.
+        // If we know about a stronger chain, but haven't synced to it, because we didn't get
+        // the blocks propagated to us, or we have a high `blocks_before_considered_lagging`
+        // then we will wait at least `time_before_considered_lagging` before we try to sync
+        // to that new chain. If you want to sync to a new chain immediately, then you can
+        // set this value to 1 second or lower.
+        if let SyncStatus::BehindButNotYetLagging {
+            local,
+            network,
+            sync_peers,
+        } = &sync_mode
+        {
+            if state.time_since_better_block.is_none() {
+                state.time_since_better_block = Some(Instant::now());
+            }
+            if state
+                .time_since_better_block
+                .map(|t| t.elapsed() > shared.config.time_before_considered_lagging)
+                .unwrap()
+            // unwrap is safe because time_since_better_block is set right above
+            {
+                sync_mode = SyncStatus::Lagging {
+                    local: local.clone(),
+                    network: network.clone(),
+                    sync_peers: sync_peers.clone(),
+                };
+            }
+        } else {
+            // We might have gotten up to date via propagation outside of this state, so reset the timer
+            if sync_mode == SyncStatus::UpToDate {
+                state.time_since_better_block = None;
+            }
+        }
+
+        state.chain_status_log.record(&local_metadata, peer_metadata);
+
+        if !self.is_synced && sync_mode.is_up_to_date() {
+            state.ahead_of_peers_counter += 1;
+            if state.ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
+                self.set_synced_response(shared);
+                info!(target: LOG_TARGET, "Initial sync achieved");
+            } else {
+                info!(
+                    target: LOG_TARGET,
+                    "We are ahead of at least {} peers, waiting for more info",
+                    state.ahead_of_peers_counter
+                );
+                self.set_synced_response(shared);
+            }
+        }
+
+        // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
+        // immediately return fallen behind with the peer that has a higher pow than us
+        if sync_mode.is_lagging() && self.is_synced {
+            state.chain_status_log.log_and_clear();
+            return Some(StateEvent::FallenBehind(sync_mode));
+        }
+        // if we are lagging and not yet reached initial sync, we delay a bit till we get
+        // INITIAL_SYNC_PEER_COUNT metadata updates from peers to ensure we make a better choice of which
+        // peer to sync from in the next stages
+        if let SyncStatus::Lagging {
+            local,
+            network,
+            sync_peers,
+        } = sync_mode
+        {
+            state.initial_sync_counter += 1;
+            self.initial_delay_count = state.initial_sync_counter;
+            for peer in sync_peers {
+                let node_id = peer.node_id().to_string();
+                state.initial_sync_peer_list.insert(node_id, peer);
+            }
+            // We use a map here to ensure that we dont wait for even for INITIAL_SYNC_PEER_COUNT different
+            // peers
+            if state.initial_sync_counter >= shared.config.initial_sync_peer_count {
+                state.chain_status_log.log_and_clear();
+                // lets return now that we have enough peers to chose from
+                return Some(StateEvent::FallenBehind(SyncStatus::Lagging {
+                    local,
+                    network,
+                    sync_peers: std::mem::take(&mut state.initial_sync_peer_list)
+                        .into_values()
+                        .collect(),
+                }));
+            }
         }
 
         None
@@ -606,8 +607,8 @@ fn determine_sync_mode(
         // we only require some data from it, we need to ensure that they can supply the data we need, as in their
         // effective pruned horizon is greater than our local current chain tip.
         let pruned_mode = local.pruning_horizon() > 0;
-        let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0 &&
-            network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
+        let pruning_horizon_check = network.claimed_chain_metadata().pruning_horizon() > 0
+            && network.claimed_chain_metadata().pruning_horizon() < local.pruning_horizon();
         let pruning_height_check = network.claimed_chain_metadata().pruned_height() > local.best_block_height();
         let sync_able_peer = match (pruned_mode, pruning_horizon_check, pruning_height_check) {
             (true, true, _) => {
@@ -642,8 +643,8 @@ fn determine_sync_mode(
         if blocks_behind_before_considered_lagging > 0 {
             // Otherwise, only wait when the tip is above us, otherwise
             // chains with a lower height will never be reorged to.
-            if network_tip_height > local_tip_height &&
-                local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
+            if network_tip_height > local_tip_height
+                && local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
             {
                 trace!(
                     target: LOG_TARGET,
@@ -773,6 +774,22 @@ mod test {
 
         chain_status_log.log_and_clear();
         assert!(chain_status_log.summary_message().is_none());
+    }
+
+    #[test]
+    fn test_chain_status_log_summarizes_ahead_with_lagging_peer_count() {
+        let local = chain_metadata(5000, U512::from(10000));
+        let lagging_peer = peer_chain_metadata(4999, U512::from(9999));
+        let lagging_peer_id = lagging_peer.node_id().to_string();
+        let mut chain_status_log = ChainStatusLog::default();
+
+        chain_status_log.record(&local, &lagging_peer);
+
+        let message = chain_status_log.summary_message().unwrap();
+        assert!(message.contains("We are ahead"));
+        assert!(message.contains("with 0 in sync peer(s)"));
+        assert!(message.contains("lagging peers"));
+        assert!(message.contains(&lagging_peer_id));
     }
 
     #[test]

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 use log::*;
+use primitive_types::U512;
 use serde::{Deserialize, Serialize};
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_utilities::epoch_time::EpochTime;
@@ -110,6 +111,26 @@ impl ListeningInfo {
     }
 }
 
+/// Tracks the last up-to-date/ahead chain status emitted at debug level.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainStatusLogState {
+    local_height: u64,
+    local_accumulated_difficulty: U512,
+    network_height: u64,
+    network_accumulated_difficulty: U512,
+}
+
+impl ChainStatusLogState {
+    fn new(local: &ChainMetadata, network: &ChainMetadata) -> Self {
+        Self {
+            local_height: local.best_block_height(),
+            local_accumulated_difficulty: local.accumulated_difficulty(),
+            network_height: network.best_block_height(),
+            network_accumulated_difficulty: network.accumulated_difficulty(),
+        }
+    }
+}
+
 /// This state listens for chain metadata events received from the liveness and chain metadata service. Based on the
 /// received metadata, if it detects that the current node is lagging behind the network it will switch to block sync
 /// state.
@@ -118,6 +139,7 @@ pub struct Listening {
     is_synced: bool,
     initial_delay_count: u64,
     network_silence: bool,
+    last_chain_status_log: Option<ChainStatusLogState>,
 }
 
 impl Listening {
@@ -140,6 +162,44 @@ impl Listening {
             shared.config.initial_sync_peer_count,
             self.network_silence,
         )));
+    }
+
+    fn should_log_chain_status_at_debug(&mut self, local: &ChainMetadata, network: &ChainMetadata) -> bool {
+        let log_state = ChainStatusLogState::new(local, network);
+        if self.last_chain_status_log == Some(log_state) {
+            return false;
+        }
+
+        self.last_chain_status_log = Some(log_state);
+        true
+    }
+
+    fn log_current_chain_status(&mut self, local: &ChainMetadata, network: &PeerChainMetadata) {
+        let network_metadata = network.claimed_chain_metadata();
+        let level = if self.should_log_chain_status_at_debug(local, network_metadata) {
+            Level::Debug
+        } else {
+            Level::Trace
+        };
+        let local_tip_accum_difficulty = local.accumulated_difficulty();
+        let network_tip_accum_difficulty = network_metadata.accumulated_difficulty();
+
+        log!(
+            target: LOG_TARGET,
+            level,
+            "{} We're at block {} with an accumulated difficulty of {} and the network chain tip is at {} with an \
+             accumulated difficulty of {}",
+            if local_tip_accum_difficulty > network_tip_accum_difficulty {
+                "Our blockchain is ahead of the network."
+            } else {
+                // Equals
+                "Our blockchain is up-to-date."
+            },
+            local.best_block_height(),
+            local_tip_accum_difficulty,
+            network_metadata.best_block_height(),
+            network_tip_accum_difficulty,
+        );
     }
 
     #[allow(clippy::too_many_lines)]
@@ -285,6 +345,7 @@ impl Listening {
                         // We might have gotten up to date via propagation outside of this state, so reset the timer
                         if sync_mode == SyncStatus::UpToDate {
                             time_since_better_block = None;
+                            self.log_current_chain_status(&local_metadata, peer_metadata);
                         }
                     }
 
@@ -369,6 +430,7 @@ impl From<Waiting> for Listening {
             is_synced: false,
             initial_delay_count: 0,
             network_silence: false,
+            last_chain_status_log: None,
         }
     }
 }
@@ -379,6 +441,7 @@ impl From<HeaderSyncState> for Listening {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
             network_silence: false,
+            last_chain_status_log: None,
         }
     }
 }
@@ -389,6 +452,7 @@ impl From<BlockSync> for Listening {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
             network_silence: false,
+            last_chain_status_log: None,
         }
     }
 }
@@ -399,6 +463,7 @@ impl From<DecideNextSync> for Listening {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
             network_silence: false,
+            last_chain_status_log: None,
         }
     }
 }
@@ -511,21 +576,6 @@ fn determine_sync_mode(
                 peers: vec![network.clone().into()],
             };
         }
-        debug!(
-            target: LOG_TARGET,
-            "{} We're at block {} with an accumulated difficulty of {} and the network chain tip is at {} with an \
-             accumulated difficulty of {}",
-            if local_tip_accum_difficulty > network_tip_accum_difficulty {
-                "Our blockchain is ahead of the network."
-            } else {
-                // Equals
-                "Our blockchain is up-to-date."
-            },
-            local.best_block_height(),
-            local_tip_accum_difficulty,
-            network.claimed_chain_metadata().best_block_height(),
-            network_tip_accum_difficulty,
-        );
         SyncStatus::UpToDate
     }
 }
@@ -581,5 +631,22 @@ mod test {
 
         let sync_mode = determine_sync_mode(2, behind_node.claimed_chain_metadata(), &archival_node);
         assert!(matches!(sync_mode, SyncStatus::BehindButNotYetLagging { .. }));
+    }
+
+    #[test]
+    fn test_chain_status_debug_log_is_deduplicated_by_tip() {
+        const NETWORK_TIP_HEIGHT: u64 = 5000;
+        let block_hash = FixedHash::from([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+            29, 30, 31,
+        ]);
+
+        let metadata = ChainMetadata::new(NETWORK_TIP_HEIGHT, block_hash, 0, 0, U512::from(10000), 0).unwrap();
+        let next_metadata = ChainMetadata::new(NETWORK_TIP_HEIGHT + 1, block_hash, 0, 0, U512::from(10001), 0).unwrap();
+        let mut listening = Listening::new();
+
+        assert!(listening.should_log_chain_status_at_debug(&metadata, &metadata));
+        assert!(!listening.should_log_chain_status_at_debug(&metadata, &metadata));
+        assert!(listening.should_log_chain_status_at_debug(&metadata, &next_metadata));
     }
 }

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -259,13 +259,6 @@ struct ListeningLoopState {
     chain_status_log: ChainStatusLog,
 }
 
-#[derive(Debug)]
-enum MetadataEventAction {
-    Continue,
-    StopListening,
-    Transition(StateEvent),
-}
-
 /// This state listens for chain metadata events received from the liveness and chain metadata service. Based on the
 /// received metadata, if it detects that the current node is lagging behind the network it will switch to block sync
 /// state.
@@ -303,7 +296,7 @@ impl Listening {
         shared: &mut BaseNodeStateMachine<B>,
         metadata_event: Result<Arc<ChainMetadataEvent>, broadcast::error::RecvError>,
         state: &mut ListeningLoopState,
-    ) -> MetadataEventAction {
+    ) -> Option<StateEvent> {
         match metadata_event.as_ref().map(|v| v.deref()) {
             Ok(ChainMetadataEvent::NetworkSilence) => {
                 self.network_silence = true;
@@ -331,7 +324,7 @@ impl Listening {
                             "Ignoring chain metadata from banned peer {}",
                             peer_metadata.node_id()
                         );
-                        return MetadataEventAction::Continue;
+                        return None;
                     },
                     Ok(false) => {},
                     Err(e) => {
@@ -340,7 +333,7 @@ impl Listening {
                             "Ignoring chain metadata from peer {} due to error: {}",
                             peer_metadata.node_id(), e
                         );
-                        return MetadataEventAction::Continue;
+                        return None;
                     },
                 }
 
@@ -360,7 +353,7 @@ impl Listening {
                     // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
                     // we're out of sync
                     if !configured_sync_peers.contains(peer_metadata.node_id()) {
-                        return MetadataEventAction::Continue;
+                        return None;
                     }
                 };
 
@@ -368,9 +361,7 @@ impl Listening {
                     Ok(m) => m,
                     Err(e) => {
                         state.chain_status_log.log_and_clear();
-                        return MetadataEventAction::Transition(FatalError(format!(
-                            "Could not get local blockchain metadata. {e}"
-                        )));
+                        return Some(FatalError(format!("Could not get local blockchain metadata. {e}")));
                     },
                 };
 
@@ -436,7 +427,7 @@ impl Listening {
                 // immediately return fallen behind with the peer that has a higher pow than us
                 if sync_mode.is_lagging() && self.is_synced {
                     state.chain_status_log.log_and_clear();
-                    return MetadataEventAction::Transition(StateEvent::FallenBehind(sync_mode));
+                    return Some(StateEvent::FallenBehind(sync_mode));
                 }
                 // if we are lagging and not yet reached initial sync, we delay a bit till we get
                 // INITIAL_SYNC_PEER_COUNT metadata updates from peers to ensure we make a better choice of which
@@ -472,7 +463,7 @@ impl Listening {
                     if state.initial_sync_counter >= shared.config.initial_sync_peer_count {
                         state.chain_status_log.log_and_clear();
                         // lets return now that we have enough peers to chose from
-                        return MetadataEventAction::Transition(StateEvent::FallenBehind(SyncStatus::Lagging {
+                        return Some(StateEvent::FallenBehind(SyncStatus::Lagging {
                             local,
                             network,
                             sync_peers: std::mem::take(&mut state.initial_sync_peer_list),
@@ -486,11 +477,15 @@ impl Listening {
             Err(broadcast::error::RecvError::Closed) => {
                 state.chain_status_log.log_and_clear();
                 debug!(target: LOG_TARGET, "Metadata event subscriber closed");
-                return MetadataEventAction::StopListening;
+                debug!(
+                    target: LOG_TARGET,
+                    "Event listener is complete because liveness metadata and timeout streams were closed"
+                );
+                return Some(StateEvent::UserQuit);
             },
         }
 
-        MetadataEventAction::Continue
+        None
     }
 
     #[allow(clippy::too_many_lines)]
@@ -537,19 +532,12 @@ impl Listening {
                     state.chain_status_log.log_and_clear();
                 },
                 metadata_event = shared.metadata_event_stream.recv() => {
-                    match self.handle_metadata_event(shared, metadata_event, &mut state).await {
-                        MetadataEventAction::Continue => {},
-                        MetadataEventAction::StopListening => break,
-                        MetadataEventAction::Transition(state_event) => return state_event,
+                    if let Some(state_event) = self.handle_metadata_event(shared, metadata_event, &mut state).await {
+                        return state_event;
                     }
                 },
             }
         }
-        debug!(
-            target: LOG_TARGET,
-            "Event listener is complete because liveness metadata and timeout streams were closed"
-        );
-        StateEvent::UserQuit
     }
 }
 

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -21,10 +21,11 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{
+    cmp::Ordering,
     convert::TryFrom,
     fmt::{Display, Formatter},
     ops::Deref,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use log::*;
@@ -32,7 +33,10 @@ use primitive_types::U512;
 use serde::{Deserialize, Serialize};
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_utilities::epoch_time::EpochTime;
-use tokio::sync::broadcast;
+use tokio::{
+    sync::broadcast,
+    time::{MissedTickBehavior, interval},
+};
 
 use crate::{
     base_node::{
@@ -56,6 +60,7 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "c::bn::state_machine_service::states::listening";
+const CHAIN_STATUS_LOG_INTERVAL: Duration = Duration::from_secs(30);
 
 /// This struct contains the info of the peer, and is used to serialised and deserialised.
 #[derive(Serialize, Deserialize)]
@@ -111,19 +116,137 @@ impl ListeningInfo {
     }
 }
 
-/// Tracks the last up-to-date/ahead chain status emitted at debug level.
+/// Chain tip data used to aggregate peer metadata logs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ChainStatusLogState {
-    local_height: u64,
-    local_accumulated_difficulty: U512,
+struct ChainStatusTipLog {
+    height: u64,
+    accumulated_difficulty: U512,
 }
 
-impl ChainStatusLogState {
-    fn new(local: &ChainMetadata) -> Self {
+impl ChainStatusTipLog {
+    fn new(metadata: &ChainMetadata) -> Self {
         Self {
-            local_height: local.best_block_height(),
-            local_accumulated_difficulty: local.accumulated_difficulty(),
+            height: metadata.best_block_height(),
+            accumulated_difficulty: metadata.accumulated_difficulty(),
         }
+    }
+}
+
+impl Display for ChainStatusTipLog {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            fmt,
+            "height={}, diff={}",
+            self.height, self.accumulated_difficulty
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ChainStatusPeerLog {
+    node_id: String,
+    tip: ChainStatusTipLog,
+}
+
+impl ChainStatusPeerLog {
+    fn new(peer_metadata: &PeerChainMetadata) -> Self {
+        Self {
+            node_id: peer_metadata.node_id().to_string(),
+            tip: ChainStatusTipLog::new(peer_metadata.claimed_chain_metadata()),
+        }
+    }
+}
+
+impl Display for ChainStatusPeerLog {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(fmt, "({}, {})", self.node_id, self.tip)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ChainStatusLog {
+    local_tip: Option<ChainStatusTipLog>,
+    peers: Vec<ChainStatusPeerLog>,
+}
+
+impl ChainStatusLog {
+    fn record(&mut self, local: &ChainMetadata, peer_metadata: &PeerChainMetadata) {
+        self.local_tip = Some(ChainStatusTipLog::new(local));
+        let peer_log = ChainStatusPeerLog::new(peer_metadata);
+        if let Some(existing) = self.peers.iter_mut().find(|peer| peer.node_id == peer_log.node_id) {
+            *existing = peer_log;
+        } else {
+            self.peers.push(peer_log);
+        }
+    }
+
+    fn summary_message(&self) -> Option<String> {
+        let local_tip = self.local_tip?;
+        if self.peers.is_empty() {
+            return None;
+        }
+
+        let mut in_sync_peers = Vec::new();
+        let mut lagging_peers = Vec::new();
+        let mut ahead_peers = Vec::new();
+
+        for peer in &self.peers {
+            match peer.tip.accumulated_difficulty.cmp(&local_tip.accumulated_difficulty) {
+                Ordering::Greater => ahead_peers.push(peer),
+                Ordering::Equal => in_sync_peers.push(peer),
+                Ordering::Less => lagging_peers.push(peer),
+            }
+        }
+
+        if !ahead_peers.is_empty() {
+            return Some(format!(
+                "We are behind the network ({local_tip}) with peers: {{{}}}",
+                Self::format_peer_tips(&ahead_peers)
+            ));
+        }
+
+        if in_sync_peers.is_empty() {
+            return Some(format!(
+                "We are ahead ({local_tip}) with lagging peers {{{}}}",
+                Self::format_peer_tips(&lagging_peers)
+            ));
+        }
+
+        if lagging_peers.is_empty() {
+            return Some(format!(
+                "We are in sync with the network ({local_tip}) with peers {{{}}}",
+                Self::format_peer_ids(&in_sync_peers)
+            ));
+        }
+
+        Some(format!(
+            "We are in sync with the network ({local_tip}), we have lagging peers {{{}}}",
+            Self::format_peer_tips(&lagging_peers)
+        ))
+    }
+
+    fn log_and_clear(&mut self) {
+        if let Some(message) = self.summary_message() {
+            debug!(target: LOG_TARGET, "{message}");
+        }
+        self.clear();
+    }
+
+    fn clear(&mut self) {
+        self.local_tip = None;
+        self.peers.clear();
+    }
+
+    fn format_peer_tips(peers: &[&ChainStatusPeerLog]) -> String {
+        peers.iter().map(|peer| peer.to_string()).collect::<Vec<_>>().join(", ")
+    }
+
+    fn format_peer_ids(peers: &[&ChainStatusPeerLog]) -> String {
+        peers
+            .iter()
+            .map(|peer| peer.node_id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 }
 
@@ -135,7 +258,6 @@ pub struct Listening {
     is_synced: bool,
     initial_delay_count: u64,
     network_silence: bool,
-    last_chain_status_log: Option<ChainStatusLogState>,
 }
 
 impl Listening {
@@ -158,44 +280,6 @@ impl Listening {
             shared.config.initial_sync_peer_count,
             self.network_silence,
         )));
-    }
-
-    fn should_log_chain_status_at_debug(&mut self, local: &ChainMetadata) -> bool {
-        let log_state = ChainStatusLogState::new(local);
-        if self.last_chain_status_log == Some(log_state) {
-            return false;
-        }
-
-        self.last_chain_status_log = Some(log_state);
-        true
-    }
-
-    fn log_current_chain_status(&mut self, local: &ChainMetadata, network: &PeerChainMetadata) {
-        let network_metadata = network.claimed_chain_metadata();
-        let level = if self.should_log_chain_status_at_debug(local) {
-            Level::Debug
-        } else {
-            Level::Trace
-        };
-        let local_tip_accum_difficulty = local.accumulated_difficulty();
-        let network_tip_accum_difficulty = network_metadata.accumulated_difficulty();
-
-        log!(
-            target: LOG_TARGET,
-            level,
-            "{} We're at block {} with an accumulated difficulty of {} and the network chain tip is at {} with an \
-             accumulated difficulty of {}",
-            if local_tip_accum_difficulty > network_tip_accum_difficulty {
-                "Our blockchain is ahead of the network."
-            } else {
-                // Equals
-                "Our blockchain is up-to-date."
-            },
-            local.best_block_height(),
-            local_tip_accum_difficulty,
-            network_metadata.best_block_height(),
-            network_tip_accum_difficulty,
-        );
     }
 
     #[allow(clippy::too_many_lines)]
@@ -235,179 +319,195 @@ impl Listening {
         let mut initial_sync_counter = 0;
         let mut ahead_of_peers_counter = 0;
         let mut initial_sync_peer_list = Vec::new();
+        let mut chain_status_log = ChainStatusLog::default();
+        let mut chain_status_log_interval = interval(CHAIN_STATUS_LOG_INTERVAL);
+        chain_status_log_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        chain_status_log_interval.tick().await;
+
         loop {
-            let metadata_event = shared.metadata_event_stream.recv().await;
-            match metadata_event.as_ref().map(|v| v.deref()) {
-                Ok(ChainMetadataEvent::NetworkSilence) => {
-                    self.network_silence = true;
-                    self.set_synced_response(shared);
-                    debug!("NetworkSilence event received");
+            tokio::select! {
+                _ = chain_status_log_interval.tick() => {
+                    chain_status_log.log_and_clear();
                 },
-                Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata)) => {
-                    // We received a valid metadata update, so the network is not silent.
-                    if self.network_silence {
-                        self.network_silence = false;
-                        self.publish_status_info(shared);
-                    }
-
-                    // if we are not yet synced, we wait for the initial delay of ping/pongs, so let's propagate the
-                    // updated info
-                    if !self.is_synced {
-                        self.publish_status_info(shared);
-                    }
-                    // We already ban the peer based on some previous logic, but this message was already in the
-                    // pipeline before the ban went into effect.
-                    match shared.peer_manager.is_peer_banned(peer_metadata.node_id()).await {
-                        Ok(true) => {
-                            warn!(
-                                target: LOG_TARGET,
-                                "Ignoring chain metadata from banned peer {}",
-                                peer_metadata.node_id()
-                            );
-                            continue;
+                metadata_event = shared.metadata_event_stream.recv() => {
+                    match metadata_event.as_ref().map(|v| v.deref()) {
+                        Ok(ChainMetadataEvent::NetworkSilence) => {
+                            self.network_silence = true;
+                            self.set_synced_response(shared);
+                            debug!("NetworkSilence event received");
                         },
-                        Ok(false) => {},
-                        Err(e) => {
-                            warn!(
-                                target: LOG_TARGET,
-                                "Ignoring chain metadata from peer {} due to error: {}",
-                                peer_metadata.node_id(), e
-                            );
-                            continue;
-                        },
-                    }
+                        Ok(ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata)) => {
+                            // We received a valid metadata update, so the network is not silent.
+                            if self.network_silence {
+                                self.network_silence = false;
+                                self.publish_status_info(shared);
+                            }
 
-                    let peer_data = PeerMetadata {
-                        metadata: peer_metadata.claimed_chain_metadata().clone(),
-                        last_updated: EpochTime::now(),
-                    };
-                    // If this fails, its not the end of the world, we just want to keep record of the stats of
-                    // the peer
-                    let _old_data = shared
-                        .peer_manager
-                        .set_peer_metadata(peer_metadata.node_id(), 1, peer_data.to_bytes())
-                        .await;
+                            // if we are not yet synced, we wait for the initial delay of ping/pongs, so let's propagate the
+                            // updated info
+                            if !self.is_synced {
+                                self.publish_status_info(shared);
+                            }
+                            // We already ban the peer based on some previous logic, but this message was already in the
+                            // pipeline before the ban went into effect.
+                            match shared.peer_manager.is_peer_banned(peer_metadata.node_id()).await {
+                                Ok(true) => {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "Ignoring chain metadata from banned peer {}",
+                                        peer_metadata.node_id()
+                                    );
+                                    continue;
+                                },
+                                Ok(false) => {},
+                                Err(e) => {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "Ignoring chain metadata from peer {} due to error: {}",
+                                        peer_metadata.node_id(), e
+                                    );
+                                    continue;
+                                },
+                            }
 
-                    let configured_sync_peers = &shared.config.blockchain_sync_config.forced_sync_peers;
-                    if !configured_sync_peers.is_empty() {
-                        // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
-                        // we're out of sync
-                        if !configured_sync_peers.contains(peer_metadata.node_id()) {
-                            continue;
-                        }
-                    };
-
-                    let local_metadata = match shared.db.get_chain_metadata().await {
-                        Ok(m) => m,
-                        Err(e) => {
-                            return FatalError(format!("Could not get local blockchain metadata. {e}"));
-                        },
-                    };
-
-                    let mut sync_mode = determine_sync_mode(
-                        shared.config.blocks_behind_before_considered_lagging,
-                        &local_metadata,
-                        peer_metadata,
-                    );
-
-                    // Generally we will receive a block via incoming blocks, but something might have
-                    // happened that we have not synced to them, e.g. our network could have been down.
-                    // If we know about a stronger chain, but haven't synced to it, because we didn't get
-                    // the blocks propagated to us, or we have a high `blocks_before_considered_lagging`
-                    // then we will wait at least `time_before_considered_lagging` before we try to sync
-                    // to that new chain. If you want to sync to a new chain immediately, then you can
-                    // set this value to 1 second or lower.
-                    if let SyncStatus::BehindButNotYetLagging {
-                        local,
-                        network,
-                        sync_peers,
-                    } = &sync_mode
-                    {
-                        if time_since_better_block.is_none() {
-                            time_since_better_block = Some(Instant::now());
-                        }
-                        if time_since_better_block
-                            .map(|t| t.elapsed() > shared.config.time_before_considered_lagging)
-                            .unwrap()
-                        // unwrap is safe because time_since_better_block is set right above
-                        {
-                            sync_mode = SyncStatus::Lagging {
-                                local: local.clone(),
-                                network: network.clone(),
-                                sync_peers: sync_peers.clone(),
+                            let peer_data = PeerMetadata {
+                                metadata: peer_metadata.claimed_chain_metadata().clone(),
+                                last_updated: EpochTime::now(),
                             };
-                        }
-                    } else {
-                        // We might have gotten up to date via propagation outside of this state, so reset the timer
-                        if sync_mode == SyncStatus::UpToDate {
-                            time_since_better_block = None;
-                            self.log_current_chain_status(&local_metadata, peer_metadata);
-                        }
-                    }
+                            // If this fails, its not the end of the world, we just want to keep record of the stats of
+                            // the peer
+                            let _old_data = shared
+                                .peer_manager
+                                .set_peer_metadata(peer_metadata.node_id(), 1, peer_data.to_bytes())
+                                .await;
 
-                    if !self.is_synced && sync_mode.is_up_to_date() {
-                        ahead_of_peers_counter += 1;
-                        if ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
-                            self.set_synced_response(shared);
-                            info!(target: LOG_TARGET, "Initial sync achieved");
-                        } else {
-                            info!(target: LOG_TARGET, "We are ahead of at least {ahead_of_peers_counter} peers, waiting for more info");
-                            self.set_synced_response(shared);
-                        }
-                    }
-
-                    // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
-                    // immediately return fallen behind with the peer that has a higher pow than us
-                    if sync_mode.is_lagging() && self.is_synced {
-                        return StateEvent::FallenBehind(sync_mode);
-                    }
-                    // if we are lagging and not yet reached initial sync, we delay a bit till we get
-                    // INITIAL_SYNC_PEER_COUNT metadata updates from peers to ensure we make a better choice of which
-                    // peer to sync from in the next stages
-                    if let SyncStatus::Lagging {
-                        local,
-                        network,
-                        sync_peers,
-                    } = sync_mode
-                    {
-                        initial_sync_counter += 1;
-                        self.initial_delay_count = initial_sync_counter;
-                        for peer in sync_peers {
-                            let mut found = false;
-                            // lets search the list to ensure we only have unique peers in the list with the latest
-                            // up-to-date information
-                            for initial_peer in &mut initial_sync_peer_list {
-                                // we compare the two peers via the comparison operator on syncpeer
-                                if *initial_peer == peer {
-                                    found = true;
-                                    // if the peer is already in the list, we replace all the information about the peer
-                                    // with the newest up-to-date information
-                                    *initial_peer = peer.clone();
-                                    break;
+                            let configured_sync_peers = &shared.config.blockchain_sync_config.forced_sync_peers;
+                            if !configured_sync_peers.is_empty() {
+                                // If a _forced_ set of sync peers have been specified, ignore other peers when determining if
+                                // we're out of sync
+                                if !configured_sync_peers.contains(peer_metadata.node_id()) {
+                                    continue;
                                 }
-                            }
-                            if !found {
-                                initial_sync_peer_list.push(peer.clone());
-                            }
-                        }
-                        // We use a list here to ensure that we dont wait for even for INITIAL_SYNC_PEER_COUNT different
-                        // peers
-                        if initial_sync_counter >= shared.config.initial_sync_peer_count {
-                            // lets return now that we have enough peers to chose from
-                            return StateEvent::FallenBehind(SyncStatus::Lagging {
+                            };
+
+                            let local_metadata = match shared.db.get_chain_metadata().await {
+                                Ok(m) => m,
+                                Err(e) => {
+                                    chain_status_log.log_and_clear();
+                                    return FatalError(format!("Could not get local blockchain metadata. {e}"));
+                                },
+                            };
+
+                            let mut sync_mode = determine_sync_mode(
+                                shared.config.blocks_behind_before_considered_lagging,
+                                &local_metadata,
+                                peer_metadata,
+                            );
+
+                            // Generally we will receive a block via incoming blocks, but something might have
+                            // happened that we have not synced to them, e.g. our network could have been down.
+                            // If we know about a stronger chain, but haven't synced to it, because we didn't get
+                            // the blocks propagated to us, or we have a high `blocks_before_considered_lagging`
+                            // then we will wait at least `time_before_considered_lagging` before we try to sync
+                            // to that new chain. If you want to sync to a new chain immediately, then you can
+                            // set this value to 1 second or lower.
+                            if let SyncStatus::BehindButNotYetLagging {
                                 local,
                                 network,
-                                sync_peers: initial_sync_peer_list,
-                            });
-                        }
+                                sync_peers,
+                            } = &sync_mode
+                            {
+                                if time_since_better_block.is_none() {
+                                    time_since_better_block = Some(Instant::now());
+                                }
+                                if time_since_better_block
+                                    .map(|t| t.elapsed() > shared.config.time_before_considered_lagging)
+                                    .unwrap()
+                                // unwrap is safe because time_since_better_block is set right above
+                                {
+                                    sync_mode = SyncStatus::Lagging {
+                                        local: local.clone(),
+                                        network: network.clone(),
+                                        sync_peers: sync_peers.clone(),
+                                    };
+                                }
+                            } else {
+                                // We might have gotten up to date via propagation outside of this state, so reset the timer
+                                if sync_mode == SyncStatus::UpToDate {
+                                    time_since_better_block = None;
+                                }
+                            }
+
+                            chain_status_log.record(&local_metadata, peer_metadata);
+
+                            if !self.is_synced && sync_mode.is_up_to_date() {
+                                ahead_of_peers_counter += 1;
+                                if ahead_of_peers_counter >= shared.config.initial_sync_peer_count {
+                                    self.set_synced_response(shared);
+                                    info!(target: LOG_TARGET, "Initial sync achieved");
+                                } else {
+                                    info!(target: LOG_TARGET, "We are ahead of at least {ahead_of_peers_counter} peers, waiting for more info");
+                                    self.set_synced_response(shared);
+                                }
+                            }
+
+                            // If we have already reached initial sync before, as indicated by the `is_synced` flagged we can
+                            // immediately return fallen behind with the peer that has a higher pow than us
+                            if sync_mode.is_lagging() && self.is_synced {
+                                chain_status_log.log_and_clear();
+                                return StateEvent::FallenBehind(sync_mode);
+                            }
+                            // if we are lagging and not yet reached initial sync, we delay a bit till we get
+                            // INITIAL_SYNC_PEER_COUNT metadata updates from peers to ensure we make a better choice of which
+                            // peer to sync from in the next stages
+                            if let SyncStatus::Lagging {
+                                local,
+                                network,
+                                sync_peers,
+                            } = sync_mode
+                            {
+                                initial_sync_counter += 1;
+                                self.initial_delay_count = initial_sync_counter;
+                                for peer in sync_peers {
+                                    let mut found = false;
+                                    // lets search the list to ensure we only have unique peers in the list with the latest
+                                    // up-to-date information
+                                    for initial_peer in &mut initial_sync_peer_list {
+                                        // we compare the two peers via the comparison operator on syncpeer
+                                        if *initial_peer == peer {
+                                            found = true;
+                                            // if the peer is already in the list, we replace all the information about the peer
+                                            // with the newest up-to-date information
+                                            *initial_peer = peer.clone();
+                                            break;
+                                        }
+                                    }
+                                    if !found {
+                                        initial_sync_peer_list.push(peer.clone());
+                                    }
+                                }
+                                // We use a list here to ensure that we dont wait for even for INITIAL_SYNC_PEER_COUNT different
+                                // peers
+                                if initial_sync_counter >= shared.config.initial_sync_peer_count {
+                                    chain_status_log.log_and_clear();
+                                    // lets return now that we have enough peers to chose from
+                                    return StateEvent::FallenBehind(SyncStatus::Lagging {
+                                        local,
+                                        network,
+                                        sync_peers: initial_sync_peer_list,
+                                    });
+                                }
+                            }
+                        },
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            debug!(target: LOG_TARGET, "Metadata event subscriber lagged by {n} item(s)");
+                        },
+                        Err(broadcast::error::RecvError::Closed) => {
+                            chain_status_log.log_and_clear();
+                            debug!(target: LOG_TARGET, "Metadata event subscriber closed");
+                            break;
+                        },
                     }
-                },
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    debug!(target: LOG_TARGET, "Metadata event subscriber lagged by {n} item(s)");
-                },
-                Err(broadcast::error::RecvError::Closed) => {
-                    debug!(target: LOG_TARGET, "Metadata event subscriber closed");
-                    break;
                 },
             }
         }
@@ -426,7 +526,6 @@ impl From<Waiting> for Listening {
             is_synced: false,
             initial_delay_count: 0,
             network_silence: false,
-            last_chain_status_log: None,
         }
     }
 }
@@ -437,7 +536,6 @@ impl From<HeaderSyncState> for Listening {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
             network_silence: false,
-            last_chain_status_log: None,
         }
     }
 }
@@ -448,7 +546,6 @@ impl From<BlockSync> for Listening {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
             network_silence: false,
-            last_chain_status_log: None,
         }
     }
 }
@@ -459,7 +556,6 @@ impl From<DecideNextSync> for Listening {
             is_synced: sync.is_synced(),
             initial_delay_count: 0,
             network_silence: false,
-            last_chain_status_log: None,
         }
     }
 }
@@ -476,7 +572,7 @@ fn determine_sync_mode(
     if local_tip_accum_difficulty < network_tip_accum_difficulty {
         let local_tip_height = local.best_block_height();
         let network_tip_height = network.claimed_chain_metadata().best_block_height();
-        info!(
+        trace!(
             target: LOG_TARGET,
             "Our local blockchain accumulated difficulty is a little behind that of the network. We're at block #{local_tip_height} \
              with an accumulated difficulty of {local_tip_accum_difficulty}, and the network chain tip is at #{network_tip_height} with an accumulated difficulty \
@@ -527,7 +623,7 @@ fn determine_sync_mode(
             if network_tip_height > local_tip_height &&
                 local_tip_height.saturating_add(blocks_behind_before_considered_lagging) > network_tip_height
             {
-                info!(
+                trace!(
                     target: LOG_TARGET,
                     "While we are behind, we are still within {blocks_behind_before_considered_lagging} blocks of them, so we are staying as listening and \
                      waiting for the propagated blocks"
@@ -540,7 +636,7 @@ fn determine_sync_mode(
             };
         }
 
-        debug!(
+        trace!(
             target: LOG_TARGET,
             "Lagging (local height = {}, network height = {}, peer = {} ({}))",
             local_tip_height,
@@ -559,7 +655,7 @@ fn determine_sync_mode(
     } else {
         if local_tip_accum_difficulty / 2 > network_tip_accum_difficulty {
             // We are ahead of the network, but not by much. We should be in listening mode.
-            info!(
+            trace!(
                 target: LOG_TARGET,
                 "Received a metadata update from a peer that is very far behind us. Disregarding. We are at block #{} with an \
                  accumulated difficulty of {} and the network chain tip is at #{} with an accumulated difficulty of {}",
@@ -590,32 +686,39 @@ mod test {
         NodeId::from_key(&public_key)
     }
 
+    fn test_block_hash() -> FixedHash {
+        FixedHash::from([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+            29, 30, 31,
+        ])
+    }
+
+    fn chain_metadata(best_block_height: u64, accumulated_difficulty: U512) -> ChainMetadata {
+        ChainMetadata::new(best_block_height, test_block_hash(), 0, 0, accumulated_difficulty, 0).unwrap()
+    }
+
+    fn peer_chain_metadata(best_block_height: u64, accumulated_difficulty: U512) -> PeerChainMetadata {
+        PeerChainMetadata::new(
+            random_node_id(),
+            chain_metadata(best_block_height, accumulated_difficulty),
+            None,
+        )
+    }
+
     #[test]
     fn test_determine_sync_mode() {
         const NETWORK_TIP_HEIGHT: u64 = 5000;
-        let block_hash = FixedHash::from([
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-            29, 30, 31,
-        ]);
         let accumulated_difficulty = U512::from(10000);
 
         let archival_node = PeerChainMetadata::new(
             random_node_id(),
-            ChainMetadata::new(NETWORK_TIP_HEIGHT, block_hash, 0, 0, accumulated_difficulty, 0).unwrap(),
+            chain_metadata(NETWORK_TIP_HEIGHT, accumulated_difficulty),
             None,
         );
 
         let behind_node = PeerChainMetadata::new(
             random_node_id(),
-            ChainMetadata::new(
-                NETWORK_TIP_HEIGHT - 1,
-                block_hash,
-                0,
-                0,
-                accumulated_difficulty - U512::from(1000),
-                0,
-            )
-            .unwrap(),
+            chain_metadata(NETWORK_TIP_HEIGHT - 1, accumulated_difficulty - U512::from(1000)),
             None,
         );
 
@@ -630,19 +733,52 @@ mod test {
     }
 
     #[test]
-    fn test_chain_status_debug_log_is_deduplicated_by_local_tip() {
-        const NETWORK_TIP_HEIGHT: u64 = 5000;
-        let block_hash = FixedHash::from([
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-            29, 30, 31,
-        ]);
+    fn test_chain_status_log_summarizes_in_sync_with_lagging_peers() {
+        let local = chain_metadata(5000, U512::from(10000));
+        let in_sync_peer = peer_chain_metadata(5000, U512::from(10000));
+        let lagging_peer = peer_chain_metadata(4999, U512::from(9999));
+        let lagging_peer_id = lagging_peer.node_id().to_string();
+        let mut chain_status_log = ChainStatusLog::default();
 
-        let metadata = ChainMetadata::new(NETWORK_TIP_HEIGHT, block_hash, 0, 0, U512::from(10000), 0).unwrap();
-        let next_metadata = ChainMetadata::new(NETWORK_TIP_HEIGHT + 1, block_hash, 0, 0, U512::from(10001), 0).unwrap();
-        let mut listening = Listening::new();
+        chain_status_log.record(&local, &in_sync_peer);
+        chain_status_log.record(&local, &lagging_peer);
 
-        assert!(listening.should_log_chain_status_at_debug(&metadata));
-        assert!(!listening.should_log_chain_status_at_debug(&metadata));
-        assert!(listening.should_log_chain_status_at_debug(&next_metadata));
+        let message = chain_status_log.summary_message().unwrap();
+        assert!(message.contains("We are in sync with the network"));
+        assert!(message.contains("lagging peers"));
+        assert!(message.contains(&lagging_peer_id));
+
+        chain_status_log.log_and_clear();
+        assert!(chain_status_log.summary_message().is_none());
+    }
+
+    #[test]
+    fn test_chain_status_log_summarizes_all_in_sync_peers() {
+        let local = chain_metadata(5000, U512::from(10000));
+        let peer = peer_chain_metadata(5000, U512::from(10000));
+        let peer_id = peer.node_id().to_string();
+        let mut chain_status_log = ChainStatusLog::default();
+
+        chain_status_log.record(&local, &peer);
+
+        let message = chain_status_log.summary_message().unwrap();
+        assert!(message.contains("We are in sync with the network"));
+        assert!(message.contains("with peers"));
+        assert!(message.contains(&peer_id));
+        assert!(!message.contains("lagging peers"));
+    }
+
+    #[test]
+    fn test_chain_status_log_summarizes_behind_network() {
+        let local = chain_metadata(5000, U512::from(10000));
+        let ahead_peer = peer_chain_metadata(5001, U512::from(10001));
+        let ahead_peer_id = ahead_peer.node_id().to_string();
+        let mut chain_status_log = ChainStatusLog::default();
+
+        chain_status_log.record(&local, &ahead_peer);
+
+        let message = chain_status_log.summary_message().unwrap();
+        assert!(message.contains("We are behind the network"));
+        assert!(message.contains(&ahead_peer_id));
     }
 }


### PR DESCRIPTION
Description
---

Reduces repeated listening-state chain metadata debug logs by aggregating peer metadata updates in the listening loop.

The listening state now collects peer chain metadata and emits a single `DEBUG` summary on a timer, and when leaving the listening state. Per-peer status details are still available at `TRACE`, so the useful signal remains without spamming debug logs. Sync decisions are unchanged.

Motivation and Context
---

Fixes #6808.

The previous debug log was emitted from `determine_sync_mode` for every peer metadata update while the node was up to date, which could create many identical debug entries.

How Has This Been Tested?
---

- `git diff --check`
- `cargo test --locked --ignore-rust-version -p tari_core base_node::state_machine_service::states::listening --lib`
- `cargo check --locked --ignore-rust-version -p tari_core`

What process can a PR reviewer use to test or verify this change?
---

Run the focused `tari_core` unit tests above and inspect `base_layer/core/src/base_node/state_machine_service/states/listening.rs` to confirm peer chain metadata is aggregated into one timed `DEBUG` summary and cleared after each log.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
