### PR TITLE
fix(sidechain)!: add fee/claimed accumulated data fields

### DIFF
--- a/applications/minotari_app_grpc/proto/sidechain_types.proto
+++ b/applications/minotari_app_grpc/proto/sidechain_types.proto
@@ -173,6 +173,8 @@ message ValidatorSignature {
 }
 
 message ShardGroupAccumulatedData {
-  uint64 total_exhaust_burn_msb = 1;
-  uint64 total_exhaust_burn_lsb = 2;
+  uint64 epoch_exhaust_burn_msb = 1;
+  uint64 epoch_exhaust_burn_lsb = 2;
+  uint64 epoch_fee = 3;
+  uint64 epoch_claimed = 4;
 }

--- a/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
@@ -686,21 +686,27 @@ impl TryFrom<grpc::ShardGroupAccumulatedData> for ShardGroupAccumulatedData {
     type Error = String;
 
     fn try_from(value: grpc::ShardGroupAccumulatedData) -> Result<Self, Self::Error> {
-        let total_exhaust_burn =
-            (u128::from(value.total_exhaust_burn_msb) << 64) | u128::from(value.total_exhaust_burn_lsb);
-        Ok(Self { total_exhaust_burn })
+        let epoch_exhaust_burn =
+            (u128::from(value.epoch_exhaust_burn_msb) << 64) | u128::from(value.epoch_exhaust_burn_lsb);
+        Ok(Self {
+            epoch_exhaust_burn,
+            epoch_fee: value.epoch_fee,
+            epoch_claimed: value.epoch_claimed,
+        })
     }
 }
 
 impl From<&ShardGroupAccumulatedData> for grpc::ShardGroupAccumulatedData {
     fn from(value: &ShardGroupAccumulatedData) -> Self {
-        let total_exhaust_burn_msb = (value.total_exhaust_burn >> 64) as u64;
+        let epoch_exhaust_burn_msb = (value.epoch_exhaust_burn >> 64) as u64;
         #[allow(clippy::cast_possible_truncation)]
-        let total_exhaust_burn_lsb = (value.total_exhaust_burn & u128::from(u64::MAX)) as u64;
+        let epoch_exhaust_burn_lsb = (value.epoch_exhaust_burn & u128::from(u64::MAX)) as u64;
 
         Self {
-            total_exhaust_burn_msb,
-            total_exhaust_burn_lsb,
+            epoch_exhaust_burn_msb,
+            epoch_exhaust_burn_lsb,
+            epoch_fee: value.epoch_fee,
+            epoch_claimed: value.epoch_claimed,
         }
     }
 }

--- a/base_layer/core/src/proto/sidechain_feature.proto
+++ b/base_layer/core/src/proto/sidechain_feature.proto
@@ -155,6 +155,8 @@ message ShardGroup {
 }
 
 message ShardGroupAccumulatedData {
-  uint64 total_exhaust_burn_msb = 1;
-  uint64 total_exhaust_burn_lsb = 2;
+  uint64 epoch_exhaust_burn_msb = 1;
+  uint64 epoch_exhaust_burn_lsb = 2;
+  uint64 epoch_fee = 3;
+  uint64 epoch_claimed = 4;
 }

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -678,22 +678,28 @@ impl TryFrom<proto::types::ShardGroupAccumulatedData> for tari_sidechain::ShardG
     type Error = String;
 
     fn try_from(value: proto::types::ShardGroupAccumulatedData) -> Result<Self, Self::Error> {
-        let total_exhaust_burn =
-            (u128::from(value.total_exhaust_burn_msb) << 64) | u128::from(value.total_exhaust_burn_lsb);
+        let epoch_exhaust_burn =
+            (u128::from(value.epoch_exhaust_burn_msb) << 64) | u128::from(value.epoch_exhaust_burn_lsb);
 
-        Ok(Self { total_exhaust_burn })
+        Ok(Self {
+            epoch_exhaust_burn,
+            epoch_fee: value.epoch_fee,
+            epoch_claimed: value.epoch_claimed,
+        })
     }
 }
 
 impl From<tari_sidechain::ShardGroupAccumulatedData> for proto::types::ShardGroupAccumulatedData {
     fn from(value: tari_sidechain::ShardGroupAccumulatedData) -> Self {
-        let total_exhaust_burn_msb = (value.total_exhaust_burn >> 64) as u64;
+        let epoch_exhaust_burn_msb = (value.epoch_exhaust_burn >> 64) as u64;
         #[allow(clippy::cast_possible_truncation)]
-        let total_exhaust_burn_lsb = (value.total_exhaust_burn & u128::from(u64::MAX)) as u64;
+        let epoch_exhaust_burn_lsb = (value.epoch_exhaust_burn & u128::from(u64::MAX)) as u64;
 
         Self {
-            total_exhaust_burn_msb,
-            total_exhaust_burn_lsb,
+            epoch_exhaust_burn_msb,
+            epoch_exhaust_burn_lsb,
+            epoch_fee: value.epoch_fee,
+            epoch_claimed: value.epoch_claimed,
         }
     }
 }

--- a/base_layer/sidechain/src/commit_proof.rs
+++ b/base_layer/sidechain/src/commit_proof.rs
@@ -245,7 +245,12 @@ impl SidechainBlockHeader {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
 pub struct ShardGroupAccumulatedData {
-    pub total_exhaust_burn: u128,
+    /// Exhaust burn attributed to this shard group over the epoch.
+    pub epoch_exhaust_burn: u128,
+    /// Network fee volume attributed to this shard group over the epoch.
+    pub epoch_fee: u64,
+    /// Peg-in claim amounts attributed to this shard group over the epoch.
+    pub epoch_claimed: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]


### PR DESCRIPTION
Description
---
fix(sidechain)!: add fee/claimed accumulated data fields

Motivation and Context
---
These values are preserved in epoch checkpoints to allow for a possible future burn controller that adjusts to the amount of TARI minted on L2 as well as for clearer tracking in general.

Also renamed the total exhaust burn field, since the value represents the exhaust burn for the epoch, not the total ever.

This is non-breaking because this data is not currently committed on any minotari node. However this PR is marked as breaking because the tari_sidechain crate upgrade needs to be coordinated with an L2 upgrade.

Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

BREAKING CHANGE: the L2 code will need to be updated when using the released version of this crate.