### PR TITLE
fix(ledger): enforce script-offset key identity disjointness

### DIFF
--- a/applications/minotari_ledger_wallet/common/src/common_types.rs
+++ b/applications/minotari_ledger_wallet/common/src/common_types.rs
@@ -118,6 +118,9 @@ pub enum LedgerKeyBranch {
     Spend = 0x07,
 }
 
+/// Fixed derivation index used for the Ledger wallet's static spend key.
+pub const STATIC_SPEND_INDEX: u64 = 42;
+
 impl LedgerKeyBranch {
     pub fn as_byte(self) -> u8 {
         self as u8
@@ -142,6 +145,16 @@ impl LedgerKeyBranch {
             LedgerKeyBranch::Spend => "Spend",
             LedgerKeyBranch::MetadataEphemeralNonce => "MetadataEphemeralNonce",
         }
+    }
+
+    /// Returns whether this branch can provide a managed script key to `GetScriptOffset`.
+    pub fn is_script_offset_script_branch(self) -> bool {
+        matches!(self, Self::Spend | Self::PreMine)
+    }
+
+    /// Returns whether this branch can provide a managed sender offset to `GetScriptOffset`.
+    pub fn is_script_offset_sender_branch(self) -> bool {
+        matches!(self, Self::OneSidedSenderOffset | Self::Random)
     }
 }
 

--- a/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
+++ b/applications/minotari_ledger_wallet/comms/src/accessor_methods.rs
@@ -23,7 +23,7 @@
 use std::sync::{LazyLock, Mutex};
 
 use log::debug;
-use minotari_ledger_wallet_common::common_types::{AppSW, Instruction, LedgerKeyBranch};
+use minotari_ledger_wallet_common::common_types::{AppSW, Instruction, LedgerKeyBranch, STATIC_SPEND_INDEX};
 use rand::Rng;
 use semver::Version;
 use tari_common::configuration::Network;
