### PR TITLE
fix(comms): filter private DHT peer addresses

### DIFF
--- a/comms/core/src/connection_manager/common.rs
+++ b/comms/core/src/connection_manager/common.rs
@@ -36,7 +36,7 @@ use crate::{
     multiaddr::Multiaddr,
     net_address::{MultiaddressesWithStats, PeerAddressSource},
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerIdentityClaim, PeerManagerError},
-    peer_validator::{PeerValidatorConfig, PeerValidatorError, validate_peer_identity_claim},
+    peer_validator::{PeerValidatorConfig, PeerValidatorError, validate_and_filter_peer_identity_claim_addresses},
     proto::identity::PeerIdentityMsg,
     protocol,
     protocol::{NodeNetworkInfo, ProtocolId},
@@ -48,6 +48,11 @@ const LOG_TARGET: &str = "comms::connection_manager::common";
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValidatedPeerIdentityExchange {
     pub claim: PeerIdentityClaim,
+    /// Addresses from `claim` that this node is permitted to store and dial.
+    ///
+    /// The unmodified claim is retained separately because its signature and
+    /// provenance cover the original address list.
+    pub permitted_addresses: Vec<Multiaddr>,
     pub metadata: PeerIdentityMetadata,
 }
 
@@ -204,10 +209,12 @@ pub(super) fn validate_peer_identity_message(
             .try_into()?,
     };
 
