### PR TITLE
feat(wallet): support excluding commitments from gRPC transfers

### DIFF
--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -2008,7 +2008,7 @@ message BroadcastSignedOneSidedTransactionResponse {
 message TransferRequest {
   repeated PaymentRecipient recipients = 1;
   bool single_tx = 2;
-  // Canonical compressed commitments that must not be selected as transaction inputs.
+  // Canonical compressed commitments to exclude from transaction input selection.
   repeated bytes excluded_commitments = 3;
 }
 

--- a/applications/minotari_app_grpc/proto/wallet.proto
+++ b/applications/minotari_app_grpc/proto/wallet.proto
@@ -2008,6 +2008,8 @@ message BroadcastSignedOneSidedTransactionResponse {
 message TransferRequest {
   repeated PaymentRecipient recipients = 1;
   bool single_tx = 2;
+  // Canonical compressed commitments that must not be selected as transaction inputs.
+  repeated bytes excluded_commitments = 3;
 }
 
 // A request to perform a range-limited coin-join to self operation.

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -382,6 +382,7 @@ impl WalletGrpcServer {
     async fn transfer_single_tx(
         &self,
         recipients: Vec<minotari_app_grpc::tari_rpc::PaymentRecipient>,
+        selection_criteria: UtxoSelectionCriteria,
     ) -> Result<Response<minotari_app_grpc::tari_rpc::TransferResponse>, Status> {
         let fee_per_gram = recipients.first().expect("already checked").fee_per_gram;
         let recipients = recipients
@@ -417,7 +418,7 @@ impl WalletGrpcServer {
         let ids = transaction_service
             .send_one_sided_multi_recipient_transaction(
                 recipients,
-                UtxoSelectionCriteria::default(),
+                selection_criteria,
                 OutputFeatures::default(),
                 fee_per_gram.into(),
             )
@@ -1179,8 +1180,11 @@ impl wallet_server::Wallet for WalletGrpcServer {
             ));
         }
 
+        let mut selection_criteria = UtxoSelectionCriteria::default();
+        selection_criteria.excluding = parse_excluded_commitments(message.excluded_commitments)?;
+
         if message.single_tx {
-            return self.transfer_single_tx(message.recipients).await;
+            return self.transfer_single_tx(message.recipients, selection_criteria).await;
         }
         let recipients = message
             .recipients
@@ -1230,6 +1234,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                 MemoField::new_empty()
             };
             let mut transaction_service = self.get_transaction_service();
+            let selection_criteria = selection_criteria.clone();
             transfers.push(async move {
                 (
                     hex_address,
@@ -1238,7 +1243,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                             .send_one_sided_transaction(
                                 address,
                                 amount.into(),
-                                UtxoSelectionCriteria::default(),
+                                selection_criteria,
                                 OutputFeatures::default(),
                                 fee_per_gram.into(),
                                 payment_id,
@@ -1249,7 +1254,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                             .send_one_sided_to_stealth_address_transaction(
                                 address,
                                 amount.into(),
-                                UtxoSelectionCriteria::default(),
+                                selection_criteria,
                                 OutputFeatures::default(),
                                 fee_per_gram.into(),
                                 payment_id,
@@ -4539,5 +4544,44 @@ fn get_payment_reference(txn: &CompletedTransaction, hash: &FixedHash) -> Vec<u8
         }
     } else {
         Default::default()
+    }
+}
+
+fn parse_excluded_commitments(commitments: Vec<Vec<u8>>) -> Result<Vec<CompressedCommitment>, Status> {
+    commitments
+        .into_iter()
+        .enumerate()
+        .map(|(index, commitment)| {
+            CompressedCommitment::from_canonical_bytes(&commitment).map_err(|error| {
+                Status::invalid_argument(format!(
+                    "excluded_commitments[{index}] is not a canonical compressed commitment: {error}"
+                ))
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_utilities::ByteArray;
+
+    use super::parse_excluded_commitments;
+
+    #[test]
+    fn parse_excluded_commitments_rejects_invalid_commitments_with_their_index() {
+        let status = parse_excluded_commitments(vec![vec![0; 32], vec![1; 31]]).unwrap_err();
+
+        assert!(status.message().contains("excluded_commitments[1]"));
+    }
+
+    #[test]
+    fn parse_excluded_commitments_accepts_canonical_commitments() {
+        let bytes = tari_common_types::types::CompressedCommitment::default()
+            .as_bytes()
+            .to_vec();
+
+        let parsed = parse_excluded_commitments(vec![bytes]).unwrap();
+
+        assert_eq!(parsed.len(), 1);
     }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -183,6 +183,7 @@ use tari_transaction_components::{
     consensus::{ConsensusConstants, ConsensusManager},
     key_manager::TransactionKeyManagerInterface,
     offline_signing::models::SignedOneSidedTransactionResult,
+    rpc::MAX_ALLOWED_QUERY_SIZE,
     transaction_components::{
         OutputFeatures,
         TransactionOutput,
@@ -1180,8 +1181,10 @@ impl wallet_server::Wallet for WalletGrpcServer {
             ));
         }
 
-        let mut selection_criteria = UtxoSelectionCriteria::default();
-        selection_criteria.excluding = parse_excluded_commitments(message.excluded_commitments)?;
+        let selection_criteria = UtxoSelectionCriteria {
+            excluding: parse_excluded_commitments(message.excluded_commitments)?,
+            ..Default::default()
+        };
 
         if message.single_tx {
             return self.transfer_single_tx(message.recipients, selection_criteria).await;
@@ -4548,40 +4551,69 @@ fn get_payment_reference(txn: &CompletedTransaction, hash: &FixedHash) -> Vec<u8
 }
 
 fn parse_excluded_commitments(commitments: Vec<Vec<u8>>) -> Result<Vec<CompressedCommitment>, Status> {
+    if commitments.len() > MAX_ALLOWED_QUERY_SIZE {
+        return Err(Status::invalid_argument(format!(
+            "excluded_commitments exceeds the maximum allowed size. Requested: {}, max: {MAX_ALLOWED_QUERY_SIZE}",
+            commitments.len()
+        )));
+    }
+
     commitments
         .into_iter()
         .enumerate()
         .map(|(index, commitment)| {
-            CompressedCommitment::from_canonical_bytes(&commitment).map_err(|error| {
+            let commitment = CompressedCommitment::from_canonical_bytes(&commitment).map_err(|error| {
                 Status::invalid_argument(format!(
                     "excluded_commitments[{index}] is not a canonical compressed commitment: {error}"
                 ))
-            })
+            })?;
+            commitment.to_commitment().map_err(|error| {
+                Status::invalid_argument(format!(
+                    "excluded_commitments[{index}] is not a valid compressed commitment: {error}"
+                ))
+            })?;
+            Ok(commitment)
         })
         .collect()
 }
 
 #[cfg(test)]
 mod tests {
+    use tari_common_types::types::{CommitmentFactory, CompressedCommitment};
+    use tari_crypto::commitment::HomomorphicCommitmentFactory;
+    use tari_transaction_components::rpc::MAX_ALLOWED_QUERY_SIZE;
     use tari_utilities::ByteArray;
 
     use super::parse_excluded_commitments;
 
     #[test]
-    fn parse_excluded_commitments_rejects_invalid_commitments_with_their_index() {
-        let status = parse_excluded_commitments(vec![vec![0; 32], vec![1; 31]]).unwrap_err();
+    fn parse_excluded_commitments_rejects_invalid_lengths_with_their_index() {
+        let status = parse_excluded_commitments(vec![vec![1; 31]]).unwrap_err();
 
-        assert!(status.message().contains("excluded_commitments[1]"));
+        assert!(status.message().contains("excluded_commitments[0]"));
+    }
+
+    #[test]
+    fn parse_excluded_commitments_rejects_invalid_points_with_their_index() {
+        let status = parse_excluded_commitments(vec![vec![0; 32]]).unwrap_err();
+
+        assert!(status.message().contains("excluded_commitments[0]"));
+    }
+
+    #[test]
+    fn parse_excluded_commitments_rejects_oversized_requests() {
+        let status = parse_excluded_commitments(vec![Vec::new(); MAX_ALLOWED_QUERY_SIZE + 1]).unwrap_err();
+
+        assert!(status.message().contains(&MAX_ALLOWED_QUERY_SIZE.to_string()));
     }
 
     #[test]
     fn parse_excluded_commitments_accepts_canonical_commitments() {
-        let bytes = tari_common_types::types::CompressedCommitment::default()
-            .as_bytes()
-            .to_vec();
+        let commitment = CompressedCommitment::from_commitment(CommitmentFactory::default().zero());
+        let bytes = commitment.as_bytes().to_vec();
 
         let parsed = parse_excluded_commitments(vec![bytes]).unwrap();
 
-        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed, vec![commitment]);
     }
 }

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -4595,8 +4595,9 @@ mod tests {
 
     #[test]
     fn parse_excluded_commitments_rejects_invalid_points_with_their_index() {
-        let mut invalid_point = vec![0; 32];
-        invalid_point[0] = 1;
+        let invalid_point = vec![
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
         let status = parse_excluded_commitments(vec![invalid_point]).unwrap_err();
 
         assert!(status.message().contains("excluded_commitments[0]"));

--- a/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/minotari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -4595,9 +4595,12 @@ mod tests {
 
     #[test]
     fn parse_excluded_commitments_rejects_invalid_points_with_their_index() {
-        let status = parse_excluded_commitments(vec![vec![0; 32]]).unwrap_err();
+        let mut invalid_point = vec![0; 32];
+        invalid_point[0] = 1;
+        let status = parse_excluded_commitments(vec![invalid_point]).unwrap_err();
 
         assert!(status.message().contains("excluded_commitments[0]"));
+        assert!(status.message().contains("not a valid compressed commitment"));
     }
 
     #[test]

--- a/base_layer/wallet/tests/output_manager_service_tests/service.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/service.rs
@@ -404,6 +404,55 @@ async fn fee_estimate() {
     assert_insufficient_funds_quote(fee.0, fee_per_gram, 1);
 }
 
+#[tokio::test]
+async fn prepare_transaction_fails_when_all_commitments_are_excluded() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection.clone());
+    let mut oms = setup_output_manager_service(backend.clone(), true).await;
+
+    let outputs = [3000u64, 4000]
+        .into_iter()
+        .map(|value| {
+            make_input(
+                &mut rand::rng(),
+                MicroMinotari::from(value),
+                &OutputFeatures::default(),
+                oms.key_manager_handle.key_manager(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for output in &outputs {
+        oms.output_manager_handle
+            .add_output(output.clone(), None)
+            .await
+            .unwrap();
+    }
+    backend
+        .mark_outputs_as_unspent(outputs.iter().map(|output| (output.output_hash(), true)).collect())
+        .unwrap();
+
+    let selection_criteria = UtxoSelectionCriteria {
+        excluding: outputs.iter().map(|output| output.commitment().clone()).collect(),
+        ..Default::default()
+    };
+    let result = oms
+        .output_manager_handle
+        .prepare_transaction_to_send(
+            TxId::new_random(),
+            MicroMinotari::from(100),
+            selection_criteria,
+            OutputFeatures::default(),
+            MicroMinotari::from(1),
+            script!(Nop).unwrap(),
+            Covenant::default(),
+            MemoField::new_empty(),
+        )
+        .await;
+
+    assert!(matches!(result, Err(OutputManagerError::NotEnoughFunds)));
+}
+
 #[allow(clippy::identity_op)]
 #[allow(clippy::too_many_lines)]
 #[tokio::test]

--- a/base_layer/wallet/tests/output_manager_service_tests/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service_tests/storage.rs
@@ -628,6 +628,51 @@ pub async fn test_must_include_filter() {
 }
 
 #[tokio::test]
+pub async fn test_excluding_commitments_filter() {
+    let (connection, _tempdir) = get_temp_sqlite_database_connection();
+    let backend = OutputManagerSqliteDatabase::new(connection);
+    let db = OutputManagerDatabase::new(backend);
+    let key_manager = create_new_random_key_manager().await.unwrap();
+
+    let mut outputs = Vec::new();
+    let mut unspent = Vec::new();
+    for value in [100, 200] {
+        let wallet_output = make_input(
+            &mut rand::rng(),
+            MicroMinotari::from(value),
+            &OutputFeatures::default(),
+            key_manager.key_manager(),
+        );
+        let output = DbWalletOutput::from_wallet_output(wallet_output, None, OutputSource::Standard, None, None);
+        db.add_unspent_output(output.clone(), &key_manager).unwrap();
+        unspent.push((output.hash, true));
+        outputs.push(output);
+    }
+    db.mark_outputs_as_unspent(unspent).unwrap();
+
+    let selection_criteria = UtxoSelectionCriteria {
+        excluding: vec![outputs[0].commitment.clone()],
+        ..Default::default()
+    };
+    let selected = db
+        .fetch_unspent_outputs_for_spending(&selection_criteria, MicroMinotari::from(100), None, &key_manager)
+        .unwrap();
+
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].commitment, outputs[1].commitment);
+
+    let selection_criteria = UtxoSelectionCriteria {
+        excluding: outputs.into_iter().map(|output| output.commitment).collect(),
+        ..Default::default()
+    };
+    let selected = db
+        .fetch_unspent_outputs_for_spending(&selection_criteria, MicroMinotari::from(100), None, &key_manager)
+        .unwrap();
+
+    assert!(selected.is_empty());
+}
+
+#[tokio::test]
 #[allow(clippy::too_many_lines)]
 pub async fn test_raw_custom_queries_regression() {
     let (connection, _tempdir) = get_temp_sqlite_database_connection();

--- a/integration_tests/tests/steps/wallet_cli_steps.rs
+++ b/integration_tests/tests/steps/wallet_cli_steps.rs
@@ -358,6 +358,7 @@ async fn send_via_cli(world: &mut TariWorld, amount: u64, sender: String, receiv
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
         single_tx: false,
+        excluded_commitments: vec![],
     };
     let tx_res = sender_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;

--- a/integration_tests/tests/steps/wallet_steps.rs
+++ b/integration_tests/tests/steps/wallet_steps.rs
@@ -649,6 +649,7 @@ async fn send_amount_from_source_wallet_to_dest_wallet_without_broadcast(
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
         single_tx: false,
+        excluded_commitments: vec![],
     };
     let tx_res = source_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -712,6 +713,7 @@ async fn send_one_sided_transaction_from_source_wallet_to_dest_wallt(
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
         single_tx: false,
+        excluded_commitments: vec![],
     };
     let tx_res = sender_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -800,6 +802,7 @@ async fn send_interactive_amount_from_wallet_to_wallet_at_fee(
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
         single_tx: false,
+        excluded_commitments: vec![],
     };
     let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -891,6 +894,7 @@ async fn send_many_interactive_amount_from_wallet_to_wallet_at_fee(
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
         single_tx: false,
+        excluded_commitments: vec![],
     };
     let mut tx_ids = Vec::with_capacity(usize::try_from(number_of_transactions).unwrap());
     for i in 0..number_of_transactions {
@@ -1413,6 +1417,7 @@ async fn send_num_one_sided_transactions_to_wallets_at_fee(
         let transfer_req = TransferRequest {
             recipients: vec![payment_recipient],
             single_tx: false,
+            excluded_commitments: vec![],
         };
         let transfer_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
         let transfer_res = transfer_res.results.first().unwrap();
@@ -1576,6 +1581,7 @@ async fn transfer_tari_from_wallet_to_receiver(world: &mut TariWorld, amount: u6
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
         single_tx: false,
+        excluded_commitments: vec![],
     };
     let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -1782,6 +1788,7 @@ async fn transfer_one_sided_from_wallet_to_two_recipients_at_fee(
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient1, payment_recipient2],
         single_tx: true,
+        excluded_commitments: vec![],
     };
     let tx_res = sender_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -1872,6 +1879,7 @@ async fn transfer_tari_to_self(world: &mut TariWorld, amount: u64, sender: Strin
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
         single_tx: false,
+        excluded_commitments: vec![],
     };
     let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -2166,6 +2174,7 @@ async fn send_one_sided_stealth_transaction(
     let transfer_req = TransferRequest {
         recipients: vec![payment_recipient],
         single_tx: false,
+        excluded_commitments: vec![],
     };
     let tx_res = sender_client.transfer(transfer_req).await.unwrap().into_inner();
     let tx_res = tx_res.results;
@@ -2678,6 +2687,7 @@ async fn multi_send_txs_from_wallet(
         let transfer_req = TransferRequest {
             recipients: vec![payment_recipient],
             single_tx: false,
+            excluded_commitments: vec![],
         };
         let tx_res = sender_wallet_client.transfer(transfer_req).await.unwrap().into_inner();
         let tx_res = tx_res.results;


### PR DESCRIPTION
Implements acceptance item 1 from tari-project/special_contributions#20.

## What changed

The wallet gRPC `TransferRequest` now accepts canonical compressed commitments to exclude from input selection. The server validates them and threads the resulting `UtxoSelectionCriteria` through both single-transaction and per-recipient transfer paths.

Existing gRPC callers were updated for the additive protobuf field. Tests cover canonical parsing, selecting another available output when one commitment is excluded, and returning insufficient funds when every available commitment is excluded.

## Validation

`cargo +nightly-2026-06-01 fmt --all -- --check` passed for all modified Rust files.