### PR TITLE
fix: gate grpc get_network_state behind the method allow-list

### DIFF
--- a/applications/minotari_mcp_common/src/process_launcher.rs
+++ b/applications/minotari_mcp_common/src/process_launcher.rs
@@ -494,10 +494,10 @@ impl TariProcessLauncher {
             "-p".to_string(),
             format!("base_node.grpc_address={multiaddr_format}"),
             "-p".to_string(),
-            "base_node.grpc_server_allow_methods=get_version,get_tip_info,get_sync_info,get_network_status,get_peers,\
-             get_header_by_hash,get_blocks,get_network_difficulty,get_tokens_in_circulation,get_mempool_stats,\
-             get_mempool_transactions,get_new_block_template,get_new_block_template_with_coinbases,submit_transaction,\
-             submit_block"
+            "base_node.grpc_server_allow_methods=get_version,get_tip_info,get_sync_info,get_network_status,\
+             get_network_state,get_peers,get_header_by_hash,get_blocks,get_network_difficulty,\
+             get_tokens_in_circulation,get_mempool_stats,get_mempool_transactions,get_new_block_template,\
+             get_new_block_template_with_coinbases,submit_transaction,submit_block"
                 .to_string(),
             "--non-interactive-mode".to_string(),
         ];

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -440,7 +440,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         _request: Request<tari_rpc::GetNetworkStateRequest>,
     ) -> Result<Response<tari_rpc::GetNetworkStateResponse>, Status> {
         self.check_method_enabled(GrpcMethod::GetNetworkState)?;
-        trace!(target: LOG_TARGET, "Incoming GRPC request for get network hash rate");
+        trace!(target: LOG_TARGET, "Incoming GRPC request for GetNetworkState");
         let report_error_flag = self.report_error_flag();
         let mut handler = self.node_service.clone();
         let metadata = handler.get_metadata().await.map_err(|e| {

--- a/applications/minotari_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/minotari_node/src/grpc/base_node_grpc_server.rs
@@ -170,6 +170,7 @@ impl BaseNodeGrpcServer {
             GrpcMethod::GetNewBlock,
             GrpcMethod::GetNewBlockBlob,
             GrpcMethod::GetNetworkDifficulty,
+            GrpcMethod::GetNetworkState,
             GrpcMethod::SubmitBlock,
             GrpcMethod::SubmitBlockBlob,
             GrpcMethod::GetTipInfo,
@@ -438,6 +439,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
         &self,
         _request: Request<tari_rpc::GetNetworkStateRequest>,
     ) -> Result<Response<tari_rpc::GetNetworkStateResponse>, Status> {
+        self.check_method_enabled(GrpcMethod::GetNetworkState)?;
         trace!(target: LOG_TARGET, "Incoming GRPC request for get network hash rate");
         let report_error_flag = self.report_error_flag();
         let mut handler = self.node_service.clone();

--- a/applications/minotari_node/src/grpc_method.rs
+++ b/applications/minotari_node/src/grpc_method.rs
@@ -59,6 +59,7 @@ pub enum GrpcMethod {
     TransactionState,
     Identify,
     GetNetworkStatus,
+    GetNetworkState,
     ListConnectedPeers,
     GetMempoolStats,
     GetActiveValidatorNodes,
@@ -72,7 +73,7 @@ pub enum GrpcMethod {
 
 impl GrpcMethod {
     /// All the GRPC methods as a fixed array
-    pub const ALL_VARIANTS: [GrpcMethod; 39] = [
+    pub const ALL_VARIANTS: [GrpcMethod; 40] = [
         GrpcMethod::ListHeaders,
         GrpcMethod::GetHeaderByHash,
         GrpcMethod::GetBlocks,
@@ -103,6 +104,7 @@ impl GrpcMethod {
         GrpcMethod::TransactionState,
         GrpcMethod::Identify,
         GrpcMethod::GetNetworkStatus,
+        GrpcMethod::GetNetworkState,
         GrpcMethod::ListConnectedPeers,
         GrpcMethod::GetMempoolStats,
         GrpcMethod::GetActiveValidatorNodes,
@@ -116,7 +118,7 @@ impl GrpcMethod {
 }
 
 impl IntoIterator for GrpcMethod {
-    type IntoIter = std::array::IntoIter<GrpcMethod, 39>;
+    type IntoIter = std::array::IntoIter<GrpcMethod, 40>;
     type Item = GrpcMethod;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -161,6 +163,7 @@ impl FromStr for GrpcMethod {
             "transaction_state" => Ok(GrpcMethod::TransactionState),
             "identify" => Ok(GrpcMethod::Identify),
             "get_network_status" => Ok(GrpcMethod::GetNetworkStatus),
+            "get_network_state" => Ok(GrpcMethod::GetNetworkState),
             "list_connected_peers" => Ok(GrpcMethod::ListConnectedPeers),
             "get_mempool_stats" => Ok(GrpcMethod::GetMempoolStats),
             "get_active_validator_nodes" => Ok(GrpcMethod::GetActiveValidatorNodes),
@@ -260,6 +263,7 @@ mod tests {
                 GrpcMethod::TransactionState => count += 1,
                 GrpcMethod::Identify => count += 1,
                 GrpcMethod::GetNetworkStatus => count += 1,
+                GrpcMethod::GetNetworkState => count += 1,
                 GrpcMethod::ListConnectedPeers => count += 1,
                 GrpcMethod::GetMempoolStats => count += 1,
                 GrpcMethod::GetActiveValidatorNodes => count += 1,
@@ -272,6 +276,31 @@ mod tests {
             }
         }
         assert_eq!(count, GrpcMethod::ALL_VARIANTS.len());
+    }
+
+    #[test]
+    fn all_variants_are_listed_once() {
+        // `ALL_VARIANTS` is the allow-list used to enable every GRPC method, so a variant that is missing or
+        // duplicated here silently changes what is served.
+        let mut seen = Vec::with_capacity(GrpcMethod::ALL_VARIANTS.len());
+        for method in &GrpcMethod::ALL_VARIANTS {
+            assert!(!seen.contains(method), "'{method}' is listed more than once");
+            seen.push(*method);
+        }
+    }
+
+    #[test]
+    fn it_converts_config_strings_to_enum() {
+        // The config file spells the methods out in snake case; a mismatch here means existing configs mis-parse
+        assert_eq!(
+            GrpcMethod::from_str("get_network_state").unwrap(),
+            GrpcMethod::GetNetworkState
+        );
+        assert_eq!(
+            GrpcMethod::from_str("get_network_status").unwrap(),
+            GrpcMethod::GetNetworkStatus
+        );
+        assert!(GrpcMethod::from_str("get_network_state_").is_err());
     }
 
     #[test]

--- a/common/config/presets/c_base_node_b_mining_allow_methods.toml
+++ b/common/config/presets/c_base_node_b_mining_allow_methods.toml
@@ -23,6 +23,7 @@ grpc_server_allow_methods = [
     "get_tip_info",
     "identify",
     #"get_network_status",
+    "get_network_state",
     "list_headers",
     #"get_header_by_hash",
     #"get_blocks",

--- a/common/config/presets/c_base_node_b_non_mining_allow_methods.toml
+++ b/common/config/presets/c_base_node_b_non_mining_allow_methods.toml
@@ -23,6 +23,7 @@ grpc_server_allow_methods = [
     #"get_tip_info",
     "identify",
     #"get_network_status",
+    #"get_network_state",
     #"list_headers",
     #"get_header_by_hash",
     #"get_blocks",


### PR DESCRIPTION
Description
---
gRPC get_network_state (base_node_grpc_server.rs:422) bypasses the method allow-list entirely