-    validate_peer_identity_claim(config, authenticated_public_key, &peer_identity_claim)?;
+    let permitted_addresses =
+        validate_and_filter_peer_identity_claim_addresses(config, authenticated_public_key, &peer_identity_claim)?;
 
     Ok(ValidatedPeerIdentityExchange {
         claim: peer_identity_claim,
+        permitted_addresses,
         metadata: PeerIdentityMetadata {
             user_agent,
             supported_protocols,
@@ -242,7 +249,7 @@ pub(super) fn create_or_update_peer_from_validated_peer_identity(
                 peer.node_id.short_str()
             );
             peer.addresses.add_or_update_addresses(
-                &peer_identity.claim.addresses,
+                &peer_identity.permitted_addresses,
                 &PeerAddressSource::FromPeerConnection {
                     peer_identity_claim: peer_identity.claim.clone(),
                 },
@@ -250,7 +257,7 @@ pub(super) fn create_or_update_peer_from_validated_peer_identity(
 
             // For inbound connections we cannot distinguish between the peer's addresses, so we mark all as seen
             peer.addresses
-                .mark_all_addresses_as_last_seen_now_with_latency(&peer_identity.claim.addresses, latency);
+                .mark_all_addresses_as_last_seen_now_with_latency(&peer_identity.permitted_addresses, latency);
 
             peer.features = peer_identity.claim.features;
             peer.supported_protocols = peer_identity.metadata.supported_protocols.clone();
@@ -265,13 +272,13 @@ pub(super) fn create_or_update_peer_from_validated_peer_identity(
                 peer_node_id.short_str()
             );
             let mut addresses = MultiaddressesWithStats::from_addresses_with_source(
-                peer_identity.claim.addresses.clone(),
+                peer_identity.permitted_addresses.clone(),
                 &PeerAddressSource::FromPeerConnection {
                     peer_identity_claim: peer_identity.claim.clone(),
                 },
             );
             // For inbound connections we cannot distinguish between the peer's addresses, so we mark all as seen
-            addresses.mark_all_addresses_as_last_seen_now_with_latency(&peer_identity.claim.addresses, latency);
+            addresses.mark_all_addresses_as_last_seen_now_with_latency(&peer_identity.permitted_addresses, latency);
             Peer::new(
                 authenticated_public_key,
                 peer_node_id,
@@ -328,4 +335,94 @@ async fn maybe_ban<T, E: ToString + Into<ConnectionManagerError>>(
     }
 
     Err(err.into())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn identity_message(node_identity: &NodeIdentity) -> PeerIdentityMsg {
+        PeerIdentityMsg {
+            addresses: node_identity
+                .public_addresses()
+                .into_iter()
+                .map(|address| address.to_vec())
+                .collect(),
+            features: node_identity.features().bits(),
+            supported_protocols: vec![],
+            user_agent: "test".to_string(),
+            identity_signature: node_identity.identity_signature_read().as_ref().map(Into::into),
+        }
+    }
+
+    #[test]
+    fn identity_exchange_filters_local_addresses_after_signature_validation() {
+        let public_address: Multiaddr = "/ip4/23.23.23.23/tcp/18189".parse().unwrap();
+        let private_address: Multiaddr = "/ip4/192.168.1.2/tcp/18189".parse().unwrap();
+        let claimed_addresses = vec![public_address.clone(), private_address.clone()];
+        let node_identity = NodeIdentity::random_multiple_addresses(
+            &mut rand::rng(),
+            claimed_addresses.clone(),
+            PeerFeatures::COMMUNICATION_NODE,
+        );
+        let config = PeerValidatorConfig {
+            allow_test_addresses: false,
+            ..PeerValidatorConfig::default()
+        };
+
+        let validated =
+            validate_peer_identity_message(&config, node_identity.public_key(), identity_message(&node_identity))
+                .unwrap();
+
+        assert_eq!(validated.claim.addresses, claimed_addresses);
+        assert!(validated.claim.is_valid(node_identity.public_key()).unwrap());
+        assert_eq!(validated.permitted_addresses, vec![public_address.clone()]);
+
+        let peer = create_or_update_peer_from_validated_peer_identity(
+            None,
+            node_identity.public_key().clone(),
+            &validated,
+            Duration::from_millis(1),
+        );
+        assert!(peer.addresses.contains(&public_address));
+        assert!(!peer.addresses.contains(&private_address));
+    }
+
+    #[test]
+    fn identity_exchange_accepts_an_all_local_claim_without_replacing_known_addresses() {
+        let local_address: Multiaddr = "/ip4/127.0.0.1/tcp/18189".parse().unwrap();
+        let known_address: Multiaddr = "/ip4/23.23.23.23/tcp/18189".parse().unwrap();
+        let node_identity = NodeIdentity::random(&mut rand::rng(), local_address, PeerFeatures::COMMUNICATION_NODE);
+        let config = PeerValidatorConfig {
+            allow_test_addresses: false,
+            ..PeerValidatorConfig::default()
+        };
+
+        let validated =
+            validate_peer_identity_message(&config, node_identity.public_key(), identity_message(&node_identity))
+                .unwrap();
+        assert!(validated.permitted_addresses.is_empty());
+
+        let known_peer = Peer::new(
+            node_identity.public_key().clone(),
+            node_identity.node_id().clone(),
+            MultiaddressesWithStats::from_addresses_with_source(
+                vec![known_address.clone()],
+                &PeerAddressSource::Config,
+            ),
+            PeerFlags::empty(),
+            PeerFeatures::COMMUNICATION_NODE,
+            vec![],
+            String::new(),
+        );
+        let peer = create_or_update_peer_from_validated_peer_identity(
+            Some(known_peer),
+            node_identity.public_key().clone(),
+            &validated,
+            Duration::from_millis(1),
+        );
+
+        assert_eq!(peer.addresses.len(), 1);
+        assert!(peer.addresses.contains(&known_address));
+    }
 }

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -235,9 +235,12 @@ where
             Ok((conn, peer_identity)) => {
                 // try save the peer back to the peer manager
                 let peer = dial_state.peer_mut();
-                peer.update_addresses(&peer_identity.claim.addresses, &PeerAddressSource::FromPeerConnection {
-                    peer_identity_claim: peer_identity.claim.clone(),
-                });
+                peer.update_addresses(
+                    &peer_identity.permitted_addresses,
+                    &PeerAddressSource::FromPeerConnection {
+                        peer_identity_claim: peer_identity.claim.clone(),
+                    },
+                );
                 peer.supported_protocols = peer_identity.metadata.supported_protocols;
                 peer.user_agent = peer_identity.metadata.user_agent;
 

--- a/comms/core/src/net_address/mod.rs
+++ b/comms/core/src/net_address/mod.rs
@@ -23,7 +23,7 @@
 //! Extension types used by the [PeerManager](crate::PeerManager) to keep track of address reliability.
 
 mod multiaddr_with_stats;
-pub use multiaddr_with_stats::{MultiaddrWithStats, PeerAddressSource};
+pub use multiaddr_with_stats::{MultiaddrWithStats, PeerAddressSource, is_external_address};
 
 mod mutliaddresses_with_stats;
 pub use mutliaddresses_with_stats::MultiaddressesWithStats;

--- a/comms/core/src/net_address/multiaddr_with_stats.rs
+++ b/comms/core/src/net_address/multiaddr_with_stats.rs
@@ -8,6 +8,7 @@ use std::{
     fmt,
     fmt::{Display, Formatter},
     hash::{Hash, Hasher},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
     time::Duration,
 };
 
@@ -22,6 +23,65 @@ const LOG_TARGET: &str = "comms::net_address::multiaddr_with_stats";
 
 const MAX_LATENCY_SAMPLE_COUNT: u32 = 100;
 const MAX_INITIAL_DIAL_TIME_SAMPLE_COUNT: u32 = 100;
+
+/// Returns true if an address is suitable for sharing with external peers.
+///
+/// This classification is intentionally separate from structural multiaddress
+/// validation. It excludes local IP ranges, IPv4-mapped local IPv6 addresses,
+/// and DNS namespaces conventionally reserved for local use.
+pub fn is_external_address(address: &Multiaddr) -> bool {
+    let Some(protocol) = address.iter().next() else {
+        return false;
+    };
+
+    match protocol {
+        Protocol::Ip4(ip) => !is_internal_ipv4(ip),
+        Protocol::Ip6(ip) => !is_internal_ipv6(ip),
+        Protocol::Dns4(name) | Protocol::Dns6(name) | Protocol::Dnsaddr(name) => !is_internal_dns_name(name.as_ref()),
+        // Structural validation decides whether other protocols are supported.
+        _ => true,
+    }
+}
+
+fn is_internal_ipv4(addr: Ipv4Addr) -> bool {
+    let [first_octet, ..] = addr.octets();
+    addr.is_unspecified() ||
+        addr.is_loopback() ||
+        addr.is_private() ||
+        addr.is_link_local() ||
+        addr.is_multicast() ||
+        addr.is_broadcast() ||
+        addr.is_documentation() ||
+        first_octet == 0 ||
+        first_octet >= 240
+}
+
+fn is_internal_ipv6(addr: Ipv6Addr) -> bool {
+    let [first_segment, second_segment, ..] = addr.segments();
+    addr.is_unspecified() ||
+        addr.is_loopback() ||
+        addr.is_unique_local() ||
+        addr.is_unicast_link_local() ||
+        addr.is_multicast() ||
+        (first_segment == 0x2001 && second_segment == 0x0db8) ||
+        addr.to_ipv4().is_some_and(is_internal_ipv4)
+}
+
+fn is_internal_dns_name(addr: &str) -> bool {
+    let addr = addr.trim_end_matches('.');
+    if let Ok(ip) = addr.parse::<IpAddr>() {
+        return match ip {
+            IpAddr::V4(ip) => is_internal_ipv4(ip),
+            IpAddr::V6(ip) => is_internal_ipv6(ip),
+        };
+    }
+
+    let addr = addr.to_ascii_lowercase();
+    const INTERNAL_DNS_NAMES: &[&str] = &["localhost", "local", "localdomain", "internal", "lan", "home.arpa"];
+    INTERNAL_DNS_NAMES
+        .iter()
+        .any(|name| addr == *name || addr.strip_suffix(name).is_some_and(|prefix| prefix.ends_with('.')))
+}
 
 #[derive(Debug, Eq, Clone, Deserialize, Serialize)]
 pub struct MultiaddrWithStats {
@@ -144,18 +204,10 @@ impl MultiaddrWithStats {
         &self.address
     }
 
-    /// Returns true if the address is an external address, i.e. not a loopback, unspecified or private IP address.
+    /// Returns true if the address is externally routable rather than a local, reserved, documentation or test
+    /// address.
     pub fn is_external(&self) -> bool {
-        if self.address.is_empty() {
-            return false;
-        }
-        let mut protocols = self.address.iter();
-        let internal = match protocols.next() {
-            Some(Protocol::Ip4(ip)) => ip.is_loopback() || ip.is_unspecified() || ip.is_private(),
-            Some(Protocol::Ip6(ip)) => ip.is_loopback() || ip.is_unspecified(),
-            _ => false, // onion3 etc = OK
-        };
-        !internal
+        is_external_address(&self.address)
     }
 
     pub fn offline_at(&self) -> Option<NaiveDateTime> {
@@ -482,6 +534,49 @@ impl PartialEq for PeerAddressSource {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_is_external_address() {
+        let external = [
+            "/ip4/1.1.1.1/tcp/8000",
+            "/ip6/2606:4700:4700::1111/tcp/8000",
+            "/dns4/example.com/tcp/8000",
+            "/dns4/mylocal.com/tcp/8000",
+            "/dns4/internal-node.example.com/tcp/8000",
+            "/dns4/locallake.io/tcp/8000",
+            "/dns4/LOCALHOST.example.com/tcp/8000",
+            "/dns4/example.com./tcp/8000",
+        ];
+        let internal = [
+            "/ip4/0.1.2.3/tcp/8000",
+            "/ip4/10.0.0.1/tcp/8000",
+            "/ip4/127.0.0.1/tcp/8000",
+            "/ip4/169.254.1.1/tcp/8000",
+            "/ip4/192.0.2.1/tcp/8000",
+            "/ip4/224.0.0.1/tcp/8000",
+            "/ip4/240.0.0.1/tcp/8000",
+            "/ip4/255.255.255.255/tcp/8000",
+            "/ip6/::ffff:127.0.0.1/tcp/8000",
+            "/ip6/::192.168.0.1/tcp/8000",
+            "/ip6/2001:db8::1/tcp/8000",
+            "/ip6/ff02::1/tcp/8000",
+            "/dns4/localhost/tcp/8000",
+            "/dns4/node.local/tcp/8000",
+            "/dns4/node.internal./tcp/8000",
+            "/dns4/127.0.0.1/tcp/8000",
+            "/dns6/printer.lan/tcp/8000",
+            "/dnsaddr/home.arpa/tcp/8000",
+        ];
+
+        for address in external {
+            let address = address.parse().unwrap();
+            assert!(is_external_address(&address), "{address} should be external");
+        }
+        for address in internal {
+            let address = address.parse().unwrap();
+            assert!(!is_external_address(&address), "{address} should not be external");
+        }
+    }
 
     #[test]
     fn test_update_latency() {

--- a/comms/core/src/net_address/multiaddr_with_stats.rs
+++ b/comms/core/src/net_address/multiaddr_with_stats.rs
@@ -44,7 +44,7 @@ pub fn is_external_address(address: &Multiaddr) -> bool {
 }
 
 fn is_internal_ipv4(addr: Ipv4Addr) -> bool {
-    let [first_octet, ..] = addr.octets();
+    let [first_octet, second_octet, third_octet, ..] = addr.octets();
     addr.is_unspecified() ||
         addr.is_loopback() ||
         addr.is_private() ||
@@ -52,17 +52,29 @@ fn is_internal_ipv4(addr: Ipv4Addr) -> bool {
         addr.is_multicast() ||
         addr.is_broadcast() ||
         addr.is_documentation() ||
+        // Shared address space (RFC 6598).
+        (first_octet == 100 && (64..=127).contains(&second_octet)) ||
+        // Deprecated 6to4 relay anycast (RFC 7526).
+        (first_octet == 192 && second_octet == 88 && third_octet == 99) ||
+        // Benchmarking networks (RFC 2544).
+        (first_octet == 198 && (18..=19).contains(&second_octet)) ||
         first_octet == 0 ||
         first_octet >= 240
 }
 
 fn is_internal_ipv6(addr: Ipv6Addr) -> bool {
-    let [first_segment, second_segment, ..] = addr.segments();
+    let [first_segment, second_segment, third_segment, fourth_segment, ..] = addr.segments();
     addr.is_unspecified() ||
         addr.is_loopback() ||
         addr.is_unique_local() ||
         addr.is_unicast_link_local() ||
         addr.is_multicast() ||
+        // Discard-only prefix (RFC 6666).
+        (first_segment == 0x0100 && second_segment == 0 && third_segment == 0 && fourth_segment == 0) ||
+        // Teredo (RFC 4380), 6to4 (RFC 3056), and deprecated site-local space.
+        (first_segment == 0x2001 && second_segment == 0) ||
+        first_segment == 0x2002 ||
+        (first_segment & 0xffc0) == 0xfec0 ||
         (first_segment == 0x2001 && second_segment == 0x0db8) ||
         addr.to_ipv4().is_some_and(is_internal_ipv4)
 }
@@ -550,15 +562,24 @@ mod test {
         let internal = [
             "/ip4/0.1.2.3/tcp/8000",
             "/ip4/10.0.0.1/tcp/8000",
+            "/ip4/100.64.0.1/tcp/8000",
+            "/ip4/100.127.255.254/tcp/8000",
             "/ip4/127.0.0.1/tcp/8000",
             "/ip4/169.254.1.1/tcp/8000",
             "/ip4/192.0.2.1/tcp/8000",
+            "/ip4/192.88.99.1/tcp/8000",
+            "/ip4/198.18.0.1/tcp/8000",
+            "/ip4/198.19.255.254/tcp/8000",
             "/ip4/224.0.0.1/tcp/8000",
             "/ip4/240.0.0.1/tcp/8000",
             "/ip4/255.255.255.255/tcp/8000",
             "/ip6/::ffff:127.0.0.1/tcp/8000",
             "/ip6/::192.168.0.1/tcp/8000",
+            "/ip6/100::1/tcp/8000",
+            "/ip6/2001::1/tcp/8000",
             "/ip6/2001:db8::1/tcp/8000",
+            "/ip6/2002:c000:0204::1/tcp/8000",
+            "/ip6/fec0::1/tcp/8000",
             "/ip6/ff02::1/tcp/8000",
             "/dns4/localhost/tcp/8000",
             "/dns4/node.local/tcp/8000",

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -367,11 +367,9 @@ pub fn create_test_peer(ban_flag: bool, features: PeerFeatures) -> Peer {
     let mut addresses = Vec::new();
     for _i in 1..=rand::rng().random_range(1..4) {
         let n = [
-            match rand::rng().random_range(0..3) {
-                0 => rand::rng().random_range(1..10),   // Range excluding 10
-                1 => rand::rng().random_range(11..127), // Range excluding 127
-                _ => rand::rng().random_range(128..255),
-            },
+            // Use a range that is always globally routable according to the
+            // address classifier; internal-address tests add their own cases.
+            rand::rng().random_range(11..100),
             rand::rng().random_range(1..255),
             rand::rng().random_range(1..255),
             rand::rng().random_range(1..255),

--- a/comms/core/src/peer_manager/storage/database.rs
+++ b/comms/core/src/peer_manager/storage/database.rs
@@ -41,7 +41,7 @@ use tari_common_sqlite::{connection::DbConnection, error::StorageError};
 use tari_utilities::{hex, hex::Hex};
 
 use crate::{
-    net_address::{MultiaddrWithStats, MultiaddressesWithStats, PeerAddressSource},
+    net_address::{MultiaddrWithStats, MultiaddressesWithStats, PeerAddressSource, is_external_address},
     peer_manager::{
         NodeId,
         Peer,
@@ -50,7 +50,7 @@ use crate::{
         PeerId,
         generate_peer_id_as_i64,
         peer_id::peer_id_from_i64,
-        storage::schema::{multi_addresses, node_identity, peers},
+        storage::schema::{db_metadata, multi_addresses, node_identity, peers},
     },
     protocol::ProtocolId,
     types::{CommsPublicKey, TransportProtocol},
@@ -64,6 +64,13 @@ const LOG_TARGET: &str = "comms::peer_manager::storage::db";
 /// peers. Peers are gossiped far faster than they are re-verified, so without a recency bound the
 /// candidate set is dominated by peers that were reachable once and have long since gone.
 const KNOWN_GOOD_LAST_SEEN_WINDOW: TimeDelta = TimeDelta::hours(1);
+
+/// `db_metadata` key holding the [`ADDRESS_CLASSIFIER_VERSION`] this database was last classified
+/// with.
+const ADDRESS_CLASSIFIER_VERSION_KEY: &str = "address_classifier_version";
+/// Bump this whenever [`is_external_address`] changes, so that stored classifications are recomputed
+/// once on the next start.
+const ADDRESS_CLASSIFIER_VERSION: u32 = 1;
 
 /// This peer's identity information
 #[derive(Clone)]
@@ -92,7 +99,85 @@ impl PeerDatabaseSql {
             },
         };
         PeerDatabaseSql::add_this_peer_node_identity_to_db(&instance)?;
+        PeerDatabaseSql::reclassify_stored_address_externality(&instance)?;
         Ok(instance)
+    }
+
+    /// Recomputes the persisted `is_external` flag for every stored address, once per classifier
+    /// version.
+    ///
+    /// The flag is derived from the address itself, so widening the classifier leaves existing rows
+    /// stale. Rows are only rewritten by the normal update path when a peer publishes a strictly
+    /// newer signed claim, and an address that the peer validator now filters out is never handed to
+    /// that path again - so without this pass a local address stored by an older version would keep
+    /// `is_external = true` indefinitely, and keep being served to other nodes by the queries that
+    /// filter on it.
+    ///
+    /// This is a data migration rather than startup work: the classifier lives in Rust, so it cannot
+    /// run from a migration's `up.sql` the way `2025-07-19-085200_external_flag` did. Once the pass
+    /// has run, the applied [`ADDRESS_CLASSIFIER_VERSION`] is recorded and later starts do nothing
+    /// beyond reading it back.
+    fn reclassify_stored_address_externality(&self) -> Result<(), StorageError> {
+        let mut conn = self.connection.get_pooled_connection()?;
+
+        conn.immediate_transaction::<_, StorageError, _>(|conn| {
+            let applied_version = db_metadata::table
+                .filter(db_metadata::key.eq(ADDRESS_CLASSIFIER_VERSION_KEY))
+                .select(db_metadata::value)
+                .first::<String>(conn)
+                .optional()?
+                .and_then(|version| version.parse::<u32>().ok());
+            if applied_version == Some(ADDRESS_CLASSIFIER_VERSION) {
+                return Ok(());
+            }
+
+            let stored = multi_addresses::table
+                .select((
+                    multi_addresses::address_id,
+                    multi_addresses::address,
+                    multi_addresses::is_external,
+                ))
+                .load::<(Option<i32>, String, bool)>(conn)?;
+
+            let mut reclassified = 0usize;
+            for (address_id, address, was_external) in stored {
+                let Some(address_id) = address_id else {
+                    continue;
+                };
+                // An address we can no longer parse can never be dialled, so it is not external.
+                let is_external = Multiaddr::from_str(&address).is_ok_and(|addr| is_external_address(&addr));
+                if is_external == was_external {
+                    continue;
+                }
+
+                diesel::update(multi_addresses::table.filter(multi_addresses::address_id.eq(address_id)))
+                    .set(multi_addresses::is_external.eq(is_external))
+                    .execute(conn)?;
+                trace!(
+                    target: LOG_TARGET,
+                    "Reclassified stored address '{address}' as {}external",
+                    if is_external { "" } else { "not " }
+                );
+                reclassified += 1;
+            }
+
+            if reclassified > 0 {
+                warn!(
+                    target: LOG_TARGET,
+                    "Reclassified {reclassified} stored peer address(es) against address classifier \
+                     v{ADDRESS_CLASSIFIER_VERSION}"
+                );
+            }
+
+            diesel::replace_into(db_metadata::table)
+                .values((
+                    db_metadata::key.eq(ADDRESS_CLASSIFIER_VERSION_KEY),
+                    db_metadata::value.eq(ADDRESS_CLASSIFIER_VERSION.to_string()),
+                ))
+                .execute(conn)?;
+
+            Ok(())
+        })
     }
 
     /// Get this peer's identity
@@ -1604,13 +1689,69 @@ mod tests {
             database::{MIGRATIONS, NewMultiaddrWithStatsSql, NewPeerSql, PeerDatabaseSql},
             manager::create_test_peer_with_onion_address,
             storage::{
-                database::{duration_to_i64_ms_infallible, u32_to_i32_infallible},
-                schema::{multi_addresses, peers},
+                database::{ADDRESS_CLASSIFIER_VERSION_KEY, duration_to_i64_ms_infallible, u32_to_i32_infallible},
+                schema::{db_metadata, multi_addresses, peers},
             },
         },
         protocol::ProtocolId,
         types::{CommsPublicKey, TransportProtocol},
     };
+
+    #[test]
+    fn test_stored_address_externality_is_reclassified_once_per_classifier_version() {
+        let db_connection = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
+        let this_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let peers_db = PeerDatabaseSql::new(db_connection.clone(), &this_peer).unwrap();
+
+        let external: Multiaddr = "/ip4/23.23.23.23/tcp/18189".parse().unwrap();
+        let internal: Multiaddr = "/ip4/192.168.1.2/tcp/18189".parse().unwrap();
+        let mut peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        peer.addresses = MultiaddressesWithStats::from_addresses_with_source(
+            vec![external.clone(), internal.clone()],
+            &PeerAddressSource::Config,
+        );
+        peers_db.add_or_update_peer(peer).unwrap();
+
+        // Rows written by a version whose classifier disagreed with the current one. They are never
+        // handed back to the update path, so only an explicit pass can fix them.
+        let misclassify = |conn: &mut _| {
+            for (address, is_external) in [(&internal, true), (&external, false)] {
+                diesel::update(multi_addresses::table.filter(multi_addresses::address.eq(address.to_string())))
+                    .set(multi_addresses::is_external.eq(is_external))
+                    .execute(conn)
+                    .unwrap();
+            }
+        };
+        let is_external = |conn: &mut _, address: &Multiaddr| {
+            multi_addresses::table
+                .filter(multi_addresses::address.eq(address.to_string()))
+                .select(multi_addresses::is_external)
+                .first::<bool>(conn)
+                .unwrap()
+        };
+
+        let mut conn = peers_db.connection.get_pooled_connection().unwrap();
+        misclassify(&mut conn);
+        // An upgrade from a build that predates the classifier version marker.
+        diesel::delete(db_metadata::table.filter(db_metadata::key.eq(ADDRESS_CLASSIFIER_VERSION_KEY)))
+            .execute(&mut conn)
+            .unwrap();
+        drop(conn);
+
+        // Opening the database reclassifies them without waiting for a newer signed claim.
+        let peers_db = PeerDatabaseSql::new(db_connection.clone(), &this_peer).unwrap();
+        let mut conn = peers_db.connection.get_pooled_connection().unwrap();
+        assert!(is_external(&mut conn, &external));
+        assert!(!is_external(&mut conn, &internal));
+
+        // The applied version is recorded, so a later start does no work at all.
+        misclassify(&mut conn);
+        drop(conn);
+        let peers_db = PeerDatabaseSql::new(db_connection, &this_peer).unwrap();
+        let mut conn = peers_db.connection.get_pooled_connection().unwrap();
+        assert!(!is_external(&mut conn, &external));
+        assert!(is_external(&mut conn, &internal));
+    }
 
     #[test]
     fn test_add_update_peer_with_addresses() {

--- a/comms/core/src/peer_manager/storage/migrations/2026-08-05-000000_db_metadata/down.sql
+++ b/comms/core/src/peer_manager/storage/migrations/2026-08-05-000000_db_metadata/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE db_metadata;

--- a/comms/core/src/peer_manager/storage/migrations/2026-08-05-000000_db_metadata/up.sql
+++ b/comms/core/src/peer_manager/storage/migrations/2026-08-05-000000_db_metadata/up.sql
@@ -1,0 +1,10 @@
+-- Key/value store for bookkeeping that does not belong to a peer.
+--
+-- The first user is the address classifier version. Whether an address is externally routable is
+-- decided in Rust (`is_external_address`), not in SQL, so a classifier change cannot be applied by
+-- an `UPDATE` here the way `2025-07-19-085200_external_flag` did. Recording the applied version
+-- instead lets the node recompute the stored `is_external` flags exactly once after an upgrade.
+CREATE TABLE db_metadata (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT NOT NULL
+);

--- a/comms/core/src/peer_manager/storage/schema.rs
+++ b/comms/core/src/peer_manager/storage/schema.rs
@@ -47,5 +47,12 @@ table! {
     }
 }
 
+table! {
+    db_metadata (key) {
+        key -> Text,
+        value -> Text,
+    }
+}
+
 allow_tables_to_appear_in_same_query!(peers, multi_addresses);
 joinable!(multi_addresses -> peers (peer_id));

--- a/comms/core/src/peer_validator/error.rs
+++ b/comms/core/src/peer_validator/error.rs
@@ -33,6 +33,8 @@ pub enum PeerValidatorError {
     InvalidPeerAddresses { peer: NodeId },
     #[error("Peer '{peer}' has no address claims")]
     PeerHasNoAddresses { peer: NodeId },
+    #[error("Peer '{peer}' has address claims, but none are usable")]
+    PeerHasNoUsableAddresses { peer: NodeId },
     #[error("Invalid multiaddr: {0}")]
     InvalidMultiaddr(String),
     #[error("Onion v2 is deprecated and not supported")]
@@ -48,7 +50,51 @@ pub enum PeerValidatorError {
 }
 
 impl PeerValidatorError {
+    /// Returns whether this validation failure indicates hostile peer input.
+    ///
+    /// A peer with no advertised address, or only local addresses, may simply
+    /// be behind NAT or misconfigured. Rejecting the update is sufficient and
+    /// avoids punishing a reachable peer that relayed it.
+    pub fn is_ban_offence(&self) -> bool {
+        match self {
+            Self::PeerHasNoAddresses { .. } | Self::PeerHasNoUsableAddresses { .. } => false,
+            Self::InvalidPeerSignature { .. } |
+            Self::InvalidPeerAddresses { .. } |
+            Self::InvalidMultiaddr(_) |
+            Self::OnionV2NotSupported |
+            Self::PeerIdentityTooManyProtocols { .. } |
+            Self::PeerIdentityTooManyAddresses { .. } |
+            Self::PeerIdentityProtocolIdTooLong { .. } |
+            Self::PeerIdentityUserAgentTooLong { .. } => true,
+        }
+    }
+
     pub fn as_ban_duration(&self) -> Option<Duration> {
-        Some(BAN_DURATION_LONG)
+        self.is_ban_offence().then_some(BAN_DURATION_LONG)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn only_non_hostile_address_absence_errors_avoid_a_ban() {
+        let peer = NodeId::default();
+        assert!(
+            PeerValidatorError::PeerHasNoAddresses { peer: peer.clone() }
+                .as_ban_duration()
+                .is_none()
+        );
+        assert!(
+            PeerValidatorError::PeerHasNoUsableAddresses { peer }
+                .as_ban_duration()
+                .is_none()
+        );
+        assert!(
+            PeerValidatorError::InvalidMultiaddr("bad address".to_string())
+                .as_ban_duration()
+                .is_some()
+        );
     }
 }

--- a/comms/core/src/peer_validator/helpers.rs
+++ b/comms/core/src/peer_validator/helpers.rs
@@ -33,8 +33,11 @@ use crate::{
 
 const LOG_TARGET: &str = "comms::peer_validator";
 
-/// Checks that the given peer addresses are well-formed and valid. If test addresses are not allowed, local, private
-/// and memory addresses are rejected.
+/// Strictly checks that every peer address is well-formed and permitted.
+///
+/// This is an all-or-nothing helper. Signed claims received from peers should
+/// normally use [`validate_and_filter_peer_identity_claim_addresses`] so that
+/// one local address does not discard an otherwise usable claim.
 pub fn validate_addresses(config: &PeerValidatorConfig, addresses: &[Multiaddr]) -> Result<(), PeerValidatorError> {
     if addresses.is_empty() {
         debug!(target: LOG_TARGET, "validate_addresses - no addresses to validate.");
@@ -65,6 +68,13 @@ pub fn find_most_recent_claim<'a, I: IntoIterator<Item = &'a PeerIdentityClaim>>
     claims.into_iter().max_by_key(|c| c.signature.updated_at())
 }
 
+/// Strictly validates a signature and rejects the entire claim if any address
+/// is disallowed.
+///
+/// Network ingestion paths should normally use
+/// [`validate_and_filter_peer_identity_claim_addresses`] instead. This strict
+/// variant remains available for callers that explicitly require every
+/// advertised address to pass the configured policy.
 pub fn validate_peer_identity_claim(
     config: &PeerValidatorConfig,
     public_key: &CommsPublicKey,
@@ -105,6 +115,11 @@ pub fn validate_and_filter_peer_identity_claim_addresses(
         // transports for the filtering step.
         validate_address(addr, true)?;
     }
+    // Do not skip authentication when every address will be filtered. The
+    // handshake and existing-peer paths may retain an authenticated claim with
+    // an empty permitted set, and accepting it without this check would allow
+    // unsigned identity metadata. DHT message rate limiting bounds the cost of
+    // repeatedly submitting validly structured all-local claims.
     validate_peer_identity_claim_signature(public_key, claim)?;
 
     if config.allow_test_addresses {

--- a/comms/core/src/peer_validator/helpers.rs
+++ b/comms/core/src/peer_validator/helpers.rs
@@ -33,25 +33,6 @@ use crate::{
 
 const LOG_TARGET: &str = "comms::peer_validator";
 
-/// Strictly checks that every peer address is well-formed and permitted.
-///
-/// This is an all-or-nothing helper. Signed claims received from peers should
-/// normally use [`validate_and_filter_peer_identity_claim_addresses`] so that
-/// one local address does not discard an otherwise usable claim.
-pub fn validate_addresses(config: &PeerValidatorConfig, addresses: &[Multiaddr]) -> Result<(), PeerValidatorError> {
-    if addresses.is_empty() {
-        debug!(target: LOG_TARGET, "validate_addresses - no addresses to validate.");
-        return Ok(());
-    }
-
-    validate_address_count(config, addresses)?;
-    for addr in addresses {
-        validate_address(addr, config.allow_test_addresses)?;
-    }
-
-    Ok(())
-}
-
 fn validate_address_count(config: &PeerValidatorConfig, addresses: &[Multiaddr]) -> Result<(), PeerValidatorError> {
     if addresses.len() > config.max_permitted_peer_addresses_per_claim {
         return Err(PeerValidatorError::PeerIdentityTooManyAddresses {
@@ -66,22 +47,6 @@ pub fn find_most_recent_claim<'a, I: IntoIterator<Item = &'a PeerIdentityClaim>>
     claims: I,
 ) -> Option<&'a PeerIdentityClaim> {
     claims.into_iter().max_by_key(|c| c.signature.updated_at())
-}
-
-/// Strictly validates a signature and rejects the entire claim if any address
-/// is disallowed.
-///
-/// Network ingestion paths should normally use
-/// [`validate_and_filter_peer_identity_claim_addresses`] instead. This strict
-/// variant remains available for callers that explicitly require every
-/// advertised address to pass the configured policy.
-pub fn validate_peer_identity_claim(
-    config: &PeerValidatorConfig,
-    public_key: &CommsPublicKey,
-    claim: &PeerIdentityClaim,
-) -> Result<(), PeerValidatorError> {
-    validate_addresses(config, &claim.addresses)?;
-    validate_peer_identity_claim_signature(public_key, claim)
 }
 
 fn validate_peer_identity_claim_signature(

--- a/comms/core/src/peer_validator/helpers.rs
+++ b/comms/core/src/peer_validator/helpers.rs
@@ -25,6 +25,7 @@ use log::debug;
 
 use crate::{
     multiaddr::{Multiaddr, Protocol},
+    net_address::is_external_address,
     peer_manager::{NodeId, PeerIdentityClaim},
     peer_validator::{PeerValidatorConfig, error::PeerValidatorError},
     types::CommsPublicKey,
@@ -32,24 +33,29 @@ use crate::{
 
 const LOG_TARGET: &str = "comms::peer_validator";
 
-/// Checks that the given peer addresses are well-formed and valid. If allow_test_addrs is false, all localhost and
-/// memory addresses will be rejected.
+/// Checks that the given peer addresses are well-formed and valid. If test addresses are not allowed, local, private
+/// and memory addresses are rejected.
 pub fn validate_addresses(config: &PeerValidatorConfig, addresses: &[Multiaddr]) -> Result<(), PeerValidatorError> {
     if addresses.is_empty() {
         debug!(target: LOG_TARGET, "validate_addresses - no addresses to validate.");
         return Ok(());
     }
 
+    validate_address_count(config, addresses)?;
+    for addr in addresses {
+        validate_address(addr, config.allow_test_addresses)?;
+    }
+
+    Ok(())
+}
+
+fn validate_address_count(config: &PeerValidatorConfig, addresses: &[Multiaddr]) -> Result<(), PeerValidatorError> {
     if addresses.len() > config.max_permitted_peer_addresses_per_claim {
         return Err(PeerValidatorError::PeerIdentityTooManyAddresses {
             length: addresses.len(),
             max: config.max_permitted_peer_addresses_per_claim,
         });
     }
-    for addr in addresses {
-        validate_address(addr, config.allow_test_addresses)?;
-    }
-
     Ok(())
 }
 
@@ -65,6 +71,13 @@ pub fn validate_peer_identity_claim(
     claim: &PeerIdentityClaim,
 ) -> Result<(), PeerValidatorError> {
     validate_addresses(config, &claim.addresses)?;
+    validate_peer_identity_claim_signature(public_key, claim)
+}
+
+fn validate_peer_identity_claim_signature(
+    public_key: &CommsPublicKey,
+    claim: &PeerIdentityClaim,
+) -> Result<(), PeerValidatorError> {
     if let Ok(true) = claim.is_valid(public_key) {
         Ok(())
     } else {
@@ -73,6 +86,52 @@ pub fn validate_peer_identity_claim(
         })
     }
 }
+
+/// Verifies a signed claim and returns only the addresses permitted by the
+/// validator configuration.
+///
+/// Discovery can safely retain a peer that advertises both reachable and local
+/// addresses: the signature is checked against the original, unmodified claim,
+/// then invalid addresses are omitted from the peer database.
+pub fn validate_and_filter_peer_identity_claim_addresses(
+    config: &PeerValidatorConfig,
+    public_key: &CommsPublicKey,
+    claim: &PeerIdentityClaim,
+) -> Result<Vec<Multiaddr>, PeerValidatorError> {
+    validate_address_count(config, &claim.addresses)?;
+    for addr in &claim.addresses {
+        // Reject malformed or unsupported addresses before the more expensive
+        // signature verification. Passing `true` permits well-formed local
+        // transports for the filtering step.
+        validate_address(addr, true)?;
+    }
+    validate_peer_identity_claim_signature(public_key, claim)?;
+
+    if config.allow_test_addresses {
+        return Ok(claim.addresses.clone());
+    }
+
+    let mut valid_addresses = Vec::with_capacity(claim.addresses.len());
+    for addr in &claim.addresses {
+        // Structural validation has already succeeded above. This second pass
+        // applies the production-only address policy and filters local/test
+        // transports without invalidating the signature over the original claim.
+        match validate_address(addr, false) {
+            Ok(()) => valid_addresses.push(addr.clone()),
+            Err(err) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Discarding disallowed address '{}' from a valid peer claim: {}",
+                    addr,
+                    err
+                );
+            },
+        }
+    }
+
+    Ok(valid_addresses)
+}
+
 fn validate_address(addr: &Multiaddr, allow_test_addrs: bool) -> Result<(), PeerValidatorError> {
     let mut addr_iter = addr.iter();
     let proto = addr_iter
@@ -86,22 +145,28 @@ fn validate_address(addr: &Multiaddr, allow_test_addrs: bool) -> Result<(), Peer
             })?;
 
             validate_tcp_port(tcp)?;
-            expect_end_of_address(addr_iter)
+            expect_end_of_address(addr_iter)?;
+            if !allow_test_addrs && !is_external_address(addr) {
+                return Err(PeerValidatorError::InvalidMultiaddr(
+                    "Non-global DNS addresses are invalid".to_string(),
+                ));
+            }
+            Ok(())
         },
 
-        Protocol::Ip4(addr) if !allow_test_addrs && addr.is_unspecified() => Err(PeerValidatorError::InvalidMultiaddr(
-            "Non-global IP addresses are invalid".to_string(),
-        )),
-        Protocol::Ip6(addr) if !allow_test_addrs && addr.is_unspecified() => Err(PeerValidatorError::InvalidMultiaddr(
-            "Non-global IP addresses are invalid".to_string(),
-        )),
         Protocol::Ip4(_) | Protocol::Ip6(_) => {
             let tcp = addr_iter.next().ok_or_else(|| {
                 PeerValidatorError::InvalidMultiaddr("Address does not include a TCP port".to_string())
             })?;
 
             validate_tcp_port(tcp)?;
-            expect_end_of_address(addr_iter)
+            expect_end_of_address(addr_iter)?;
+            if !allow_test_addrs && !is_external_address(addr) {
+                return Err(PeerValidatorError::InvalidMultiaddr(
+                    "Non-global IP addresses are invalid".to_string(),
+                ));
+            }
+            Ok(())
         },
         Protocol::Memory(0) => Err(PeerValidatorError::InvalidMultiaddr(
             "Cannot connect to a zero memory port".to_string(),
@@ -205,6 +270,20 @@ mod test {
             "/onion/aaimaq4ygg2iegci:1234".parse().unwrap(),
             "/onion/aaimaq4ygg2iegci:1234/http".parse().unwrap(),
             multiaddr!(Dnsaddr("mike-magic-nodes.com")),
+            multiaddr!(Ip4([127, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([10, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([172, 16, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([192, 168, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([169, 254, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0xfc00, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0xfe80, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
+            "/ip6/::ffff:127.0.0.1/tcp/1".parse().unwrap(),
+            "/ip6/::ffff:192.168.0.1/tcp/1".parse().unwrap(),
+            multiaddr!(Dns4("localhost"), Tcp(1u16)),
+            multiaddr!(Dns4("node.internal"), Tcp(1u16)),
+            multiaddr!(Dns6("printer.local"), Tcp(1u16)),
+            multiaddr!(Dnsaddr("home.arpa"), Tcp(1u16)),
             multiaddr!(Memory(1234u64)),
             multiaddr!(Memory(0u64)),
         ];
@@ -222,12 +301,24 @@ mod test {
         let valid = [
             multiaddr!(Ip4([127, 0, 0, 1]), Tcp(1u16)),
             multiaddr!(Ip4([169, 254, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([10, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([172, 16, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip4([192, 168, 0, 1]), Tcp(1u16)),
             multiaddr!(Ip4([172, 0, 0, 1]), Tcp(1u16)),
             multiaddr!(Ip6([172, 0, 0, 1, 1, 1, 1, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0xfc00, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
+            multiaddr!(Ip6([0xfe80, 0, 0, 0, 0, 0, 0, 1]), Tcp(1u16)),
+            "/ip6/::ffff:127.0.0.1/tcp/1".parse().unwrap(),
+            "/ip6/::ffff:192.168.0.1/tcp/1".parse().unwrap(),
             "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234"
                 .parse()
                 .unwrap(),
             multiaddr!(Dnsaddr("mike-magic-nodes.com"), Tcp(1u16)),
+            multiaddr!(Dns4("localhost"), Tcp(1u16)),
+            multiaddr!(Dns4("node.internal"), Tcp(1u16)),
+            multiaddr!(Dns6("printer.local"), Tcp(1u16)),
+            multiaddr!(Dnsaddr("home.arpa"), Tcp(1u16)),
             multiaddr!(Memory(1234u64)),
         ];
 
@@ -245,6 +336,17 @@ mod test {
         for addr in invalid {
             validate_address(addr, true).unwrap_err();
         }
+    }
+
+    #[test]
+    fn malformed_local_dns_reports_the_structural_error_first() {
+        let address = multiaddr!(Dns4("localhost"));
+        let err = validate_address(&address, false).unwrap_err();
+
+        assert!(matches!(
+            err,
+            PeerValidatorError::InvalidMultiaddr(message) if message == "Address does not include a TCP port"
+        ));
     }
 
     #[test]

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -279,12 +279,11 @@ impl DhtDiscoveryService {
     ) -> Result<T, DhtPeerValidatorError> {
         match result {
             Ok(peer) => Ok(peer),
-            Err(err @ DhtPeerValidatorError::NewAndExistingMismatch { .. }) => Err(err),
-            Err(err @ DhtPeerValidatorError::IdentityTooManyClaims { .. }) |
-            Err(err @ DhtPeerValidatorError::ValidatorError(_)) => {
+            Err(err) if err.is_ban_offence() => {
                 self.dht.ban_peer(public_key.clone(), OffenceSeverity::High, &err).await;
                 Err(err)
             },
+            Err(err) => Err(err),
         }
     }
 

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -41,7 +41,7 @@ use crate::{
     envelope::NodeDestination,
     inbound::{error::DhtInboundError, message::DecryptedDhtMessage},
     outbound::{OutboundMessageRequester, SendMessageParams},
-    peer_validator::{DhtPeerValidatorError, PeerValidator},
+    peer_validator::PeerValidator,
     proto::{
         dht::{DiscoveryMessage, DiscoveryResponseMessage, JoinMessage},
         envelope::DhtMessageType,
@@ -467,15 +467,12 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             Ok(r) => Ok(r),
             Err(err) => {
                 match &err {
-                    DhtInboundError::PeerValidatorError(err) => match err {
-                        DhtPeerValidatorError::NewAndExistingMismatch { .. } => {},
-                        err @ DhtPeerValidatorError::ValidatorError(_) |
-                        err @ DhtPeerValidatorError::IdentityTooManyClaims { .. } => {
-                            self.dht
-                                .ban_peer(authenticated_pk.clone(), OffenceSeverity::Medium, err)
-                                .await;
-                        },
+                    DhtInboundError::PeerValidatorError(err) if err.is_ban_offence() => {
+                        self.dht
+                            .ban_peer(authenticated_pk.clone(), OffenceSeverity::Medium, err)
+                            .await;
                     },
+                    DhtInboundError::PeerValidatorError(_) => {},
                     err @ DhtInboundError::MessageError(_) | err @ DhtInboundError::InvalidMessageBody => {
                         self.dht
                             .ban_peer(authenticated_pk.clone(), OffenceSeverity::High, err)

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -56,6 +56,26 @@ use crate::{
 
 const LOG_TARGET: &str = "comms::dht::network_discovery";
 
+/// How many claims that only a broken or hostile node could produce a sync peer may relay in one
+/// round before the round is aborted and the sync peer banned.
+///
+/// A peer that is behind NAT or misconfigured is common and costs nothing to skip, so those claims
+/// are not counted here. A forged signature or a malformed multiaddress is not something an honest
+/// relay produces, and without a bound a sync peer could burn the whole per-round budget on them.
+const MAX_HOSTILE_RELAYED_CLAIMS: usize = 5;
+
+/// Classifies a failure to add a single peer that a sync peer relayed to us.
+///
+/// Returns `None` when the failure is not about the relayed claim at all (storage, connectivity) and
+/// the round therefore cannot continue. Otherwise the round continues without this peer, and the
+/// boolean says whether the sync peer relayed something only a broken or hostile node would produce.
+fn classify_relay_failure(err: &NetworkDiscoveryError) -> Option<bool> {
+    match err {
+        NetworkDiscoveryError::PeerValidationError(err) => Some(err.is_ban_offence()),
+        _ => None,
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct Discovering {
     params: DiscoveryParams,
@@ -291,6 +311,7 @@ impl Discovering {
         );
         let mut stream = self.get_stream(client, sync_peer).await?;
         let mut counter = 0;
+        let mut hostile_claims = 0;
         #[allow(clippy::mutable_key_type)]
         let mut peers_received = HashSet::new();
         while let Some(resp) = self.get_peer_response(&mut stream, sync_peer).await? {
@@ -331,22 +352,38 @@ impl Discovering {
             }
             match self.validate_and_add_peer(new_peer).await {
                 Ok(()) => {},
-                Err(NetworkDiscoveryError::PeerValidationError(err)) => {
-                    // A sync peer merely relays signed claims. Skip a bad or
-                    // unusable claim without truncating the rest of the stream;
-                    // otherwise the same entry can permanently block every
-                    // subsequent peer in each discovery round.
-                    warn!(
-                        target: LOG_TARGET,
-                        "Discovering: Skipping peer relayed by sync peer `{sync_peer}` after validation failed: {err:?}"
-                    );
-                },
-                Err(err) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Discovering: Failed to add peer from sync peer `{sync_peer}`: {err:?}"
-                    );
-                    return Err(err);
+                Err(err) => match classify_relay_failure(&err) {
+                    // A sync peer merely relays signed claims. Skip a bad or unusable claim without
+                    // truncating the rest of the stream; otherwise the same entry can permanently
+                    // block every subsequent peer in each discovery round.
+                    Some(is_offence) => {
+                        if is_offence {
+                            hostile_claims += 1;
+                        }
+                        warn!(
+                            target: LOG_TARGET,
+                            "Discovering: Skipping peer relayed by sync peer `{sync_peer}` after validation failed \
+                             (hostile: {is_offence}): {err:?}"
+                        );
+                        // Relaying the occasional unusable claim is normal - relaying claims that
+                        // only a broken or hostile node could produce is not, and skipping them
+                        // must not be free.
+                        if hostile_claims > MAX_HOSTILE_RELAYED_CLAIMS {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Discovering: Sync peer `{sync_peer}` relayed more than {MAX_HOSTILE_RELAYED_CLAIMS} \
+                                 unusable peer claims."
+                            );
+                            return Err(NetworkDiscoveryError::TooManyInvalidPeersReceived);
+                        }
+                    },
+                    None => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Discovering: Failed to add peer from sync peer `{sync_peer}`: {err:?}"
+                        );
+                        return Err(err);
+                    },
                 },
             }
         }
@@ -391,7 +428,8 @@ impl Discovering {
                     NetworkDiscoveryError::EmptyPeerMessageReceived |
                     NetworkDiscoveryError::InvalidPeerDataReceived(_) |
                     NetworkDiscoveryError::DuplicatePeerReceived |
-                    NetworkDiscoveryError::TooManyPeersReceived => {
+                    NetworkDiscoveryError::TooManyPeersReceived |
+                    NetworkDiscoveryError::TooManyInvalidPeersReceived => {
                         self.ban_peer(peer, OffenceSeverity::High, &err).await;
                     },
                     NetworkDiscoveryError::RpcError(rpc_err) if rpc_err.is_caused_by_server() => {
@@ -465,5 +503,67 @@ impl Discovering {
             pending_dials.len()
         );
         pending_dials
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tari_comms::{
+        peer_manager::{NodeId, PeerManagerError},
+        peer_validator::PeerValidatorError,
+    };
+
+    use super::*;
+    use crate::peer_validator::DhtPeerValidatorError;
+
+    fn validation_error(err: PeerValidatorError) -> NetworkDiscoveryError {
+        DhtPeerValidatorError::ValidatorError(err).into()
+    }
+
+    #[test]
+    fn a_relayed_claim_that_fails_validation_does_not_end_the_round() {
+        // A peer behind NAT, or one we simply cannot use, is skipped for free.
+        assert_eq!(
+            classify_relay_failure(&validation_error(PeerValidatorError::PeerHasNoUsableAddresses {
+                peer: NodeId::default()
+            })),
+            Some(false)
+        );
+        assert_eq!(
+            classify_relay_failure(&validation_error(PeerValidatorError::PeerHasNoAddresses {
+                peer: NodeId::default()
+            })),
+            Some(false)
+        );
+
+        // A forged signature or malformed address is skipped too, but counts against the sync peer.
+        assert_eq!(
+            classify_relay_failure(&validation_error(PeerValidatorError::InvalidPeerSignature {
+                peer: NodeId::default()
+            })),
+            Some(true)
+        );
+        assert_eq!(
+            classify_relay_failure(&validation_error(PeerValidatorError::InvalidMultiaddr(
+                "bad address".to_string()
+            ))),
+            Some(true)
+        );
+        assert_eq!(
+            classify_relay_failure(&NetworkDiscoveryError::PeerValidationError(
+                DhtPeerValidatorError::IdentityTooManyClaims { length: 2, max: 1 }
+            )),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn a_local_failure_ends_the_round() {
+        // Nothing to do with what the sync peer sent, so the round cannot continue.
+        assert_eq!(
+            classify_relay_failure(&NetworkDiscoveryError::PeerManagerError(PeerManagerError::BannedPeer)),
+            None
+        );
+        assert_eq!(classify_relay_failure(&NetworkDiscoveryError::NoSyncPeers), None);
     }
 }

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -329,12 +329,26 @@ impl Discovering {
                 warn!(target: LOG_TARGET, "Discovering: Sync peer `{sync_peer}` sent duplicate peer: {err:?}");
                 return Err(err);
             }
-            self.validate_and_add_peer(new_peer).await.inspect_err(|err| {
-                warn!(
-                    target: LOG_TARGET,
-                    "Discovering: Failed to validate and add peer from sync peer `{sync_peer}`: {err:?}"
-                );
-            })?;
+            match self.validate_and_add_peer(new_peer).await {
+                Ok(()) => {},
+                Err(NetworkDiscoveryError::PeerValidationError(err)) => {
+                    // A sync peer merely relays signed claims. Skip a bad or
+                    // unusable claim without truncating the rest of the stream;
+                    // otherwise the same entry can permanently block every
+                    // subsequent peer in each discovery round.
+                    warn!(
+                        target: LOG_TARGET,
+                        "Discovering: Skipping peer relayed by sync peer `{sync_peer}` after validation failed: {err:?}"
+                    );
+                },
+                Err(err) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Discovering: Failed to add peer from sync peer `{sync_peer}`: {err:?}"
+                    );
+                    return Err(err);
+                },
+            }
         }
 
         Ok(())

--- a/comms/dht/src/network_discovery/error.rs
+++ b/comms/dht/src/network_discovery/error.rs
@@ -47,6 +47,8 @@ pub enum NetworkDiscoveryError {
     EmptyPeerMessageReceived,
     #[error("Sync peer sent too many peers")]
     TooManyPeersReceived,
+    #[error("Sync peer relayed too many peer claims that failed validation")]
+    TooManyInvalidPeersReceived,
     #[error("Sync peer sent duplicate peer")]
     DuplicatePeerReceived,
     #[error("Sync peer sent invalid peer data: {0}")]
@@ -76,6 +78,7 @@ impl PartialEq for NetworkDiscoveryError {
                 (Self::PeerValidationError(_), Self::PeerValidationError(_)) |
                 (Self::EmptyPeerMessageReceived, Self::EmptyPeerMessageReceived) |
                 (Self::TooManyPeersReceived, Self::TooManyPeersReceived) |
+                (Self::TooManyInvalidPeersReceived, Self::TooManyInvalidPeersReceived) |
                 (Self::DuplicatePeerReceived, Self::DuplicatePeerReceived) |
                 (Self::InvalidPeerDataReceived(_), Self::InvalidPeerDataReceived(_)) |
                 (Self::PeerConnectionClosed { .. }, Self::PeerConnectionClosed { .. })

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -44,6 +44,20 @@ pub enum DhtPeerValidatorError {
     NewAndExistingMismatch { existing: String, new: String },
 }
 
+impl DhtPeerValidatorError {
+    /// Returns whether the peer should be banned for this validation failure.
+    ///
+    /// A peer with no usable advertised addresses may simply be behind NAT or
+    /// misconfigured. Dropping that update is sufficient; it is not evidence of
+    /// hostile behavior.
+    pub fn is_ban_offence(&self) -> bool {
+        !matches!(
+            self,
+            Self::NewAndExistingMismatch { .. } | Self::ValidatorError(PeerValidatorError::PeerHasNoAddresses { .. })
+        )
+    }
+}
+
 /// Validator for Peers
 pub struct PeerValidator<'a> {
     config: &'a DhtConfig,
@@ -105,13 +119,15 @@ impl<'a> PeerValidator<'a> {
             )
         });
 
+        let mut accepted_address_count = 0;
         for claim in new_peer.claims {
-            peer_validator::validate_peer_identity_claim(
+            let valid_addresses = peer_validator::validate_and_filter_peer_identity_claim_addresses(
                 &self.config.peer_validator_config,
                 &new_peer.public_key,
                 &claim,
             )?;
-            peer.update_addresses(&claim.addresses, &PeerAddressSource::FromDiscovery {
+            accepted_address_count += valid_addresses.len();
+            peer.update_addresses(&valid_addresses, &PeerAddressSource::FromDiscovery {
                 peer_identity_claim: claim.clone(),
             });
             trace!(
@@ -119,8 +135,21 @@ impl<'a> PeerValidator<'a> {
                 "Peer '{}' / '{}' added with address(es) from claim: {:?}",
                 node_id,
                 new_peer.public_key.to_hex(),
-                claim.addresses
+                valid_addresses
             );
+        }
+
+        if accepted_address_count == 0 {
+            if peer.addresses.iter().any(|address| address.is_external()) {
+                trace!(
+                    target: LOG_TARGET,
+                    "Peer '{}' / '{}' supplied no usable new addresses; retaining its existing addresses",
+                    node_id,
+                    new_peer.public_key.to_hex()
+                );
+                return Ok(peer);
+            }
+            return Err(PeerValidatorError::PeerHasNoAddresses { peer: node_id }.into());
         }
 
         Ok(peer)
@@ -133,7 +162,7 @@ mod tests {
 
     use tari_comms::{
         multiaddr::Multiaddr,
-        peer_manager::{IdentitySignature, PeerFeatures, PeerIdentityClaim},
+        peer_manager::{IdentitySignature, NodeIdentity, PeerFeatures, PeerIdentityClaim},
         types::{CompressedSignature, Signature},
     };
     use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
@@ -141,6 +170,38 @@ mod tests {
 
     use super::*;
     use crate::test_utils::make_node_identity;
+
+    fn make_unvalidated_peer(addresses: Vec<Multiaddr>) -> UnvalidatedPeerInfo {
+        let node_identity = NodeIdentity::random_multiple_addresses(
+            &mut rand::rng(),
+            addresses.clone(),
+            PeerFeatures::COMMUNICATION_NODE,
+        );
+        let signature = node_identity
+            .identity_signature_read()
+            .as_ref()
+            .expect("node identity must be signed")
+            .clone();
+        UnvalidatedPeerInfo {
+            public_key: node_identity.public_key().clone(),
+            claims: vec![PeerIdentityClaim {
+                addresses,
+                features: PeerFeatures::COMMUNICATION_NODE,
+                signature,
+            }],
+        }
+    }
+
+    #[test]
+    fn peers_without_usable_addresses_are_not_ban_offences() {
+        let error = DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoAddresses {
+            peer: NodeId::default(),
+        });
+        assert!(!error.is_ban_offence());
+
+        let error = DhtPeerValidatorError::IdentityTooManyClaims { length: 2, max: 1 };
+        assert!(error.is_ban_offence());
+    }
 
     #[tokio::test]
     async fn it_errors_with_invalid_signature() {
@@ -189,5 +250,114 @@ mod tests {
             err,
             DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoAddresses { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn it_filters_local_addresses_but_keeps_the_peer() {
+        let valid: Multiaddr = "/ip4/23.23.23.23/tcp/18189".parse().unwrap();
+        let loopback: Multiaddr = "/ip4/127.0.0.1/tcp/18189".parse().unwrap();
+        let private: Multiaddr = "/ip4/192.168.1.2/tcp/18189".parse().unwrap();
+        let link_local: Multiaddr = "/ip4/169.254.1.2/tcp/18189".parse().unwrap();
+        let private_ipv6: Multiaddr = "/ip6/fc00::1/tcp/18189".parse().unwrap();
+        let mapped_loopback: Multiaddr = "/ip6/::ffff:127.0.0.1/tcp/18189".parse().unwrap();
+        let internal_dns: Multiaddr = "/dns4/node.internal/tcp/18189".parse().unwrap();
+        let claimed_addresses = vec![
+            valid.clone(),
+            loopback.clone(),
+            private.clone(),
+            link_local.clone(),
+            private_ipv6.clone(),
+            mapped_loopback.clone(),
+            internal_dns.clone(),
+        ];
+        let claimed_address_count = claimed_addresses.len();
+        let new_peer = make_unvalidated_peer(claimed_addresses);
+        let mut config = DhtConfig::default_local_test();
+        config.peer_validator_config.allow_test_addresses = false;
+        config.peer_validator_config.max_permitted_peer_addresses_per_claim = claimed_address_count;
+
+        let peer = PeerValidator::new(&config)
+            .validate_peer(new_peer, None)
+            .expect("a peer with a valid public address must be retained");
+
+        assert_eq!(peer.addresses.len(), 1);
+        assert!(peer.addresses.contains(&valid));
+        assert!(!peer.addresses.contains(&loopback));
+        assert!(!peer.addresses.contains(&private));
+        assert!(!peer.addresses.contains(&link_local));
+        assert!(!peer.addresses.contains(&private_ipv6));
+        assert!(!peer.addresses.contains(&mapped_loopback));
+        assert!(!peer.addresses.contains(&internal_dns));
+    }
+
+    #[tokio::test]
+    async fn it_rejects_a_peer_with_only_local_addresses() {
+        let new_peer = make_unvalidated_peer(vec![
+            "/ip4/127.0.0.1/tcp/18189".parse().unwrap(),
+            "/ip4/10.0.0.2/tcp/18189".parse().unwrap(),
+            "/ip6/fe80::1/tcp/18189".parse().unwrap(),
+        ]);
+        let mut config = DhtConfig::default_local_test();
+        config.peer_validator_config.allow_test_addresses = false;
+
+        let err = PeerValidator::new(&config).validate_peer(new_peer, None).unwrap_err();
+
+        assert!(matches!(
+            err,
+            DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoAddresses { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn it_keeps_existing_addresses_after_an_all_local_update() {
+        let new_peer = make_unvalidated_peer(vec![
+            "/ip4/127.0.0.1/tcp/18189".parse().unwrap(),
+            "/ip4/192.168.1.2/tcp/18189".parse().unwrap(),
+        ]);
+        let node_id = NodeId::from_public_key(&new_peer.public_key);
+        let existing_address: Multiaddr = "/ip4/23.23.23.23/tcp/18189".parse().unwrap();
+        let mut existing_peer = Peer::new(
+            new_peer.public_key.clone(),
+            node_id,
+            MultiaddressesWithStats::default(),
+            PeerFlags::default(),
+            PeerFeatures::COMMUNICATION_NODE,
+            vec![],
+            String::new(),
+        );
+        existing_peer.addresses = MultiaddressesWithStats::from_addresses_with_source(
+            vec![existing_address.clone()],
+            &PeerAddressSource::Config,
+        );
+        let mut config = DhtConfig::default_local_test();
+        config.peer_validator_config.allow_test_addresses = false;
+
+        let peer = PeerValidator::new(&config)
+            .validate_peer(new_peer, Some(existing_peer))
+            .expect("an all-local update must not discard a reachable existing peer");
+
+        assert_eq!(peer.addresses.len(), 1);
+        assert!(peer.addresses.contains(&existing_address));
+    }
+
+    #[tokio::test]
+    async fn it_keeps_local_addresses_when_test_addresses_are_allowed() {
+        let addresses = vec![
+            "/ip4/127.0.0.1/tcp/18189".parse().unwrap(),
+            "/ip4/192.168.1.2/tcp/18189".parse().unwrap(),
+            "/ip6/fe80::1/tcp/18189".parse().unwrap(),
+            "/dns4/node.internal/tcp/18189".parse().unwrap(),
+        ];
+        let new_peer = make_unvalidated_peer(addresses.clone());
+        let config = DhtConfig::default_local_test();
+
+        let peer = PeerValidator::new(&config)
+            .validate_peer(new_peer, None)
+            .expect("test addresses must be retained when explicitly allowed");
+
+        assert_eq!(peer.addresses.len(), addresses.len());
+        for address in addresses {
+            assert!(peer.addresses.contains(&address));
+        }
     }
 }

--- a/comms/dht/src/peer_validator.rs
+++ b/comms/dht/src/peer_validator.rs
@@ -51,10 +51,11 @@ impl DhtPeerValidatorError {
     /// misconfigured. Dropping that update is sufficient; it is not evidence of
     /// hostile behavior.
     pub fn is_ban_offence(&self) -> bool {
-        !matches!(
-            self,
-            Self::NewAndExistingMismatch { .. } | Self::ValidatorError(PeerValidatorError::PeerHasNoAddresses { .. })
-        )
+        match self {
+            Self::ValidatorError(err) => err.is_ban_offence(),
+            Self::IdentityTooManyClaims { .. } => true,
+            Self::NewAndExistingMismatch { .. } => false,
+        }
     }
 }
 
@@ -149,7 +150,7 @@ impl<'a> PeerValidator<'a> {
                 );
                 return Ok(peer);
             }
-            return Err(PeerValidatorError::PeerHasNoAddresses { peer: node_id }.into());
+            return Err(PeerValidatorError::PeerHasNoUsableAddresses { peer: node_id }.into());
         }
 
         Ok(peer)
@@ -195,6 +196,11 @@ mod tests {
     #[test]
     fn peers_without_usable_addresses_are_not_ban_offences() {
         let error = DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoAddresses {
+            peer: NodeId::default(),
+        });
+        assert!(!error.is_ban_offence());
+
+        let error = DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoUsableAddresses {
             peer: NodeId::default(),
         });
         assert!(!error.is_ban_offence());
@@ -304,7 +310,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoAddresses { .. })
+            DhtPeerValidatorError::ValidatorError(PeerValidatorError::PeerHasNoUsableAddresses { .. })
         ));
     }
 


### PR DESCRIPTION
Description
---

Filter disallowed local/test addresses out of signed peer identity claims after verifying the original claim, while retaining that claim for signature verification and address provenance.

- Apply the filtering path to connection handshakes as well as DHT peer validation.
- Accept mixed public/local claims and use only their permitted addresses for storage and dialing.
- Drop new claims with no usable addresses without issuing a ban.
- Preserve an existing peer's known usable addresses when an all-local update arrives.
- Reject IPv4 unspecified, loopback, RFC1918, link-local, multicast, broadcast, documentation, `0.0.0.0/8`, and reserved `240.0.0.0/4` addresses.
- Reject IPv6 unspecified, loopback, unique-local, link-local, multicast, documentation, and IPv4-mapped or IPv4-compatible local addresses.
- Reject DNS-style internal names such as `localhost`, `.local`, `.internal`, `.lan`, `.localdomain`, and `home.arpa`.
- Reuse the same classifier for validation and the peer database's external-address flag.
- Preserve the existing opt-in behavior when test addresses are allowed.

Fixes #7935

Motivation and Context
---

A valid signature proves that a peer authored its address claim, but it does not make loopback or private addresses useful to another node. Filtering therefore happens only after verifying the original, unmodified signed claim. This avoids storing or dialing unusable local addresses without discarding or banning a peer that also advertises a valid route.

Persistence and propagation scope
---

`is_external` is persisted in the peer database. This patch does not eagerly rewrite existing rows; their classification converges when an address is next inserted or updated.

The original signed claim remains unmodified and may continue to be gossiped because its signature covers the complete claim. Recipients filter the claim before storing or dialing its addresses.

How Has This Been Tested?
---

- `cargo test -p tari_comms connection_manager::common::test --lib`
  - 2 passed
- `cargo test -p tari_comms net_address::multiaddr_with_stats::test --lib`
  - 5 passed
- `cargo test -p tari_comms peer_validator::helpers::test --lib`
  - 4 passed
- `cargo test -p tari_comms_dht peer_validator::tests --lib`
  - 7 passed
- Peer-database classification tests:
  - `test_filtering_peers_by_transport_protocols`
  - both `discovery_syncing_peers_with_external_addresses_only` implementations
  - all passed
- `cargo clippy -p tari_comms -p tari_comms_dht --lib --tests -- -D warnings -A clippy::result_large_err`
  - passed; the allow is for a pre-existing warning in `comms/core/src/test_utils/mocks/connection_manager.rs`

What process can a PR reviewer use to test or verify this change?
---

Run the commands above. The tests cover valid signatures with mixed claims on both handshake and DHT paths, all-local claims for new and existing peers, non-ban semantics, the explicit `allow_test_addresses = true` path, invalid signatures, address-class boundaries, DNS false positives, trailing-dot FQDNs, and structural-error ordering.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
