### PR TITLE
fix: enforce safe limits on RPC request handling

### DIFF
--- a/applications/minotari_node/src/bootstrap.rs
+++ b/applications/minotari_node/src/bootstrap.rs
@@ -293,6 +293,7 @@ where B: BlockchainBackend + 'static
             .with_maximum_sessions_per_client(p2p_config.rpc_max_sessions_per_peer)
             .with_cull_oldest_peer_rpc_connection_on_full(p2p_config.cull_oldest_peer_rpc_connection_on_full)
             .with_idle_session_timeout(p2p_config.rpc_idle_session_timeout)
+            .with_maximum_client_deadline(p2p_config.rpc_maximum_client_deadline)
             .finish();
 
         // Add your RPC services here ‍🏴‍☠️️☮️🌊

--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -165,6 +165,16 @@ pub struct P2pConfig {
     /// Default: 10 minutes
     #[serde(with = "serializers::seconds")]
     pub rpc_idle_session_timeout: Duration,
+    /// The longest deadline the RPC server will honour from a client. The deadline bounds a single
+    /// service call and the gap between two messages of a streaming response, and arrives on the
+    /// wire as an unbounded number of seconds, so without a ceiling a peer can switch off those
+    /// timeouts entirely. Requests asking for more are clamped to this, not rejected; a request
+    /// that then runs past it gets a `Timeout` status. Raise it if peers legitimately need a longer
+    /// `rpc_deadline` than this allows. Values below the 1s minimum client deadline are floored at
+    /// it, so a misconfigured zero cannot stop the node serving.
+    /// Default: 10 minutes
+    #[serde(with = "serializers::seconds")]
+    pub rpc_maximum_client_deadline: Duration,
     /// The maximum time a seed peer connection is allowed to stay open before being forcibly closed.
     /// Default: 15 minutes
     #[serde(with = "serializers::seconds")]
@@ -195,6 +205,7 @@ impl Default for P2pConfig {
             rpc_max_sessions_per_peer: 10,
             cull_oldest_peer_rpc_connection_on_full: true,
             rpc_idle_session_timeout: Duration::from_secs(10 * 60),
+            rpc_maximum_client_deadline: Duration::from_secs(10 * 60),
             max_seed_peer_age: Duration::from_secs(15 * 60),
         }
     }

