### PR TITLE
fix(comms): filter internal addresses from peer claims

### DIFF
--- a/comms/core/src/net_address/mod.rs
+++ b/comms/core/src/net_address/mod.rs
@@ -23,7 +23,7 @@
 //! Extension types used by the [PeerManager](crate::PeerManager) to keep track of address reliability.
 
 mod multiaddr_with_stats;
-pub use multiaddr_with_stats::{MultiaddrWithStats, PeerAddressSource};
+pub use multiaddr_with_stats::{MultiaddrWithStats, PeerAddressSource, is_external_address};
 
 mod mutliaddresses_with_stats;
 pub use mutliaddresses_with_stats::MultiaddressesWithStats;

--- a/comms/core/src/net_address/multiaddr_with_stats.rs
+++ b/comms/core/src/net_address/multiaddr_with_stats.rs
@@ -23,6 +23,31 @@ const LOG_TARGET: &str = "comms::net_address::multiaddr_with_stats";
 const MAX_LATENCY_SAMPLE_COUNT: u32 = 100;
 const MAX_INITIAL_DIAL_TIME_SAMPLE_COUNT: u32 = 100;
 
+/// Returns true if an address is suitable for sharing with external peers.
+///
+/// Loopback, unspecified, private and link-local IP addresses are local-only.
+/// The same applies to DNS names in the reserved `.localhost` and `.local`
+/// namespaces.
+pub fn is_external_address(address: &Multiaddr) -> bool {
+    if address.is_empty() {
+        return false;
+    }
+
+    let mut protocols = address.iter();
+    let internal = match protocols.next() {
+        Some(Protocol::Ip4(ip)) => ip.is_loopback() || ip.is_unspecified() || ip.is_private() || ip.is_link_local(),
+        Some(Protocol::Ip6(ip)) => {
+            ip.is_loopback() || ip.is_unspecified() || ip.is_unique_local() || ip.is_unicast_link_local()
+        },
+        Some(Protocol::Dns4(name)) | Some(Protocol::Dns6(name)) | Some(Protocol::Dnsaddr(name)) => {
+            let name = name.trim_end_matches('.').to_ascii_lowercase();
+            name == "localhost" || name.ends_with(".localhost") || name == "local" || name.ends_with(".local")
+        },
+        _ => false,
+    };
+    !internal
+}
+
 #[derive(Debug, Eq, Clone, Deserialize, Serialize)]
 pub struct MultiaddrWithStats {
     address: Multiaddr,
@@ -146,16 +171,7 @@ impl MultiaddrWithStats {
 
     /// Returns true if the address is an external address, i.e. not a loopback, unspecified or private IP address.
     pub fn is_external(&self) -> bool {
-        if self.address.is_empty() {
-            return false;
-        }
-        let mut protocols = self.address.iter();
-        let internal = match protocols.next() {
-            Some(Protocol::Ip4(ip)) => ip.is_loopback() || ip.is_unspecified() || ip.is_private(),
-            Some(Protocol::Ip6(ip)) => ip.is_loopback() || ip.is_unspecified(),
-            _ => false, // onion3 etc = OK
-        };
-        !internal
+        is_external_address(&self.address)
     }
 
     pub fn offline_at(&self) -> Option<NaiveDateTime> {

--- a/comms/core/src/peer_validator/helpers.rs
+++ b/comms/core/src/peer_validator/helpers.rs
@@ -25,6 +25,7 @@ use log::debug;
 
 use crate::{
     multiaddr::{Multiaddr, Protocol},
+    net_address::is_external_address,
     peer_manager::{NodeId, PeerIdentityClaim},
     peer_validator::{PeerValidatorConfig, error::PeerValidatorError},
     types::CommsPublicKey,
@@ -80,6 +81,13 @@ fn validate_address(addr: &Multiaddr, allow_test_addrs: bool) -> Result<(), Peer
         .ok_or_else(|| PeerValidatorError::InvalidMultiaddr("Multiaddr was empty".to_string()))?;
 
     match proto {
+        Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Dnsaddr(_)
+            if !allow_test_addrs && !is_external_address(addr) =>
+        {
+            Err(PeerValidatorError::InvalidMultiaddr(
+                "Non-global DNS addresses are invalid".to_string(),
+            ))
+        },
         Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Dnsaddr(_) => {
             let tcp = addr_iter.next().ok_or_else(|| {
                 PeerValidatorError::InvalidMultiaddr("Address does not include a TCP port".to_string())
@@ -89,12 +97,9 @@ fn validate_address(addr: &Multiaddr, allow_test_addrs: bool) -> Result<(), Peer
             expect_end_of_address(addr_iter)
         },
 
-        Protocol::Ip4(addr) if !allow_test_addrs && addr.is_unspecified() => Err(PeerValidatorError::InvalidMultiaddr(
-            "Non-global IP addresses are invalid".to_string(),
-        )),
-        Protocol::Ip6(addr) if !allow_test_addrs && addr.is_unspecified() => Err(PeerValidatorError::InvalidMultiaddr(
-            "Non-global IP addresses are invalid".to_string(),
-        )),
+        Protocol::Ip4(_) | Protocol::Ip6(_) if !allow_test_addrs && !is_external_address(addr) => Err(
+            PeerValidatorError::InvalidMultiaddr("Non-global IP addresses are invalid".to_string()),
+        ),
         Protocol::Ip4(_) | Protocol::Ip6(_) => {
             let tcp = addr_iter.next().ok_or_else(|| {
                 PeerValidatorError::InvalidMultiaddr("Address does not include a TCP port".to_string())
@@ -205,6 +210,15 @@ mod test {
             "/onion/aaimaq4ygg2iegci:1234".parse().unwrap(),
             "/onion/aaimaq4ygg2iegci:1234/http".parse().unwrap(),
             multiaddr!(Dnsaddr("mike-magic-nodes.com")),
+            multiaddr!(Dnsaddr("localhost"), Tcp(1u16)),
+            multiaddr!(Dns4("peer.local"), Tcp(1u16)),
+            multiaddr!(Ip4([127, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([10, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([172, 16, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([192, 168, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([169, 254, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0xfc00, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0xfe80, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
             multiaddr!(Memory(1234u64)),
             multiaddr!(Memory(0u64)),
         ];
@@ -221,9 +235,16 @@ mod test {
     fn validate_address_allow_test_addrs() {
         let valid = [
             multiaddr!(Ip4([127, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([10, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([172, 16, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([192, 168, 0, 1]), Tcp(1u16)),
             multiaddr!(Ip4([169, 254, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0xfc00, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0xfe80, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
             multiaddr!(Ip4([172, 0, 0, 1]), Tcp(1u16)),
             multiaddr!(Ip6([172, 0, 0, 1, 1, 1, 1, 1]), Tcp(1u16)),
+            multiaddr!(Dnsaddr("localhost"), Tcp(1u16)),
+            multiaddr!(Dns4("peer.local"), Tcp(1u16)),
             "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234"
                 .parse()
                 .unwrap(),

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -22,7 +22,7 @@
 
 use log::*;
 use tari_comms::{
-    net_address::{MultiaddressesWithStats, PeerAddressSource},
+    net_address::{MultiaddressesWithStats, PeerAddressSource, is_external_address},
     peer_manager::{NodeId, Peer, PeerFlags},
     peer_validator,
     peer_validator::{PeerValidatorError, find_most_recent_claim},
@@ -105,13 +105,36 @@ impl<'a> PeerValidator<'a> {
             )
         });
 
+        let mut accepted_address_count = 0;
         for claim in new_peer.claims {
-            peer_validator::validate_peer_identity_claim(
-                &self.config.peer_validator_config,
-                &new_peer.public_key,
-                &claim,
-            )?;
-            peer.update_addresses(&claim.addresses, &PeerAddressSource::FromDiscovery {
+            if claim.addresses.len() > self.config.peer_validator_config.max_permitted_peer_addresses_per_claim {
+                return Err(PeerValidatorError::PeerIdentityTooManyAddresses {
+                    length: claim.addresses.len(),
+                    max: self.config.peer_validator_config.max_permitted_peer_addresses_per_claim,
+                }
+                .into());
+            }
+            if !matches!(claim.is_valid(&new_peer.public_key), Ok(true)) {
+                return Err(PeerValidatorError::InvalidPeerSignature { peer: node_id.clone() }.into());
+            }
+
+            let addresses = if self.config.peer_validator_config.allow_test_addresses {
+                claim.addresses.clone()
+            } else {
+                claim
+                    .addresses
+                    .iter()
+                    .filter(|address| is_external_address(address))
+                    .cloned()
+                    .collect()
+            };
+            peer_validator::validate_addresses(&self.config.peer_validator_config, &addresses)?;
+            if addresses.is_empty() {
+                continue;
+            }
+
+            accepted_address_count += addresses.len();
+            peer.update_addresses(&addresses, &PeerAddressSource::FromDiscovery {
                 peer_identity_claim: claim.clone(),
             });
             trace!(
@@ -119,8 +142,12 @@ impl<'a> PeerValidator<'a> {
                 "Peer '{}' / '{}' added with address(es) from claim: {:?}",
                 node_id,
                 new_peer.public_key.to_hex(),
-                claim.addresses
+                addresses
             );
+        }
+
+        if accepted_address_count == 0 {
+            return Err(PeerValidatorError::PeerHasNoAddresses { peer: node_id }.into());
         }
 
         Ok(peer)
@@ -185,6 +212,54 @@ mod tests {
         let err = validator
             .validate_peer(UnvalidatedPeerInfo::from_peer_limited_claims(peer, 5, 5), None)
             .unwrap_err();
+        assert!(matches!(
+            err,
+            DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoAddresses { .. })
+        ));
+    }
+
+    #[test]
+    fn it_filters_internal_addresses_from_mixed_signed_claims() {
+        let mut config = DhtConfig::default_local_test();
+        config.peer_validator_config.allow_test_addresses = false;
+        let node_identity = make_node_identity();
+        let public_address = Multiaddr::from_str("/ip4/23.23.23.23/tcp/80").unwrap();
+        let private_address = Multiaddr::from_str("/ip4/192.168.1.20/tcp/80").unwrap();
+        let loopback_address = Multiaddr::from_str("/ip4/127.0.0.1/tcp/80").unwrap();
+        let link_local_address = Multiaddr::from_str("/ip4/169.254.1.20/tcp/80").unwrap();
+        node_identity.set_public_addresses(vec![
+            public_address.clone(),
+            private_address,
+            loopback_address,
+            link_local_address,
+        ]);
+
+        let peer = node_identity.to_peer();
+        let validated = PeerValidator::new(&config)
+            .validate_peer(UnvalidatedPeerInfo::from_peer_limited_claims(peer, 5, 5), None)
+            .unwrap();
+        let addresses = validated.addresses.address_iter().collect::<Vec<_>>();
+
+        assert_eq!(addresses, vec![&public_address]);
+    }
+
+    #[test]
+    fn it_rejects_claims_with_only_internal_addresses() {
+        let mut config = DhtConfig::default_local_test();
+        config.peer_validator_config.allow_test_addresses = false;
+        let node_identity = make_node_identity();
+        node_identity.set_public_addresses(vec![
+            Multiaddr::from_str("/ip4/10.1.2.3/tcp/80").unwrap(),
+            Multiaddr::from_str("/ip4/172.16.2.3/tcp/80").unwrap(),
+            Multiaddr::from_str("/ip4/192.168.2.3/tcp/80").unwrap(),
+            Multiaddr::from_str("/ip4/127.0.0.1/tcp/80").unwrap(),
+        ]);
+
+        let peer = node_identity.to_peer();
+        let err = PeerValidator::new(&config)
+            .validate_peer(UnvalidatedPeerInfo::from_peer_limited_claims(peer, 5, 5), None)
+            .unwrap_err();
+
         assert!(matches!(
             err,
             DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoAddresses { .. })


### PR DESCRIPTION
Description
---

Filter local-only addresses from signed peer claims when
`allow_test_addresses` is disabled.

The shared classifier rejects:

- IPv4 loopback, unspecified, RFC1918 private, and link-local addresses;
- IPv6 loopback, unspecified, unique-local, and unicast link-local addresses;
- DNS names reserved for local use under `.localhost` and `.local`.

The DHT validates the signature against the original claim before filtering,
so a mixed signed claim remains trustworthy and the peer is accepted with only
its externally usable addresses. Claims containing no usable address are
rejected.

Fixes #7935.

Motivation and Context
---

The shipped configuration sets `allow_test_addresses = false`, but the
validator previously rejected only unspecified IP addresses. A discovered peer
could therefore add loopback, private, or link-local endpoints to the peer
store.

This change reuses one external-address classifier in both the peer-address
statistics path and the validator, avoiding divergent definitions of an
externally usable address.

How Has This Been Tested?
---

- `cargo +nightly-2026-06-01 fmt -p tari_comms -p tari_comms_dht -- --check`
- `cargo +1.93.0 clippy -p tari_comms -p tari_comms_dht --all-targets -- -D warnings`
- `cargo +1.93.0 test -p tari_comms -p tari_comms_dht --lib --no-fail-fast`
  - `tari_comms`: 196 passed, 2 pre-existing network tests ignored
  - `tari_comms_dht`: 70 passed

What process can a PR reviewer use to test or verify this change?
---

1. Run the commands above.
2. Inspect `it_filters_internal_addresses_from_mixed_signed_claims` to verify
   that a peer with one public and several internal addresses is accepted with
   only the public address retained.
3. Inspect `it_rejects_claims_with_only_internal_addresses` to verify that a
   peer with no externally usable address is rejected.
4. Set `allow_test_addresses = true` and run the core validator tests to verify
   that local development addresses remain permitted.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
