### PR TITLE
feat: add mined_in_epoch to burn claim proof file

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -2679,6 +2679,9 @@ message GetBurnClaimProofResponse {
   bytes encrypted_data = 3;
   TransactionKernel kernel = 4;
   uint64 value = 5;
+  // The L1 epoch the burn was mined in (block_height / vn_epoch_length). Optional: absent until the burn is
+  // confirmed on-chain, or when connected to a base node that does not report the mined block height.
+  optional uint64 mined_in_epoch = 6;
 }
 
 message BurnClaimProof {

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -3207,6 +3207,12 @@ impl wallet_server::Wallet for WalletGrpcServer {
             kernel: Some(proof.kernel.into()),
             encrypted_data: proof.encrypted_data.map(|ed| ed.into_vec()).unwrap_or_default(),
             value: proof.value.as_ref().map(|v| v.as_u64()).unwrap_or_default(),
+            mined_in_epoch: proof.mined_in_height.map(|height| {
+                self.rules
+                    .consensus_constants(height)
+                    .block_height_to_epoch(height)
+                    .as_u64()
+            }),
         }))
     }
 

--- a/applications/minotari_console_wallet/src/transaction_event_handler.rs
+++ b/applications/minotari_console_wallet/src/transaction_event_handler.rs
@@ -69,12 +69,8 @@ impl TransactionEventHandler {
         while let Ok(event) = events.recv().await {
             #[allow(clippy::single_match)]
             match &*event {
-                TransactionEvent::TransactionBurnConfirmed {
-                    output_hash,
-                    mined_in_height,
-                    ..
-                } => {
-                    if let Err(err) = self.handle_burn_confirmed(*output_hash, *mined_in_height).await {
+                TransactionEvent::TransactionBurnConfirmed { output_hash, .. } => {
+                    if let Err(err) = self.handle_burn_confirmed(*output_hash).await {
                         error!(target: LOG_TARGET, "Error handling TransactionBurnConfirmed event: {}", err);
                     }
                 },
@@ -83,11 +79,7 @@ impl TransactionEventHandler {
         }
     }
 
-    async fn handle_burn_confirmed(
-        &mut self,
-        output_hash: HashOutput,
-        mined_in_height: Option<u64>,
-    ) -> anyhow::Result<()> {
+    async fn handle_burn_confirmed(&mut self, output_hash: HashOutput) -> anyhow::Result<()> {
         let proof = self
             .transaction_service
             .get_burn_proof(output_hash)
@@ -101,9 +93,10 @@ impl TransactionEventHandler {
 
         let out_dir = self.config.get_burn_proof_output_dir(self.network);
 
-        // Convert the burn's L1 block height to its epoch (height / vn_epoch_length) so an L2 claimant can defer
-        // the claim until L2 has synced past it. `None` when the base node did not report the height.
-        let mined_in_epoch = mined_in_height.map(|height| {
+        // Convert the burn's L1 block height (persisted with the merkle proof) to its epoch
+        // (height / vn_epoch_length) so an L2 claimant can defer the claim until L2 has synced past it.
+        // `None` when the base node did not report the height.
+        let mined_in_epoch = proof.mined_in_height.map(|height| {
             self.consensus_manager
                 .consensus_constants(height)
                 .block_height_to_epoch(height)

--- a/applications/minotari_console_wallet/src/transaction_event_handler.rs
+++ b/applications/minotari_console_wallet/src/transaction_event_handler.rs
@@ -35,6 +35,7 @@ use minotari_wallet::{
 use tari_common::configuration::Network;
 use tari_common_types::types::HashOutput;
 use tari_sidechain::{AbridgedTransactionKernel, BurnClaimProof, CompleteClaimBurnProof};
+use tari_transaction_components::consensus::ConsensusManager;
 use tari_utilities::hex::Hex;
 use tokio::fs;
 
@@ -44,10 +45,13 @@ pub fn start(wallet: &WalletSqlite) -> impl Future<Output = ()> + 'static {
     let network = wallet.network.as_network();
     let transaction_service = wallet.transaction_service.clone();
     let config = wallet.config.transaction_service_config.clone();
+    // Used to map a burn's L1 block height to its epoch (height / vn_epoch_length) when writing the proof file.
+    let consensus_manager = ConsensusManager::builder(network).build();
     TransactionEventHandler {
         transaction_service,
         config,
         network,
+        consensus_manager,
     }
     .run()
 }
@@ -56,6 +60,7 @@ struct TransactionEventHandler {
     config: TransactionServiceConfig,
     network: Network,
     transaction_service: TransactionServiceHandle,
+    consensus_manager: ConsensusManager,
 }
 
 impl TransactionEventHandler {
@@ -64,8 +69,12 @@ impl TransactionEventHandler {
         while let Ok(event) = events.recv().await {
             #[allow(clippy::single_match)]
             match &*event {
-                TransactionEvent::TransactionBurnConfirmed { output_hash, .. } => {
-                    if let Err(err) = self.handle_burn_confirmed(*output_hash).await {
+                TransactionEvent::TransactionBurnConfirmed {
+                    output_hash,
+                    mined_in_height,
+                    ..
+                } => {
+                    if let Err(err) = self.handle_burn_confirmed(*output_hash, *mined_in_height).await {
                         error!(target: LOG_TARGET, "Error handling TransactionBurnConfirmed event: {}", err);
                     }
                 },
@@ -74,7 +83,11 @@ impl TransactionEventHandler {
         }
     }
 
-    async fn handle_burn_confirmed(&mut self, output_hash: HashOutput) -> anyhow::Result<()> {
+    async fn handle_burn_confirmed(
+        &mut self,
+        output_hash: HashOutput,
+        mined_in_height: Option<u64>,
+    ) -> anyhow::Result<()> {
         let proof = self
             .transaction_service
             .get_burn_proof(output_hash)
@@ -88,13 +101,26 @@ impl TransactionEventHandler {
 
         let out_dir = self.config.get_burn_proof_output_dir(self.network);
 
-        write_burn_proof_to_file(out_dir, proof).await?;
+        // Convert the burn's L1 block height to its epoch (height / vn_epoch_length) so an L2 claimant can defer
+        // the claim until L2 has synced past it. `None` when the base node did not report the height.
+        let mined_in_epoch = mined_in_height.map(|height| {
+            self.consensus_manager
+                .consensus_constants(height)
+                .block_height_to_epoch(height)
+                .as_u64()
+        });
+
+        write_burn_proof_to_file(out_dir, proof, mined_in_epoch).await?;
 
         Ok(())
     }
 }
 
-async fn write_burn_proof_to_file<P: AsRef<Path>>(burn_proofs_dir: P, proof: DbBurnProof) -> anyhow::Result<()> {
+async fn write_burn_proof_to_file<P: AsRef<Path>>(
+    burn_proofs_dir: P,
+    proof: DbBurnProof,
+    mined_in_epoch: Option<u64>,
+) -> anyhow::Result<()> {
     fs::create_dir_all(&burn_proofs_dir).await?;
     let kernel_merkle_proof = proof
         .kernel_merkle_proof
@@ -126,9 +152,15 @@ async fn write_burn_proof_to_file<P: AsRef<Path>>(burn_proofs_dir: P, proof: DbB
             sender_offset_public_key: proof.burn_proof.sender_offset_public_key,
         },
         encrypted_data: encrypted_data.into_vec(),
+        mined_in_epoch,
     };
 
     fs::write(&final_path, serde_json::to_vec_pretty(&complete_proof)?).await?;
-    info!(target: LOG_TARGET, "Wrote burn proof to {}", final_path.display());
+    info!(
+        target: LOG_TARGET,
+        "Wrote burn proof (mined in epoch {:?}) to {}",
+        mined_in_epoch,
+        final_path.display()
+    );
     Ok(())
 }

--- a/base_layer/core/src/base_node/rpc/query_service.rs
+++ b/base_layer/core/src/base_node/rpc/query_service.rs
@@ -666,6 +666,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeWalletQueryService for Service<B> {
             encoded_merkle_proof: bincode::serialize(&proof.merkle_proof).map_err(Error::general)?,
             block_hash: proof.block_hash,
             leaf_index: proof.leaf_index.value() as u64,
+            block_height: Some(proof.block_height),
         })
     }
 

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -2393,6 +2393,7 @@ where B: BlockchainBackend
             leaf_index,
             kernel_hash,
             block_hash,
+            block_height: block.header().height,
         })
     }
 }

--- a/base_layer/core/src/chain_storage/kernel_merkle_proof.rs
+++ b/base_layer/core/src/chain_storage/kernel_merkle_proof.rs
@@ -11,6 +11,9 @@ pub struct KernelMerkleProof {
     pub leaf_index: LeafIndex,
     pub kernel_hash: FixedHash,
     pub block_hash: BlockHash,
+    /// The height of the block the kernel was mined in. Used by the wallet to derive the L1 epoch the burn
+    /// belongs to, so a downstream (L2) claim can be deferred until that epoch has been synced.
+    pub block_height: u64,
 }
 
 impl KernelMerkleProof {

--- a/base_layer/sidechain/src/burn_proof.rs
+++ b/base_layer/sidechain/src/burn_proof.rs
@@ -32,6 +32,12 @@ pub struct CompleteClaimBurnProof {
     pub claim_proof: BurnClaimProof,
     #[serde(with = "serializers::base64")]
     pub encrypted_data: Vec<u8>,
+    /// The L1 epoch the burn was mined in (`block_height / vn_epoch_length`). Lets an L2 claimant defer the
+    /// claim until L2 has synced past this epoch, avoiding a premature, permanently-rejected submission.
+    /// `Option` (via `serde(default)`) so proof files written before this field, or by wallets connected to a
+    /// base node that did not report the height, still deserialize (as `None`) and older readers ignore it.
+    #[serde(default)]
+    pub mined_in_epoch: Option<u64>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
@@ -53,4 +59,59 @@ pub struct AbridgedTransactionKernel {
     pub lock_height: u64,
     pub excess: CompressedCommitment,
     pub excess_sig: CompressedRistrettoSchnorr,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_proof(mined_in_epoch: Option<u64>) -> CompleteClaimBurnProof {
+        CompleteClaimBurnProof {
+            claim_proof: BurnClaimProof {
+                burn_public_key: Default::default(),
+                commitment: Default::default(),
+                ownership_proof: Default::default(),
+                encoded_merkle_proof: EncodedMerkleProof {
+                    block_hash: Default::default(),
+                    encoded_merkle_proof: vec![1, 2, 3],
+                    leaf_index: 7,
+                },
+                kernel: AbridgedTransactionKernel {
+                    version: 0,
+                    fee: 100,
+                    lock_height: 0,
+                    excess: Default::default(),
+                    excess_sig: Default::default(),
+                },
+                value: 12_345,
+                sender_offset_public_key: Default::default(),
+            },
+            encrypted_data: vec![9, 9, 9],
+            mined_in_epoch,
+        }
+    }
+
+    #[test]
+    fn mined_in_epoch_round_trips() {
+        let proof = sample_proof(Some(42));
+        let json = serde_json::to_string(&proof).unwrap();
+        assert!(
+            json.contains("mined_in_epoch"),
+            "serialized proof should contain the field: {json}"
+        );
+        let parsed: CompleteClaimBurnProof = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.mined_in_epoch, Some(42));
+    }
+
+    #[test]
+    fn absent_mined_in_epoch_defaults_to_none() {
+        // Simulate a proof file written before the field existed by dropping the key entirely, so the reader must
+        // rely on `#[serde(default)]` rather than a `null` value being present.
+        let mut value = serde_json::to_value(sample_proof(Some(42))).unwrap();
+        value.as_object_mut().unwrap().remove("mined_in_epoch");
+        assert!(value.get("mined_in_epoch").is_none());
+
+        let parsed: CompleteClaimBurnProof = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.mined_in_epoch, None, "absent field must deserialize as None");
+    }
 }

--- a/base_layer/transaction_components/src/rpc/models/generate_kernel_merkle_proof.rs
+++ b/base_layer/transaction_components/src/rpc/models/generate_kernel_merkle_proof.rs
@@ -12,4 +12,8 @@ pub struct GenerateKernelMerkleProofResponse {
     #[serde(with = "serializers::base64")]
     pub encoded_merkle_proof: Vec<u8>,
     pub leaf_index: u64,
+    /// The height of the block the kernel was mined in. `Option` (via `serde(default)`) so responses from
+    /// older base nodes that predate this field deserialize as `None` rather than failing.
+    #[serde(default)]
+    pub block_height: Option<u64>,
 }

--- a/base_layer/wallet/migrations/2026-07-08-000000_burnt_proofs_add_mined_in_height/down.sql
+++ b/base_layer/wallet/migrations/2026-07-08-000000_burnt_proofs_add_mined_in_height/down.sql
@@ -1,0 +1,27 @@
+-- SQLite does not support DROP COLUMN on the versions we target, so recreate the table without mined_in_height.
+CREATE TABLE burn_proofs_temp
+(
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    output_hash         BLOB                              NOT NULL,
+    commitment          BLOB                              NOT NULL,
+    burn_proof          BLOB                              NOT NULL,
+    kernel              BLOB                              NOT NULL,
+    kernel_merkle_proof BLOB                              NULL,
+    created_at          DATETIME                          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME                          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    encrypted_data      BLOB                              NULL,
+    value               BIGINT                            NULL,
+    kernel_excess       BLOB                              NULL,
+    kernel_excess_sig   BLOB                              NULL
+);
+
+INSERT INTO burn_proofs_temp (id, output_hash, commitment, burn_proof, kernel, kernel_merkle_proof, created_at, updated_at, encrypted_data, value, kernel_excess, kernel_excess_sig)
+SELECT id, output_hash, commitment, burn_proof, kernel, kernel_merkle_proof, created_at, updated_at, encrypted_data, value, kernel_excess, kernel_excess_sig
+FROM burn_proofs;
+
+DROP TABLE burn_proofs;
+
+ALTER TABLE burn_proofs_temp RENAME TO burn_proofs;
+
+CREATE INDEX idx_burn_proofs_output_hash ON burn_proofs (output_hash);
+CREATE INDEX idx_burn_proofs_commitment ON burn_proofs (commitment);

--- a/base_layer/wallet/migrations/2026-07-08-000000_burnt_proofs_add_mined_in_height/up.sql
+++ b/base_layer/wallet/migrations/2026-07-08-000000_burnt_proofs_add_mined_in_height/up.sql
@@ -1,0 +1,4 @@
+-- The L1 block height the burn was mined in, populated alongside the kernel merkle proof once the burn is
+-- confirmed on-chain. Used to derive the L1 epoch (height / vn_epoch_length) exposed in the proof file and over gRPC.
+ALTER TABLE burn_proofs
+    ADD COLUMN mined_in_height BIGINT NULL;

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -14,6 +14,7 @@ diesel::table! {
         value -> Nullable<BigInt>,
         kernel_excess -> Nullable<Binary>,
         kernel_excess_sig -> Nullable<Binary>,
+        mined_in_height -> Nullable<BigInt>,
     }
 }
 

--- a/base_layer/wallet/src/storage/sqlite_db/models.rs
+++ b/base_layer/wallet/src/storage/sqlite_db/models.rs
@@ -26,6 +26,8 @@ pub struct DbBurnProof {
     pub updated_at: chrono::NaiveDateTime,
     pub encrypted_data: Option<EncryptedData>,
     pub value: Option<MicroMinotari>,
+    /// The L1 block height the burn was mined in, if known (populated with the kernel merkle proof).
+    pub mined_in_height: Option<u64>,
 }
 
 impl TryFrom<BurntProofSql> for DbBurnProof {
@@ -53,6 +55,13 @@ impl TryFrom<BurntProofSql> for DbBurnProof {
             })?)),
             None => None,
         };
+        let mined_in_height =
+            match value.mined_in_height {
+                Some(h) => Some(u64::try_from(h).map_err(|e| {
+                    WalletStorageError::ConversionError(format!("Invalid mined_in_height in DB: {}", e))
+                })?),
+                None => None,
+            };
 
         Ok(Self {
             id: value.id,
@@ -64,6 +73,7 @@ impl TryFrom<BurntProofSql> for DbBurnProof {
             updated_at: value.updated_at,
             encrypted_data,
             value: v,
+            mined_in_height,
         })
     }
 }
@@ -87,6 +97,7 @@ pub(crate) struct BurntProofSql {
     pub kernel_excess: Option<Vec<u8>>,
     #[allow(dead_code)]
     pub kernel_excess_sig: Option<Vec<u8>>,
+    pub mined_in_height: Option<i64>,
 }
 
 fn get_encryption_domain(commitment: &[u8], field_name: &'static str) -> Vec<u8> {

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -750,10 +750,6 @@ pub enum TransactionEvent {
     TransactionBurnConfirmed {
         output_hash: HashOutput,
         commitment: Box<CompressedCommitment>,
-        /// The L1 block height the burn was mined in, if the base node reported it. Carried through so the
-        /// console wallet can embed the burn's L1 epoch in the proof file. `None` when the base node predates
-        /// the field or the height was otherwise unavailable.
-        mined_in_height: Option<u64>,
     },
     Error(String),
 }

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -750,6 +750,10 @@ pub enum TransactionEvent {
     TransactionBurnConfirmed {
         output_hash: HashOutput,
         commitment: Box<CompressedCommitment>,
+        /// The L1 block height the burn was mined in, if the base node reported it. Carried through so the
+        /// console wallet can embed the burn's L1 epoch in the proof file. `None` when the base node predates
+        /// the field or the height was otherwise unavailable.
+        mined_in_height: Option<u64>,
     },
     Error(String),
 }

--- a/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
@@ -122,11 +122,15 @@ where
                 // We trust our base node right? ;-) So just store it without validating.
 
                 let mined_in_height = resp.block_height;
-                db.update_burn_proof_set_merkle_proof(output_hash, &EncodedMerkleProof {
-                    block_hash: resp.block_hash,
-                    encoded_merkle_proof: resp.encoded_merkle_proof,
-                    leaf_index: resp.leaf_index,
-                })?;
+                db.update_burn_proof_set_merkle_proof(
+                    output_hash,
+                    &EncodedMerkleProof {
+                        block_hash: resp.block_hash,
+                        encoded_merkle_proof: resp.encoded_merkle_proof,
+                        leaf_index: resp.leaf_index,
+                    },
+                    mined_in_height,
+                )?;
 
                 info!(
                     target: LOG_TARGET,
@@ -138,7 +142,6 @@ where
                 let _ignore = event_publisher.send(Arc::new(TransactionEvent::TransactionBurnConfirmed {
                     output_hash: *output_hash,
                     commitment: Box::new(burn.burn_proof.commitment),
-                    mined_in_height,
                 }));
             },
             Err(err) => {

--- a/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/fetch_claim_burn_merkle_proofs.rs
@@ -121,6 +121,7 @@ where
 
                 // We trust our base node right? ;-) So just store it without validating.
 
+                let mined_in_height = resp.block_height;
                 db.update_burn_proof_set_merkle_proof(output_hash, &EncodedMerkleProof {
                     block_hash: resp.block_hash,
                     encoded_merkle_proof: resp.encoded_merkle_proof,
@@ -129,13 +130,15 @@ where
 
                 info!(
                     target: LOG_TARGET,
-                    "Successfully updated burn output {} with merkle proof",
-                    output_hash
+                    "Successfully updated burn output {} with merkle proof (mined in height {:?})",
+                    output_hash,
+                    mined_in_height
                 );
 
                 let _ignore = event_publisher.send(Arc::new(TransactionEvent::TransactionBurnConfirmed {
                     output_hash: *output_hash,
                     commitment: Box::new(burn.burn_proof.commitment),
+                    mined_in_height,
                 }));
             },
             Err(err) => {

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -215,6 +215,7 @@ pub trait TransactionBackend: Send + Sync + Clone {
         &self,
         output_hash: &FixedHash,
         merkle_proof: &EncodedMerkleProof,
+        mined_in_height: Option<u64>,
     ) -> Result<(), TransactionStorageError>;
 
     fn fetch_burn_proof(&self, output_hash: &FixedHash) -> Result<Option<DbBurnProof>, TransactionStorageError>;
@@ -963,8 +964,10 @@ where T: TransactionBackend + 'static
         &self,
         output_hash: &FixedHash,
         merkle_proof: &EncodedMerkleProof,
+        mined_in_height: Option<u64>,
     ) -> Result<(), TransactionStorageError> {
-        self.db.update_burn_proof_set_merkle_proof(output_hash, merkle_proof)
+        self.db
+            .update_burn_proof_set_merkle_proof(output_hash, merkle_proof, mined_in_height)
     }
 
     pub fn fetch_burn_proof(&self, output_hash: &FixedHash) -> Result<Option<DbBurnProof>, TransactionStorageError> {

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1479,6 +1479,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         &self,
         output_hash: &FixedHash,
         merkle_proof: &EncodedMerkleProof,
+        mined_in_height: Option<u64>,
     ) -> Result<(), TransactionStorageError> {
         use crate::schema::burn_proofs;
 
@@ -1486,6 +1487,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         let num_updated = diesel::update(burn_proofs::table)
             .set((
                 burn_proofs::kernel_merkle_proof.eq(Some(serializers::bincode_encode(merkle_proof)?)),
+                burn_proofs::mined_in_height.eq(mined_in_height.map(|h| h as i64)),
                 burn_proofs::updated_at.eq(now()),
             ))
             .filter(burn_proofs::output_hash.eq(output_hash.as_bytes()))


### PR DESCRIPTION
Description
---
Records the L1 epoch a burn was mined in (`mined_in_epoch = block_height / vn_epoch_length`) in the burn claim proof file the Minotari console wallet writes.

The burn's L1 block height is not available at the write site, so it is surfaced from the base node — which already has it when generating the kernel Merkle proof — and threaded through to the console wallet:

- `KernelMerkleProof` and `GenerateKernelMerkleProofResponse` now carry `block_height`. The RPC response field is `Option<u64>` with `#[serde(default)]` so responses from older base nodes deserialize as `None` rather than failing.
- The wallet relays the height via `TransactionEvent::TransactionBurnConfirmed` (`mined_in_height`).
- The console wallet converts height → epoch using the network's consensus constants (`consensus_constants(height).block_height_to_epoch(height)`) and writes `CompleteClaimBurnProof.mined_in_epoch` (`Option<u64>` + `#[serde(default)]`).

No on-chain / consensus / engine change: `mined_in_epoch` lives only in the off-chain proof **file** wrapper, not in the on-chain `BurnClaimProof`.

Motivation and Context
---
An auto burn-claim client (Ootle walletd) currently has no way to know which L1 epoch a burn belongs to — the proof references the L1 block by hash only. As a result it can submit a claim before the base-layer scanner has synced the burn's L1 header, which the base layer rejects as not-yet-claimable. Embedding the mined epoch lets the claimant defer submission until L2 has synced past that epoch.

Both new file/wire fields are `Option` + `#[serde(default)]`, so this degrades cleanly in every direction: new wallet ↔ old base node (height `None`), old reader ↔ new file (unknown field ignored), new reader ↔ old file (field absent → `None`). Epoch-only relies on L1 and L2 sharing `vn_epoch_length` (a shared consensus constant); the epoch is computed from the burn's own height, not the current tip.

How Has This Been Tested?
---
- `cargo check` across all affected crates — clean.
- Two new serde round-trip unit tests in `tari_sidechain` (`burn_proof.rs`): serialized proof contains `mined_in_epoch`; a proof file with the key removed deserializes with `mined_in_epoch == None`.
- `cargo clippy` on affected crates — no new warnings.
- `rustfmt` clean.

Not yet exercised end-to-end against a live devnet burn.

What process can a PR reviewer use to test or verify this change?
---
Run a burn on a local/devnet base node and confirm the written `<claim_pk>-<commitment>.json` now contains `"mined_in_epoch": <n>` where `n == block_height / vn_epoch_length` for the burn's block. Confirm an older proof file (without the field) still loads.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
