### PR TITLE
ci: use App Store Connect API key for macOS notarization

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -438,18 +438,16 @@ jobs:
           path: "${{ env.MTS_SOURCE }}/*"
 
       - name: Sign macOS Artifacts
-        # Disabled - macOS signing/notarization is currently broken; upload unsigned binaries instead
-        if: ${{ false }}
-        # if: ${{ ( startsWith(runner.os,'macOS') ) && ( env.MACOS_NOTARIZE_USERNAME != '' ) }}
+        if: ${{ ( startsWith(runner.os,'macOS') ) && ( env.MACOS_NOTARY_ISSUER != '' ) }}
         # continue-on-error: true
         env:
           MACOS_KEYCHAIN_PASS: ${{ secrets.MACOS_KEYCHAIN_PASS }}
           MACOS_APPLICATION_ID: ${{ secrets.MACOS_APPLICATION_ID }}
           MACOS_APPLICATION_CERT: ${{ secrets.MACOS_APPLICATION_CERT }}
           MACOS_APPLICATION_PASS: ${{ secrets.MACOS_APPLICATION_PASS }}
-          MACOS_NOTARIZE_USERNAME: ${{ secrets.MACOS_NOTARIZE_USERNAME }}
-          MACOS_NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZE_PASSWORD }}
-          MACOS_ASC_PROVIDER: ${{ secrets.MACOS_ASC_PROVIDER }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
         run: |
           set -xo pipefail
           echo "${MACOS_APPLICATION_CERT}" | base64 --decode > application.p12
@@ -518,12 +516,14 @@ jobs:
           echo "Checksum verification archive is "
           ${SHARUN} --check "${{ env.BINFILE }}.zip.sha256"
 
+          printf '%s' "${MACOS_NOTARY_KEY}" > "${RUNNER_TEMP}/notary_key.p8"
+
           echo -e "Submitting to Apple...\n\n"
           xcrun notarytool submit \
             "${{ env.BINFILE }}.zip" \
-            --apple-id "${MACOS_NOTARIZE_USERNAME}" \
-            --password ${MACOS_NOTARIZE_PASSWORD} \
-            --team-id ${MACOS_ASC_PROVIDER} \
+            --key "${RUNNER_TEMP}/notary_key.p8" \
+            --key-id "${MACOS_NOTARY_KEY_ID}" \
+            --issuer "${MACOS_NOTARY_ISSUER}" \
             --verbose --wait 2>&1 | tee -a notarisation.result
           # Maybe use line from with "Processing complete"?
           requestUUID=$(tail -n5 notarisation.result | grep "id:" | cut -d" " -f 4)
@@ -653,10 +653,9 @@ jobs:
           cargo audit bin *minotari*${{ env.TS_EXT }}
 
       - name: Archive and Checksum Binaries
-        # macOS signing disabled (broken) -> archive unsigned binaries on every platform, incl. macOS
-        # if: ${{ ! ( ( startsWith(runner.os, 'macOS') && ( env.MACOS_NOTARIZE_USERNAME != '' ) ) ) }}
+        if: ${{ ! ( ( startsWith(runner.os, 'macOS') && ( env.MACOS_NOTARY_ISSUER != '' ) ) ) }}
         env:
-          MACOS_NOTARIZE_USERNAME: ${{ secrets.MACOS_NOTARIZE_USERNAME }}
+          MACOS_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
         shell: bash
         run: |
           echo "Archive ${{ env.BINFILE }} too ${{ env.BINFILE }}.zip"
@@ -789,16 +788,16 @@ jobs:
           ls -alhtR macos-universal
 
       - name: Build the macOS universal Archive and code-sign
-        if: ${{ ( startsWith(runner.os,'macOS') ) && ( env.MACOS_NOTARIZE_USERNAME != '' ) }}
+        if: ${{ ( startsWith(runner.os,'macOS') ) && ( env.MACOS_NOTARY_ISSUER != '' ) }}
         # continue-on-error: true
         env:
           MACOS_KEYCHAIN_PASS: ${{ secrets.MACOS_KEYCHAIN_PASS }}
           MACOS_APPLICATION_ID: ${{ secrets.MACOS_APPLICATION_ID }}
           MACOS_APPLICATION_CERT: ${{ secrets.MACOS_APPLICATION_CERT }}
           MACOS_APPLICATION_PASS: ${{ secrets.MACOS_APPLICATION_PASS }}
-          MACOS_NOTARIZE_USERNAME: ${{ secrets.MACOS_NOTARIZE_USERNAME }}
-          MACOS_NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZE_PASSWORD }}
-          MACOS_ASC_PROVIDER: ${{ secrets.MACOS_ASC_PROVIDER }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
         run: |
           # set -xo pipefail
           echo "${MACOS_APPLICATION_CERT}" | base64 --decode > application.p12
@@ -879,12 +878,14 @@ jobs:
           echo "Checksum verification archive is "
           ${SHARUN} --check "${{ env.BINFILE }}.zip.sha256"
 
+          printf '%s' "${MACOS_NOTARY_KEY}" > "${RUNNER_TEMP}/notary_key.p8"
+
           echo -e "Submitting to Apple...\n\n"
           xcrun notarytool submit \
             "${{ env.BINFILE }}.zip" \
-            --apple-id "${MACOS_NOTARIZE_USERNAME}" \
-            --password ${MACOS_NOTARIZE_PASSWORD} \
-            --team-id ${MACOS_ASC_PROVIDER} \
+            --key "${RUNNER_TEMP}/notary_key.p8" \
+            --key-id "${MACOS_NOTARY_KEY_ID}" \
+            --issuer "${MACOS_NOTARY_ISSUER}" \
             --verbose --wait 2>&1 | tee -a notarisation.result
           # Maybe use line from with "Processing complete"?
           requestUUID=$(tail -n5 notarisation.result | grep "id:" | cut -d" " -f 4)


### PR DESCRIPTION
## Problem

macOS builds fail at **Sign macOS Artifacts → notarization**, e.g. [this rc.2 run](https://github.com/tari-project/tari/actions/runs/28578155619/job/84731624027):

```
/notary/v2/asp          -> 200  (Apple ID + app-specific password valid)
/notary/v2/submissions  -> 403  forbidden
Error: HTTP status code: 403. Invalid or inaccessible developer team ID
for the provided Apple ID. Ensure the Team ID is correct and that you are
a member of that team.
```

Code-signing (team-level `Developer ID Application` cert) still succeeds — only notarization fails. Root cause: notarization authenticated as an **individual team member's Apple ID** (`--apple-id`/`--password`/`--team-id`). Those secrets were set in Dec 2023; that member was since removed from the Apple developer team, so the notary service rejects the submission. The Apple ID still logs in (personal account → `/asp` 200) but is no longer a team member.

## Fix

Switch both `notarytool submit` calls to a **team-scoped App Store Connect API key** (`--key`/`--key-id`/`--issuer`). The key belongs to the team, not a person, so it survives member changes.

## Required repo secrets (new)

| Secret | Value |
|---|---|
| `MACOS_NOTARY_KEY` | contents of the `.p8` API key |
| `MACOS_NOTARY_KEY_ID` | Key ID |
| `MACOS_NOTARY_ISSUER` | Issuer ID (also the new signing gate) |

The old `MACOS_NOTARIZE_USERNAME` / `MACOS_NOTARIZE_PASSWORD` / `MACOS_ASC_PROVIDER` can be deleted once this merges. Code-signing secrets (`MACOS_APPLICATION_*`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)