@@ -41,6 +41,95 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "ledger_wallet::accessor_methods";
+
+const MIN_SCRIPT_OFFSET_IDENTITIES: usize = 2;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct ScriptOffsetKeyIdentity {
+    branch: LedgerKeyBranch,
+    index: u64,
+}
+
+fn validate_script_offset_keys(
+    derived_script_key_count: usize,
+    script_key_indexes: &[(LedgerKeyBranch, u64)],
+    derived_sender_offset_count: usize,
+    sender_offset_indexes: &[(LedgerKeyBranch, u64)],
+) -> Result<(), LedgerDeviceError> {
+    if sender_offset_indexes
+        .iter()
+        .any(|(branch, _)| !branch.is_script_offset_sender_branch())
+    {
+        return Err(LedgerDeviceError::Processing(
+            "GetScriptOffset: invalid managed sender-offset branch".to_string(),
+        ));
+    }
+    if script_key_indexes
+        .iter()
+        .any(|(branch, _)| !branch.is_script_offset_script_branch())
+    {
+        return Err(LedgerDeviceError::Processing(
+            "GetScriptOffset: invalid managed script-key branch".to_string(),
+        ));
+    }
+
+    let mut sender_identities = Vec::new();
+    for (branch, index) in sender_offset_indexes {
+        let identity = ScriptOffsetKeyIdentity {
+            branch: *branch,
+            index: *index,
+        };
+        if !sender_identities.contains(&identity) {
+            sender_identities.push(identity);
+        }
+    }
+    if derived_sender_offset_count > 0 {
+        let identity = ScriptOffsetKeyIdentity {
+            branch: LedgerKeyBranch::Spend,
+            index: STATIC_SPEND_INDEX,
+        };
+        if !sender_identities.contains(&identity) {
+            sender_identities.push(identity);
+        }
+    }
+
+    let mut script_identities = Vec::new();
+    for (branch, index) in script_key_indexes {
+        let identity = ScriptOffsetKeyIdentity {
+            branch: *branch,
+            index: *index,
+        };
+        if !script_identities.contains(&identity) {
+            script_identities.push(identity);
+        }
+    }
+    if derived_script_key_count > 0 {
+        let identity = ScriptOffsetKeyIdentity {
+            branch: LedgerKeyBranch::Spend,
+            index: STATIC_SPEND_INDEX,
+        };
+        if !script_identities.contains(&identity) {
+            script_identities.push(identity);
+        }
+    }
+
+    let overlap = sender_identities
+        .iter()
+        .any(|identity| script_identities.contains(identity));
+    let unique_count = sender_identities.len() +
+        script_identities
+            .iter()
+            .filter(|identity| !sender_identities.contains(identity))
+            .count();
+    if overlap || unique_count < MIN_SCRIPT_OFFSET_IDENTITIES {
+        return Err(LedgerDeviceError::Processing(
+            "GetScriptOffset: script and sender-offset key identities must be disjoint and contain at least two keys"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
+}
 
 /// The script signature key
 pub enum ScriptSignatureKey {
@@ -345,6 +434,12 @@ pub fn ledger_get_script_offset(
         derived_sender_offsets.len(),
         sender_offset_indexes
     );
+    validate_script_offset_keys(
+        derived_script_keys.len(),
+        script_key_indexes,
+        derived_sender_offsets.len(),
+        sender_offset_indexes,
+    )?;
     verify_ledger_application()?;
 
     // 1. data sizes
@@ -631,5 +726,47 @@ pub fn ledger_get_one_sided_metadata_signature(
         Err(e) => Err(LedgerDeviceError::Instruction(format!(
             "GetOneSidedMetadataSignature: {e}"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn script_offset_host_validation_rejects_one_unique_identity() {
+        assert!(
+            validate_script_offset_keys(1, &[], 0, &[]).is_err(),
+            "one static spend identity must not satisfy the anti-extraction guard"
+        );
+    }
+
+    #[test]
+    fn script_offset_host_validation_accepts_independent_valid_roles() {
+        assert!(validate_script_offset_keys(1, &[], 0, &[(LedgerKeyBranch::OneSidedSenderOffset, 9)],).is_ok());
+    }
+
+    #[test]
+    fn script_offset_host_validation_rejects_cross_side_static_identity() {
+        assert!(validate_script_offset_keys(0, &[(LedgerKeyBranch::Spend, STATIC_SPEND_INDEX)], 1, &[],).is_err());
+        assert!(validate_script_offset_keys(1, &[], 1, &[]).is_err());
+    }
+
+    #[test]
+    fn script_offset_host_validation_rejects_wrong_role_branches() {
+        assert!(
+            validate_script_offset_keys(0, &[(LedgerKeyBranch::OneSidedSenderOffset, 1)], 0, &[(
+                LedgerKeyBranch::Random,
+                2
+            )],)
+            .is_err()
+        );
+        assert!(
+            validate_script_offset_keys(0, &[(LedgerKeyBranch::Spend, STATIC_SPEND_INDEX)], 0, &[(
+                LedgerKeyBranch::Spend,
+                STATIC_SPEND_INDEX
+            )],)
+            .is_err()
+        );
     }
 }

--- a/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_offset.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/handlers/get_script_offset.rs
@@ -17,6 +17,13 @@ use crate::{
 
 const MIN_UNIQUE_KEYS: usize = 2;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct KeyIdentity {
+    account: u64,
+    branch: KeyType,
+    index: u64,
+}
+
 pub struct ScriptOffsetCtx {
     sender_offset_sum: RistrettoSecretKey,
     script_private_key_sum: RistrettoSecretKey,
@@ -25,7 +32,8 @@ pub struct ScriptOffsetCtx {
     total_script_indexes: u64,
     total_derived_offset_keys: u64,
     total_derived_script_keys: u64,
-    unique_keys: Vec<RistrettoSecretKey>,
+    sender_key_identities: Vec<KeyIdentity>,
+    script_key_identities: Vec<KeyIdentity>,
 }
 
 // Implement constructor for TxInfo with default values
@@ -39,7 +47,8 @@ impl ScriptOffsetCtx {
             total_script_indexes: 0,
             total_derived_offset_keys: 0,
             total_derived_script_keys: 0,
-            unique_keys: Vec::new(),
+            sender_key_identities: Vec::new(),
+            script_key_identities: Vec::new(),
         }
     }
 
@@ -52,13 +61,53 @@ impl ScriptOffsetCtx {
         self.total_script_indexes = 0;
         self.total_derived_offset_keys = 0;
         self.total_derived_script_keys = 0;
-        self.unique_keys = Vec::new();
+        self.sender_key_identities = Vec::new();
+        self.script_key_identities = Vec::new();
     }
 
-    fn add_unique_key(&mut self, secret_key: RistrettoSecretKey) {
-        if !self.unique_keys.contains(&secret_key) {
-            self.unique_keys.push(secret_key);
+    fn add_sender_identity(&mut self, branch: KeyType, index: u64) {
+        let identity = KeyIdentity {
+            account: self.account,
+            branch,
+            index,
+        };
+        if !self.sender_key_identities.contains(&identity) {
+            self.sender_key_identities.push(identity);
         }
+    }
+
+    fn add_script_identity(&mut self, branch: KeyType, index: u64) {
+        let identity = KeyIdentity {
+            account: self.account,
+            branch,
+            index,
+        };
+        if !self.script_key_identities.contains(&identity) {
+            self.script_key_identities.push(identity);
+        }
+    }
+
+    fn sides_are_disjoint(&self) -> bool {
+        !self
+            .sender_key_identities
+            .iter()
+            .any(|identity| self.script_key_identities.contains(identity))
+    }
+
+    fn unique_identity_count(&self) -> usize {
+        self.sender_key_identities.len() +
+            self
+                .script_key_identities
+                .iter()
+                .filter(|identity| !self.sender_key_identities.contains(identity))
+                .count()
+    }
+
+    fn validate_key_identities(&self) -> Result<(), AppSW> {
+        if !self.sides_are_disjoint() || self.unique_identity_count() < MIN_UNIQUE_KEYS {
+            return Err(AppSW::ScriptOffsetNotUnique);
+        }
+        Ok(())
     }
 }
 
@@ -109,15 +158,12 @@ fn extract_branch_and_index(data: &[u8]) -> Result<(KeyType, u64), AppSW> {
 fn derive_key_from_alpha(
     account: u64,
     data: &[u8],
-    offset_ctx: &mut ScriptOffsetCtx,
 ) -> Result<RistrettoSecretKey, AppSW> {
     if data.len() != 32 {
         return Err(AppSW::WrongApduLength);
     }
     let alpha = derive_from_bip32_key(account, STATIC_SPEND_INDEX, KeyType::Spend)?;
     let blinding_factor: RistrettoSecretKey = get_key_from_canonical_bytes::<RistrettoSecretKey>(&data[0..32])?.into();
-
-    offset_ctx.add_unique_key(alpha.clone());
 
     alpha_hasher(alpha, blinding_factor)
 }
@@ -154,9 +200,12 @@ pub fn handler_get_script_offset(
     // 3. Indexed Sender offset
     if (payload_offset..end_offset_indexes).contains(&(chunk_number as u64)) {
         let (branch, index) = extract_branch_and_index(data)?;
+        if !branch.is_script_offset_sender_branch() {
+            return Err(AppSW::BadBranchKey);
+        }
         let offset = derive_from_bip32_key(offset_ctx.account, index, branch)?;
 
-        offset_ctx.add_unique_key(offset.clone());
+        offset_ctx.add_sender_identity(branch, index);
         offset_ctx.sender_offset_sum = &offset_ctx.sender_offset_sum + offset;
     }
 
@@ -164,25 +213,30 @@ pub fn handler_get_script_offset(
     let end_script_indexes = end_offset_indexes + offset_ctx.total_script_indexes;
     if (end_offset_indexes..end_script_indexes).contains(&(chunk_number as u64)) {
         let (branch, index) = extract_branch_and_index(data)?;
+        if !branch.is_script_offset_script_branch() {
+            return Err(AppSW::BadBranchKey);
+        }
         let script_key = derive_from_bip32_key(offset_ctx.account, index, branch)?;
 
-        offset_ctx.add_unique_key(script_key.clone());
+        offset_ctx.add_script_identity(branch, index);
         offset_ctx.script_private_key_sum = &offset_ctx.script_private_key_sum + script_key;
     }
 
     // 5. Derived sender offsets key
     let end_derived_offset_keys = end_script_indexes + offset_ctx.total_derived_offset_keys;
     if (end_script_indexes..end_derived_offset_keys).contains(&(chunk_number as u64)) {
-        let k = derive_key_from_alpha(offset_ctx.account, data, offset_ctx)?;
+        let k = derive_key_from_alpha(offset_ctx.account, data)?;
 
+        offset_ctx.add_sender_identity(KeyType::Spend, STATIC_SPEND_INDEX);
         offset_ctx.sender_offset_sum = &offset_ctx.sender_offset_sum + k;
     }
 
     // 6. Derived script key
     let end_derived_script_keys = end_derived_offset_keys + offset_ctx.total_derived_script_keys;
     if (end_derived_offset_keys..end_derived_script_keys).contains(&(chunk_number as u64)) {
-        let k = derive_key_from_alpha(offset_ctx.account, data, offset_ctx)?;
+        let k = derive_key_from_alpha(offset_ctx.account, data)?;
 
+        offset_ctx.add_script_identity(KeyType::Spend, STATIC_SPEND_INDEX);
         offset_ctx.script_private_key_sum = &offset_ctx.script_private_key_sum + k
     }
 
@@ -190,10 +244,9 @@ pub fn handler_get_script_offset(
         return Ok(());
     }
 
-    // Guard against attacks to extract the spending private key
-    if offset_ctx.unique_keys.len() < MIN_UNIQUE_KEYS {
-        return Err(AppSW::ScriptOffsetNotUnique);
-    }
+    // Guard against attacks to extract the spending private key: the two sides must be disjoint in
+    // key identity, not merely contain two distinct keys overall.
+    offset_ctx.validate_key_identities()?;
 
     let script_offset = &offset_ctx.script_private_key_sum - &offset_ctx.sender_offset_sum;
 
@@ -202,4 +255,61 @@ pub fn handler_get_script_offset(
     offset_ctx.reset();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn context() -> ScriptOffsetCtx {
+        let mut ctx = ScriptOffsetCtx::new();
+        ctx.account = 7;
+        ctx
+    }
+
+    #[test]
+    fn rejects_one_unique_key() {
+        let mut ctx = context();
+        ctx.add_script_identity(KeyType::Spend, STATIC_SPEND_INDEX);
+
+        assert_eq!(ctx.validate_key_identities(), Err(AppSW::ScriptOffsetNotUnique));
+    }
+
+    #[test]
+    fn accepts_two_independent_semantically_valid_keys() {
+        let mut ctx = context();
+        ctx.add_sender_identity(KeyType::OneSidedSenderOffset, 1);
+        ctx.add_script_identity(KeyType::Spend, STATIC_SPEND_INDEX);
+
+        assert_eq!(ctx.validate_key_identities(), Ok(()));
+    }
+
+    #[test]
+    fn rejects_sender_ab_script_b_overlap() {
+        let mut ctx = context();
+        ctx.add_sender_identity(KeyType::OneSidedSenderOffset, 1);
+        ctx.add_sender_identity(KeyType::Random, 2);
+        ctx.add_script_identity(KeyType::Random, 2);
+
+        assert_eq!(ctx.validate_key_identities(), Err(AppSW::ScriptOffsetNotUnique));
+    }
+
+    #[test]
+    fn rejects_sender_a_script_ab_overlap() {
+        let mut ctx = context();
+        ctx.add_sender_identity(KeyType::Random, 2);
+        ctx.add_script_identity(KeyType::Spend, STATIC_SPEND_INDEX);
+        ctx.add_script_identity(KeyType::Random, 2);
+
+        assert_eq!(ctx.validate_key_identities(), Err(AppSW::ScriptOffsetNotUnique));
+    }
+
+    #[test]
+    fn rejects_static_spend_identity_on_both_sides() {
+        let mut ctx = context();
+        ctx.add_sender_identity(KeyType::Spend, STATIC_SPEND_INDEX);
+        ctx.add_script_identity(KeyType::Spend, STATIC_SPEND_INDEX);
+
+        assert_eq!(ctx.validate_key_identities(), Err(AppSW::ScriptOffsetNotUnique));
+    }
 }

--- a/applications/minotari_ledger_wallet/wallet/src/main.rs
+++ b/applications/minotari_ledger_wallet/wallet/src/main.rs
@@ -47,6 +47,7 @@ use minotari_ledger_wallet_common::common_types::{
     AppSW as AppSWMapping,
     Instruction as InstructionMapping,
     LedgerKeyBranch as BranchMapping,
+    STATIC_SPEND_INDEX,
 };
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 
@@ -100,12 +101,11 @@ pub enum Instruction {
 }
 
 const P2_MORE: u8 = 0x01;
-const STATIC_SPEND_INDEX: u64 = 42;
 const STATIC_VIEW_INDEX: u64 = 57311; // No significance, just a random number by large dice roll
 const MAX_PAYLOADS: u8 = 250;
 
 #[repr(u8)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyType {
     Spend = 0x01,
     Nonce = 0x02,
@@ -136,6 +136,14 @@ impl KeyType {
         } else {
             return Err(AppSW::BadBranchKey);
         }
+    }
+
+    fn is_script_offset_script_branch(self) -> bool {
+        matches!(self, Self::Spend | Self::PreMine)
+    }
+
+    fn is_script_offset_sender_branch(self) -> bool {
+        matches!(self, Self::OneSidedSenderOffset | Self::Random)
     }
 }
 

--- a/base_layer/transaction_components/src/key_manager/manager.rs
+++ b/base_layer/transaction_components/src/key_manager/manager.rs
@@ -28,6 +28,8 @@ use digest::{KeyInit, consts::U64};
 use log::trace;
 use minotari_ledger_wallet_common::common_types::LedgerKeyBranch;
 #[cfg(feature = "ledger")]
+use minotari_ledger_wallet_common::common_types::STATIC_SPEND_INDEX;
+#[cfg(feature = "ledger")]
 use minotari_ledger_wallet_comms::accessor_methods::{
     ScriptSignatureKey,
     ledger_get_dh_shared_secret,
@@ -102,6 +104,65 @@ use crate::{
 const HASHER_LABEL_STEALTH_KEY: &str = "script key";
 const CODE_TEMPLATE_AUTHOR_LABEL: &str = "code-template-author";
 const HASHER_LABEL_BURN_SENDER_OFFSET: &str = "burn-sender-offset";
+
+#[cfg(feature = "ledger")]
+fn validate_ledger_script_offset_key_ids(
+    script_key_ids: &[TariKeyId],
+    sender_offset_key_ids: &[TariKeyId],
+) -> Result<(), KeyManagerError> {
+    let mut script_identities = Vec::new();
+    for key_id in script_key_ids {
+        let identity = match key_id {
+            TariKeyId::LedgerKey { branch, index } => {
+                if !branch.is_script_offset_script_branch() {
+                    return Err(KeyManagerError::LedgerError(format!(
+                        "Ledger branch {branch} cannot be used as a script key"
+                    )));
+                }
+                Some((*branch, *index))
+            },
+            TariKeyId::Derived { .. } => Some((LedgerKeyBranch::Spend, STATIC_SPEND_INDEX)),
+            _ => None,
+        };
+        if let Some(identity) = identity &&
+            !script_identities.contains(&identity)
+        {
+            script_identities.push(identity);
+        }
+    }
+
+    let mut sender_identities = Vec::new();
+    for key_id in sender_offset_key_ids {
+        let identity = match key_id {
+            TariKeyId::LedgerKey { branch, index } => {
+                if !branch.is_script_offset_sender_branch() {
+                    return Err(KeyManagerError::LedgerError(format!(
+                        "Ledger branch {branch} cannot be used as a sender offset"
+                    )));
+                }
+                Some((*branch, *index))
+            },
+            TariKeyId::Derived { .. } => Some((LedgerKeyBranch::Spend, STATIC_SPEND_INDEX)),
+            _ => None,
+        };
+        if let Some(identity) = identity &&
+            !sender_identities.contains(&identity)
+        {
+            sender_identities.push(identity);
+        }
+    }
+
+    if sender_identities
+        .iter()
+        .any(|identity| script_identities.contains(identity))
+    {
+        return Err(KeyManagerError::LedgerError(
+            "Ledger script and sender-offset key identities must be disjoint".to_string(),
+        ));
+    }
+
+    Ok(())
+}
 
 #[derive(Clone)]
 pub struct KeyManager {
@@ -286,6 +347,7 @@ impl KeyManager {
     ) -> Result<PrivateKey, KeyManagerError> {
         #[cfg(feature = "ledger")]
         if let Some(ledger) = self.wallet_type.get_ledger_details() {
+            validate_ledger_script_offset_key_ids(script_key_ids, sender_offset_key_ids)?;
             let mut partial_script_offset = PrivateKey::default();
             let mut derived_script_keys = vec![];
             let mut script_key_indexes = vec![];


### PR DESCRIPTION
## Summary

This hardens the Ledger `GetScriptOffset` anti-extraction boundary by tracking hardware key identity as `(account, branch, index)` instead of comparing derived secret values.

The device now:

1. Rejects any key identity present on both the sender-offset and script sides.
2. Preserves the existing minimum-two-identities guard.
3. Allows only `Spend`/`PreMine` for managed script keys and `OneSidedSenderOffset`/`Random` for managed sender offsets.
4. Treats alpha-derived keys as the static spend identity.

The host accessor and key-manager wrapper mirror the role and overlap checks so malformed requests fail before APDU exchange. Regression tests cover the acceptance matrix, including asymmetric overlap, one identity, a valid independent pair, and static-spend overlap.

Addresses tari-project/special_contributions#18.

## Validation

`cargo +nightly fmt --all` was run and the affected files were checked with `git diff --check`. Local dependency resolution on Windows is blocked by Cargo/Schannel `SEC_E_NO_CREDENTIALS`; the repository's Linux CI and Ledger builder are requested as the authoritative compilation and test environment. A maintainer with a development Ledger device is also needed for the final real-device transaction flow described in the issue.