### PR TITLE
feat: extra warning for printing seed words

### DIFF
--- a/applications/minotari_console_wallet/src/init/mod.rs
+++ b/applications/minotari_console_wallet/src/init/mod.rs
@@ -23,7 +23,13 @@
 // This is here because this crate is used as a lib and a binary, mainly to support Cucumber tests. In future, something
 // should be done so this is not needed.
 #![allow(dead_code, unused)]
-use std::{fs, io, path::PathBuf, sync::Arc, time::Instant};
+use std::{
+    fs,
+    io,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Instant,
+};
 
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, is_raw_mode_enabled};
 use dialoguer::Input as InputPrompt;
@@ -455,6 +461,41 @@ pub(crate) fn confirm_seed_words(wallet: &mut WalletSqlite) -> Result<(), ExitEr
         match readline {
             Ok(line) => match line.to_lowercase().as_ref() {
                 "confirm" => return Ok(()),
+                _ => continue,
+            },
+            Err(e) => {
+                return Err(ExitError::new(ExitCode::IOError, e));
+            },
+        }
+    }
+}
+
+/// Confirm with the user that the wallet seed words may be written, in the clear, to the given file.
+///
+/// This is only asked when the wallet passphrase was not supplied up front (via the CLI or the config file), as in
+/// that case the wallet is being driven interactively and the user may not have intended to export the seed words.
+///
+/// Returns `true` if and only if the user confirmed the export.
+pub(crate) fn confirm_seed_words_file(file_name: &Path) -> Result<bool, ExitError> {
+    println!();
+    println!("=========================");
+    println!("       IMPORTANT!        ");
+    println!("=========================");
+    println!("You asked for the wallet seed words to be written to:");
+    println!("  {}", file_name.display());
+    println!("They will be written unencrypted; anyone able to read that file can spend your funds.");
+    println!();
+    println!("\x07"); // beep!
+
+    let mut rl = Editor::<()>::new();
+    loop {
+        println!("Are you sure you want to write the seed words to this file?");
+        println!(r#"Type "yes" or "y" to continue, or "no" or "n" to start the wallet without exporting them."#);
+        let readline = rl.readline(">> ");
+        match readline {
+            Ok(line) => match line.trim().to_lowercase().as_ref() {
+                "yes" | "y" => return Ok(true),
+                "no" | "n" => return Ok(false),
                 _ => continue,
             },
             Err(e) => {

--- a/applications/minotari_console_wallet/src/lib.rs
+++ b/applications/minotari_console_wallet/src/lib.rs
@@ -58,7 +58,6 @@ use tari_common::{
 };
 use tari_common_types::seeds::cipher_seed::CipherSeed;
 use tari_shutdown::Shutdown;
-use tari_utilities::SafePassword;
 use tokio::runtime::Runtime;
 use wallet_modes::{WalletMode, command_mode, grpc_mode, recovery_mode, script_mode, tui_mode};
 
@@ -133,11 +132,10 @@ pub fn run_wallet_with_cli(
         consts::APP_VERSION
     );
 
-    let password = get_password(config, &cli);
     // Whether the passphrase was supplied up front, i.e. without the wallet having to prompt for it
-    let password_supplied = password.is_some();
+    let password_supplied = password_supplied(config, &cli);
 
-    if password.is_none() {
+    if !password_supplied {
         tari_splash_screen("Console Wallet");
     }
 
@@ -154,7 +152,7 @@ pub fn run_wallet_with_cli(
 
     let recovery_seed = get_recovery_seed(boot_mode, &cli, &wallet_type)?;
 
-    // get command line password if provided
+    // Determine where, if anywhere, the seed words should be written on startup
     let seed_words_file_name = match cli.seed_words_file_name.clone() {
         // The passphrase was not supplied up front, so the user is here interactively; make sure that writing the
         // seed words to disk in the clear is really what they want.
@@ -265,11 +263,10 @@ pub fn run_wallet_with_cli(
     result
 }
 
-fn get_password(config: &ApplicationConfig, cli: &Cli) -> Option<SafePassword> {
-    cli.password
-        .as_ref()
-        .or(config.wallet.password.as_ref())
-        .map(|s| s.to_owned())
+/// Returns `true` if the wallet passphrase was supplied on the command line or in the config file, meaning the wallet
+/// will not have to prompt the user for it.
+fn password_supplied(config: &ApplicationConfig, cli: &Cli) -> bool {
+    cli.password.is_some() || config.wallet.password.is_some()
 }
 
 fn get_recovery_seed(

--- a/applications/minotari_console_wallet/src/lib.rs
+++ b/applications/minotari_console_wallet/src/lib.rs
@@ -64,7 +64,14 @@ use wallet_modes::{WalletMode, command_mode, grpc_mode, recovery_mode, script_mo
 
 pub use crate::config::ApplicationConfig;
 use crate::{
-    init::{boot_with_password, confirm_direct_only_send, confirm_seed_words, prompt_wallet_type, wallet_mode},
+    init::{
+        boot_with_password,
+        confirm_direct_only_send,
+        confirm_seed_words,
+        confirm_seed_words_file,
+        prompt_wallet_type,
+        wallet_mode,
+    },
     recovery::prompt_private_key_from_seed_words,
 };
 
@@ -127,6 +134,8 @@ pub fn run_wallet_with_cli(
     );
 
     let password = get_password(config, &cli);
+    // Whether the passphrase was supplied up front, i.e. without the wallet having to prompt for it
+    let password_supplied = password.is_some();
 
     if password.is_none() {
         tari_splash_screen("Console Wallet");
@@ -146,7 +155,19 @@ pub fn run_wallet_with_cli(
     let recovery_seed = get_recovery_seed(boot_mode, &cli, &wallet_type)?;
 
     // get command line password if provided
-    let seed_words_file_name = cli.seed_words_file_name.clone();
+    let seed_words_file_name = match cli.seed_words_file_name.clone() {
+        // The passphrase was not supplied up front, so the user is here interactively; make sure that writing the
+        // seed words to disk in the clear is really what they want.
+        Some(file_name) if !password_supplied => {
+            if confirm_seed_words_file(&file_name)? {
+                Some(file_name)
+            } else {
+                println!("Seed words will not be written to file.");
+                None
+            }
+        },
+        seed_words_file_name => seed_words_file_name,
+    };
 
     let shutdown_signal = shutdown.to_signal();
 


### PR DESCRIPTION
Description
---
If the wallet is not running via an automated system, add an extra user verifies step to ensure the user wants to print the seed words