### PR TITLE
fix: tari transaction component security hardening

### DIFF
--- a/applications/minotari_offline_signer/src/cli.rs
+++ b/applications/minotari_offline_signer/src/cli.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{ffi::OsString, fs, path::PathBuf, str::FromStr};
+use std::{ffi::OsString, fs, io::IsTerminal, path::PathBuf, str::FromStr};
 
 use anyhow::{Context, Result, anyhow};
 use clap::{Args, Parser, Subcommand};
@@ -36,6 +36,7 @@ use tari_transaction_components::{
         wallet_types::{SeedWordsWallet, SpendWallet, WalletType},
     },
     offline_signing::{
+        PayloadSummary,
         models::{PrepareOneSidedTransactionForSigningResult, TransactionResult},
         sign_locked_transaction,
     },
@@ -134,6 +135,15 @@ pub struct SignArgs {
     /// Network to use (mainnet, nextnet, esmeralda, localnet)
     #[clap(short, long, default_value = "mainnet")]
     pub network: String,
+
+    /// Sign without asking the operator to confirm the transaction summary.
+    ///
+    /// SECURITY: the payload integrity signature is produced with the wallet's *view* key, which is shareable by
+    /// design. Anyone holding the view key can forge a payload that redirects the funds and it will still verify as
+    /// authentic. Confirming the printed summary is the only check that catches this, so only use this flag where the
+    /// payload's origin is trusted by other means.
+    #[clap(long, alias = "assume-yes")]
+    pub yes: bool,
 }
 
 impl Cli {
@@ -233,6 +243,45 @@ fn init_with_seed_words(args: InitSeedWordsArgs) -> Result<()> {
     Ok(())
 }
 
+/// Asks the operator to confirm the transaction before any spend key is used.
+///
+/// SECURITY: this is the authoritative authorisation step for offline signing. The payload integrity signature that
+/// `sign_locked_transaction` verifies is made with the *view* key, which is shareable, so a party holding the view key
+/// can forge a payload that pays itself and it will verify as authentic. Only a human checking the recipient and the
+/// amount catches that, so this must run before signing and must fail closed.
+fn confirm_payload(summary: &PayloadSummary, assume_yes: bool) -> Result<()> {
+    println!();
+    println!("The following transaction is about to be signed with your spend key:");
+    println!();
+    print!("{summary}");
+    println!();
+
+    if assume_yes {
+        println!("Confirmation skipped (--yes).");
+        return Ok(());
+    }
+
+    if !std::io::stdin().is_terminal() {
+        return Err(anyhow!(
+            "Refusing to sign: the transaction summary could not be confirmed because stdin is not a terminal. Run \
+             this command interactively, or pass --yes if the payload's origin is trusted by other means."
+        ));
+    }
+
+    print!("Sign this transaction? [y/N]: ");
+    std::io::Write::flush(&mut std::io::stdout())?;
+
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    if input.trim().to_lowercase() != "y" {
+        return Err(anyhow!(
+            "Aborted: the transaction was not confirmed. Nothing was signed."
+        ));
+    }
+
+    Ok(())
+}
+
 fn sign_transaction(args: SignArgs) -> Result<()> {
     // Check if initialized
     if !keystore::is_initialized() {
@@ -241,10 +290,6 @@ fn sign_transaction(args: SignArgs) -> Result<()> {
 
     // Get passphrase (prompt if not provided)
     let passphrase = args.passphrase;
-
-    // Retrieve keys from keystore
-    let (spend_key, view_key) =
-        keystore::get_keys(&passphrase).map_err(|e| anyhow!("Failed to retrieve keys: {}", e))?;
 
     // Parse the network
     let network = Network::from_str(&args.network).map_err(|_| {
@@ -269,6 +314,14 @@ fn sign_transaction(args: SignArgs) -> Result<()> {
 
     let request = PrepareOneSidedTransactionForSigningResult::from_json(&data)
         .map_err(|e| OfflineSignerError::ParseError(format!("Failed to parse transaction: {}", e)))?;
+
+    // Show the operator what is about to be signed and get their confirmation, before any key material is touched
+    let summary = PayloadSummary::from_one_sided(request.tx_id, &request.info);
+    confirm_payload(&summary, args.yes)?;
+
+    // Retrieve keys from keystore
+    let (spend_key, view_key) =
+        keystore::get_keys(&passphrase).map_err(|e| anyhow!("Failed to retrieve keys: {}", e))?;
 
     // Create the key manager with the spend wallet type
     let spend_wallet = SpendWallet::new(spend_key, view_key, None);

--- a/base_layer/common_types/src/seeds/cipher_seed.rs
+++ b/base_layer/common_types/src/seeds/cipher_seed.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{mem::size_of, str::FromStr};
+use std::{fmt, mem::size_of, str::FromStr};
 
 use blake2::Blake2b;
 use chacha20::{
@@ -120,12 +120,27 @@ hidden_type!(CipherSeedMacKey, SafeArray< u8, CIPHER_SEED_MAC_KEY_BYTES>);
 /// only have to scan the blocks in the chain since that day for full recovery, rather than scanning the entire
 /// blockchain.
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct CipherSeed {
     version: u8,
     birthday: u16,
     entropy: Box<[u8; CIPHER_SEED_ENTROPY_BYTES]>,
     salt: [u8; CIPHER_SEED_MAIN_SALT_BYTES],
+}
+
+/// `Debug` is implemented by hand rather than derived: the entropy is the wallet master secret, and every key in the
+/// wallet can be re-derived from it. A derived `Debug` would render it in full, and any `{:?}` sink (log lines, error
+/// messages, `Display` impls of enclosing types) would then leak the master seed. The secret fields are rendered the
+/// same way `Hidden` renders its contents so that the redaction is obvious in output.
+impl fmt::Debug for CipherSeed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CipherSeed")
+            .field("version", &self.version)
+            .field("birthday", &self.birthday)
+            .field("entropy", &format_args!("Hidden<[u8; {CIPHER_SEED_ENTROPY_BYTES}]>"))
+            .field("salt", &format_args!("Hidden<[u8; {CIPHER_SEED_MAIN_SALT_BYTES}]>"))
+            .finish()
+    }
 }
 
 // This is a separate type to make the linter happy
@@ -457,7 +472,7 @@ mod test {
 
     use chrono::{DateTime, TimeZone, Utc};
     use crc32fast::Hasher as CrcHasher;
-    use tari_utilities::{Hidden, SafePassword};
+    use tari_utilities::{Hidden, SafePassword, hex::to_hex};
 
     use super::{BIRTHDAY_GENESIS_FROM_UNIX_EPOCH, SECONDS_PER_DAY};
     use crate::seeds::{
@@ -473,6 +488,28 @@ mod test {
         mnemonic::{Mnemonic, MnemonicLanguage},
         seed_words::{SeedWords, get_birthday_from_unix_epoch_in_seconds},
     };
+
+    #[test]
+    fn test_cipher_seed_debug_does_not_leak_entropy() {
+        let seed = CipherSeed::random();
+        let rendered = format!("{seed:?}");
+
+        // Neither the entropy nor the salt may appear, in hex or in the byte-slice rendering a derived `Debug` uses
+        assert!(
+            !rendered.contains(&to_hex(seed.entropy())),
+            "CipherSeed Debug leaked the entropy: {rendered}"
+        );
+        assert!(
+            !rendered.contains(&format!("{:?}", seed.entropy())),
+            "CipherSeed Debug leaked the entropy: {rendered}"
+        );
+        assert!(
+            !rendered.contains(&format!("{:?}", seed.salt)),
+            "CipherSeed Debug leaked the salt: {rendered}"
+        );
+        assert!(rendered.contains("Hidden<[u8; 16]>"), "entropy was not redacted");
+        assert!(rendered.contains("Hidden<[u8; 5]>"), "salt was not redacted");
+    }
 
     #[test]
     fn test_cipher_seed_generation_and_deciphering() {

--- a/base_layer/common_types/src/seeds/cipher_seed.rs
+++ b/base_layer/common_types/src/seeds/cipher_seed.rs
@@ -481,6 +481,7 @@ mod test {
             CIPHER_SEED_CHECKSUM_BYTES,
             CIPHER_SEED_ENTROPY_BYTES,
             CIPHER_SEED_MAC_BYTES,
+            CIPHER_SEED_MAIN_SALT_BYTES,
             CIPHER_SEED_VERSION,
             CipherSeed,
         },
@@ -507,8 +508,14 @@ mod test {
             !rendered.contains(&format!("{:?}", seed.salt)),
             "CipherSeed Debug leaked the salt: {rendered}"
         );
-        assert!(rendered.contains("Hidden<[u8; 16]>"), "entropy was not redacted");
-        assert!(rendered.contains("Hidden<[u8; 5]>"), "salt was not redacted");
+        assert!(
+            rendered.contains(&format!("Hidden<[u8; {CIPHER_SEED_ENTROPY_BYTES}]>")),
+            "entropy was not redacted: {rendered}"
+        );
+        assert!(
+            rendered.contains(&format!("Hidden<[u8; {CIPHER_SEED_MAIN_SALT_BYTES}]>")),
+            "salt was not redacted: {rendered}"
+        );
     }
 
     #[test]

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -478,10 +478,13 @@ async fn it_rejects_zero_conf_double_spends() {
     let (unmined, _) = blockchain.create_unmined_block(block_spec!("2", parent: "1", transactions: transactions));
     let txn = blockchain.db().db_read_access().unwrap();
     let err = validator.validate_body(&*txn, &unmined).unwrap_err();
-    assert!(matches!(
-        err,
-        ValidationError::AggregatedBodyValidationError(AggregatedBodyValidationError::UnsortedOrDuplicateInput)
-    ));
+    // `verify_no_duplicated_inputs_outputs` rejects this first, via `AggregateBody::contains_duplicated_inputs`.
+    // It previously did not: `contains_duplicated_inputs` compares with `==`, and `TransactionInput::eq` used to
+    // include the script signature and input data, so the two competing spends of the same output - which differ in
+    // exactly those fields - compared as unequal and slipped past it. The body was still rejected, but only further
+    // on by the internal validator's sortedness check, as
+    // `AggregatedBodyValidationError::UnsortedOrDuplicateInput`.
+    assert!(matches!(err, ValidationError::UnsortedOrDuplicateInput));
 }
 
 mod body_only {

--- a/base_layer/transaction_components/src/key_manager/manager.rs
+++ b/base_layer/transaction_components/src/key_manager/manager.rs
@@ -66,7 +66,7 @@ use tari_crypto::{
 use tari_hashing::{KeyManagerTransactionsHashDomain, WalletMessageSigningDomain};
 use tari_script::{CheckSigSchnorrSignature, CompressedCheckSigSchnorrSignature, TariScript};
 use tari_utilities::{ByteArray, Hidden, hex::Hex};
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
     MicroMinotari,
@@ -151,7 +151,9 @@ impl KeyManager {
         private_key: PrivateKey,
         encryption_key: TariKeyId,
     ) -> Result<TariKeyId, KeyManagerError> {
-        let private_encryption_key = self.get_private_key(&encryption_key)?.to_vec();
+        // `to_vec` copies the key out of the zeroizing `PrivateKey` into a plain heap allocation; wrap it so that copy
+        // is wiped when it goes out of scope rather than left in freed memory.
+        let private_encryption_key = Zeroizing::new(self.get_private_key(&encryption_key)?.to_vec());
         let domain = "KEY_MANAGER_private_key".as_bytes().to_vec();
         let cipher = XChaCha20Poly1305::new(Key::from_slice(&private_encryption_key));
         let encrypted_vec = encrypt_bytes_integral_nonce(&cipher, domain, Hidden::hide(private_key.to_vec()))

--- a/base_layer/transaction_components/src/offline_signing/mod.rs
+++ b/base_layer/transaction_components/src/offline_signing/mod.rs
@@ -23,6 +23,7 @@ pub mod marshal_output_pair;
 pub mod models;
 pub mod offline_signer;
 pub mod one_sided_signer;
+pub mod payload_summary;
 
 pub use models::PaymentRecipient;
 pub use offline_signer::{
@@ -33,6 +34,7 @@ pub use offline_signer::{
     sign_locked_transaction,
     sign_locked_withdraw_multisig_transaction,
 };
+pub use payload_summary::{PayloadSummary, RecipientSummary};
 
 #[cfg(test)]
 mod test {

--- a/base_layer/transaction_components/src/offline_signing/models.rs
+++ b/base_layer/transaction_components/src/offline_signing/models.rs
@@ -79,14 +79,29 @@ pub trait TransactionResult: HasVersion + Serialize + DeserializeOwned + Sized {
 }
 
 /// A domain-separated Schnorr signature produced by the view wallet over the Borsh-encoded
-/// payload data.  The offline signer verifies this before using the spend key, ensuring
-/// that any in-transit tampering (recipient swap, amount change, input substitution, …)
-/// is detected and the signing operation is aborted.
+/// payload data.  The offline signer verifies this before using the spend key, so that any
+/// in-transit tampering (recipient swap, amount change, input substitution, …) by a party
+/// that does not hold the view key is detected and the signing operation is aborted.
 ///
 /// The challenge binds the nonce public key R, the view public key P, and the canonical
 /// Borsh bytes of the transaction payload: `H_domain(R || P || borsh_bytes)`.  Both
 /// wallets share the same view key, so the verifier derives P locally rather than
 /// trusting a key embedded in the payload.
+///
+/// # Security — what this does *not* prove
+///
+/// The signing key here is the wallet's **view key**, which is shareable by design: it is
+/// handed out to view-only wallets, auditors, exchanges and block explorers so that they can
+/// observe incoming payments.  Anyone holding the view key can therefore *forge* this
+/// signature over a payload of their choosing — for example one that redirects the funds to
+/// themselves — and the air-gapped signer will verify it as authentic.
+///
+/// This signature is consequently a **transit-integrity** check, not an authenticity check.
+/// The authoritative authorisation step is the human operating the air-gapped signer
+/// confirming a [`crate::offline_signing::PayloadSummary`] of what is about to be signed.
+/// Closing the gap in the protocol itself requires a dedicated authentication key that is
+/// provisioned to the online wallet separately from the view key, which is a breaking change
+/// to the key-export format and the payload version.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct PayloadIntegritySignature {
     /// Schnorr signature produced with the view private key.

--- a/base_layer/transaction_components/src/offline_signing/offline_signer.rs
+++ b/base_layer/transaction_components/src/offline_signing/offline_signer.rs
@@ -101,6 +101,15 @@ fn sign_payload<KM: TransactionKeyManagerInterface>(
 /// wallets share the same view key, so no key needs to be transmitted in the
 /// payload).  The challenge is reconstructed as `H_domain(R || P || canonical)`
 /// and the Schnorr verification is performed.
+///
+/// # Security
+///
+/// The view key is a shareable key, so a party that holds it can forge this signature over
+/// an arbitrary payload.  Passing this check therefore means "the payload was not mangled by
+/// someone without view access", **not** "the payload is what the wallet owner asked for".
+/// Callers that use a spend key MUST additionally have the operator confirm a
+/// [`crate::offline_signing::PayloadSummary`] of the payload.  See the docs on
+/// [`PayloadIntegritySignature`] for the full rationale.
 fn verify_payload_signature<KM: TransactionKeyManagerInterface>(
     key_manager: &KM,
     payload_sig: &PayloadIntegritySignature,

--- a/base_layer/transaction_components/src/offline_signing/payload_summary.rs
+++ b/base_layer/transaction_components/src/offline_signing/payload_summary.rs
@@ -1,0 +1,249 @@
+// Copyright 2025. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! Human-readable summaries of offline-signing payloads.
+//!
+//! # Why this exists
+//!
+//! The `PayloadIntegritySignature` carried by a `Prepare*` result is produced with the wallet's **view key**. The view
+//! key is a *shareable* key by design — it is handed to view-only wallets, auditors, exchanges and block explorers so
+//! that they can see incoming payments. It follows that the integrity signature only proves that the payload was not
+//! mangled by a party that has *no* view access; it proves nothing at all against anyone who holds the view key. Such
+//! a party can build a payload that pays themselves, sign it with the view key, and the air-gapped signer will verify
+//! it as authentic.
+//!
+//! The only defence that holds against a view-key holder is for the human operating the air-gapped signer to check
+//! what is about to be signed. This module produces the summary that is shown to them, so that the rendering lives
+//! next to the payload types and cannot drift out of sync with the fields that are actually signed.
+
+use std::fmt::{Display, Formatter};
+
+use tari_common_types::{tari_address::TariAddress, transaction::TxId};
+
+use crate::{
+    MicroMinotari,
+    offline_signing::models::{OneSidedMultisigTransactionInfo, OneSidedTransactionInfo},
+    transaction_components::MemoField,
+};
+
+/// A single recipient line in a [`PayloadSummary`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecipientSummary {
+    pub address: TariAddress,
+    pub amount: MicroMinotari,
+    pub payment_id: MemoField,
+}
+
+/// The security-relevant contents of an offline-signing payload, in a form that can be shown to a human before any
+/// spend key is used.
+///
+/// Every field here is covered by the canonical Borsh bytes that the integrity signature commits to, so a summary that
+/// the operator approves is a summary of what will actually be signed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PayloadSummary {
+    pub tx_id: TxId,
+    pub sender_address: TariAddress,
+    pub payment_id: MemoField,
+    pub recipients: Vec<RecipientSummary>,
+    pub fee: MicroMinotari,
+    pub fee_per_gram: MicroMinotari,
+    /// The sum of all inputs the payload asks to spend.
+    pub total_input_value: MicroMinotari,
+    /// The sum of all recipient amounts.
+    pub total_recipient_amount: MicroMinotari,
+    pub num_inputs: usize,
+    /// The multisig parties this payload pays into, if it is a multisig deposit.
+    pub multisig_public_keys: Vec<String>,
+    /// The party number this signer is acting as, if it is a multisig payload.
+    pub multisig_party_number: Option<u8>,
+}
+
+impl PayloadSummary {
+    /// Builds a summary of a one-sided payload.
+    pub fn from_one_sided(tx_id: TxId, info: &OneSidedTransactionInfo) -> Self {
+        Self {
+            tx_id,
+            sender_address: info.sender_address.clone(),
+            payment_id: info.payment_id.clone(),
+            recipients: info
+                .recipients
+                .iter()
+                .map(|r| RecipientSummary {
+                    address: r.address.clone(),
+                    amount: r.amount,
+                    payment_id: r.payment_id.clone(),
+                })
+                .collect(),
+            fee: info.fee,
+            fee_per_gram: info.fee_per_gram,
+            // Saturating: a payload is attacker-controlled, and a summary must never panic before it can be shown
+            total_input_value: info
+                .inputs
+                .iter()
+                .fold(MicroMinotari::zero(), |acc, o| acc.saturating_add(o.value())),
+            total_recipient_amount: info
+                .recipients
+                .iter()
+                .fold(MicroMinotari::zero(), |acc, r| acc.saturating_add(r.amount)),
+            num_inputs: info.inputs.len(),
+            multisig_public_keys: Vec::new(),
+            multisig_party_number: None,
+        }
+    }
+
+    /// Builds a summary of a multisig payload.
+    pub fn from_multisig(tx_id: TxId, info: &OneSidedMultisigTransactionInfo) -> Self {
+        use tari_utilities::hex::Hex;
+
+        let mut summary = Self::from_one_sided(tx_id, &info.base);
+        summary.multisig_public_keys = info.public_keys.iter().map(|pk| pk.to_hex()).collect();
+        summary.multisig_party_number = Some(info.party_number);
+        summary
+    }
+
+    /// The total value leaving the wallet, i.e. everything paid out plus the fee. Anything left over from the inputs
+    /// comes back as change.
+    pub fn total_spend(&self) -> MicroMinotari {
+        self.total_recipient_amount.saturating_add(self.fee)
+    }
+
+    /// The change that should return to the sender. `None` if the inputs do not cover the spend, which is itself a
+    /// reason to refuse to sign.
+    pub fn change(&self) -> Option<MicroMinotari> {
+        self.total_input_value.checked_sub(self.total_spend())
+    }
+}
+
+impl Display for PayloadSummary {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Transaction ID : {}", self.tx_id)?;
+        writeln!(f, "From           : {}", self.sender_address.to_base58())?;
+        if !self.payment_id.is_empty() {
+            writeln!(f, "Payment ID     : {}", self.payment_id)?;
+        }
+        writeln!(
+            f,
+            "Inputs         : {} totalling {}",
+            self.num_inputs, self.total_input_value
+        )?;
+        writeln!(f, "Recipients     : {}", self.recipients.len())?;
+        for (i, recipient) in self.recipients.iter().enumerate() {
+            writeln!(f, "  [{}] amount  : {}", i + 1, recipient.amount)?;
+            // Both forms are shown so the operator can check the address against whichever one they were given
+            writeln!(f, "      address : {}", recipient.address.to_base58())?;
+            writeln!(f, "      emoji   : {}", recipient.address)?;
+            if !recipient.payment_id.is_empty() {
+                writeln!(f, "      memo    : {}", recipient.payment_id)?;
+            }
+        }
+        if let Some(party_number) = self.multisig_party_number {
+            writeln!(f, "Multisig party : {party_number}")?;
+            for (i, pk) in self.multisig_public_keys.iter().enumerate() {
+                writeln!(f, "  [{}] key     : {}", i + 1, pk)?;
+            }
+        }
+        writeln!(f, "Fee            : {} (at {}/gram)", self.fee, self.fee_per_gram)?;
+        writeln!(f, "Total spend    : {}", self.total_spend())?;
+        match self.change() {
+            Some(change) => writeln!(f, "Change         : {change}")?,
+            None => writeln!(f, "Change         : INPUTS DO NOT COVER THE SPEND")?,
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tari_common_types::tari_address::{TariAddress, TariAddressFeatures};
+    use tari_crypto::keys::{PublicKey, SecretKey};
+
+    use super::*;
+    use crate::{offline_signing::models::PaymentRecipient, transaction_components::OutputFeatures};
+
+    fn address() -> TariAddress {
+        use tari_common::configuration::Network;
+        use tari_common_types::types::{CompressedPublicKey, PrivateKey, UncompressedPublicKey};
+
+        let view = UncompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rand::rng()));
+        let spend = UncompressedPublicKey::from_secret_key(&PrivateKey::random(&mut rand::rng()));
+        TariAddress::new_dual_address(
+            CompressedPublicKey::new_from_pk(view),
+            CompressedPublicKey::new_from_pk(spend),
+            Network::LocalNet,
+            TariAddressFeatures::create_one_sided_only(),
+            None,
+        )
+        .unwrap()
+    }
+
+    fn info(amounts: &[u64]) -> OneSidedTransactionInfo {
+        OneSidedTransactionInfo {
+            payment_id: MemoField::new_empty(),
+            recipients: amounts
+                .iter()
+                .map(|a| PaymentRecipient {
+                    amount: MicroMinotari::from(*a),
+                    output_features: OutputFeatures::default(),
+                    address: address(),
+                    payment_id: MemoField::new_empty(),
+                })
+                .collect(),
+            inputs: vec![],
+            outputs: vec![],
+            fee: MicroMinotari::from(100),
+            fee_per_gram: MicroMinotari::from(20),
+            sender_address: address(),
+        }
+    }
+
+    #[test]
+    fn it_sums_recipients_and_fee() {
+        let summary = PayloadSummary::from_one_sided(TxId::from(42u64), &info(&[1000, 2500]));
+        assert_eq!(summary.total_recipient_amount, MicroMinotari::from(3500));
+        assert_eq!(summary.total_spend(), MicroMinotari::from(3600));
+        assert_eq!(summary.recipients.len(), 2);
+        assert_eq!(summary.tx_id, TxId::from(42u64));
+    }
+
+    #[test]
+    fn it_reports_when_inputs_do_not_cover_the_spend() {
+        let summary = PayloadSummary::from_one_sided(TxId::from(1u64), &info(&[1000]));
+        // No inputs were supplied, so the spend cannot be covered
+        assert!(summary.change().is_none());
+        assert!(summary.to_string().contains("INPUTS DO NOT COVER THE SPEND"));
+    }
+
+    #[test]
+    fn it_renders_every_recipient_address_and_amount() {
+        let info = info(&[1000, 2500]);
+        let summary = PayloadSummary::from_one_sided(TxId::from(7u64), &info);
+        let rendered = summary.to_string();
+        for recipient in &info.recipients {
+            assert!(
+                rendered.contains(&recipient.address.to_base58()),
+                "recipient address missing from summary:\n{rendered}"
+            );
+        }
+        assert!(rendered.contains("1000 µT"), "amount missing from summary:\n{rendered}");
+        assert!(rendered.contains("2500 µT"), "amount missing from summary:\n{rendered}");
+    }
+}

--- a/base_layer/transaction_components/src/transaction_components/covenants/arguments.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/arguments.rs
@@ -73,6 +73,12 @@ impl CovenantArg {
 
     /// Reads a `CovenantArg` from a buffer of bytes
     pub fn read_from(reader: &mut &[u8], code: u8) -> Result<Self, CovenantDecodeError> {
+        Self::read_from_at_depth(reader, code, 0)
+    }
+
+    /// As [`CovenantArg::read_from`], but tracking how deeply the enclosing covenant is nested so that a nested
+    /// covenant argument can refuse to recurse without bound.
+    pub(super) fn read_from_at_depth(reader: &mut &[u8], code: u8, depth: usize) -> Result<Self, CovenantDecodeError> {
         use byte_codes::*;
         match code {
             ARG_HASH => {
@@ -92,8 +98,10 @@ impl CovenantArg {
             ARG_COVENANT => {
                 let buf = reader.read_variable_length_bytes(MAX_COVENANT_ARG_SIZE)?;
                 // Do not use consensus_decoding here because the compiler infinitely recurses to resolve the R generic,
-                // R becomes the reader of this call and so on. This impl has an arg limit anyway and so is safe
-                let covenant = Covenant::from_bytes(&mut buf.as_bytes())?;
+                // R becomes the reader of this call and so on. This impl has an arg limit anyway and so is safe.
+                // The depth is incremented so that the recursion this introduces stays bounded: the size limit alone
+                // still allows well over a thousand levels of nesting in a single message.
+                let covenant = Covenant::from_bytes_at_depth(&mut buf.as_bytes(), depth + 1)?;
                 Ok(CovenantArg::Covenant(covenant))
             },
             ARG_OUTPUT_TYPE => {

--- a/base_layer/transaction_components/src/transaction_components/covenants/covenant.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/covenant.rs
@@ -49,7 +49,17 @@ use crate::{
 
 const MAX_COVENANT_BYTES: usize = 4096;
 
-pub(crate) type CovenantTokens = MaxSizeVec<CovenantToken, 128>;
+pub(crate) const MAX_COVENANT_TOKENS: usize = 128;
+
+/// The deepest a covenant may nest another covenant (via `ARG_COVENANT`).
+///
+/// Decoding a nested covenant recurses, and each nesting level only costs the attacker the byte code plus a length
+/// varint. Without this limit a single ~4KB covenant — the size cap is `MAX_COVENANT_BYTES` — nests over a thousand
+/// levels deep and overflows the stack of whichever thread is validating it. The limit is set far above anything a
+/// real covenant needs so that it bounds the recursion without constraining legitimate use.
+pub(crate) const MAX_COVENANT_DEPTH: usize = 16;
+
+pub(crate) type CovenantTokens = MaxSizeVec<CovenantToken, MAX_COVENANT_TOKENS>;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 /// A covenant allows a UTXO to specify some restrictions on how it is spent in a future transaction.
@@ -99,13 +109,40 @@ impl Covenant {
     /// Produces a new `Covenant` instance, out of a byte buffer. It errors
     /// if the byte buffer length is higher than `MAX_COVENANT_BYTES`.
     pub fn from_bytes(bytes: &mut &[u8]) -> Result<Self, CovenantDecodeError> {
+        Self::from_bytes_at_depth(bytes, 0)
+    }
+
+    /// As [`Covenant::from_bytes`], but tracking how deeply this covenant is nested inside an enclosing one so that
+    /// the recursion through `ARG_COVENANT` stays bounded.
+    pub(super) fn from_bytes_at_depth(bytes: &mut &[u8], depth: usize) -> Result<Self, CovenantDecodeError> {
+        if depth > MAX_COVENANT_DEPTH {
+            return Err(CovenantDecodeError::ExceededMaxDepth {
+                max: MAX_COVENANT_DEPTH,
+            });
+        }
         if bytes.is_empty() {
             return Ok(Self::new());
         }
         if bytes.len() > MAX_COVENANT_BYTES {
             return Err(CovenantDecodeError::ExceededMaxBytes);
         }
-        CovenantTokenDecoder::new(bytes).collect()
+
+        // Collect into a plain `Vec` and convert: `MaxSizeVec`'s `FromIterator` silently stops at the cap, so
+        // collecting straight into `CovenantTokens` would drop every token past the 128th and accept the covenant
+        // anyway. That makes the decoded covenant differ from the bytes it came from — two distinct encodings map to
+        // the same `Covenant`, and the re-serialised (truncated) form is what gets hashed.
+        let tokens = CovenantTokenDecoder::new(bytes, depth).collect::<Result<Vec<_>, _>>()?;
+        let tokens = CovenantTokens::try_from(tokens).map_err(|_| CovenantDecodeError::ExceededMaxTokens {
+            max: MAX_COVENANT_TOKENS,
+        })?;
+
+        // A complete decode consumes the whole buffer; anything left over means the token stream did not describe
+        // these bytes and must not be accepted as if it did.
+        if !bytes.is_empty() {
+            return Err(CovenantDecodeError::TrailingBytes { remaining: bytes.len() });
+        }
+
+        Ok(Self { tokens })
     }
 
     /// Given a `Covenant` instance, it writes its bytes content to a
@@ -180,6 +217,10 @@ impl Covenant {
 
 impl FromIterator<CovenantToken> for Covenant {
     /// Creates a new `CovenantToken` instance from an iterator with `Item = CovenantToken`.
+    ///
+    /// NOTE: `FromIterator` cannot fail, so anything past `MAX_COVENANT_TOKENS` is silently dropped. Never use this to
+    /// build a covenant from untrusted bytes — the result would not match its input. `Covenant::from_bytes` converts
+    /// with `TryFrom` for exactly this reason.
     fn from_iter<T: IntoIterator<Item = CovenantToken>>(iter: T) -> Self {
         Self {
             tokens: iter.into_iter().collect(),
@@ -191,13 +232,17 @@ impl FromIterator<CovenantToken> for Covenant {
 mod test {
     #![allow(clippy::indexing_slicing)]
     use borsh::{BorshDeserialize, BorshSerialize};
+    use integer_encoding::VarIntWriter;
 
+    use super::{MAX_COVENANT_DEPTH, MAX_COVENANT_TOKENS};
     use crate::{
         covenant,
         key_manager::KeyManager,
         test_helpers::UtxoTestParams,
         transaction_components::covenants::{
             Covenant,
+            byte_codes,
+            decoder::CovenantDecodeError,
             test::{create_input, create_outputs},
         },
     };
@@ -259,5 +304,79 @@ mod test {
         let buf = vec![255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 49, 8, 2, 5, 6];
         let buf = &mut buf.as_slice();
         assert!(Covenant::deserialize(buf).is_err());
+    }
+
+    /// Builds `depth` levels of `covenant(covenant(covenant(... identity() ...)))` as raw bytes.
+    ///
+    /// Each level costs three bytes — the `ARG_COVENANT` byte code, a one byte length varint and the enclosed
+    /// covenant — so the whole thing comfortably fits inside the 4096 byte covenant size limit.
+    fn nested_covenant_bytes(depth: usize) -> Vec<u8> {
+        // `identity()` is a single filter byte code
+        let mut buf = vec![byte_codes::FILTER_IDENTITY];
+        for _ in 0..depth {
+            let mut next = vec![byte_codes::ARG_COVENANT];
+            next.write_varint(buf.len()).unwrap();
+            next.extend_from_slice(&buf);
+            buf = next;
+        }
+        buf
+    }
+
+    #[test]
+    fn it_rejects_deeply_nested_covenants() {
+        // A single message under the size limit that nests far deeper than the recursion limit allows. Before the
+        // depth limit this recursed once per level and overflowed the stack of the validating thread.
+        let bytes = nested_covenant_bytes(1300);
+        assert!(
+            bytes.len() <= 4096,
+            "the payload must stay within the covenant size limit to show that size alone does not bound the recursion"
+        );
+        let err = Covenant::from_bytes(&mut bytes.as_slice()).unwrap_err();
+        assert!(
+            matches!(err, CovenantDecodeError::ExceededMaxDepth { .. }),
+            "expected a depth error, got {err}"
+        );
+    }
+
+    #[test]
+    fn it_accepts_nesting_up_to_the_depth_limit() {
+        Covenant::from_bytes(&mut nested_covenant_bytes(MAX_COVENANT_DEPTH).as_slice()).unwrap();
+        let err = Covenant::from_bytes(&mut nested_covenant_bytes(MAX_COVENANT_DEPTH + 1).as_slice()).unwrap_err();
+        assert!(matches!(err, CovenantDecodeError::ExceededMaxDepth { .. }));
+    }
+
+    #[test]
+    fn it_rejects_more_tokens_than_the_maximum() {
+        // `MaxSizeVec`'s `FromIterator` stops at the cap rather than failing, so decoding used to silently drop every
+        // token past the 128th and accept the covenant. The extra tokens then vanished from the re-serialised form,
+        // which is what gets hashed — two different encodings for one covenant.
+        let bytes = vec![byte_codes::FILTER_IDENTITY; MAX_COVENANT_TOKENS + 1];
+        let err = Covenant::from_bytes(&mut bytes.as_slice()).unwrap_err();
+        assert!(
+            matches!(err, CovenantDecodeError::ExceededMaxTokens { .. }),
+            "expected a token count error, got {err}"
+        );
+
+        // Exactly at the limit still decodes, and round-trips to the same bytes
+        let covenant =
+            Covenant::from_bytes(&mut vec![byte_codes::FILTER_IDENTITY; MAX_COVENANT_TOKENS].as_slice()).unwrap();
+        assert_eq!(covenant.num_tokens(), MAX_COVENANT_TOKENS);
+        assert_eq!(covenant.to_bytes(), vec![
+            byte_codes::FILTER_IDENTITY;
+            MAX_COVENANT_TOKENS
+        ]);
+    }
+
+    #[test]
+    fn it_is_not_malleable_by_appending_tokens() {
+        // Truncation made these two distinct encodings decode to the same covenant, so an appended token changed the
+        // wire bytes without changing the covenant that gets hashed into the output.
+        let base = vec![byte_codes::FILTER_IDENTITY; MAX_COVENANT_TOKENS];
+        let mut extended = base.clone();
+        extended.push(byte_codes::FILTER_IDENTITY);
+
+        let decoded = Covenant::from_bytes(&mut base.as_slice()).unwrap();
+        assert_eq!(decoded.to_bytes(), base);
+        assert!(Covenant::from_bytes(&mut extended.as_slice()).is_err());
     }
 }

--- a/base_layer/transaction_components/src/transaction_components/covenants/decoder.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/decoder.rs
@@ -31,14 +31,19 @@ use crate::transaction_components::covenants::token::CovenantToken;
 pub struct CovenantTokenDecoder<'a, R> {
     buf: &'a mut R,
     is_complete: bool,
+    /// How deeply the covenant being decoded is nested inside enclosing covenants. Carried through so that a nested
+    /// `ARG_COVENANT` can refuse to recurse past `MAX_COVENANT_DEPTH`.
+    depth: usize,
 }
 
 impl<'a, R: io::Read> CovenantTokenDecoder<'a, R> {
-    /// Given a read buffer, it creates a new instance of `CovenantTokenDecoder`.
-    pub fn new(buf: &'a mut R) -> Self {
+    /// Given a read buffer, it creates a new instance of `CovenantTokenDecoder` for a covenant nested `depth` levels
+    /// inside enclosing covenants (`0` for a top-level covenant).
+    pub fn new(buf: &'a mut R, depth: usize) -> Self {
         Self {
             buf,
             is_complete: false,
+            depth,
         }
     }
 }
@@ -53,7 +58,7 @@ impl Iterator for CovenantTokenDecoder<'_, &[u8]> {
             return None;
         }
 
-        match CovenantToken::read_from(self.buf) {
+        match CovenantToken::read_from_at_depth(self.buf, self.depth) {
             Ok(Some(token)) => Some(Ok(token)),
             Ok(None) => {
                 self.is_complete = true;
@@ -82,6 +87,12 @@ pub enum CovenantDecodeError {
     ScriptError(#[from] ScriptError),
     #[error("Covenant exceeded maximum bytes")]
     ExceededMaxBytes,
+    #[error("Covenant exceeded the maximum of {max} tokens")]
+    ExceededMaxTokens { max: usize },
+    #[error("Covenant nested more than {max} levels deep")]
+    ExceededMaxDepth { max: usize },
+    #[error("Covenant had {remaining} trailing byte(s) after a complete decode")]
+    TrailingBytes { remaining: usize },
     #[error(transparent)]
     Io(#[from] io::Error),
 }
@@ -146,14 +157,14 @@ mod test {
     #[test]
     fn it_immediately_ends_iterator_given_empty_bytes() {
         let buf = &[] as &[u8; 0];
-        assert!(CovenantTokenDecoder::new(&mut &buf[..]).next().is_none());
+        assert!(CovenantTokenDecoder::new(&mut &buf[..], 0).next().is_none());
     }
 
     #[test]
     fn it_ends_after_an_error() {
         let buf = &[0xffu8];
         let mut reader = &buf[..];
-        let mut decoder = CovenantTokenDecoder::new(&mut reader);
+        let mut decoder = CovenantTokenDecoder::new(&mut reader, 0);
         assert!(matches!(decoder.next(), Some(Err(_))));
         assert!(decoder.next().is_none());
     }
@@ -162,7 +173,7 @@ mod test {
     fn it_returns_an_error_if_arg_expected() {
         let buf = &[ARG_OUTPUT_FIELD];
         let mut reader = &buf[..];
-        let mut decoder = CovenantTokenDecoder::new(&mut reader);
+        let mut decoder = CovenantTokenDecoder::new(&mut reader, 0);
 
         assert!(matches!(
             decoder.next(),
@@ -183,7 +194,7 @@ mod test {
         .write_to(&mut bytes)
         .unwrap();
         let mut buf = bytes.as_slice();
-        let mut decoder = CovenantTokenDecoder::new(&mut buf);
+        let mut decoder = CovenantTokenDecoder::new(&mut buf, 0);
         let token = decoder.next().unwrap().unwrap();
         assert!(matches!(
             token,

--- a/base_layer/transaction_components/src/transaction_components/covenants/token.rs
+++ b/base_layer/transaction_components/src/transaction_components/covenants/token.rs
@@ -58,6 +58,12 @@ pub enum CovenantToken {
 impl CovenantToken {
     /// Reads from a byte buffer.
     pub fn read_from(reader: &mut &[u8]) -> Result<Option<Self>, CovenantDecodeError> {
+        Self::read_from_at_depth(reader, 0)
+    }
+
+    /// As [`CovenantToken::read_from`], but tracking how deeply the enclosing covenant is nested so that a nested
+    /// covenant argument can refuse to recurse without bound.
+    pub(super) fn read_from_at_depth(reader: &mut &[u8], depth: usize) -> Result<Option<Self>, CovenantDecodeError> {
         let code = match reader.read_next_byte_code()? {
             Some(c) => c,
             // Nothing further to read
@@ -69,7 +75,7 @@ impl CovenantToken {
                 Ok(Some(CovenantToken::Filter(filter)))
             },
             code if CovenantArg::is_valid_code(code) => {
-                let arg = CovenantArg::read_from(reader, code)?;
+                let arg = CovenantArg::read_from_at_depth(reader, code, depth)?;
                 Ok(Some(CovenantToken::Arg(Box::new(arg))))
             },
             code => Err(CovenantDecodeError::UnknownByteCode { code }),

--- a/base_layer/transaction_components/src/transaction_components/transaction_input.rs
+++ b/base_layer/transaction_components/src/transaction_components/transaction_input.rs
@@ -535,11 +535,22 @@ impl Display for TransactionInput {
     }
 }
 
+/// An input is identified by the output it spends, and `Ord` orders inputs on exactly that. `Eq` must agree with it —
+/// `Ord` requires that `a.cmp(b) == Ordering::Equal` exactly when `a == b`, and `sort`, `dedup`, `binary_search` and
+/// `contains` all assume it.
+///
+/// `eq` used to additionally compare the script signature and the input data, so two inputs spending the same output
+/// with different witnesses compared as *unequal* while `cmp` reported them *equal*. That is precisely the shape a
+/// competing double spend takes, and it made `ReorgPool::discard_double_spends` — which asks `contains` whether a
+/// published block spent an input — miss them.
+///
+/// Note that the ordering itself is deliberately left alone: `is_all_unique_and_sorted` is the consensus check that
+/// rejects a body containing two inputs spending the same output, and it does so by relying on `cmp` reporting them
+/// equal. Adding tie-breakers to `cmp` would let such a body through, so the inconsistency is resolved by narrowing
+/// `eq` instead. Inputs that differ only in their witness are still distinguished by `canonical_hash`.
 impl PartialEq<Self> for TransactionInput {
     fn eq(&self, other: &Self) -> bool {
-        self.output_hash() == other.output_hash() &&
-            self.script_signature == other.script_signature &&
-            self.input_data == other.input_data
+        self.output_hash() == other.output_hash()
     }
 }
 
@@ -620,5 +631,52 @@ impl SpentOutput {
             rangeproof_hash: rp_hash,
             minimum_value_promise: output.minimum_value_promise,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Two inputs that spend the same output but carry different witnesses. This is the shape a competing double
+    /// spend takes.
+    fn same_output_different_witness() -> (TransactionInput, TransactionInput) {
+        let a = TransactionInput::default();
+        let mut b = a.clone();
+        b.input_data = ExecutionStack::new(vec![StackItem::Number(1)]);
+        (a, b)
+    }
+
+    #[test]
+    fn eq_agrees_with_cmp() {
+        // `Ord` requires `a == b` exactly when `a.cmp(b)` is `Equal`; `sort`, `dedup`, `binary_search` and `contains`
+        // all rely on it
+        let (a, b) = same_output_different_witness();
+        assert_eq!((a == b), (a.cmp(&b) == Ordering::Equal));
+        assert_eq!(a, b);
+        assert_eq!(a.cmp(&b), Ordering::Equal);
+
+        // Inputs spending different outputs are neither equal nor ordered equal
+        let c = TransactionInput::new_with_output_hash(
+            FixedHash::from([1u8; 32]),
+            ExecutionStack::default(),
+            Default::default(),
+        );
+        assert_ne!(a, c);
+        assert_ne!(a.cmp(&c), Ordering::Equal);
+    }
+
+    #[test]
+    fn inputs_spending_the_same_output_are_found_by_contains() {
+        // `ReorgPool::discard_double_spends` asks `contains` whether a published block spent an input; a different
+        // witness on the same output must not hide the double spend
+        let (a, b) = same_output_different_witness();
+        assert!([a].contains(&b));
+    }
+
+    #[test]
+    fn differing_witnesses_are_still_distinguished_by_the_canonical_hash() {
+        let (a, b) = same_output_different_witness();
+        assert_ne!(a.canonical_hash(), b.canonical_hash());
     }
 }

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -374,7 +374,9 @@ where T: WalletBackend + 'static
 impl Display for DbValue {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            DbValue::MasterSeed(k) => f.write_str(&format!("MasterSeed: {k:?}")),
+            // The master seed is the wallet's root secret; it must never reach a log line, so nothing about it other
+            // than its presence is rendered here.
+            DbValue::MasterSeed(_) => f.write_str("MasterSeed"),
             DbValue::ClientValue(v) => f.write_str(&format!("ClientValue: {v:?}")),
             DbValue::ValueCleared => f.write_str("ValueCleared"),
             DbValue::CommsFeatures(_) => f.write_str("Node features"),
@@ -388,7 +390,9 @@ impl Display for DbValue {
             DbValue::CommsIdentitySignature(_) => f.write_str("CommsIdentitySignature"),
             DbValue::LastAccessedNetwork(network) => f.write_str(&format!("LastAccessedNetwork: {network}")),
             DbValue::LastAccessedVersion(version) => f.write_str(&format!("LastAccessedVersion: {version}")),
-            DbValue::WalletType(wallet_type) => f.write_str(&format!("WalletType: {wallet_type:?}")),
+            // Use `Display`, not `Debug`: a wallet type can carry a `CipherSeed`, and only `Display` is guaranteed to
+            // render just the public key material.
+            DbValue::WalletType(wallet_type) => f.write_str(&format!("WalletType: {wallet_type}")),
         }
     }
 }

--- a/integration_tests/tests/features/OfflineSigning.feature
+++ b/integration_tests/tests/features/OfflineSigning.feature
@@ -43,6 +43,11 @@ Feature: Offline One-Sided Transaction Signing
     # Since v5.0.0 the view wallet signs the canonical payload bytes with its view key.
     # The offline signer verifies this signature before using any spend key material.
     # Any tampering with the signed content must be detected and signing must abort.
+    #
+    # NOTE: the view key is shareable by design, so this signature only stops a MITM
+    # that has no view access. A holder of the view key can forge a payload that passes
+    # this check — see the operator confirmation scenario below, which is the defence
+    # that covers that case.
     Given I have a seed node NODE
     When I have wallet WALLET_SENDER connected to all seed nodes
     When I have wallet WALLET_RECEIVER connected to all seed nodes
@@ -59,6 +64,29 @@ Feature: Offline One-Sided Transaction Signing
     When I tamper with the prepared offline signing payload
     # The offline signer must detect the tamper and refuse to produce a signed output
     Then signing the tampered payload using standalone offline signer OFFLINE_SIGNER fails with an integrity error
+
+  @security
+  Scenario: Offline signer refuses to sign without operator confirmation
+    # The payload integrity signature is produced with the wallet's view key, which is
+    # shareable by design (view-only wallets, auditors, exchanges, explorers). Anyone
+    # holding the view key can therefore build a payload that pays themselves, sign it,
+    # and have the air-gapped signer verify it as authentic. The only check that catches
+    # that is the operator confirming the transaction summary before the spend key is used,
+    # so the signer must fail closed when it cannot obtain a confirmation.
+    Given I have a seed node NODE
+    When I have wallet WALLET_SENDER connected to all seed nodes
+    When I have wallet WALLET_RECEIVER connected to all seed nodes
+    When I have SHA3X mining node MINER connected to base node NODE and wallet WALLET_SENDER
+    When mining node MINER mines 4 blocks
+    Then all nodes are at height 4
+    When I wait for wallet WALLET_SENDER to have at least 1002000 uT
+    Then I initialize standalone offline signer OFFLINE_SIGNER from wallet WALLET_SENDER seed words
+    Then I export wallet WALLET_SENDER view and spend keys as SENDER_KEYS
+    Then I create view wallet VIEW_WALLET from view and spend keys SENDER_KEYS on node NODE
+    When I wait for wallet VIEW_WALLET to have at least 1002000 uT
+    When I prepare an offline one-sided transaction of 100000 uT from wallet VIEW_WALLET to wallet WALLET_RECEIVER at fee 20
+    # The payload here is perfectly valid; it is the missing confirmation that must stop the signing
+    Then signing the prepared payload using standalone offline signer OFFLINE_SIGNER without confirmation is refused
 
   @standalone-offline-signer
   Scenario: Full offline signing flow via standalone offline signer

--- a/integration_tests/tests/steps/offline_signing_steps.rs
+++ b/integration_tests/tests/steps/offline_signing_steps.rs
@@ -223,6 +223,8 @@ async fn sign_prepared_transaction_using_standalone_offline_signer(world: &mut T
         OsString::from(OFFLINE_SIGNER_TEST_PASSPHRASE),
         OsString::from("--network"),
         OsString::from("localnet"),
+        // The signer requires the operator to confirm the transaction summary; there is no operator here
+        OsString::from("--yes"),
     ]))
     .unwrap_or_else(|e| panic!("Failed to sign transaction with standalone offline signer: {e}"));
 
@@ -307,6 +309,8 @@ async fn sign_tampered_payload_fails_integrity_check(world: &mut TariWorld, sign
         OsString::from(OFFLINE_SIGNER_TEST_PASSPHRASE),
         OsString::from("--network"),
         OsString::from("localnet"),
+        // Confirm the summary so that the only thing that can reject this payload is the integrity check
+        OsString::from("--yes"),
     ]));
 
     assert!(
@@ -317,10 +321,71 @@ async fn sign_tampered_payload_fails_integrity_check(world: &mut TariWorld, sign
         !output_file.exists(),
         "Offline signer wrote a signed output for a tampered payload — integrity check was bypassed"
     );
-    println!(
-        "Standalone offline signer correctly rejected the tampered payload: {:?}",
-        result.unwrap_err()
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("integrity"),
+        "Expected a payload integrity error, got: {err:?}"
     );
+    println!("Standalone offline signer correctly rejected the tampered payload: {err:?}");
+}
+
+/// Assert that the offline signer refuses to sign when the operator has not confirmed the transaction summary.
+///
+/// The payload integrity signature is made with the *view* key, which is shareable, so it cannot distinguish a
+/// payload the wallet owner asked for from one forged by any holder of the view key. The operator confirming the
+/// summary is the check that catches that, so the signer must fail closed when it cannot obtain one — here stdin is
+/// not a terminal and `--yes` was not passed.
+#[then(expr = "signing the prepared payload using standalone offline signer {word} without confirmation is refused")]
+async fn sign_without_confirmation_is_refused(world: &mut TariWorld, signer_name: String) {
+    let prepared_json = world
+        .offline_signing_prepared
+        .as_ref()
+        .expect("No prepared transaction found — run the prepare step first")
+        .clone();
+    let keystore_file = world
+        .offline_signer_keystores
+        .get(&signer_name)
+        .unwrap_or_else(|| panic!("Standalone offline signer '{signer_name}' not initialized"))
+        .clone();
+    let signer_dir = keystore_file
+        .parent()
+        .unwrap_or_else(|| panic!("Keystore file {keystore_file:?} has no parent directory"))
+        .to_path_buf();
+    let input_file = signer_dir.join("offline_signing_unconfirmed_input.json");
+    let output_file = signer_dir.join("offline_signing_unconfirmed_output.json");
+    drop(std::fs::remove_file(&output_file));
+    std::fs::write(&input_file, prepared_json).expect("Failed to write prepared transaction file");
+
+    let result = execute_offline_signer_from_args(os_args([
+        OsString::from("minotari_offline_signer"),
+        OsString::from("--test-keystore-file"),
+        keystore_file.as_os_str().to_os_string(),
+        OsString::from("sign"),
+        OsString::from("--input-file"),
+        input_file.as_os_str().to_os_string(),
+        OsString::from("--output-file"),
+        output_file.as_os_str().to_os_string(),
+        OsString::from("--passphrase"),
+        OsString::from(OFFLINE_SIGNER_TEST_PASSPHRASE),
+        OsString::from("--network"),
+        OsString::from("localnet"),
+        // Deliberately no --yes
+    ]));
+
+    assert!(
+        result.is_err(),
+        "Expected the standalone offline signer to refuse to sign without operator confirmation, but it succeeded"
+    );
+    assert!(
+        !output_file.exists(),
+        "Offline signer wrote a signed output without operator confirmation"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("could not be confirmed"),
+        "Expected a confirmation error, got: {err:?}"
+    );
+    println!("Standalone offline signer correctly refused to sign without confirmation: {err:?}");
 }
 
 #[when(expr = "I broadcast the signed transaction via wallet {word}")]


### PR DESCRIPTION
Description
---
fix: MaxSizeBytes/MaxSizeString/MaxSizeVec don't enforce their size cap on the derived Borsh deserialize path (only TryFrom checks).
fix:  Master seed entropy leaks via derived Debug: CipherSeed derives Debug over unredacted entropy, and a live sink
fix:  Offline-signing payload integrity is authenticated with the shareable view key; anyone with view access can forge a payload
swapping recipient/amount, and the airgapped signer verifies it as authentic. Use a non-distributed key + user confirmation.
fix: unbounded covenant recursion (stack-overflow DoS from one ~4KB message), covenant token truncation/trailing-bytes malleability,
fix: TransactionInput Ord/Eq inconsistency (currently neutralized by is_all_unique_and_sorted), unzeroized key copy in created_encrypted_key.