--- a/base_layer/transaction_components/src/validation/aggregate_body/aggregate_body_internal_validator.rs
+++ b/base_layer/transaction_components/src/validation/aggregate_body/aggregate_body_internal_validator.rs
@@ -108,19 +108,24 @@ impl AggregateBodyInternalConsistencyValidator {
     ) -> Result<(), AggregatedBodyValidationError> {
         let total_reward = total_reward.unwrap_or(MicroMinotari::zero());
 
+        let constants = self.consensus_manager.consensus_constants(height);
+
+        // Structural checks first. Everything below this point costs at least one signature
+        // verification per kernel or output, so the bound on how many of those there can be has to
+        // be applied before any of it runs - otherwise a peer can spend a single oversized
+        // `submit_transaction` to buy an unbounded amount of our CPU for a body we were always
+        // going to reject. Neither of these does any crypto.
+        check_weight(body, height, constants)?;
+        check_sorting_and_duplicates(body)?;
+
         // old internal validator
         verify_kernel_signatures(body)?;
-
-        let constants = self.consensus_manager.consensus_constants(height);
 
         validate_versions(body, constants)?;
 
         for output in body.outputs() {
             validate_individual_output(output, constants)?;
         }
-
-        check_weight(body, height, constants)?;
-        check_sorting_and_duplicates(body)?;
 
         // Check that inputs are allowed to be spent
         check_maturity(height, body.inputs())?;

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -195,6 +195,11 @@ listener_self_liveness_check_interval = 15
 # slot in `rpc_max_simultaneous_sessions`. Time spent servicing a request does not count towards this. A peer that
 # disappears without closing its substream would otherwise hold its session forever. (default value = 600).
 #rpc_idle_session_timeout = 600
+# The longest deadline, in seconds, the RPC server will honour from a client. The deadline bounds a single service call
+# and the gap between two messages of a streaming response, so without a ceiling a peer can switch off those timeouts
+# entirely. Requests asking for more are clamped to this, not rejected; a request that then runs past it gets a Timeout
+# status. Values below the 1 second minimum client deadline are floored at it. (default value = 600).
+#rpc_maximum_client_deadline = 600
 
 [base_node.p2p.transport]
 # -------------- Transport configuration --------------

--- a/common_sqlite/src/connection.rs
+++ b/common_sqlite/src/connection.rs
@@ -138,6 +138,39 @@ lazy_static::lazy_static! {
 #[derive(Clone)]
 pub struct DbConnection {
     pool: SqliteConnectionPool,
+    /// Set only for the temp-file databases created by [`Self::connect_temp_file_and_migrate`].
+    /// Shared across clones so the directory is removed exactly once - see [`TempDatabaseDir`].
+    temp_dir: Option<Arc<TempDatabaseDir>>,
+}
+
+/// Owns the temporary directory backing a temp-file database and removes it when the last
+/// [`DbConnection`] sharing it is dropped.
+///
+/// `DbConnection` is `Clone`, and one database is routinely held through several handles at once:
+/// `DhtActor`, for instance, hands one to `DedupCacheDatabase` and another to `DhtDatabase`, which
+/// then makes further clones per spawned task. Removing the directory in `DbConnection::drop` let
+/// whichever handle went out of scope first delete the file out from under all the others, which
+/// surfaced as `disk I/O error` and silently empty query results in the surviving handles.
+struct TempDatabaseDir {
+    pool: SqliteConnectionPool,
+    dir: PathBuf,
+}
+
+impl Drop for TempDatabaseDir {
+    fn drop(&mut self) {
+        if !self.dir.exists() {
+            return;
+        }
+        // Release the pool's connections before unlinking the files they are open on.
+        let pool_state = self.pool.cleanup();
+        debug!(target: LOG_TARGET, "DbConnection - Pool stats before cleanup: {pool_state:?}");
+        debug!(target: LOG_TARGET, "DbConnection - Cleaning up tempdir: {}", self.dir.display());
+        if let Err(e) = fs::remove_dir_all(&self.dir) {
+            error!(target: LOG_TARGET, "Failed to clean up temp dir: {e}");
+        } else {
+            debug!(target: LOG_TARGET, "Temp dir cleaned up: {}", self.dir.display());
+        }
+    }
 }
 
 impl DbConnection {
@@ -216,11 +249,16 @@ impl DbConnection {
         let path = DbConnection::temp_db_dir().join(prefixed_string("data-", 20));
         fs::create_dir_all(&path)?;
         let db_url = DbConnectionUrl::File(path.join("my_temp.db"));
-        DbConnection::connect_and_migrate(&db_url, migrations, Some(10))
+        let mut conn = DbConnection::connect_and_migrate(&db_url, migrations, Some(10))?;
+        conn.temp_dir = Some(Arc::new(TempDatabaseDir {
+            pool: conn.pool.clone(),
+            dir: path,
+        }));
+        Ok(conn)
     }
 
     fn new(pool: SqliteConnectionPool) -> Self {
-        Self { pool }
+        Self { pool, temp_dir: None }
     }
 
     /// Fetch a connection from the pool. This function synchronously blocks the current thread for up to 60 seconds or
@@ -243,28 +281,6 @@ impl DbConnection {
     #[cfg(test)]
     pub(crate) fn db_path(&self) -> PathBuf {
         self.pool.db_path()
-    }
-}
-
-impl Drop for DbConnection {
-    fn drop(&mut self) {
-        let path = self.pool.db_path();
-
-        if path.exists() &&
-            let Some(parent) = path.parent() &&
-            parent.starts_with(DbConnection::temp_db_dir())
-        {
-            debug!(target: LOG_TARGET, "DbConnection - Dropping database: {}", path.display());
-            // Explicitly cleanup and drop the connection pool to ensure all connections are released
-            let pool_state = self.pool.cleanup();
-            debug!(target: LOG_TARGET, "DbConnection - Pool stats before cleanup: {pool_state:?}");
-            debug!(target: LOG_TARGET, "DbConnection - Cleaning up tempdir: {}", parent.display());
-            if let Err(e) = fs::remove_dir_all(parent) {
-                error!(target: LOG_TARGET, "Failed to clean up temp dir: {e}");
-            } else {
-                debug!(target: LOG_TARGET, "Temp dir cleaned up: {}", parent.display());
-            }
-        }
     }
 }
 
@@ -309,6 +325,47 @@ mod test {
         drop(pool_conn);
         drop(db_conn);
         assert!(!path.exists());
+    }
+
+    /// A temp database is routinely held through several clones at once - `DhtActor`, for instance,
+    /// hands one to `DedupCacheDatabase` and another to `DhtDatabase`, which then clones further per
+    /// spawned task. Cleaning up in `DbConnection::drop` let whichever clone went out of scope first
+    /// delete the file out from under the rest, which surfaced as `disk I/O error` and silently
+    /// empty results in the survivors.
+    #[tokio::test]
+    async fn temp_dir_survives_until_the_last_clone_is_dropped() {
+        const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./test/migrations");
+
+        let db_conn = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
+        let path = db_conn.db_path();
+        assert!(path.exists());
+
+        // Write through a clone, then drop the clone. This is the point at which the old `Drop`
+        // removed the directory.
+        let clone = db_conn.clone();
+        {
+            let mut pool_conn = clone.get_pooled_connection().unwrap();
+            pool_conn
+                .batch_execute("INSERT INTO test_table (id) VALUES (1);")
+                .unwrap();
+        }
+        drop(clone);
+
+        assert!(path.exists(), "the database was removed while another handle was live");
+
+        // ...and the original handle can still read what the clone wrote.
+        let mut pool_conn = db_conn
+            .get_pooled_connection()
+            .expect("surviving handle lost its database");
+        let count: i32 = sql::<Integer>("SELECT COUNT(*) FROM test_table")
+            .get_result(&mut pool_conn)
+            .expect("query through the surviving handle failed");
+        assert_eq!(count, 1);
+
+        // The last handle going away is what cleans up.
+        drop(pool_conn);
+        drop(db_conn);
+        assert!(!path.exists(), "temp dir was not cleaned up by the last handle");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -60,7 +60,6 @@ use crate::{
 ///
 /// ```rust
 /// # use std::{sync::Arc, time::Duration};
-/// # use rand::;
 /// # use tari_shutdown::Shutdown;
 /// # use tari_comms::{
 /// #     {CommsBuilder, NodeIdentity},
@@ -69,17 +68,9 @@ use crate::{
 /// # };
 /// # #[tokio::main]
 /// # async fn main() {
-/// use std::env::temp_dir;
 /// use tari_common_sqlite::connection::DbConnection;
-/// use tari_comms::connectivity::ConnectivityConfig;
-/// use tari_comms::peer_manager::create_test_peer;
 /// use tari_comms::peer_manager::database::{PeerDatabaseSql, MIGRATIONS};
-/// use tari_comms::test_utils::peer_manager::random_name;
 ///
-/// use tari_storage::{
-///     lmdb_store::{LMDBBuilder, LMDBConfig},
-///     LMDBWrapper,
-/// };
 /// let node_identity = Arc::new(NodeIdentity::random(
 ///     &mut rand::rng(),
 ///     "/dns4/basenodezforhire.com/tcp/18000".parse().unwrap(),
@@ -88,7 +79,8 @@ use crate::{
 /// node_identity.sign();
 /// let mut shutdown = Shutdown::new();
 /// let db_connection = DbConnection::connect_temp_file_and_migrate(MIGRATIONS).unwrap();
-/// let peer_database = PeerDatabaseSql::new(db_connection, &create_test_peer(false, PeerFeatures::COMMUNICATION_NODE)).unwrap();
+/// // The peer database is seeded with this node's own identity.
+/// let peer_database = PeerDatabaseSql::new(db_connection, &node_identity.to_peer()).unwrap();
 ///
 /// let unspawned_node = CommsBuilder::new()
 ///   // .with_listener_address("/ip4/0.0.0.0/tcp/18000".parse().unwrap())

--- a/comms/core/src/protocol/rpc/server/error.rs
+++ b/comms/core/src/protocol/rpc/server/error.rs
@@ -60,6 +60,8 @@ pub enum RpcServerError {
     ServiceCallExceededDeadline,
     #[error("Stream read exceeded deadline")]
     ReadStreamExceededDeadline,
+    #[error("Stream write exceeded deadline")]
+    WriteStreamExceededDeadline,
     #[error("Early close: {0}")]
     EarlyClose(#[from] EarlyCloseError<BytesMut>),
     #[error("Protocol error: {0}")]

--- a/comms/core/src/protocol/rpc/server/mod.rs
+++ b/comms/core/src/protocol/rpc/server/mod.rs
@@ -178,11 +178,27 @@ impl Default for RpcServer {
 /// gone.
 const DEFAULT_IDLE_SESSION_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
+/// The default ceiling applied to the deadline a client asks for. The largest deadline any client
+/// in this workspace sets is the 240s block-sync deadline (sized for full blocks over Tor), so this
+/// leaves generous headroom for an operator who raises it while still bounding how long a single
+/// request can occupy a session. It matches [`DEFAULT_IDLE_SESSION_TIMEOUT`] deliberately: a
+/// request in flight should not be able to hold a session slot for longer than an idle one may sit.
+const DEFAULT_MAXIMUM_CLIENT_DEADLINE: Duration = Duration::from_secs(10 * 60);
+
+/// How long the server will spend trying to shut a substream down gracefully before dropping it.
+///
+/// A close is a handful of bytes, so this only ever elapses when the peer is not reading. It is
+/// deliberately short and not client-controlled: unlike a request deadline there is no legitimate
+/// reason for teardown to take long, and the whole point is to stop a stalled peer from holding the
+/// session's executor permit.
+const SESSION_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[derive(Clone)]
 pub struct RpcServerBuilder {
     maximum_simultaneous_sessions: Option<usize>,
     maximum_sessions_per_client: Option<usize>,
     minimum_client_deadline: Duration,
+    maximum_client_deadline: Duration,
     handshake_timeout: Duration,
     idle_session_timeout: Option<Duration>,
     cull_oldest_peer_rpc_connection_on_full: bool,
@@ -223,6 +239,34 @@ impl RpcServerBuilder {
         self
     }
 
+    /// Cap the deadline a client is allowed to ask for. The deadline arrives on the wire as a u64
+    /// of seconds and bounds both the service call and each message of a streaming response, so
+    /// without a ceiling a peer can simply ask for `u64::MAX` and switch off the server's own
+    /// timeouts for that request.
+    ///
+    /// The request is clamped rather than rejected outright: a peer asking for more than the
+    /// ceiling is still served, and only sees a difference if the work actually runs past the
+    /// ceiling - in which case it gets a prompt `Timeout` status instead of the longer wait it
+    /// asked for.
+    ///
+    /// Note this bounds a single service call and the gap between two messages of a stream. It
+    /// does not bound a stream's total duration, which is deliberate: `sync_blocks` streams an
+    /// entire initial block download in one request and a total budget would cut it short.
+    pub fn with_maximum_client_deadline(mut self, deadline: Duration) -> Self {
+        self.maximum_client_deadline = deadline;
+        self
+    }
+
+    /// The deadline this server will actually apply for a client that asked for `requested`.
+    ///
+    /// Floored at `minimum_client_deadline` so that a `maximum_client_deadline` misconfigured below
+    /// it cannot silently reduce every request's deadline to nothing - which would leave the node
+    /// up but aborting every RPC call it is asked to serve.
+    fn clamp_client_deadline(&self, requested: Duration) -> Duration {
+        let capped = cmp::min(requested, self.maximum_client_deadline);
+        cmp::max(capped, self.minimum_client_deadline)
+    }
+
     /// Close a session that has not received a request for `timeout`. A session holds a slot in the
     /// global session limit for as long as its substream is open, and a peer that goes away without
     /// closing the substream (common over Tor) never releases it. Only idle time counts; a session
@@ -255,6 +299,7 @@ impl Default for RpcServerBuilder {
             maximum_simultaneous_sessions: None,
             maximum_sessions_per_client: None,
             minimum_client_deadline: Duration::from_secs(1),
+            maximum_client_deadline: DEFAULT_MAXIMUM_CLIENT_DEADLINE,
             handshake_timeout: Duration::from_secs(15),
             idle_session_timeout: Some(DEFAULT_IDLE_SESSION_TIMEOUT),
             cull_oldest_peer_rpc_connection_on_full: false,
@@ -659,6 +704,53 @@ where
         }
     }
 
+    /// Write one frame to the peer, giving up after `deadline`.
+    ///
+    /// Every write here goes into a yamux window the peer controls, so a peer that simply stops
+    /// reading can park any unbounded `send`. Route all of them through this so the bound is
+    /// structural rather than something to remember at each call site.
+    async fn send_with_deadline(&mut self, msg: Bytes, deadline: Duration) -> Result<(), RpcServerError> {
+        match time::timeout(deadline, self.framed.send(msg)).await {
+            Ok(result) => result.map_err(Into::into),
+            Err(_elapsed) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "({}) Peer did not accept a response within the deadline ({:.0?}). Aborting the session.",
+                    self.logging_context_string,
+                    deadline
+                );
+
+                #[cfg(feature = "metrics")]
+                metrics::error_counter(&self.protocol, &RpcServerError::WriteStreamExceededDeadline).inc();
+                Err(RpcServerError::WriteStreamExceededDeadline)
+            },
+        }
+    }
+
+    /// Shut the substream down, giving up after [`SESSION_CLOSE_TIMEOUT`] and letting it drop.
+    ///
+    /// `EarlyClose::poll_close` falls through to `check_for_early_close`, which returns `Pending`
+    /// for a peer that is merely silent - so closing a substream whose window the peer has filled
+    /// and stopped draining never completes. That is worse than one stuck task: the session holds a
+    /// `BoundedExecutor` permit until `start()` returns, and nothing can reclaim it. The idle timer
+    /// is not running (we are not in the select), and culling only signals `stop_rx`, which this
+    /// task is no longer watching. One peer could walk the global session limit down to zero and
+    /// lock every other peer out of the node.
+    async fn close_framed(&mut self) -> Result<(), RpcServerError> {
+        match time::timeout(SESSION_CLOSE_TIMEOUT, self.framed.close()).await {
+            Ok(result) => result.map_err(Into::into),
+            Err(_elapsed) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "({}) Peer did not accept the substream close within {:.0?}. Dropping it.",
+                    self.logging_context_string,
+                    SESSION_CLOSE_TIMEOUT
+                );
+                Ok(())
+            },
+        }
+    }
+
     async fn run(&mut self) -> Result<(), RpcServerError> {
         // Only the time spent waiting for the next request is bounded - handling a request holds
         // this loop and cannot trip the timer. Without this, a session (and the slot it occupies in
@@ -692,8 +784,16 @@ where
                             let start = Instant::now();
 
                             if let Err(err) = self.handle_request(frame.freeze()).await {
-                                if let Err(err) = self.framed.close().await {
-                                    let level = err.io().map(err_to_log_level).unwrap_or(log::Level::Error);
+                                // A write deadline means the peer stopped reading, so the window is
+                                // already full and a graceful close cannot land - skip straight to
+                                // dropping the substream rather than burning the close timeout.
+                                let close_result = if matches!(err, RpcServerError::WriteStreamExceededDeadline) {
+                                    Ok(())
+                                } else {
+                                    self.close_framed().await
+                                };
+                                if let Err(err) = close_result {
+                                    let level = err.early_close_io().map(err_to_log_level).unwrap_or(log::Level::Error);
 
                                     log!(
                                         target: LOG_TARGET,
@@ -729,7 +829,7 @@ where
                             }
                         },
                         Some(Err(err)) => {
-                            if let Err(err) = self.framed.close().await {
+                            if let Err(err) = self.close_framed().await {
                                 error!(
                                     target: LOG_TARGET,
                                     "({}) Failed to close substream after socket error: {}", self.logging_context_string, err
@@ -743,7 +843,7 @@ where
             }
         }
 
-        self.framed.close().await?;
+        self.close_framed().await?;
         Ok(())
     }
 
@@ -754,10 +854,10 @@ where
 
         let request_id = decoded_msg.request_id;
         let method = RpcMethod::from(decoded_msg.method);
-        let deadline = Duration::from_secs(decoded_msg.deadline);
+        let requested_deadline = Duration::from_secs(decoded_msg.deadline);
 
         // The client side deadline MUST be greater or equal to the minimum_client_deadline
-        if deadline < self.config.minimum_client_deadline {
+        if requested_deadline < self.config.minimum_client_deadline {
             debug!(
                 target: LOG_TARGET,
                 "({}) Client has an invalid deadline. {}", self.logging_context_string, decoded_msg
@@ -765,7 +865,7 @@ where
             // Let the client know that they have disobeyed the spec
             let status = RpcStatus::bad_request(&format!(
                 "Invalid deadline ({:.0?}). The deadline MUST be greater than {:.0?}.",
-                self.node_id, deadline,
+                requested_deadline, self.config.minimum_client_deadline,
             ));
             let bad_request = proto::rpc::RpcResponse {
                 request_id,
@@ -775,8 +875,26 @@ where
             };
             #[cfg(feature = "metrics")]
             metrics::status_error_counter(&self.protocol, status.as_status_code()).inc();
-            self.framed.send(bad_request.to_encoded_bytes().into()).await?;
+            // The client's own deadline was rejected as invalid, so there is nothing to honour
+            // here - bound this on the teardown timeout instead.
+            self.send_with_deadline(bad_request.to_encoded_bytes().into(), SESSION_CLOSE_TIMEOUT)
+                .await?;
             return Ok(());
+        }
+
+        // ...and it is capped from above, because the deadline governs both the service call and
+        // each message of a streaming response. An uncapped `u64` of seconds lets a peer disable
+        // those timeouts outright and hold a session slot for as long as it likes. Clamp instead of
+        // rejecting so a peer configured above our ceiling still works.
+        let deadline = self.config.clamp_client_deadline(requested_deadline);
+        if deadline < requested_deadline {
+            debug!(
+                target: LOG_TARGET,
+                "({}) Client requested a deadline of {:.0?}, capping it at {:.0?}.",
+                self.logging_context_string,
+                requested_deadline,
+                deadline
+            );
         }
 
         let msg_flags = RpcMessageFlags::from_bits(u8::try_from(decoded_msg.flags).map_err(|_| {
@@ -802,7 +920,7 @@ where
                 flags: RpcMessageFlags::ACK.bits().into(),
                 ..Default::default()
             };
-            self.framed.send(ack.to_encoded_bytes().into()).await?;
+            self.send_with_deadline(ack.to_encoded_bytes().into(), deadline).await?;
             return Ok(());
         }
 
@@ -839,6 +957,22 @@ where
 
                 #[cfg(feature = "metrics")]
                 metrics::error_counter(&self.protocol, &RpcServerError::ServiceCallExceededDeadline).inc();
+
+                // Tell the client, rather than going silent and leaving it to unwind on its own
+                // timeout. This matters whenever the deadline we applied is shorter than the one the
+                // client asked for - a clamped request would otherwise look identical to a hung
+                // server for the remainder of the client's own (longer) deadline.
+                let status = RpcStatus::timed_out("RPC service did not complete within the deadline");
+                let timed_out = proto::rpc::RpcResponse {
+                    request_id,
+                    status: status.as_code(),
+                    flags: RpcMessageFlags::FIN.bits().into(),
+                    payload: status.to_details_bytes(),
+                };
+                #[cfg(feature = "metrics")]
+                metrics::status_error_counter(&self.protocol, status.as_status_code()).inc();
+                self.send_with_deadline(timed_out.to_encoded_bytes().into(), deadline)
+                    .await?;
                 return Ok(());
             },
         };
@@ -861,7 +995,8 @@ where
 
                 #[cfg(feature = "metrics")]
                 metrics::status_error_counter(&self.protocol, err.as_status_code()).inc();
-                self.framed.send(resp.to_encoded_bytes().into()).await?;
+                self.send_with_deadline(resp.to_encoded_bytes().into(), deadline)
+                    .await?;
             },
         }
 
@@ -932,7 +1067,14 @@ where
                                 msg.len()
                             );
 
-                            self.framed.send(msg).await?;
+                            // Bounded because this sits outside the `timeout` branch below: it is
+                            // the yamux window that backs up here, so a peer that opens a stream
+                            // and then stops draining it parks this task - and the session slot it
+                            // holds - with no timer running anywhere. The outer `run()` loop cannot
+                            // rescue it either; its idle timer does not tick while a request is
+                            // being handled. On elapse the peer is mid-frame, so the substream can
+                            // no longer be trusted for a subsequent request and the session ends.
+                            self.send_with_deadline(msg, deadline).await?;
                         },
                         None => {
                             trace!(target: LOG_TARGET, "{} Request complete", self.logging_context_string,);
@@ -1066,5 +1208,79 @@ fn err_to_log_level(err: &io::Error) -> log::Level {
         ErrorKind::WriteZero |
         ErrorKind::UnexpectedEof => log::Level::Debug,
         _ => log::Level::Error,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn client_deadline_is_capped_from_above() {
+        let builder = RpcServerBuilder::new();
+        assert_eq!(builder.maximum_client_deadline, DEFAULT_MAXIMUM_CLIENT_DEADLINE);
+
+        // Anything at or below the ceiling is honoured as asked for.
+        assert_eq!(
+            builder.clamp_client_deadline(Duration::from_secs(1)),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            builder.clamp_client_deadline(DEFAULT_MAXIMUM_CLIENT_DEADLINE),
+            DEFAULT_MAXIMUM_CLIENT_DEADLINE
+        );
+        // The 240s block-sync deadline must survive untouched, or syncing full blocks over Tor
+        // would start being cut short by peers.
+        assert_eq!(
+            builder.clamp_client_deadline(Duration::from_secs(240)),
+            Duration::from_secs(240)
+        );
+
+        // Above it, the server's own limit applies...
+        assert_eq!(
+            builder.clamp_client_deadline(DEFAULT_MAXIMUM_CLIENT_DEADLINE + Duration::from_secs(1)),
+            DEFAULT_MAXIMUM_CLIENT_DEADLINE
+        );
+        // ...including the case this exists for: a peer asking for an effectively infinite deadline
+        // to switch off the service-call and streaming timeouts.
+        assert_eq!(
+            builder.clamp_client_deadline(Duration::from_secs(u64::MAX)),
+            DEFAULT_MAXIMUM_CLIENT_DEADLINE
+        );
+    }
+
+    #[test]
+    fn maximum_client_deadline_is_configurable() {
+        let builder = RpcServerBuilder::new().with_maximum_client_deadline(Duration::from_secs(30));
+        assert_eq!(
+            builder.clamp_client_deadline(Duration::from_secs(u64::MAX)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            builder.clamp_client_deadline(Duration::from_secs(5)),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn a_maximum_below_the_minimum_does_not_starve_requests() {
+        // An operator setting this to zero (or anything under the minimum) would otherwise leave
+        // the node up while aborting every request it is asked to serve.
+        let builder = RpcServerBuilder::new()
+            .with_minimum_client_deadline(Duration::from_secs(1))
+            .with_maximum_client_deadline(Duration::from_secs(0));
+
+        assert_eq!(
+            builder.clamp_client_deadline(Duration::from_secs(0)),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            builder.clamp_client_deadline(Duration::from_secs(120)),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            builder.clamp_client_deadline(Duration::from_secs(u64::MAX)),
+            Duration::from_secs(1)
+        );
     }
 }

--- a/comms/core/src/protocol/rpc/test/smoke.rs
+++ b/comms/core/src/protocol/rpc/test/smoke.rs
@@ -142,7 +142,17 @@ pub(super) async fn setup<T: GreetingRpc>(
     service_impl: T,
     num_concurrent_sessions: usize,
 ) -> (Control, Yamux, task::JoinHandle<()>, Arc<NodeIdentity>, Shutdown) {
-    let (notif_tx, server_hnd, context, shutdown) = setup_service(service_impl, num_concurrent_sessions).await;
+    let builder = RpcServer::builder()
+        .with_maximum_simultaneous_sessions(num_concurrent_sessions)
+        .with_minimum_client_deadline(Duration::from_secs(0));
+    setup_with_builder(service_impl, builder).await
+}
+
+pub(super) async fn setup_with_builder<T: GreetingRpc>(
+    service_impl: T,
+    builder: RpcServerBuilder,
+) -> (Control, Yamux, task::JoinHandle<()>, Arc<NodeIdentity>, Shutdown) {
+    let (notif_tx, server_hnd, context, shutdown) = setup_service_with_builder(service_impl, builder).await;
     let (_, inbound, outbound) = build_multiplexed_connections().await;
     let inbound_control = inbound.get_yamux_control();
 
@@ -363,6 +373,44 @@ async fn timeout() {
     assert_eq!(resp.greeting, "took a while to load");
 }
 
+/// A peer asking for a deadline beyond the server's ceiling must be held to the ceiling, and must
+/// be *told* when the request runs past it - not left waiting out its own, much longer, deadline.
+#[tokio::test]
+async fn client_deadline_is_capped_and_the_client_is_told() {
+    let delay = Arc::new(RwLock::new(Duration::from_secs(60)));
+    let builder = RpcServer::builder()
+        .with_maximum_simultaneous_sessions(1)
+        .with_minimum_client_deadline(Duration::from_secs(0))
+        .with_maximum_client_deadline(Duration::from_secs(1));
+    let (_inbound, outbound, _, _, _shutdown) =
+        setup_with_builder(SlowGreetingService::new(delay.clone()), builder).await;
+    let socket = outbound.get_yamux_control().open_stream().await.unwrap();
+    let framed = framing::canonical(socket, 1024);
+
+    // Ask for far more than the server allows. If the cap were not applied on the wire, or if the
+    // server went silent instead of replying, this request would not resolve until the client's own
+    // deadline expires - well past the timeout below.
+    let mut client = GreetingClient::builder()
+        .with_deadline(Duration::from_secs(600))
+        .with_deadline_grace_period(Duration::from_secs(60))
+        .connect(framed)
+        .await
+        .unwrap();
+
+    let result = time::timeout(Duration::from_secs(10), client.say_hello(Default::default()))
+        .await
+        .expect("client was not told about the capped deadline and waited on its own instead");
+
+    let err = result.unwrap_err();
+    unpack_enum!(RpcError::RequestFailed(status) = err);
+    assert_eq!(status.as_status_code(), RpcStatusCode::Timeout);
+
+    // The session survives: the next request is served normally.
+    *delay.write().await = Duration::from_secs(0);
+    let resp = client.say_hello(Default::default()).await.unwrap();
+    assert_eq!(resp.greeting, "took a while to load");
+}
+
 #[tokio::test]
 async fn unknown_protocol() {
     let (notif_tx, _, _, _shutdown) = setup_service(GreetingService::new(&[]), 1).await;
@@ -448,6 +496,69 @@ async fn stream_still_works_after_cancel() {
     resp.collect::<Vec<_>>().await.into_iter().for_each(|r| {
         r.unwrap();
     });
+}
+
+/// A peer that opens a streaming request and then stops draining its yamux window used to park the
+/// server, and keep its session slot, indefinitely.
+///
+/// Two separate bounds are needed. The read timeout does not cover `framed.send`, and the outer
+/// session loop's idle timer does not tick while a request is being handled - so the write parks.
+/// Bounding only the write is not enough either: `run()` then tries to close the substream
+/// gracefully, and `EarlyClose::poll_close` returns `Pending` for a peer that is merely silent, so
+/// the task parks one level up instead. Either way the session's `BoundedExecutor` permit is held
+/// until `start()` returns, which is what actually locks other peers out of the node.
+///
+/// So the assertion here is the one that matters: another session can still be opened.
+#[tokio::test]
+async fn a_peer_that_stops_reading_does_not_hold_its_session_slot() {
+    const NUM_ITEMS: u32 = 512;
+    // A single global session, so the second handshake below succeeds only if the first session's
+    // slot was genuinely reclaimed.
+    let builder = RpcServer::builder()
+        .with_maximum_simultaneous_sessions(1)
+        .with_minimum_client_deadline(Duration::from_secs(0));
+    let (_inbound, outbound, _, _, _shutdown) = setup_with_builder(GreetingService::default(), builder).await;
+
+    let socket = outbound.get_yamux_control().open_stream().await.unwrap();
+    let framed = framing::canonical(socket, rpc::RPC_MAX_FRAME_SIZE);
+    let mut stalled_client = GreetingClient::builder()
+        .with_deadline(Duration::from_secs(2))
+        .with_deadline_grace_period(Duration::from_secs(1))
+        .connect(framed)
+        .await
+        .unwrap();
+
+    // Far more data than a yamux window holds, produced as fast as the server can send it.
+    let _stalled_stream = stalled_client
+        .slow_stream(SlowStreamRequest {
+            num_items: NUM_ITEMS,
+            item_size: 64 * 1024,
+            delay_ms: 0,
+        })
+        .await
+        .unwrap();
+
+    // Never drain it. Wait out the write deadline and the close timeout with room to spare, and do
+    // not touch `_stalled_stream` - reading it would unblock the server and mask the bug.
+    time::sleep(Duration::from_secs(10)).await;
+
+    // The slot must be free for somebody else.
+    let socket = outbound.get_yamux_control().open_stream().await.unwrap();
+    let framed = framing::canonical(socket, rpc::RPC_MAX_FRAME_SIZE);
+    let mut client = GreetingClient::builder()
+        .with_deadline(Duration::from_secs(5))
+        .connect(framed)
+        .await
+        .expect("session slot was not reclaimed from the stalled peer");
+
+    let resp = client
+        .say_hello(SayHelloRequest {
+            name: "Norman".to_string(),
+            language: 0,
+        })
+        .await
+        .unwrap();
+    assert_eq!(resp.greeting, "Sawubona Norman");
 }
 
 #[tokio::test]

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -34,6 +34,7 @@ use crate::{Dht, DhtConfig, dht::DhtInitializationError, outbound::DhtOutboundRe
 /// Builder for the DHT.
 ///
 /// ```rust
+/// use tari_common_sqlite::connection::DbConnectionUrl;
 /// use tari_comms_dht::Dht;
 /// let builder = Dht::builder()
 ///     .mainnet()

--- a/comms/dht/src/network_discovery/seed_strap.rs
+++ b/comms/dht/src/network_discovery/seed_strap.rs
@@ -774,7 +774,10 @@ async fn fetch_peers_from_connection(
     };
 
     let seed_node_id_str = conn.peer_node_id().to_string(); // Used for logging
-    let peers_from_seed = collect_peer_stream(&seed_node_id_str, &mut peer_stream, rpc_streaming_timeout).await?;
+    // Bound what we accept by what we asked for - the seed does not have to honour `n` itself.
+    let max_peers = usize::try_from(num_peers_to_request).unwrap_or(usize::MAX);
+    let peers_from_seed =
+        collect_peer_stream(&seed_node_id_str, &mut peer_stream, max_peers, rpc_streaming_timeout).await?;
 
     debug!(
         target: LOG_TARGET,
@@ -785,15 +788,25 @@ async fn fetch_peers_from_connection(
     Ok(peers_from_seed)
 }
 
+/// Collect at most `max_peers` peer entries from a `get_peers` stream.
+///
+/// A seed is under no obligation to respect the `n` we asked for, so the stream is bounded here
+/// rather than trusting it to end. Without a cap, a seed that keeps emitting items - including
+/// empty ones, which cost it nothing to produce - grows the returned `Vec` without limit and keeps
+/// this task alive indefinitely, since the only other exit is the per-item timeout.
 async fn collect_peer_stream<S>(
     seed_node_id_str: &str,
     peer_stream: &mut S,
+    max_peers: usize,
     rpc_streaming_timeout: Duration,
 ) -> Result<Vec<crate::proto::rpc::PeerInfo>, NetworkDiscoveryError>
 where
     S: StreamExt<Item = Result<crate::proto::rpc::GetPeersResponse, tari_comms::protocol::rpc::RpcStatus>> + Unpin,
 {
-    let mut peers_from_seed = Vec::new();
+    let max_peers = max_peers.max(1);
+    // Allow some slack for empty responses interleaved with real ones before abandoning the round.
+    let max_items = max_peers.saturating_mul(2);
+    let mut peers_from_seed = Vec::with_capacity(max_peers);
     let mut stream_items_processed_total = 0usize; // Total items received from stream
     let mut stream_items_with_peers = 0usize; // Items that actually contained peer data
 
@@ -845,6 +858,22 @@ where
                                 GetPeersResponse.peer field."
                             );
                         }
+
+                        if peers_from_seed.len() >= max_peers {
+                            debug!(
+                                target: LOG_TARGET,
+                                "SeedStrap: Collected the {max_peers} peer(s) requested from seed '{seed_node_id_str}'. Closing the stream."
+                            );
+                            break;
+                        }
+                        if stream_items_processed_total >= max_items {
+                            warn!(
+                                target: LOG_TARGET,
+                                "SeedStrap: Seed '{seed_node_id_str}' sent {stream_items_processed_total} stream item(s) but only \
+                                {stream_items_with_peers} contained a peer. Closing the stream."
+                            );
+                            break;
+                        }
                     },
                     Some(Err(e)) => {
                         stream_items_processed_total = stream_items_processed_total.saturating_add(1);
@@ -885,4 +914,110 @@ where
     );
 
     Ok(peers_from_seed)
+}
+
+#[cfg(test)]
+mod test {
+    use futures::stream;
+    use tari_comms::protocol::rpc::RpcStatus;
+
+    use super::*;
+    use crate::proto::rpc::{GetPeersResponse, PeerInfo};
+
+    const TIMEOUT: Duration = Duration::from_secs(30);
+
+    fn peer_response(n: usize) -> Vec<Result<GetPeersResponse, RpcStatus>> {
+        (0..n)
+            .map(|i| {
+                Ok(GetPeersResponse {
+                    peer: Some(PeerInfo {
+                        public_key: vec![u8::try_from(i % 256).unwrap_or_default(); 32],
+                        claims: vec![],
+                    }),
+                })
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn it_returns_everything_when_the_seed_sends_fewer_than_requested() {
+        let mut peer_stream = stream::iter(peer_response(3));
+        let peers = collect_peer_stream("seed", &mut peer_stream, 10, TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(peers.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn it_truncates_a_seed_that_sends_more_than_requested() {
+        let mut peer_stream = stream::iter(peer_response(50));
+        let peers = collect_peer_stream("seed", &mut peer_stream, 5, TIMEOUT).await.unwrap();
+        assert_eq!(peers.len(), 5);
+    }
+
+    /// The stream here never ends and every item is immediately ready, so the per-item timeout can
+    /// never fire. Without the item budget this call does not return at all.
+    #[tokio::test]
+    async fn it_gives_up_on_an_endless_stream_of_empty_responses() {
+        let mut peer_stream = stream::repeat(Ok(GetPeersResponse { peer: None }));
+        let peers = tokio::time::timeout(
+            Duration::from_secs(5),
+            collect_peer_stream("seed", &mut peer_stream, 10, TIMEOUT),
+        )
+        .await
+        .expect("collect_peer_stream did not terminate on an endless empty stream")
+        .unwrap();
+        assert!(peers.is_empty());
+    }
+
+    /// Same, but the peer drip-feeds real entries as well, so the peer cap is what stops it.
+    #[tokio::test]
+    async fn it_gives_up_on_an_endless_stream_of_peers() {
+        let mut peer_stream = stream::repeat(Ok(GetPeersResponse {
+            peer: Some(PeerInfo {
+                public_key: vec![1u8; 32],
+                claims: vec![],
+            }),
+        }));
+        let peers = tokio::time::timeout(
+            Duration::from_secs(5),
+            collect_peer_stream("seed", &mut peer_stream, 7, TIMEOUT),
+        )
+        .await
+        .expect("collect_peer_stream did not terminate on an endless peer stream")
+        .unwrap();
+        assert_eq!(peers.len(), 7);
+    }
+
+    #[tokio::test]
+    async fn it_propagates_a_stream_error() {
+        let mut responses = peer_response(1);
+        responses.push(Err(RpcStatus::general("the seed fell over")));
+        let mut peer_stream = stream::iter(responses);
+
+        let err = collect_peer_stream("seed", &mut peer_stream, 10, TIMEOUT)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, NetworkDiscoveryError::RpcStatus(_)), "got {err:?}");
+    }
+
+    /// `max_peers` is derived from config, so guard the degenerate value rather than looping forever
+    /// or collecting nothing.
+    #[tokio::test]
+    async fn a_zero_request_still_makes_progress_and_terminates() {
+        let mut peer_stream = stream::repeat(Ok(GetPeersResponse {
+            peer: Some(PeerInfo {
+                public_key: vec![1u8; 32],
+                claims: vec![],
+            }),
+        }));
+        let peers = tokio::time::timeout(
+            Duration::from_secs(5),
+            collect_peer_stream("seed", &mut peer_stream, 0, TIMEOUT),
+        )
+        .await
+        .expect("collect_peer_stream did not terminate for max_peers = 0")
+        .unwrap();
+        assert_eq!(peers.len(), 1);
+    }
 }


### PR DESCRIPTION
 Motivation

  An audit of every remote-callable entry point in the workspace — the four P2P comms RPC services, the wallet-query HTTP service, both gRPC servers, the merge-mining
  proxy and the MCP servers, ~100 methods in total — looked for places where a caller controls how much work the node does with nothing bounding it.

  This PR fixes the three highest-severity findings, plus a session-slot exhaustion bug uncovered while reviewing the first attempt at one of them. The remaining audit
  findings are listed at the end and are not addressed here.

  What's fixed
  
  1. Transaction validation ran every signature check before the size cap

  AggregateBodyInternalConsistencyValidator::validate called verify_kernel_signatures, then a per-output validate_individual_output (a full verify_metadata_signature
  each), and only then check_weight — the consensus size limit, and the only thing bounding how many of those there are.

  A body was therefore fully signature-checked before anything asked whether it was allowed to be that big. A 6 MiB payload of minimal kernels is on the order of tens of
  thousands of Schnorr verifications, seconds of CPU, for a request rejected the moment it reached the weight check. Three unauthenticated paths reach this:
  submit_transaction on t/mempool/1, submit_transaction on t/bnwallet/1, and POST /json_rpc on the wallet-query HTTP service.

  check_weight and check_sorting_and_duplicates now run first. Both are O(n) with no crypto.

  Validity is unchanged — a body is still valid iff every check passes. What changes is which error a body breaking several rules at once reports.

  2. SeedStrap accepted unbounded peer entries from a single seed

  collect_peer_stream pushed every streamed item into a Vec with no count limit; the n it requested (at most 250) was never enforced against what came back. A malicious
  seed emitting one small GetPeersResponse every few seconds grew that Vec indefinitely, with a peer-manager lookup per entry downstream. The sibling path in
  on_connect.rs already did this correctly with .take(NUM_FETCH_PEERS).

  Now bounded by the requested count, with a second bound on total stream items so a seed cannot keep the task alive with an endless run of empty responses either.

  3. The RPC server enforced a minimum client deadline but no maximum

  The deadline arrives on the wire as a u64 of seconds and was used as-is. A peer sending u64::MAX switched off both the service-call timeout and the per-message
  streaming timeout for that request.

  Added maximum_client_deadline (default 10 minutes) to RpcServerBuilder, exposed as rpc_maximum_client_deadline on P2pConfig. Requests are clamped, not rejected, so a
  peer configured above the ceiling keeps working. The clamp is floored at minimum_client_deadline so a misconfigured 0 degrades to 1s rather than aborting every request
  the node is asked to serve.

  10 minutes because the largest deadline any client in this workspace sets is the 240s block-sync deadline (sized for full blocks over Tor), and it matches
  DEFAULT_IDLE_SESSION_TIMEOUT — a request in flight should not hold a session slot longer than an idle one may sit.

  4. A stalled peer could hold its session slot forever, locking out the whole node

  Found while reviewing the fix for #3, and the most serious issue here.

  Two separate bounds were missing, either of which parks the session task indefinitely:                                          

  - The write. framed.send sat inside the msg = next_item select arm in process_body, so it was not covered by the timeout branch at all. A peer that opens a streaming
    request and then stops draining its yamux window parks the task on that send with no timer running anywhere. The outer run() loop cannot rescue it — its idle timer
    does not tick while a request is being handled.
  - The teardown. Bounding the write alone is not enough: run() then calls framed.close(), and EarlyClose::poll_close falls through to check_for_early_close, which
    returns Pending for a peer that is merely silent. The task parks one level up instead.

  Either way the session holds its BoundedExecutor permit until start() returns, and nothing reclaims it. The idle timer is not running, and culling only signals stop_rx,
  which the parked task is no longer watching. Because cull_oldest_peer_rpc_connection_on_full defaults to true on the base node, a peer over its own quota keeps being
  granted new sessions while its culled ones stay parked — so one peer can walk rpc_max_simultaneous_sessions (100) down to zero and lock every other peer out node-wide.
  This is the "Used all 100 sessions" failure mode.

  Fixed structurally rather than per-call-site:

  - send_with_deadline(msg, deadline) — every write now goes through it. Five call sites: the streaming send, the ACK, the bad_request frame, the service-error response,
    and the new timed-out frame. No bare framed.send remains.
  - close_framed() — every close now goes through it, bounded by a fixed 5s SESSION_CLOSE_TIMEOUT, dropping the substream on elapse. A close is a handful of bytes, so
    this only ever elapses when the peer is not reading; it is deliberately not client-controlled. All three close sites use it, including the normal-exit close reached
    by the idle timeout — the one a departed peer with a full window would otherwise defeat.
  - On WriteStreamExceededDeadline the graceful close is skipped entirely, since the window is known to be full and the 5s would be pure attacker-controlled cost.

  New error variant: RpcServerError::WriteStreamExceededDeadline.

  5. Deadline-exceeded requests went silent instead of replying

  The service-call timeout path logged a warning and returned Ok(()) without sending anything, leaving the client to unwind on its own — possibly much longer — deadline.
  It now sends an RpcStatus::timed_out with FIN. This is what makes the "clamped requests still work" contract in #3 actually hold.

  Also fixed a transposed-argument bug in the adjacent bad_request message, which printed the node ID where the deadline goes and the deadline where the minimum goes.

  Test infrastructure fix (why tari_comms_dht was red)

  Three actor::test cases were failing on development — dedup_cache_cleanup, get_and_set_metadata, insert_message_signature — with disk I/O error and silently empty
  results. Not flakes.

  DbConnection derives Clone but also had a Drop impl running remove_dir_all on the temp directory. The pool inside is Arc-backed, so clones share one database, but each
  clone ran that Drop independently — the first clone to go out of scope deleted the database out from under all the others. DhtActor::new hands one handle to
  DedupCacheDatabase and another to DhtDatabase, which then clones further per spawned task, so the first task to finish wiped the file.

  The temp directory now lives behind an Option<Arc<TempDatabaseDir>> that clones along with the connection, so cleanup runs exactly once when the last handle drops — and
  releases the pool's connections before unlinking, which the old code did in the wrong order relative to surviving clones. Drop for DbConnection is gone.

  Two broken doctests in comms were also failing and are fixed:
  - comms/core/src/builder/mod.rs — use rand::; was a syntax error, and the example used create_test_peer, which is #[cfg(test)] and so invisible to doctests. Rewritten
    to use node_identity.to_peer(), which is public and is actually the right value for that argument; the example was seeding the peer DB with a random stranger as if it
    were the local node.
  - comms/dht/src/builder.rs — missing DbConnectionUrl import.
