### PR TITLE
chore(deps): update cucumber junit path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16cbb27bc2064274afa3a3d8bc9a0e71333589850573aa632ec4520e4af14d94"
+checksum = "96a87e18d925b19ebe0fd47ea45316abd216d81ec0879c2448c3f9a0e9da62be"
 dependencies = [
  "anyhow",
  "clap",
@@ -1531,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1afaf9c422380861111c6be56f39b324e351fd9efc07a1486268798bf79cfd"
+checksum = "ed2fc8a8bbb73af3230db699e8690c5c786655f75eb89e5f18d76055fa1a9a4d"
 dependencies = [
  "cucumber-expressions",
  "inflections",
@@ -1861,13 +1861,13 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2720,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "gherkin"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70197ce7751bfe8bc828e3a855502d3a869a1e9416b58b10c4bde5cf8a0a3cb3"
+checksum = "9e2c0d8c632f8a251ce9a8198079b1022adc586ff4e3d33e18debd40eb463b31"
 dependencies = [
  "heck 0.5.0",
  "peg",
@@ -3794,13 +3794,11 @@ dependencies = [
 
 [[package]]
 name = "junit-report"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c3a3342e6720a82d7d179f380e9841b73a1dd49344e33959fdfe571ce56b55"
+version = "0.9.0"
+source = "git+https://github.com/bachp/junit-report-rs?rev=d4eb4902e245a64d08110891069d3024f9db9d04#d4eb4902e245a64d08110891069d3024f9db9d04"
 dependencies = [
  "derive-getters",
  "quick-xml",
- "strip-ansi-escapes",
  "time",
 ]
 
@@ -6037,9 +6035,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -7339,15 +7337,6 @@ name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
-name = "strip-ansi-escapes"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
-dependencies = [
- "vte",
-]
 
 [[package]]
 name = "strsim"
@@ -9083,15 +9072,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vte"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1750,7 +1750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2344,7 +2344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3795,7 +3795,8 @@ dependencies = [
 [[package]]
 name = "junit-report"
 version = "0.9.0"
-source = "git+https://github.com/bachp/junit-report-rs?rev=d4eb4902e245a64d08110891069d3024f9db9d04#d4eb4902e245a64d08110891069d3024f9db9d04"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39792dac833b56356eb7d6a97dd1cc7a752f7fe95e6aba4d458b4c16002f64b1"
 dependencies = [
  "derive-getters",
  "quick-xml",
@@ -5939,8 +5940,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap 0.10.1",
  "once_cell",
@@ -5973,7 +5974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6035,9 +6036,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -6588,7 +6589,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6645,7 +6646,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7244,7 +7245,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7283,7 +7284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8217,7 +8218,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8227,7 +8228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9276,7 +9277,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,6 @@ debug = false
 
 [patch.crates-io]
 liblmdb-sys = { git = "https://github.com/tari-project/lmdb-rs", tag = "0.7.6-tari.1" }
+# crates.io junit-report 0.9.0 still depends on quick-xml 0.39, which is below
+# the RustSec-patched quick-xml 0.41 line used by upstream junit-report master.
+junit-report = { git = "https://github.com/bachp/junit-report-rs", rev = "d4eb4902e245a64d08110891069d3024f9db9d04" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,3 @@ debug = false
 
 [patch.crates-io]
 liblmdb-sys = { git = "https://github.com/tari-project/lmdb-rs", tag = "0.7.6-tari.1" }
-# crates.io junit-report 0.9.0 still depends on quick-xml 0.39, which is below
-# the RustSec-patched quick-xml 0.41 line used by upstream junit-report master.
-junit-report = { git = "https://github.com/bachp/junit-report-rs", rev = "d4eb4902e245a64d08110891069d3024f9db9d04" }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = { workspace = true }
 async-trait = "0.1.50"
 chrono = { version = "0.4", default-features = false }
 csv = "1.1"
-cucumber = { version = "0.22", features = [
+cucumber = { version = "0.23", features = [
     "default",
     "libtest",
     "output-junit",


### PR DESCRIPTION
Description
---
Updates the integration-test Cucumber/JUnit dependency path without keeping a global `junit-report` patch override.

This bumps `cucumber` from `0.22.1` to `0.23.0` and lets Cargo resolve crates.io `junit-report 0.9.0`. That moves the JUnit output path from:

```text
cucumber 0.22.1 -> junit-report 0.8.3 -> quick-xml 0.31.0
```

to:

```text
cucumber 0.23.0 -> junit-report 0.9.0 -> quick-xml 0.39.4
```

Refs #7912.
Refs #7914.

Motivation and Context
---
Issues #7912 and #7914 report RustSec advisories against `quick-xml 0.31.0`. In this workspace that dependency is pulled only through the integration-test JUnit output path:

```text
cucumber -> junit-report -> quick-xml
```

The integration workflow still uploads `integration_tests/cucumber-output-junit.xml`, so this keeps the `output-junit` feature instead of removing JUnit reporting.

Review note: crates.io `junit-report 0.9.0` still resolves `quick-xml 0.39.4`, which is below the advisory fixed range of `quick-xml >=0.41.0`. A previous revision temporarily patched `junit-report` to an upstream commit that used `quick-xml 0.41.0`, but that global override was removed after review because it would keep forcing `junit-report` for all dependants until a crates.io release catches up.

How Has This Been Tested?
---
- `cargo tree -i quick-xml --locked`
- `cargo tree -i crossbeam-epoch --locked`
- `cargo +1.93.0 test --no-run --locked --all-features --package tari_integration_tests --test cucumber`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo audit`

Audit note: `cargo audit` still reports `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` for `quick-xml 0.39.4`. That residual finding is expected with the normal crates.io `junit-report 0.9.0` path and should be revisited when `junit-report` publishes a release that depends on `quick-xml >=0.41.0`.

What process can a PR reviewer use to test or verify this change?
---
- Run `cargo tree -i quick-xml --locked` and confirm the path resolves through crates.io `junit-report 0.9.0`.
- Run `cargo audit` and confirm the remaining quick-xml findings match the expected residual advisories above.
- Compile the Cucumber integration target with `cargo +1.93.0 test --no-run --locked --all-features --package tari_integration_tests --test cucumber`.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
