### PR TITLE
fix(mmr): return an error instead of panicking on malformed merkle pr…

### DIFF
--- a/base_layer/mmr/src/balanced_binary_merkle_proof.rs
+++ b/base_layer/mmr/src/balanced_binary_merkle_proof.rs
@@ -160,12 +160,17 @@ where D: Digest
                     let parent = indices.get(index).expect("Index should expect").saturating_sub(1) >> 1;
                     if let Some(other_proof_idx) = hash_map.insert(parent, index) {
                         *join_indices.get_mut(index).expect("Index should expect") = true;
-                        // The other proof doesn't need a hash, it needs an index to this hash
+                        // The other proof doesn't need a hash, it needs an index to this hash. It must have
+                        // contributed a hash at this height, otherwise the proofs we were given cannot be merged
+                        // (e.g. more than two proofs sharing the same parent).
                         *paths
                             .get_mut(other_proof_idx)
-                            .expect("should exist")
+                            .ok_or(BalancedBinaryMerkleProofError::BadProofSemantics)?
                             .first_mut()
-                            .unwrap() = MergedBalancedBinaryMerkleIndexOrHash::Index(index as u64);
+                            .ok_or(BalancedBinaryMerkleProofError::BadProofSemantics)? =
+                            MergedBalancedBinaryMerkleIndexOrHash::Index(
+                                u64::try_from(index).map_err(|_| BalancedBinaryMerkleProofError::MathOverflow)?,
+                            );
                     } else {
                         paths.get_mut(index).expect("should exist").insert(
                             0,
@@ -198,7 +203,7 @@ where D: Digest
     ) -> Result<bool, BalancedBinaryMerkleProofError> {
         // Check that the proof and verifier data match
         let n = self.node_indices.len(); // number of merged proofs
-        if self.paths.len() != n || leaf_hashes.len() != n {
+        if self.paths.len() != n || self.heights.len() != n || leaf_hashes.len() != n {
             return Err(BalancedBinaryMerkleProofError::BadProofSemantics);
         }
 
@@ -316,6 +321,34 @@ mod test {
                 .verify_consume(&root, vec![leaves[0].clone(), leaves[1].clone()])
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn test_merged_proof_with_short_heights_is_rejected() {
+        // `heights` is deserialised along with the rest of the proof, so it may not line up with the other fields
+        let proof = MergedBalancedBinaryMerkleProof::<TestHasher> {
+            paths: vec![vec![], vec![]],
+            node_indices: vec![0, 1],
+            heights: vec![1],
+            _phantom: PhantomData,
+        };
+        assert!(matches!(
+            proof.verify_consume(&vec![0u8; 32], vec![vec![], vec![]]).unwrap_err(),
+            BalancedBinaryMerkleProofError::BadProofSemantics
+        ));
+    }
+
+    #[test]
+    fn test_merging_proofs_that_share_a_parent_is_rejected() {
+        // Three proofs for the same leaf all share a parent, so they cannot be merged into a single proof
+        let leaves = (0..4usize)
+            .map(|i| vec![u8::try_from(i).unwrap(); 32])
+            .collect::<Vec<_>>();
+        let bmt = BalancedBinaryMerkleTree::<TestHasher>::create(leaves);
+        let proof = BalancedBinaryMerkleProof::generate_proof(&bmt, 0).unwrap();
+        let err =
+            MergedBalancedBinaryMerkleProof::create_from_proofs(&[proof.clone(), proof.clone(), proof]).unwrap_err();
+        assert!(matches!(err, BalancedBinaryMerkleProofError::BadProofSemantics));
     }
 
     #[test]

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -108,7 +108,12 @@ pub fn find_peaks(size: usize) -> Option<Vec<usize>> {
 #[allow(clippy::arithmetic_side_effects)]
 pub fn family(pos: usize) -> Result<(usize, usize), MerkleMountainRangeError> {
     let (peak_map, height) = peak_map_height(pos);
-    let peak = 1 << height;
+    // The type of the literal must be given explicitly. Inference only sees the `i128::from` below, which is
+    // satisfied by many integer types, so the literal would otherwise default to `i32` and the shift would silently
+    // produce `i32::MIN` at height 31 and panic (overflow checks are enabled for release builds too) at height 32
+    // and above. The smallest node index at height `h` is `2^(h+1) - 2`, so `height` is at most 63 for a `usize`
+    // position and the shift below can never overflow a `u64`.
+    let peak: u64 = 1 << height;
 
     // Convert to i128 so that we don't over/underflow, and then we will cast back to usize after
     let pos = pos as i128;
@@ -134,7 +139,8 @@ pub fn family_branch(pos: usize, last_pos: usize) -> Vec<(usize, usize)> {
     // loop going up the tree, from node to parent, as long as we stay inside
     // the tree (as defined by last_pos).
     let (peak_map, height) = peak_map_height(pos);
-    let mut peak = 1 << height;
+    // `height` is at most 63 for a `usize` position, so the shift cannot overflow
+    let mut peak: usize = 1 << height;
     let mut branch = vec![];
     let mut current = pos;
     let mut sibling;
@@ -192,7 +198,8 @@ pub fn peak_map_height(mut pos: usize) -> (usize, usize) {
 /// Is the node at this pos the "left" sibling of its parent?
 pub fn is_left_sibling(pos: usize) -> bool {
     let (peak_map, height) = peak_map_height(pos);
-    let peak = 1 << height;
+    // `height` is at most 63 for a `usize` position, so the shift cannot overflow
+    let peak: usize = 1 << height;
     (peak_map & peak) == 0
 }
 
@@ -346,6 +353,23 @@ mod test {
         assert_eq!(family(15).unwrap(), (17, 16));
         assert_eq!(family(6).unwrap(), (14, 13));
         assert_eq!(family(13).unwrap(), (14, 6));
+    }
+
+    /// The peak of a node must be calculated in a type wide enough to hold it. The first node at height `h` sits at
+    /// index `2^(h+1) - 2` and is a left child, so its parent is `2^(h+1)` positions further along and its sibling is
+    /// the node just before the parent.
+    #[test]
+    fn families_at_every_height() {
+        for height in 0..63u32 {
+            let peak = 1usize << height.saturating_add(1);
+            let pos = peak.saturating_sub(2);
+            assert_eq!(
+                family(pos).unwrap(),
+                (pos.saturating_add(peak), pos.saturating_add(peak).saturating_sub(1)),
+                "family({pos}) at height {height}"
+            );
+            assert!(is_left_sibling(pos), "is_left_sibling({pos}) at height {height}");
+        }
     }
 
     #[test]

--- a/base_layer/mmr/src/merkle_proof.rs
+++ b/base_layer/mmr/src/merkle_proof.rs
@@ -190,19 +190,23 @@ impl MerkleProof {
         if peaks.len() != self.peaks.len().saturating_add(1) {
             return Err(MerkleProofError::IncorrectPeakMap);
         }
-        let hasher = D::new();
+        let mut hasher = D::new();
         // We're going to hash the peaks together, but insert the provided hash in the correct position.
-        let peak_hashes = self.peaks.iter();
-        let (hasher, _) = peaks
-            .iter()
-            .fold((hasher, peak_hashes), |(hasher, mut peak_hashes), i| {
-                if *i == pos {
-                    (hasher.chain_update(hash), peak_hashes)
-                } else {
-                    let hash = peak_hashes.next().unwrap();
-                    (hasher.chain_update(hash), peak_hashes)
-                }
-            });
+        // A malformed proof can walk us up to a position that is not a canonical peak, in which case we would consume
+        // more peak hashes than the proof provides. That is an invalid proof, not a reason to panic.
+        let mut peak_hashes = self.peaks.iter();
+        for peak_pos in peaks {
+            if *peak_pos == pos {
+                hasher = hasher.chain_update(hash);
+            } else {
+                let peak_hash = peak_hashes.next().ok_or(MerkleProofError::IncorrectPeakMap)?;
+                hasher = hasher.chain_update(peak_hash);
+            }
+        }
+        // Every hash given in the proof must have been used, otherwise the candidate position was not a peak.
+        if peak_hashes.next().is_some() {
+            return Err(MerkleProofError::IncorrectPeakMap);
+        }
         Ok(hasher.finalize().to_vec())
     }
 
@@ -238,7 +242,7 @@ impl MerkleProof {
 
         let sibling = self.path.remove(0); // FIXME Compare perf vs using a VecDeque
         let (parent_pos, sibling_pos) = family(pos)?;
-        if parent_pos > self.mmr_size {
+        if parent_pos >= self.mmr_size {
             Err(MerkleProofError::Unexpected)
         } else {
             let parent = if is_left_sibling(sibling_pos) {

--- a/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
+++ b/base_layer/mmr/src/sparse_merkle_tree/proofs.rs
@@ -107,33 +107,23 @@ trait MerkleProofDigest<H: Digest<OutputSize = U32>> {
     /// Returns an array to the vector of sibling hashes along the path to the key's leaf node for this proof.
     fn siblings(&self) -> &[NodeHash];
 
-    /// Calculate the Merkle& tree root for this proof, given the key and value hash.
-    fn calculate_root_hash(&self, key: &NodeKey, leaf_hash: NodeHash) -> NodeHash {
+    /// Calculate the Merkle tree root for this proof, given the key and value hash. Returns `None` if the proof is
+    /// malformed, i.e. it carries more siblings than there are bits in a key, since there is no key for that height.
+    fn calculate_root_hash(&self, key: &NodeKey, leaf_hash: NodeHash) -> Option<NodeHash> {
         let n = self.siblings().len();
         let dirs = key.as_directions().take(n);
-        let hash = self.siblings().iter().zip(dirs).rev().enumerate().fold(
-            leaf_hash,
-            |current, (i, (sibling_hash, direction))| {
-                let height = n.saturating_sub(i).saturating_sub(1);
-                match direction {
-                    TraverseDirection::Left => BranchNode::<H>::branch_hash(
-                        height,
-                        &height_key(key, height).expect("Should exist"),
-                        &current,
-                        sibling_hash,
-                    ),
-                    TraverseDirection::Right => BranchNode::<H>::branch_hash(
-                        height,
-                        &height_key(key, height).expect("Should exist"),
-                        sibling_hash,
-                        &current,
-                    ),
-                }
-            },
-        );
+        let mut current = leaf_hash;
+        for (i, (sibling_hash, direction)) in self.siblings().iter().zip(dirs).rev().enumerate() {
+            let height = n.saturating_sub(i).saturating_sub(1);
+            let height_key = height_key(key, height)?;
+            current = match direction {
+                TraverseDirection::Left => BranchNode::<H>::branch_hash(height, &height_key, &current, sibling_hash),
+                TraverseDirection::Right => BranchNode::<H>::branch_hash(height, &height_key, sibling_hash, &current),
+            };
+        }
         let mut result = [0; 32];
-        result.copy_from_slice(hash.as_slice());
-        result.into()
+        result.copy_from_slice(current.as_slice());
+        Some(result.into())
     }
 }
 
@@ -170,8 +160,11 @@ impl<H: Digest<OutputSize = U32>> InclusionProof<H> {
     pub fn validate(&self, expected_key: &NodeKey, expected_value: &ValueHash, expected_root: &NodeHash) -> bool {
         // calculate expected leaf node hash
         let leaf_hash = LeafNode::<H>::hash_value(expected_key, expected_value);
-        let calculated_root = self.calculate_root_hash(expected_key, leaf_hash);
-        calculated_root == *expected_root
+        match self.calculate_root_hash(expected_key, leaf_hash) {
+            Some(calculated_root) => calculated_root == *expected_root,
+            // The proof is malformed, so it cannot be valid
+            None => false,
+        }
     }
 }
 
@@ -215,7 +208,10 @@ impl<H: Digest<OutputSize = U32>> ExclusionProof<H> {
             Some(leaf) => leaf.hash().clone(),
             None => (EmptyNode {}).hash().clone(),
         };
-        let root = self.calculate_root_hash(expected_key, leaf_hash);
+        // If the proof is malformed, a root cannot be calculated and the proof cannot be valid
+        let Some(root) = self.calculate_root_hash(expected_key, leaf_hash) else {
+            return false;
+        };
         // For exclusion proof, roots must match AND existing leaf must be empty, or keys must not match
         root == *expected_root &&
             match &self.leaf {
@@ -237,6 +233,23 @@ mod test {
     use blake2::Blake2b;
 
     use super::*;
+    use crate::sparse_merkle_tree::node::KEY_LENGTH;
+
+    #[test]
+    fn proof_with_too_many_siblings_is_rejected() {
+        // A proof cannot have more siblings than there are bits in a key, since there is no key for those heights.
+        // Such a proof is malformed and must be rejected rather than panicking.
+        let key = NodeKey::from([64u8; 32]);
+        let value = ValueHash::from([128u8; 32]);
+        let root = NodeHash::from([0u8; 32]);
+        let siblings = vec![NodeHash::from([1u8; 32]); KEY_LENGTH * 8 + 1];
+
+        let in_proof = InclusionProof::<Blake2b<U32>>::new(siblings.clone());
+        assert!(!in_proof.validate(&key, &value, &root));
+
+        let ex_proof = ExclusionProof::<Blake2b<U32>>::new(siblings, None);
+        assert!(!ex_proof.validate(&key, &root));
+    }
 
     #[test]
     fn root_proof() {

--- a/base_layer/mmr/tests/tests/merkle_proof.rs
+++ b/base_layer/mmr/tests/tests/merkle_proof.rs
@@ -95,6 +95,131 @@ fn for_leaf_node() {
     )
 }
 
+/// A proof whose sibling path has been truncated must be rejected with an error, not panic. The truncated path
+/// terminates the walk at a position that is not a canonical peak, so the peak hashes given in the proof are not
+/// enough to hash the peaks together.
+#[test]
+fn truncated_path_is_rejected() {
+    let mmr = create_mmr(4);
+    let root = mmr.get_merkle_root().unwrap();
+    let hash = int_to_hash(0);
+
+    let proof = MerkleProof::for_node(&mmr, 0).unwrap();
+    assert!(proof.verify::<MmrTestHasherBlake256>(&root, &hash, 0).is_ok());
+
+    let mut truncated = proof;
+    truncated.path.pop();
+    assert_eq!(
+        truncated.verify::<MmrTestHasherBlake256>(&root, &hash, 0),
+        Err(MerkleProofError::IncorrectPeakMap)
+    );
+}
+
+/// A proof with extra siblings appended to the path must be rejected with an error, not panic. The walk continues
+/// past the local peak, ending up outside of the MMR.
+#[test]
+fn padded_path_is_rejected() {
+    let mmr = create_mmr(4);
+    let root = mmr.get_merkle_root().unwrap();
+    let hash = int_to_hash(0);
+
+    let mut padded = MerkleProof::for_node(&mmr, 0).unwrap();
+    padded.path.push(int_to_hash(1024));
+    assert_eq!(
+        padded.verify::<MmrTestHasherBlake256>(&root, &hash, 0),
+        Err(MerkleProofError::Unexpected)
+    );
+}
+
+/// A hand-crafted proof that claims an MMR size but provides no path and no peaks at all must be rejected with an
+/// error, not panic.
+#[test]
+fn empty_hand_crafted_proof_is_rejected() {
+    let mmr = create_mmr(2);
+    let root = mmr.get_merkle_root().unwrap();
+    let hash = int_to_hash(0);
+
+    let proof = MerkleProof {
+        mmr_size: 3,
+        path: Vec::new(),
+        peaks: Vec::new(),
+    };
+    assert_eq!(
+        proof.verify::<MmrTestHasherBlake256>(&root, &hash, 0),
+        Err(MerkleProofError::IncorrectPeakMap)
+    );
+}
+
+/// Neither truncating nor padding the sibling path of an otherwise valid proof may panic, and no mangled proof may
+/// verify.
+#[test]
+fn mangled_proofs_never_panic_or_verify() {
+    for size in 1..24 {
+        let mmr = create_mmr(size);
+        let root = mmr.get_merkle_root().unwrap();
+        let mut hash_value = 0usize;
+        for pos in 0..mmr.len().unwrap() {
+            if !is_leaf(pos) {
+                continue;
+            }
+            let hash = int_to_hash(hash_value);
+            hash_value += 1;
+            let proof = MerkleProof::for_node(&mmr, pos).unwrap();
+            // The proof we are about to mangle must itself be valid, otherwise the assertions below prove nothing
+            assert!(proof.verify::<MmrTestHasherBlake256>(&root, &hash, pos).is_ok());
+
+            // Truncate the path, one sibling at a time
+            for n in 0..proof.path.len() {
+                let mut mangled = proof.clone();
+                mangled.path.truncate(n);
+                assert!(mangled.verify::<MmrTestHasherBlake256>(&root, &hash, pos).is_err());
+            }
+
+            // Pad the path with junk siblings
+            for n in 1..4 {
+                let mut mangled = proof.clone();
+                for i in 0..n {
+                    mangled.path.push(int_to_hash(1024 + i));
+                }
+                assert!(mangled.verify::<MmrTestHasherBlake256>(&root, &hash, pos).is_err());
+            }
+
+            // Drop the peak hashes
+            if !proof.peaks.is_empty() {
+                let mut mangled = proof.clone();
+                mangled.peaks.clear();
+                assert!(mangled.verify::<MmrTestHasherBlake256>(&root, &hash, pos).is_err());
+            }
+
+            // Add a junk peak hash
+            let mut mangled = proof.clone();
+            mangled.peaks.push(int_to_hash(2048));
+            assert!(mangled.verify::<MmrTestHasherBlake256>(&root, &hash, pos).is_err());
+        }
+    }
+}
+
+/// Walking a proof up past height 31 must return an error rather than overflowing the shift used to calculate the
+/// peak of a node. Both the `mmr_size` and the path are provided by whoever sent us the proof, and the leaf index is
+/// provided by the caller, so none of them can be trusted.
+#[test]
+fn proof_that_walks_past_height_31_is_rejected() {
+    let mmr = create_mmr(2);
+    let root = mmr.get_merkle_root().unwrap();
+    let hash = int_to_hash(0);
+
+    let proof = MerkleProof {
+        mmr_size: usize::MAX,
+        path: vec![int_to_hash(0); 33],
+        peaks: Vec::new(),
+    };
+    assert!(
+        proof
+            .verify_leaf::<MmrTestHasherBlake256>(&root, &hash, LeafIndex(1usize << 31))
+            .is_err()
+    );
+}
+
 const JSON_PROOF: &str = r#"{"mmr_size":8,"path":["2e53af27cab59e217386f5138cbac4f0ee53087e8fd1500b8ef836d7e80fd9a8","aa72bf6d136aac5df8faec94246439f7045487a1bd9984101f46fa926f527e8d"],"peaks":["fd11974cff85dcac247817c33efaf3f7b8c9bc43e980dd80553af84231389088"]}"#;
 const BINCODE_PROOF: &str = "0800000000000000020000000000000020000000000000002e53af27cab59e217386f5138cbac4f0ee53087e8fd1500b8ef836d7e80fd9a82000000000000000aa72bf6d136aac5df8faec94246439f7045487a1bd9984101f46fa926f527e8d01000000000000002000000000000000fd11974cff85dcac247817c33efaf3f7b8c9bc43e980dd80553af84231389088";
 


### PR DESCRIPTION
…oofs

`MerkleProof::verify()` panicked on malformed input rather than returning an error. `check_root()` only validated the length of the peak list and then unwrapped the peak hash iterator inside its fold. Any proof whose sibling path is truncated terminates the walk at a position that is not a canonical peak, so the fold consumed more items than the iterator held and unwrapped `None`. A hand-crafted proof with an empty path and no peaks panicked in the same way. Since these proofs are fetched from a remote node, a malicious peer could crash the verifying process.

The fold is now a loop that propagates `IncorrectPeakMap` when the proof does not carry a hash for every peak, and it also rejects proofs that carry more peak hashes than were consumed. The boundary check in `verify_consume()` is tightened to `parent_pos >= self.mmr_size`, since the largest valid node index is `mmr_size - 1`.

`family()` had the same problem one level down. The type of the literal in `let peak = 1 << height` was only constrained by the `i128::from()` below it, which many integer types satisfy, so it defaulted to `i32`. At height 31 that silently produced `i32::MIN`, corrupting both the peak mask and the parent arithmetic, and at height 32 and above it panicked with "attempt to shift left with overflow" - in release builds too, since the workspace enables overflow checks there. A proof with a long enough path and a large enough `mmr_size` walks a verification straight into it, and both of those, along with the leaf index, are supplied by the remote node in the burn claim flow. The literal is now typed as `u64`; the smallest node index at height `h` is `2^(h+1) - 2`, so `height` cannot exceed 63 for a `usize` position and the shift cannot overflow. The shifts in `family_branch()` and `is_left_sibling()` correctly infer `usize` from their surrounding arithmetic, but are now annotated to say so.

Auditing the rest of the crate for the same class of defect turned up three more panics reachable from proof data supplied by someone else:

- `InclusionProof::validate()` and `ExclusionProof::validate()` panicked for any proof carrying more siblings than there are bits in a key, since there is no key at that height. `calculate_root_hash()` now returns `None` and both validations return `false`.
- `MergedBalancedBinaryMerkleProof::verify_consume()` never checked the length of the deserialized `heights` field against the other fields and panicked when it was short.
- `MergedBalancedBinaryMerkleProof::create_from_proofs()` panicked when three or more proofs shared a parent; it now returns `BadProofSemantics`.

Valid proofs are unaffected, and nothing that previously failed to verify now verifies.

