### PR TITLE
fix(deps): update crossbeam-epoch advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Description
---
Updates `crossbeam-epoch` from `0.9.18` to `0.9.20` in `Cargo.lock` to address `RUSTSEC-2026-0204`.

Fixes #7917.

Motivation and Context
---
`cargo audit` reports `RUSTSEC-2026-0204` for `crossbeam-epoch 0.9.18`:

> Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid.

The fixed release is `crossbeam-epoch >=0.9.20`. This is a lockfile-only update and keeps the existing `crossbeam`, `crossbeam-deque`, `rayon`, `moka`, and `hickory-resolver` dependency paths unchanged except for the patched `crossbeam-epoch` package version.

How Has This Been Tested?
---
- `cargo tree -i crossbeam-epoch --locked`
- `cargo audit`
- `cargo +1.93.0 check --locked -p minotari_miner -p tari_p2p`
- `git diff --check`

Audit note: `cargo audit` no longer reports `RUSTSEC-2026-0204`. It still reports the existing `quick-xml` advisories `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195`, which are tracked separately by #7912 and #7914 and are covered by #7915.

What process can a PR reviewer use to test or verify this change?
---
- Run `cargo tree -i crossbeam-epoch --locked` and confirm `crossbeam-epoch v0.9.20`.
- Run `cargo audit` and confirm `RUSTSEC-2026-0204` is no longer reported.
- Run `cargo +1.93.0 check --locked -p minotari_miner -p tari_p2p`.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
