### PR TITLE
fix: stop running peer-database SQLite on tokio worker threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7650,6 +7650,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "snow",
+ "syn 2.0.118",
  "tari_common",
  "tari_common_sqlite",
  "tari_comms_rpc_macros",

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -48,6 +48,7 @@ use tari_comms::{
     multiaddr::multiaddr,
     peer_manager::{
         NodeIdentity,
+        PEER_DATABASE_BUSY_TIMEOUT,
         Peer,
         PeerFeatures,
         PeerFlags,
@@ -151,7 +152,12 @@ where
     fs::create_dir_all(&data_path)?;
     let database_url = DbConnectionUrl::File(PathBuf::from(data_path).join("peers.db"));
     debug!(target: LOG_TARGET, "initialize_local_test_comms - node_identity: {}, database URL: {}", node_identity.node_id().to_hex(), database_url.to_url_string());
-    let db_connection = DbConnection::connect_and_migrate(&database_url, MIGRATIONS, Some(5))?;
+    let db_connection = DbConnection::connect_and_migrate_with_busy_timeout(
+        &database_url,
+        MIGRATIONS,
+        Some(5),
+        PEER_DATABASE_BUSY_TIMEOUT,
+    )?;
     let peer_database = PeerDatabaseSql::new(db_connection, &node_identity.to_peer())?;
 
     //---------------------------------- Comms --------------------------------------------//
@@ -298,7 +304,14 @@ async fn configure_comms_and_dht(
             .join(&config.peer_database_name)
             .with_extension("db"),
     );
-    let db_connection = DbConnection::connect_and_migrate(&database_url, MIGRATIONS, Some(16))?;
+    // The peer database is written on every dial result, so it must not be able to park a caller for
+    // the shared 60s default - see `PEER_DATABASE_BUSY_TIMEOUT`.
+    let db_connection = DbConnection::connect_and_migrate_with_busy_timeout(
+        &database_url,
+        MIGRATIONS,
+        Some(16),
+        PEER_DATABASE_BUSY_TIMEOUT,
+    )?;
     let this_node = builder
         .node_identity()
         .as_deref()

--- a/common_sqlite/src/connection.rs
+++ b/common_sqlite/src/connection.rs
@@ -27,6 +27,7 @@ use std::{
     iter,
     path::{Path, PathBuf},
     sync::{Arc, RwLock, RwLockWriteGuard},
+    time::Duration,
 };
 
 use diesel::{
@@ -178,7 +179,22 @@ impl DbConnection {
     /// override the default setting of 1.
     /// Note: See https://github.com/launchbadge/sqlx/issues/362#issuecomment-636661146
     pub fn connect_url(db_url: &DbConnectionUrl, sqlite_pool_size: Option<usize>) -> Result<Self, StorageError> {
-        debug!(target: LOG_TARGET, "Connecting to database using '{db_url:?}'");
+        Self::connect_url_with_busy_timeout(db_url, sqlite_pool_size, PRAGMA_BUSY_TIMEOUT)
+    }
+
+    /// As [`Self::connect_url`], but with an explicit `PRAGMA busy_timeout`.
+    ///
+    /// The default ([`PRAGMA_BUSY_TIMEOUT`], 60s) suits databases where losing a write is worse than
+    /// waiting - the wallet, for instance. It is a poor fit for databases on a hot networking path,
+    /// where a call that waits a minute for a lock has long outlived the request that made it and,
+    /// even when run on a blocking thread pool, occupies a thread in it for that whole minute. Such
+    /// callers should pass something far shorter.
+    pub fn connect_url_with_busy_timeout(
+        db_url: &DbConnectionUrl,
+        sqlite_pool_size: Option<usize>,
+        busy_timeout: Duration,
+    ) -> Result<Self, StorageError> {
+        debug!(target: LOG_TARGET, "Connecting to database using '{db_url:?}' (busy_timeout {busy_timeout:.0?})");
 
         // Ensure the path exists
         if let DbConnectionUrl::File(path) = db_url &&
@@ -192,7 +208,7 @@ impl DbConnection {
             sqlite_pool_size.unwrap_or(1),
             true,
             true,
-            PRAGMA_BUSY_TIMEOUT,
+            busy_timeout,
         );
         pool.create_pool()?;
 
@@ -224,8 +240,19 @@ impl DbConnection {
         migrations: EmbeddedMigrations,
         sqlite_pool_size: Option<usize>,
     ) -> Result<Self, StorageError> {
+        Self::connect_and_migrate_with_busy_timeout(db_url, migrations, sqlite_pool_size, PRAGMA_BUSY_TIMEOUT)
+    }
+
+    /// As [`Self::connect_and_migrate`], but with an explicit `PRAGMA busy_timeout`. See
+    /// [`Self::connect_url_with_busy_timeout`] for when to override the default.
+    pub fn connect_and_migrate_with_busy_timeout(
+        db_url: &DbConnectionUrl,
+        migrations: EmbeddedMigrations,
+        sqlite_pool_size: Option<usize>,
+        busy_timeout: Duration,
+    ) -> Result<Self, StorageError> {
         let _lock = Self::acquire_migration_write_lock()?;
-        let conn = Self::connect_url(db_url, sqlite_pool_size)?;
+        let conn = Self::connect_url_with_busy_timeout(db_url, sqlite_pool_size, busy_timeout)?;
         let output = conn.migrate(migrations)?;
         debug!(target: LOG_TARGET, "Database migration: {}", output.trim());
         Ok(conn)

--- a/comms/core/Cargo.toml
+++ b/comms/core/Cargo.toml
@@ -77,6 +77,9 @@ toml = { version = "0.5" }
 tokio = { workspace = true, features = ["test-util"] }
 
 env_logger = "0.11"
+# Used by `no_peer_manager_method_performs_synchronous_storage_io` to parse the peer manager sources
+# rather than pattern-match them. Already in the lockfile as a transitive proc-macro dependency.
+syn = { version = "2.0.118", features = ["full", "visit"] }
 tempfile = "3.1.0"
 
 [build-dependencies]

--- a/comms/core/src/bounded_executor.rs
+++ b/comms/core/src/bounded_executor.rs
@@ -35,6 +35,10 @@ pub struct TrySpawnError;
 ///
 /// Use the asynchronous spawn method to spawn a task. If a given number of tasks are already spawned and have not
 /// completed, the spawn function will block (asynchronously) until a previously spawned task completes.
+///
+/// Cloning shares the same permit pool, so a clone can be handed to a spawned task purely to read
+/// the live occupancy from inside it.
+#[derive(Clone)]
 pub struct BoundedExecutor {
     // inner: runtime::Handle,
     semaphore: Arc<Semaphore>,

--- a/comms/core/src/connection_manager/dialer.rs
+++ b/comms/core/src/connection_manager/dialer.rs
@@ -65,7 +65,7 @@ use crate::{
     multiplexing::Yamux,
     net_address::{MultiaddrRange, PeerAddressSource},
     noise::{NoiseConfig, NoiseSocket},
-    peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
+    peer_manager::{NodeId, NodeIdentity, PEER_LOOKUP_TIMEOUT, Peer, PeerManager},
     protocol::ProtocolId,
     transports::Transport,
     types::{CommsPublicKey, TransportProtocol},
@@ -290,16 +290,31 @@ where
             },
         }
 
-        let _ = self
-            .peer_manager
-            .add_or_update_peer(dial_state.peer().clone())
-            .await
-            .map_err(|e| {
+        // Bounded, because this write-back sits on the dialer's `select!` loop: every failed dial
+        // writes the peer back, so under a dial storm this is exactly where the dialer used to wedge.
+        // The write still completes on the blocking pool if it overruns - we just stop waiting for it
+        // and carry on servicing dial requests.
+        let write_back = time::timeout(
+            PEER_LOOKUP_TIMEOUT,
+            self.peer_manager.add_or_update_peer(dial_state.peer().clone()),
+        )
+        .await;
+        match write_back {
+            Ok(Ok(_)) => {},
+            Ok(Err(e)) => {
                 error!(target: LOG_TARGET, "Could not update peer data: {e}");
                 let _ = dial_state
                     .send_reply(Err(ConnectionManagerError::PeerManagerError(e)))
                     .map_err(|e| error!(target: LOG_TARGET, "Could not send reply to dial request: {e:?}"));
-            });
+            },
+            Err(_) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Peer write-back for '{node_id}' exceeded {PEER_LOOKUP_TIMEOUT:.0?}; it will complete in the \
+                     background. The peer database is slow."
+                );
+            },
+        }
 
         #[cfg(feature = "metrics")]
         metrics::pending_connections(ConnectionDirection::Outbound).dec();

--- a/comms/core/src/connection_manager/error.rs
+++ b/comms/core/src/connection_manager/error.rs
@@ -44,6 +44,8 @@ pub enum ConnectionManagerError {
     SendToActorFailed,
     #[error("Dial request queue is full, the dial was shed")]
     DialQueueFull,
+    #[error("Peer database lookup did not complete within the actor lookup timeout, the request was shed")]
+    PeerLookupTimeout,
     #[error("Request was canceled before the response could be sent")]
     ActorRequestCanceled,
     #[error("Failed to connect on all addresses for peer")]

--- a/comms/core/src/connection_manager/manager.rs
+++ b/comms/core/src/connection_manager/manager.rs
@@ -53,7 +53,7 @@ use crate::{
     multiplexing::Substream,
     net_address::MultiaddrRange,
     noise::NoiseConfig,
-    peer_manager::{NodeId, NodeIdentity, PeerManagerError},
+    peer_manager::{NodeId, NodeIdentity, PEER_LOOKUP_TIMEOUT, PeerManagerError},
     peer_validator::PeerValidatorConfig,
     protocol::{NodeNetworkInfo, ProtocolEvent, ProtocolId, Protocols},
     transports::{TcpTransport, Transport},
@@ -540,7 +540,27 @@ where
         node_id: NodeId,
         reply: Option<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>,
     ) {
-        match self.peer_manager.find_by_node_id(&node_id).await {
+        // Shed rather than block. This lookup is the first thing the ConnectionManager's request loop
+        // does for a dial, ahead of any log line or timeout guard, so a slow peer database used to
+        // stall the whole actor here. The query itself runs on the blocking pool and completes
+        // regardless of this timeout; we simply stop waiting for it.
+        let lookup = time::timeout(PEER_LOOKUP_TIMEOUT, self.peer_manager.find_by_node_id(&node_id)).await;
+        let lookup = match lookup {
+            Ok(result) => result,
+            Err(_) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Peer database lookup for dial to '{}' exceeded {PEER_LOOKUP_TIMEOUT:.0?}. Shedding the dial \
+                     rather than stalling the connection manager.",
+                    node_id.short_str()
+                );
+                if let Some(reply) = reply {
+                    let _result = reply.send(Err(ConnectionManagerError::PeerLookupTimeout));
+                }
+                return;
+            },
+        };
+        match lookup {
             Ok(Some(peer)) => {
                 // The reply channel travels inside the request, so a shed request drops it and the
                 // caller sees a cancelled reply — never an indefinite wait.

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -60,7 +60,7 @@ use crate::{
         ConnectionManagerEvent,
         ConnectionManagerRequester,
     },
-    peer_manager::NodeId,
+    peer_manager::{NodeId, PEER_LOOKUP_TIMEOUT},
     utils::datetime::format_duration,
 };
 
@@ -375,7 +375,25 @@ impl ConnectivityManagerActor {
         ref_kind: RefKind,
         reply_tx: Option<oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>>,
     ) {
-        match self.peer_manager.is_peer_banned(&node_id).await {
+        // Shed rather than block. `handle_dial_peer` runs on the ConnectivityManager's single request
+        // loop and this ban check precedes every other statement in it, so a slow peer database used
+        // to wedge the actor here — and with it `select_connections`, which the DHT needs to
+        // propagate anything at all. The query still completes on the blocking pool; we just stop
+        // waiting on it.
+        let ban_check = time::timeout(PEER_LOOKUP_TIMEOUT, self.peer_manager.is_peer_banned(&node_id)).await;
+        let Ok(ban_check) = ban_check else {
+            warn!(
+                target: LOG_TARGET,
+                "Ban check for dial to peer '{}' exceeded {PEER_LOOKUP_TIMEOUT:.0?}. Shedding the dial rather than \
+                 stalling the connectivity manager.",
+                node_id.short_str()
+            );
+            if let Some(reply) = reply_tx {
+                let _result = reply.send(Err(ConnectionManagerError::PeerLookupTimeout));
+            }
+            return;
+        };
+        match ban_check {
             Ok(true) => {
                 if let Some(reply) = reply_tx {
                     let _result = reply.send(Err(ConnectionManagerError::PeerBanned));

--- a/comms/core/src/connectivity/test.rs
+++ b/comms/core/src/connectivity/test.rs
@@ -22,7 +22,10 @@
 // DAMAGE.
 
 #![allow(clippy::indexing_slicing)]
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use futures::{StreamExt, future};
 use tari_shutdown::Shutdown;
@@ -64,6 +67,22 @@ fn setup_connectivity_manager(
 ) {
     let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     let peer_manager = build_peer_manager(&node_identity.to_peer()).unwrap();
+    setup_connectivity_manager_with_peer_manager(config, node_identity, peer_manager)
+}
+
+#[allow(clippy::type_complexity)]
+fn setup_connectivity_manager_with_peer_manager(
+    config: ConnectivityConfig,
+    node_identity: Arc<NodeIdentity>,
+    peer_manager: Arc<PeerManager>,
+) -> (
+    ConnectivityRequester,
+    ConnectivityEventRx,
+    Arc<NodeIdentity>,
+    Arc<PeerManager>,
+    ConnectionManagerMockState,
+    Shutdown,
+) {
     let (cm_requester, mock) = create_connection_manager_mock();
     let cm_mock_state = mock.get_shared_state();
     tokio::spawn(mock.run());
@@ -523,4 +542,117 @@ async fn seed_peer_release() {
         &normal_peer.node_id,
         "Remaining peer should be the normal peer"
     );
+}
+
+/// The ConnectivityManager must keep answering `select_connections` even while the peer database is
+/// unresponsive.
+///
+/// `handle_dial_peer` consults the peer database (`is_peer_banned`) before doing anything else, so a
+/// contended peer database used to wedge the actor there. Once it is wedged `select_connections`
+/// never answers, the DHT blocks mid-propagation, and every outbound message holds a pipeline slot
+/// until it times out — which is how this surfaced in production, four layers downstream.
+///
+/// The runtime has a single worker so that a peer database call which blocks its caller's *thread*
+/// (rather than merely its task) is fatal to the test, as it was to the node.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn select_connections_is_served_while_the_peer_database_is_slow() {
+    use diesel::connection::SimpleConnection;
+    use tari_common_sqlite::connection::{DbConnection, DbConnectionUrl};
+
+    use crate::peer_manager::database::{MIGRATIONS, PeerDatabaseSql};
+
+    let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_url = DbConnectionUrl::File(temp_dir.path().join("slow_peers.db"));
+    // A long busy timeout on purpose: if a peer database call is allowed to block its caller, it
+    // blocks for far longer than this test is prepared to wait.
+    // A small pool and a long busy timeout on purpose. Writers that are stuck on SQLite's single
+    // write lock hold their pooled connections while they wait, so the pool empties and every
+    // subsequent call - reads included, WAL or not - blocks on the r2d2 checkout instead. That is the
+    // shape of the production failure: `is_peer_banned` is a read, and it still wedged the actor.
+    let db_connection =
+        DbConnection::connect_and_migrate_with_busy_timeout(&db_url, MIGRATIONS, Some(4), Duration::from_secs(15))
+            .unwrap();
+    let peers_db = PeerDatabaseSql::new(db_connection.clone(), &node_identity.to_peer()).unwrap();
+    let peer_manager = Arc::new(PeerManager::new(peers_db, crate::types::TransportProtocol::get_all()).unwrap());
+
+    let (connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
+        setup_connectivity_manager_with_peer_manager(Default::default(), node_identity, peer_manager);
+
+    let peers = add_test_peers(&peer_manager, 3).await;
+    let connections = future::join_all(
+        peers
+            .iter()
+            .cloned()
+            .map(|peer| create_peer_connection_mock_pair(peer, node_identity.to_peer())),
+    )
+    .await
+    .into_iter()
+    .map(|(_, _, conn, _)| conn)
+    .collect::<Vec<_>>();
+
+    let mut events = collect_try_recv!(event_stream, take = 1, timeout = Duration::from_secs(10));
+    unpack_enum!(ConnectivityEvent::ConnectivityStateInitialized = events.remove(0));
+    for conn in &connections {
+        cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(conn.clone().into()));
+    }
+    let _events = collect_try_recv!(event_stream, take = 4, timeout = Duration::from_secs(10));
+
+    // Take SQLite's write lock on one pooled connection, then pile on more writes than the pool has
+    // connections left. Every one of them parks holding (or waiting for) a connection, so the peer
+    // database stops answering anything at all.
+    let mut lock_holder = db_connection.get_pooled_connection().unwrap();
+    lock_holder.batch_execute("BEGIN IMMEDIATE;").unwrap();
+
+    // The probe runs on a real OS thread, outside the runtime's single worker, and both timestamps
+    // are taken there. That is the whole point: when a worker is parked by a blocking call the
+    // runtime's timers stop too, so a task that measures its own latency (or a `tokio::time::timeout`)
+    // sees nothing at all - it is not scheduled until after the stall has passed.
+    let handle = tokio::runtime::Handle::current();
+    let mut probe_connectivity = connectivity.clone();
+    let probe = std::thread::spawn(move || {
+        // Let the writers below saturate the peer database first.
+        std::thread::sleep(Duration::from_millis(400));
+        let started = Instant::now();
+        let result =
+            handle.block_on(probe_connectivity.select_connections(ConnectivitySelection::random_nodes(3, vec![])));
+        (started.elapsed(), result)
+    });
+
+    let writers = (0..6)
+        .map(|_| {
+            let peer_manager = peer_manager.clone();
+            let peer = build_node_identity(PeerFeatures::COMMUNICATION_NODE).to_peer();
+            tokio::spawn(async move { peer_manager.add_or_update_peer(peer).await })
+        })
+        .collect::<Vec<_>>();
+
+    // Ask for a dial too. This is the request that reaches the peer database first, from the
+    // connectivity manager's own request loop, and it is where the actor used to wedge.
+    let dial = tokio::spawn({
+        let connectivity = connectivity.clone();
+        let node_id = peers[0].node_id.clone();
+        async move { connectivity.dial_peer(node_id, RefKind::Weak).await }
+    });
+
+    let (elapsed, result) = tokio::task::spawn_blocking(move || probe.join().expect("probe thread panicked"))
+        .await
+        .unwrap();
+    let conns = result.unwrap();
+    assert_eq!(conns.len(), 3);
+    // Bounded by `PEER_LOOKUP_TIMEOUT` (the shed), not by the peer database's busy timeout.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "the connectivity manager took {elapsed:.1?} to answer select_connections while the peer database was \
+         saturated; it should shed the peer lookup, not park on it"
+    );
+
+    lock_holder.batch_execute("COMMIT;").unwrap();
+    drop(lock_holder);
+    let _result = dial.await.unwrap();
+    for writer in writers {
+        // Under this much artificial contention an individual write may legitimately give up with
+        // "database is locked". What matters is that none of them took the actor down with them.
+        let _result = writer.await.unwrap();
+    }
 }

--- a/comms/core/src/peer_manager/blocking_storage.rs
+++ b/comms/core/src/peer_manager/blocking_storage.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Async-safe access to the (synchronous) peer database.
+//!
+//! Every peer database call ultimately runs diesel/r2d2 against SQLite, which is *blocking*: it
+//! waits on an r2d2 pool checkout and then on SQLite's own single-writer lock. Calling that
+//! directly from an `async fn` does not park a task, it parks the tokio **worker thread** running
+//! that task. Under sustained peer-database write pressure the worker pool drains one thread at a
+//! time until the comms actors (`ConnectionManager`, `Dialer`, `ConnectivityManager`) stop being
+//! scheduled at all - the node keeps its TCP connections but can no longer dial or propagate.
+//!
+//! [`BlockingPeerStorage`] exists to make that mistake unrepresentable: it owns the only
+//! [`PeerStorageSql`] handle, never hands it out, and the sole way to reach it is
+//! [`BlockingPeerStorage::call`], which moves the work onto `tokio::task::spawn_blocking`.
+
+use tokio::task;
+
+use crate::peer_manager::{PeerManagerError, ThisPeerIdentity, peer_storage_sql::PeerStorageSql};
+
+/// Owns the peer database handle and only ever touches it from the blocking thread pool.
+///
+/// The inner [`PeerStorageSql`] is deliberately private with no accessor. Adding a synchronous peer
+/// database call to [`PeerManager`](crate::peer_manager::PeerManager) therefore does not compile
+/// unless it goes through [`Self::call`].
+#[derive(Clone)]
+pub(super) struct BlockingPeerStorage {
+    storage: PeerStorageSql,
+}
+
+impl BlockingPeerStorage {
+    pub(super) fn new(storage: PeerStorageSql) -> Self {
+        Self { storage }
+    }
+
+    /// This node's own identity.
+    ///
+    /// The single exception to the "no synchronous access" rule: the identity is captured in memory
+    /// when the database handle is constructed and reading it performs no I/O at all.
+    pub(super) fn this_peer_identity(&self) -> ThisPeerIdentity {
+        self.storage.this_peer_identity()
+    }
+
+    /// Run `f` against the peer database on tokio's blocking thread pool and await the result.
+    ///
+    /// The caller's worker thread stays free while the query waits on the r2d2 pool and the SQLite
+    /// lock. Note that dropping the returned future (for example because the caller wrapped it in
+    /// `tokio::time::timeout`) does not cancel `f` - it runs to completion on the blocking pool,
+    /// which is what makes a timed-out lookup safe to shed.
+    pub(super) async fn call<F, R>(&self, f: F) -> Result<R, PeerManagerError>
+    where
+        F: FnOnce(&PeerStorageSql) -> Result<R, PeerManagerError> + Send + 'static,
+        R: Send + 'static,
+    {
+        let storage = self.storage.clone();
+        task::spawn_blocking(move || f(&storage)).await?
+    }
+}

--- a/comms/core/src/peer_manager/manager.rs
+++ b/comms/core/src/peer_manager/manager.rs
@@ -34,6 +34,7 @@ use crate::{
         PeerFlags,
         PeerManagerError,
         ThisPeerIdentity,
+        blocking_storage::BlockingPeerStorage,
         peer::Peer,
         peer_id::PeerId,
         peer_storage_sql::PeerStorageSql,
@@ -43,12 +44,38 @@ use crate::{
 
 /// The PeerManager provides functionality to add, find and delete peers. It wraps synchronous
 /// WAL-enabled SQLite database access and provides an async interface to the rest of the code base.
+///
+/// Every database call is dispatched to tokio's blocking thread pool by [`BlockingPeerStorage`], so
+/// a contended peer database can never park a tokio worker thread. See that type's documentation for
+/// why that matters.
 #[derive(Clone)]
 pub struct PeerManager {
     // yo dawg, I heard you like wrappers, so I wrapped your wrapper in a wrapper so you can wrap while you wrap
-    peer_storage_sql: PeerStorageSql,
+    peer_storage: BlockingPeerStorage,
     transport_protocols: Vec<TransportProtocol>,
 }
+
+/// How long an actor's main loop should be prepared to wait on a peer database lookup before
+/// treating it as sheddable.
+///
+/// `ConnectionManager`, `Dialer` and `ConnectivityManager` all hit the peer database from their
+/// single request loop. Even though the query itself now runs on the blocking pool, a caller that
+/// awaits it without bound still stops servicing every other request behind it. Anything slower
+/// than this is not worth the head-of-line blocking: the dial it was for is already stale.
+pub const PEER_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// `PRAGMA busy_timeout` for the peer database.
+///
+/// Deliberately far below the shared 60s default. The peer database is written on every dial result,
+/// so a dial storm produces a sustained stream of writes against SQLite's single writer. A 60s lock
+/// wait means one contended call occupies a thread for a minute — a tokio worker before this was
+/// moved to the blocking pool, and a blocking-pool thread after. Neither is affordable, and the
+/// answer is never worth waiting a minute for: the dial the query was for is long dead by then.
+/// Callers above this shed at [`PEER_LOOKUP_TIMEOUT`] anyway.
+///
+/// This is scoped to the peer database only. Databases where losing a write is worse than waiting —
+/// the wallet in particular — keep the 60s default.
+pub const PEER_DATABASE_BUSY_TIMEOUT: Duration = Duration::from_secs(10);
 
 impl PeerManager {
     /// Constructs a new empty PeerManager
@@ -59,25 +86,25 @@ impl PeerManager {
         let peer_storage_sql = PeerStorageSql::new_indexed(database)?;
 
         Ok(Self {
-            peer_storage_sql,
+            peer_storage: BlockingPeerStorage::new(peer_storage_sql),
             transport_protocols,
         })
     }
 
     /// Get this peer's identity
     pub fn this_peer_identity(&self) -> ThisPeerIdentity {
-        self.peer_storage_sql.this_peer_identity()
+        self.peer_storage.this_peer_identity()
     }
 
     /// Get the number of peers in the PeerManager - any error will translate to a size of zero
     pub async fn count(&self) -> usize {
-        self.peer_storage_sql.count()
+        self.peer_storage.call(|s| Ok(s.count())).await.unwrap_or_default()
     }
 
     /// Adds a peer to the routing table of the PeerManager if the peer does not already exist. When a peer already
     /// exist, the stored version will be replaced with the newly provided peer.
     pub async fn add_or_update_peer(&self, peer: Peer) -> Result<PeerId, PeerManagerError> {
-        let peer_id = self.peer_storage_sql.add_or_update_peer(peer)?;
+        let peer_id = self.peer_storage.call(move |s| s.add_or_update_peer(peer)).await?;
         #[cfg(feature = "metrics")]
         {
             let count = self.count().await;
@@ -89,7 +116,8 @@ impl PeerManager {
 
     /// The peer with the specified node id will be soft deleted (marked as deleted)
     pub async fn soft_delete_peer(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
-        self.peer_storage_sql.soft_delete_peer(node_id)?;
+        let node_id = node_id.clone();
+        self.peer_storage.call(move |s| s.soft_delete_peer(&node_id)).await?;
         #[cfg(feature = "metrics")]
         {
             let count = self.count().await;
@@ -101,7 +129,10 @@ impl PeerManager {
 
     /// Get all peers based on a list of their node_ids
     pub async fn get_peers_by_node_ids(&self, node_ids: &[NodeId]) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.get_peers_by_node_ids(node_ids)
+        let node_ids = node_ids.to_vec();
+        self.peer_storage
+            .call(move |s| s.get_peers_by_node_ids(&node_ids))
+            .await
     }
 
     /// Get all peers based on a list of their node_ids
@@ -109,47 +140,55 @@ impl PeerManager {
         &self,
         node_ids: &[NodeId],
     ) -> Result<Vec<CommsPublicKey>, PeerManagerError> {
-        self.peer_storage_sql.get_peer_public_keys_by_node_ids(node_ids)
+        let node_ids = node_ids.to_vec();
+        self.peer_storage
+            .call(move |s| s.get_peer_public_keys_by_node_ids(&node_ids))
+            .await
     }
 
     /// Get all banned peers
     pub async fn get_banned_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.get_banned_peers()
+        self.peer_storage.call(PeerStorageSql::get_banned_peers).await
     }
 
     /// Find the peer with the provided NodeID
     pub async fn find_by_node_id(&self, node_id: &NodeId) -> Result<Option<Peer>, PeerManagerError> {
-        self.peer_storage_sql.get_peer_by_node_id(node_id)
+        let node_id = node_id.clone();
+        self.peer_storage.call(move |s| s.get_peer_by_node_id(&node_id)).await
     }
 
     /// gets all seed peers
     pub async fn get_seed_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.get_seed_peers()
+        self.peer_storage.call(PeerStorageSql::get_seed_peers).await
     }
 
     /// Find the peer with the provided PublicKey
     pub async fn find_by_public_key(&self, public_key: &CommsPublicKey) -> Result<Option<Peer>, PeerManagerError> {
-        self.peer_storage_sql.find_by_public_key(public_key)
+        let public_key = public_key.clone();
+        self.peer_storage.call(move |s| s.find_by_public_key(&public_key)).await
     }
 
     /// Find the peer with the provided substring. This currently only compares the given bytes to the NodeId
     pub async fn find_all_starts_with(&self, partial: &[u8]) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.find_all_starts_with(partial)
+        let partial = partial.to_vec();
+        self.peer_storage.call(move |s| s.find_all_starts_with(&partial)).await
     }
 
     /// Check if a peer exist using the specified public_key
     pub async fn exists(&self, public_key: &CommsPublicKey) -> Result<bool, PeerManagerError> {
-        self.peer_storage_sql.exists_public_key(public_key)
+        let public_key = public_key.clone();
+        self.peer_storage.call(move |s| s.exists_public_key(&public_key)).await
     }
 
     /// Check if a peer exist using the specified node_id
     pub async fn exists_node_id(&self, node_id: &NodeId) -> Result<bool, PeerManagerError> {
-        self.peer_storage_sql.exists_node_id(node_id)
+        let node_id = node_id.clone();
+        self.peer_storage.call(move |s| s.exists_node_id(&node_id)).await
     }
 
     /// Returns all peers
     pub async fn all(&self, features: Option<PeerFeatures>) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.all(features)
+        self.peer_storage.call(move |s| s.all(features)).await
     }
 
     /// Get available dial candidates that are communication nodes, not banned, not deleted, reachable
@@ -161,13 +200,19 @@ impl PeerManager {
         exclude_failed: bool,
         randomize: bool,
     ) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.get_available_dial_candidates(
-            exclude_node_ids,
-            limit,
-            &self.transport_protocols,
-            exclude_failed,
-            randomize,
-        )
+        let exclude_node_ids = exclude_node_ids.to_vec();
+        let transport_protocols = self.transport_protocols.clone();
+        self.peer_storage
+            .call(move |s| {
+                s.get_available_dial_candidates(
+                    &exclude_node_ids,
+                    limit,
+                    &transport_protocols,
+                    exclude_failed,
+                    randomize,
+                )
+            })
+            .await
     }
 
     /// Return "good" peers for syncing
@@ -184,8 +229,10 @@ impl PeerManager {
         external_addresses_only: bool,
         max_n: usize,
     ) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql
-            .discovery_syncing(n, excluded_peers, features, external_addresses_only, max_n)
+        let excluded_peers = excluded_peers.to_vec();
+        self.peer_storage
+            .call(move |s| s.discovery_syncing(n, &excluded_peers, features, external_addresses_only, max_n))
+            .await
     }
 
     /// Adds or updates a peer and sets the last connection as successful.
@@ -198,17 +245,26 @@ impl PeerManager {
         peer_features: &PeerFeatures,
         source: &PeerAddressSource,
     ) -> Result<Peer, PeerManagerError> {
-        self.peer_storage_sql
-            .add_or_update_online_peer(pubkey, node_id, addresses, peer_features, source)
+        let pubkey = pubkey.clone();
+        let node_id = node_id.clone();
+        let addresses = addresses.to_vec();
+        let peer_features = *peer_features;
+        let source = source.clone();
+        self.peer_storage
+            .call(move |s| s.add_or_update_online_peer(&pubkey, &node_id, &addresses, &peer_features, &source))
+            .await
     }
 
     /// Get a peer matching the given node ID
     pub async fn direct_identity_node_id(&self, node_id: &NodeId) -> Result<Option<Peer>, PeerManagerError> {
-        match self.peer_storage_sql.direct_identity_node_id(node_id) {
-            Ok(peer) => Ok(Some(peer)),
-            Err(PeerManagerError::PeerNotFound(_)) | Err(PeerManagerError::BannedPeer) => Ok(None),
-            Err(err) => Err(err),
-        }
+        let node_id = node_id.clone();
+        self.peer_storage
+            .call(move |s| match s.direct_identity_node_id(&node_id) {
+                Ok(peer) => Ok(Some(peer)),
+                Err(PeerManagerError::PeerNotFound(_)) | Err(PeerManagerError::BannedPeer) => Ok(None),
+                Err(err) => Err(err),
+            })
+            .await
     }
 
     /// Get a peer matching the given public key
@@ -216,16 +272,21 @@ impl PeerManager {
         &self,
         public_key: &CommsPublicKey,
     ) -> Result<Option<Peer>, PeerManagerError> {
-        match self.peer_storage_sql.direct_identity_public_key(public_key) {
-            Ok(peer) => Ok(Some(peer)),
-            Err(PeerManagerError::PeerNotFound(_)) | Err(PeerManagerError::BannedPeer) => Ok(None),
-            Err(err) => Err(err),
-        }
+        let public_key = public_key.clone();
+        self.peer_storage
+            .call(move |s| match s.direct_identity_public_key(&public_key) {
+                Ok(peer) => Ok(Some(peer)),
+                Err(PeerManagerError::PeerNotFound(_)) | Err(PeerManagerError::BannedPeer) => Ok(None),
+                Err(err) => Err(err),
+            })
+            .await
     }
 
     /// Fetch all peers (except banned ones)
     pub async fn get_not_banned_or_deleted_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
-        self.peer_storage_sql.get_not_banned_or_deleted_peers()
+        self.peer_storage
+            .call(PeerStorageSql::get_not_banned_or_deleted_peers)
+            .await
     }
 
     /// Fetch n random peers that are Communication Nodes and have at least one external address
@@ -236,39 +297,46 @@ impl PeerManager {
         flags: Option<PeerFlags>,
         known_good: bool,
     ) -> Result<Vec<Peer>, PeerManagerError> {
-        let mut peers =
-            self.peer_storage_sql
-                .random_peers(n, excluded, flags, &self.transport_protocols, known_good)?;
-        if known_good && peers.len() < n {
-            // The fallback must also exclude what the first query already returned: a known-good peer
-            // satisfies the relaxed query too, so without this it is selected twice and the caller
-            // dials the same peer more than once while believing it reached `n` distinct peers.
-            let mut excluded = excluded.to_vec();
-            excluded.extend(peers.iter().map(|peer| peer.node_id.clone()));
-            let mut additional = self.peer_storage_sql.random_peers(
-                n.checked_sub(peers.len()).unwrap_or(1),
-                &excluded,
-                flags,
-                &self.transport_protocols,
-                false,
-            )?;
-            peers.append(&mut additional);
-        }
-        Ok(peers)
+        let excluded = excluded.to_vec();
+        let transport_protocols = self.transport_protocols.clone();
+        self.peer_storage
+            .call(move |s| {
+                let mut peers = s.random_peers(n, &excluded, flags, &transport_protocols, known_good)?;
+                if known_good && peers.len() < n {
+                    // The fallback must also exclude what the first query already returned: a known-good peer
+                    // satisfies the relaxed query too, so without this it is selected twice and the caller
+                    // dials the same peer more than once while believing it reached `n` distinct peers.
+                    let mut excluded = excluded.clone();
+                    excluded.extend(peers.iter().map(|peer| peer.node_id.clone()));
+                    let mut additional = s.random_peers(
+                        n.checked_sub(peers.len()).unwrap_or(1),
+                        &excluded,
+                        flags,
+                        &transport_protocols,
+                        false,
+                    )?;
+                    peers.append(&mut additional);
+                }
+                Ok(peers)
+            })
+            .await
     }
 
     /// Unbans the peer if it is banned. This function is idempotent.
     pub async fn unban_peer(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
-        self.peer_storage_sql.unban_peer(node_id)
+        let node_id = node_id.clone();
+        self.peer_storage.call(move |s| s.unban_peer(&node_id)).await
     }
 
     /// Unbans the peer if it is banned. This function is idempotent.
     pub async fn unban_all_peers(&self) -> Result<usize, PeerManagerError> {
-        self.peer_storage_sql.unban_all_peers()
+        self.peer_storage.call(PeerStorageSql::unban_all_peers).await
     }
 
     pub async fn reset_offline_non_wallet_peers(&self) -> Result<usize, PeerManagerError> {
-        self.peer_storage_sql.reset_offline_non_wallet_peers()
+        self.peer_storage
+            .call(PeerStorageSql::reset_offline_non_wallet_peers)
+            .await
     }
 
     /// Ban the peer for a length of time specified by the duration
@@ -278,7 +346,10 @@ impl PeerManager {
         duration: Duration,
         reason: String,
     ) -> Result<NodeId, PeerManagerError> {
-        self.peer_storage_sql.ban_peer(public_key, duration, reason)
+        let public_key = public_key.clone();
+        self.peer_storage
+            .call(move |s| s.ban_peer(&public_key, duration, reason))
+            .await
     }
 
     /// Ban the peer for a length of time specified by the duration
@@ -288,12 +359,16 @@ impl PeerManager {
         duration: Duration,
         reason: String,
     ) -> Result<NodeId, PeerManagerError> {
-        self.peer_storage_sql.ban_peer_by_node_id(node_id, duration, reason)
+        let node_id = node_id.clone();
+        self.peer_storage
+            .call(move |s| s.ban_peer_by_node_id(&node_id, duration, reason))
+            .await
     }
 
     /// Get the ban status of a peer
     pub async fn is_peer_banned(&self, node_id: &NodeId) -> Result<bool, PeerManagerError> {
-        self.peer_storage_sql.is_peer_banned(node_id)
+        let node_id = node_id.clone();
+        self.peer_storage.call(move |s| s.is_peer_banned(&node_id)).await
     }
 
     /// Get the peer's features
@@ -343,7 +418,10 @@ impl PeerManager {
         key: u8,
         data: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, PeerManagerError> {
-        self.peer_storage_sql.set_peer_metadata(node_id, key, data)
+        let node_id = node_id.clone();
+        self.peer_storage
+            .call(move |s| s.set_peer_metadata(&node_id, key, data))
+            .await
     }
 }
 
@@ -614,7 +692,7 @@ pub fn create_peer_address_source_with_claim(
 mod test {
     #![allow(clippy::indexing_slicing)]
     use chrono::{DateTime, Utc};
-    use tari_common_sqlite::connection::DbConnection;
+    use tari_common_sqlite::connection::{DbConnection, DbConnectionUrl};
 
     use super::*;
     use crate::peer_manager::database::{MIGRATIONS, PeerDatabaseSql};
@@ -627,6 +705,426 @@ mod test {
         )
         .unwrap();
         PeerManager::new(peers_db, TransportProtocol::get_all()).unwrap()
+    }
+
+    /// A peer manager plus a second handle on the same database, so a test can take SQLite's write
+    /// lock out from under it and create genuine contention.
+    ///
+    /// The busy timeout is deliberately short: a test that trips the fallback should fail fast
+    /// rather than sit on the shared 60s default.
+    fn create_contended_peer_manager() -> (PeerManager, DbConnection, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_url = DbConnectionUrl::File(temp_dir.path().join("contended_peers.db"));
+        let db_connection =
+            DbConnection::connect_and_migrate_with_busy_timeout(&db_url, MIGRATIONS, Some(6), Duration::from_secs(5))
+                .unwrap();
+        let peers_db = PeerDatabaseSql::new(
+            db_connection.clone(),
+            &create_test_peer(false, PeerFeatures::COMMUNICATION_NODE),
+        )
+        .unwrap();
+        let peer_manager = PeerManager::new(peers_db, TransportProtocol::get_all()).unwrap();
+        (peer_manager, db_connection, temp_dir)
+    }
+
+    /// Regression test for the peer-database worker-thread starvation bug.
+    ///
+    /// `PeerManager` methods used to be `async fn`s with no await points that called straight into
+    /// diesel/r2d2. A contended peer database therefore blocked the tokio *worker thread* running
+    /// the caller, not merely the calling task, and under sustained write pressure the worker pool
+    /// drained one thread at a time until the comms actors stopped being scheduled at all.
+    ///
+    /// The runtime here has exactly one worker, so any peer database call that blocks it is
+    /// immediately visible: the concurrently spawned ticker stops making progress.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn peer_database_writes_do_not_park_the_runtime_worker() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        use diesel::connection::SimpleConnection;
+
+        let (peer_manager, db_connection, _temp_dir) = create_contended_peer_manager();
+
+        // Take SQLite's single write lock on a separate connection. Every peer write issued below
+        // now parks inside SQLite until this is released.
+        let mut lock_holder = db_connection.get_pooled_connection().unwrap();
+        lock_holder.batch_execute("BEGIN IMMEDIATE;").unwrap();
+
+        // A plain async task that only ever needs the worker thread for a few microseconds at a
+        // time. It is the canary: if the worker is parked, it stops counting.
+        let progress = Arc::new(AtomicUsize::new(0));
+        let ticker = tokio::spawn({
+            let progress = progress.clone();
+            async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    progress.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        });
+
+        let writers = (0..4)
+            .map(|_| {
+                let peer_manager = peer_manager.clone();
+                let peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+                tokio::spawn(async move { peer_manager.add_or_update_peer(peer).await })
+            })
+            .collect::<Vec<_>>();
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let ticks = progress.load(Ordering::Relaxed);
+        assert!(
+            ticks > 10,
+            "the runtime worker was parked by the peer database: the canary task only ran {ticks} time(s) in 300ms              while 4 peer writes were contended"
+        );
+
+        // Release the write lock and confirm the writes actually landed - shedding the wait must not
+        // mean losing the write.
+        lock_holder.batch_execute("COMMIT;").unwrap();
+        drop(lock_holder);
+        for writer in writers {
+            writer.await.unwrap().unwrap();
+        }
+        ticker.abort();
+    }
+
+    /// Structural guard: the peer database must never be touched from a tokio worker thread.
+    ///
+    /// # Why this parses instead of pattern-matching
+    ///
+    /// Four successive review rounds broke a text-scanning version of this guard, each time by a
+    /// different route, and each time with the same symptom: the scan silently checked less than it
+    /// appeared to and still reported `ok`. Line-oriented matching missed rustfmt-wrapped calls; an
+    /// unbounded region false-positived on test code; a `}`-at-column-zero bound was truncated by a
+    /// multi-line string literal; a `#[cfg(test)]` bound took the *first* match and so skipped the
+    /// 258 lines between manager.rs's module-scope test helpers and its actual test module, hiding a
+    /// violation in a second, non-contiguous `impl PeerManager` block.
+    ///
+    /// Every one of those is a boundary guessed from bytes. They are not five bugs, they are one
+    /// bug with five faces, and patching the sixth face was not going to end. So the boundary now
+    /// comes from the grammar: [`syn::parse_file`] gives real items, real attributes and real
+    /// expressions. A `#[cfg(test)]` item is skipped because it *is* a test item, not because it
+    /// follows some byte offset; a string literal is a `Lit` and can never be mistaken for a field
+    /// access; and non-contiguous impl blocks anywhere in the file are visited like any other.
+    ///
+    /// The two behavioural tests above (`peer_database_writes_do_not_park_the_runtime_worker` and
+    /// `select_connections_is_served_while_the_peer_database_is_slow`) prove the runtime
+    /// consequence. This one prevents the regression from being reintroduced at the source level,
+    /// where it is cheap to catch.
+    mod storage_access {
+        use syn::{
+            Attribute,
+            Expr,
+            File,
+            ImplItem,
+            ImplItemFn,
+            Item,
+            Member,
+            visit::{self, Visit},
+        };
+
+        /// True for the canonical `#[cfg(test)]`.
+        ///
+        /// Anything else - `#[cfg(all(test))]`, `#[cfg(feature = "...")]` - reads as false, so the
+        /// item is *scanned* rather than skipped. That is the safe direction: an unrecognised
+        /// attribute spelling can only ever cause an over-strict failure, never a silent hole.
+        fn is_cfg_test(attrs: &[Attribute]) -> bool {
+            attrs.iter().any(|attr| {
+                if !attr.path().is_ident("cfg") {
+                    return false;
+                }
+                let mut mentions_test = false;
+                let _result = attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("test") {
+                        mentions_test = true;
+                    }
+                    Ok(())
+                });
+                mentions_test
+            })
+        }
+
+        /// Attributes of the item kinds that can contain expressions. Kinds that cannot are given an
+        /// empty slice, which at worst means visiting something harmless.
+        fn item_attrs(item: &Item) -> &[Attribute] {
+            match item {
+                Item::Const(i) => &i.attrs,
+                Item::Enum(i) => &i.attrs,
+                Item::Fn(i) => &i.attrs,
+                Item::Impl(i) => &i.attrs,
+                Item::Macro(i) => &i.attrs,
+                Item::Mod(i) => &i.attrs,
+                Item::Static(i) => &i.attrs,
+                Item::Struct(i) => &i.attrs,
+                Item::Trait(i) => &i.attrs,
+                Item::Type(i) => &i.attrs,
+                Item::Union(i) => &i.attrs,
+                Item::Use(i) => &i.attrs,
+                _ => &[],
+            }
+        }
+
+        /// How a `self.<field>` access is used.
+        #[derive(Debug, Default)]
+        pub(super) struct FieldUsage {
+            /// Every `self.<field>` expression found, however it is used.
+            pub(super) accesses: usize,
+            /// The method invoked, for those accesses that are a method-call receiver.
+            pub(super) methods: Vec<String>,
+        }
+
+        /// Walks production items looking for `self.<field>`.
+        struct FieldVisitor<'a> {
+            field: &'a str,
+            usage: FieldUsage,
+        }
+
+        /// True when `expr` is exactly `self.<field>`.
+        fn is_self_field(expr: &Expr, field: &str) -> bool {
+            let Expr::Field(access) = expr else {
+                return false;
+            };
+            let Expr::Path(base) = access.base.as_ref() else {
+                return false;
+            };
+            let Member::Named(name) = &access.member else {
+                return false;
+            };
+            base.path.is_ident("self") && name == field
+        }
+
+        impl<'ast> Visit<'ast> for FieldVisitor<'_> {
+            fn visit_item(&mut self, item: &'ast Item) {
+                if is_cfg_test(item_attrs(item)) {
+                    return;
+                }
+                visit::visit_item(self, item);
+            }
+
+            fn visit_impl_item(&mut self, item: &'ast ImplItem) {
+                let attrs = match item {
+                    ImplItem::Const(i) => &i.attrs,
+                    ImplItem::Fn(i) => &i.attrs,
+                    ImplItem::Type(i) => &i.attrs,
+                    ImplItem::Macro(i) => &i.attrs,
+                    _ => &[][..],
+                };
+                if is_cfg_test(attrs) {
+                    return;
+                }
+                visit::visit_impl_item(self, item);
+            }
+
+            fn visit_expr(&mut self, expr: &'ast Expr) {
+                match expr {
+                    // A method call directly on `self.<field>`: record which method.
+                    Expr::MethodCall(call) if is_self_field(&call.receiver, self.field) => {
+                        self.usage.methods.push(call.method.to_string());
+                    },
+                    // Any other appearance of `self.<field>` is counted by `accesses` below and will
+                    // fail the "every access is a permitted method call" balance check - a borrow
+                    // stashed in a local, say, and called synchronously later.
+                    _ => {},
+                }
+                if is_self_field(expr, self.field) {
+                    self.usage.accesses = self.usage.accesses.saturating_add(1);
+                }
+                visit::visit_expr(self, expr);
+            }
+        }
+
+        /// Find every use of `self.<field>` in the file's production items.
+        pub(super) fn field_usage(file: &File, field: &str) -> FieldUsage {
+            let mut visitor = FieldVisitor {
+                field,
+                usage: FieldUsage::default(),
+            };
+            visitor.visit_file(file);
+            visitor.usage
+        }
+
+        /// The named inherent method of the named type, if the file declares one.
+        pub(super) fn inherent_method<'a>(file: &'a File, type_name: &str, method: &str) -> Option<&'a ImplItemFn> {
+            file.items.iter().find_map(|item| {
+                let Item::Impl(block) = item else {
+                    return None;
+                };
+                if block.trait_.is_some() || is_cfg_test(&block.attrs) {
+                    return None;
+                }
+                let syn::Type::Path(path) = block.self_ty.as_ref() else {
+                    return None;
+                };
+                if path.path.segments.last().is_none_or(|seg| seg.ident != type_name) {
+                    return None;
+                }
+                block.items.iter().find_map(|impl_item| match impl_item {
+                    ImplItem::Fn(func) if func.sig.ident == method => Some(func),
+                    _ => None,
+                })
+            })
+        }
+
+        /// Counts invocations of a bare function-path such as the closure parameter `f`.
+        struct CallCounter<'a> {
+            callee: &'a str,
+            count: usize,
+        }
+
+        impl<'ast> Visit<'ast> for CallCounter<'_> {
+            fn visit_expr(&mut self, expr: &'ast Expr) {
+                if let Expr::Call(call) = expr &&
+                    let Expr::Path(path) = call.func.as_ref() &&
+                    path.path.is_ident(self.callee)
+                {
+                    self.count = self.count.saturating_add(1);
+                }
+                visit::visit_expr(self, expr);
+            }
+        }
+
+        fn count_calls_in_block(block: &syn::Block, callee: &str) -> usize {
+            let mut counter = CallCounter { callee, count: 0 };
+            counter.visit_block(block);
+            counter.count
+        }
+
+        fn count_calls_in_expr(expr: &Expr, callee: &str) -> usize {
+            let mut counter = CallCounter { callee, count: 0 };
+            counter.visit_expr(expr);
+            counter.count
+        }
+
+        /// Every invocation of `callee` inside `func`, and how many of those sit inside a closure
+        /// handed as the first argument to `dispatcher`.
+        pub(super) fn dispatch_balance(func: &ImplItemFn, callee: &str, dispatcher: &str) -> (usize, usize) {
+            let total = count_calls_in_block(&func.block, callee);
+
+            struct DispatcherVisitor<'a> {
+                dispatcher: &'a str,
+                callee: &'a str,
+                dispatched: usize,
+            }
+
+            impl<'ast> Visit<'ast> for DispatcherVisitor<'_> {
+                fn visit_expr(&mut self, expr: &'ast Expr) {
+                    if let Expr::Call(call) = expr &&
+                        let Expr::Path(path) = call.func.as_ref() &&
+                        path.path
+                            .segments
+                            .last()
+                            .is_some_and(|seg| seg.ident == self.dispatcher) &&
+                        let Some(Expr::Closure(closure)) = call.args.first()
+                    {
+                        self.dispatched = self
+                            .dispatched
+                            .saturating_add(count_calls_in_expr(closure.body.as_ref(), self.callee));
+                    }
+                    visit::visit_expr(self, expr);
+                }
+            }
+
+            let mut visitor = DispatcherVisitor {
+                dispatcher,
+                callee,
+                dispatched: 0,
+            };
+            visitor.visit_block(&func.block);
+            (total, visitor.dispatched)
+        }
+    }
+
+    /// Assert that `self.<field>` is only ever used as a receiver of one of `permitted`.
+    fn assert_field_only_reached_via(source: &str, file: &str, field: &str, permitted: &[&str]) -> usize {
+        let parsed = syn::parse_file(source).unwrap_or_else(|err| panic!("{file} must parse: {err}"));
+        let usage = storage_access::field_usage(&parsed, field);
+
+        let offending = usage
+            .methods
+            .iter()
+            .filter(|method| !permitted.contains(&method.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert!(
+            offending.is_empty(),
+            "{file}: `self.{field}` is used as the receiver of {offending:?}, but only {permitted:?} are permitted. \
+             Anything else runs SQLite on the caller's tokio worker thread."
+        );
+
+        // Every access must be one of those method calls. A `self.<field>` that is borrowed into a
+        // local, passed to a function or returned would not appear in `methods`, and is caught here.
+        assert_eq!(
+            usage.accesses,
+            usage.methods.len(),
+            "{file}: {} of the {} `self.{field}` access(es) are not direct method calls. The handle must not escape - \
+             once it does, nothing constrains how it is used.",
+            usage.accesses.saturating_sub(usage.methods.len()),
+            usage.accesses,
+        );
+
+        usage.accesses
+    }
+
+    /// The peer database must never be touched from a tokio worker thread.
+    ///
+    /// Two halves, because the invariant has two halves. The compiler enforces the first - only
+    /// `BlockingPeerStorage` can reach `PeerStorageSql`, it lives in another module and has no
+    /// accessor - but nothing stops a `PeerManager` method reaching it through some future
+    /// synchronous passthrough, and nothing stops `BlockingPeerStorage::call` being rewritten to
+    /// invoke the closure inline. Both are checked here, structurally. See [`storage_access`].
+    #[test]
+    fn no_peer_manager_method_performs_synchronous_storage_io() {
+        const MANAGER_SOURCE: &str = include_str!("manager.rs");
+        const BLOCKING_STORAGE_SOURCE: &str = include_str!("blocking_storage.rs");
+
+        // Half one: every peer storage access in production `manager.rs` goes through the blocking
+        // dispatcher, or through the documented I/O-free identity accessor. Position in the file is
+        // irrelevant - a second, non-contiguous `impl PeerManager` is visited like any other item.
+        let inspected = assert_field_only_reached_via(MANAGER_SOURCE, "manager.rs", "peer_storage", &[
+            "call",
+            "this_peer_identity",
+        ]);
+        // Anti-vacuity floor: a renamed field would leave the guard inspecting nothing while still
+        // reporting success. There are around thirty accesses today.
+        assert!(
+            inspected >= 20,
+            "manager.rs: the guard found only {inspected} `self.peer_storage` access(es), so it is no longer guarding \
+             anything meaningful. Check that the field name still matches the source."
+        );
+
+        // Half two: nothing in production `blocking_storage.rs` reaches the database synchronously.
+        let inspected = assert_field_only_reached_via(BLOCKING_STORAGE_SOURCE, "blocking_storage.rs", "storage", &[
+            // The handle moved into the blocking closure, and the documented exception that
+            // reads an in-memory field and performs no I/O.
+            "clone",
+            "this_peer_identity",
+        ]);
+        assert!(
+            inspected > 0,
+            "blocking_storage.rs: the guard found no `self.storage` accesses at all, so the field name no longer \
+             matches the source and this guard is inert."
+        );
+
+        // And the dispatch itself: every invocation of the caller's closure `f` must happen inside a
+        // closure handed to `spawn_blocking`. Asserting on the call graph rather than on token order
+        // is what makes a decoy `spawn_blocking(|| {})` sitting in front of an inline `f(&storage)`
+        // fail - the decoy's closure does not invoke `f`, so the two counts do not balance.
+        let parsed = syn::parse_file(BLOCKING_STORAGE_SOURCE).expect("blocking_storage.rs must parse");
+        let call = storage_access::inherent_method(&parsed, "BlockingPeerStorage", "call")
+            .expect("blocking_storage.rs must declare `BlockingPeerStorage::call`");
+        let (total, dispatched) = storage_access::dispatch_balance(call, "f", "spawn_blocking");
+        assert!(
+            total > 0,
+            "`BlockingPeerStorage::call` never invokes the caller's closure `f`; this guard is inert."
+        );
+        assert_eq!(
+            total, dispatched,
+            "`BlockingPeerStorage::call` invokes the caller's closure `f` {total} time(s) but only {dispatched} of \
+             those are inside a closure passed to `spawn_blocking`. The rest run SQLite on the caller's tokio worker \
+             thread."
+        );
     }
 
     #[tokio::test]

--- a/comms/core/src/peer_manager/mod.rs
+++ b/comms/core/src/peer_manager/mod.rs
@@ -70,6 +70,8 @@
 //! let returned_peer = peer_manager.find_by_node_id(&node_id).unwrap();
 //! ```
 
+mod blocking_storage;
+
 mod error;
 pub use error::PeerManagerError;
 
@@ -94,7 +96,7 @@ mod peer_id;
 pub use peer_id::{PeerId, generate_peer_id_as_i64};
 
 mod manager;
-pub use manager::PeerManager;
+pub use manager::{PEER_DATABASE_BUSY_TIMEOUT, PEER_LOOKUP_TIMEOUT, PeerManager};
 #[cfg(test)]
 pub use manager::{
     create_test_peer,

--- a/comms/core/src/pipeline/outbound.rs
+++ b/comms/core/src/pipeline/outbound.rs
@@ -33,6 +33,9 @@ use crate::{bounded_executor::BoundedExecutor, pipeline::builder::OutboundPipeli
 
 const LOG_TARGET: &str = "comms::pipeline::outbound";
 
+/// How long a single outbound message may occupy a pipeline slot before it is abandoned.
+const PIPELINE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Calls a service in a new task whenever a message is received by the configured channel and forwards the resulting
 /// message as a [MessageRequest](crate::protocol::messaging::MessageRequest).
 pub struct Outbound<TPipeline, TItem> {
@@ -77,11 +80,14 @@ where
             let pipeline = self.config.pipeline.clone();
             let id = current_id;
             current_id = current_id.wrapping_add(1) % u64::MAX;
+            // Shares the permit pool with `self.executor`, so the task can read the pipeline's live
+            // occupancy at the moment it times out rather than at the moment it was spawned.
+            let occupancy = self.executor.clone();
             self.executor
                 .spawn(async move {
                     let timer = Instant::now();
                     trace!(target: LOG_TARGET, "Start outbound pipeline {id}");
-                    match time::timeout(Duration::from_secs(10), pipeline.oneshot(msg)).await {
+                    match time::timeout(PIPELINE_TIMEOUT, pipeline.oneshot(msg)).await {
                         Ok(Ok(_)) => {},
                         Ok(Err(err)) => {
                             error!(
@@ -89,12 +95,30 @@ where
                                 "Outbound pipeline {id} returned an error: '{err}'"
                             );
                         },
-                        Err(err) => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "Outbound pipeline {id} timed out and was aborted. THIS SHOULD NOT HAPPEN: there was a \
-                                 deadlock or excessive delay in processing this pipeline. {err}"
-                            );
+                        Err(_) => {
+                            // Distinguish the two very different faults that both surface here. A
+                            // saturated pipeline is self-inflicted back-pressure; a near-empty one
+                            // means the message is stuck on something downstream (typically an actor
+                            // that has stopped being scheduled), and reporting that as a "deadlock in
+                            // this pipeline" sends the reader four layers away from the actual fault.
+                            let max_available = occupancy.max_available();
+                            let in_use = max_available.saturating_sub(occupancy.num_available());
+                            if in_use.saturating_mul(2) >= max_available {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "Outbound pipeline {id} timed out after {PIPELINE_TIMEOUT:.0?} and was aborted. \
+                                     The outbound pipeline is saturated ({in_use}/{max_available} slots in use): it \
+                                     is not draining as fast as messages arrive."
+                                );
+                            } else {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "Outbound pipeline {id} timed out after {PIPELINE_TIMEOUT:.0?} and was aborted, \
+                                     but the pipeline itself is nearly empty ({in_use}/{max_available} slots in use). \
+                                     This message is blocked on an unresponsive downstream service, not on pipeline \
+                                     capacity — look at the comms actors (connectivity/connection manager), not here."
+                                );
+                            }
                         },
                     }
 

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -82,6 +82,51 @@ const DIAL_OVERSUBSCRIBE_FACTOR: usize = 3;
 /// requests when flooded — so the dial budget is capped regardless of how far below target we are.
 const MAX_IN_FLIGHT_POOL_MULTIPLE: usize = 2;
 
+/// How long a peer is excluded from selection after its first failed dial. Doubles per consecutive
+/// failure up to [`DIAL_BACKOFF_MAX`].
+const DIAL_BACKOFF_BASE: Duration = Duration::from_secs(30);
+
+/// Ceiling on the per-peer dial backoff. This also bounds the worst case where *every* known peer is
+/// unreachable: the pool then dials nothing until the earliest backoff expires, which is the correct
+/// response — those dials were failing anyway — but should not be open-ended.
+const DIAL_BACKOFF_MAX: Duration = Duration::from_secs(10 * 60);
+
+/// Hard cap on the number of peers we track backoff state for. Every tracked peer becomes one more
+/// `node_id != ?` term in the candidate-selection query, so this is kept well clear of SQLite's bind
+/// parameter limit and of making that query expensive. When the cap is hit the entries that expire
+/// soonest are dropped, which at worst lets those peers become eligible again early.
+const MAX_DIAL_BACKOFF_ENTRIES: usize = 500;
+
+/// Per-peer dial backoff state.
+///
+/// Without this, a node whose pool never becomes healthy re-dials the same set of unreachable peers
+/// on every refresh cycle, forever. Every one of those failures writes back through
+/// `PeerManager::add_or_update_peer`, and that write pressure is what tips the peer database — and
+/// with it the comms actors — over.
+#[derive(Debug, Clone, Copy)]
+struct DialBackoff {
+    /// Consecutive failed dials. Reset when the peer connects.
+    failures: u32,
+    /// The peer is not a dial candidate before this instant.
+    retry_after: Instant,
+}
+
+impl DialBackoff {
+    /// Advance the backoff after another failed dial.
+    fn next(previous: Option<Self>) -> Self {
+        let failures = previous.map_or(1, |b| b.failures.saturating_add(1));
+        // `2^(failures - 1) * base`, saturating rather than wrapping into a short delay.
+        let backoff = DIAL_BACKOFF_BASE
+            .checked_mul(1u32.checked_shl(failures.saturating_sub(1)).unwrap_or(u32::MAX))
+            .unwrap_or(DIAL_BACKOFF_MAX)
+            .min(DIAL_BACKOFF_MAX);
+        Self {
+            failures,
+            retry_after: Instant::now().checked_add(backoff).unwrap_or_else(Instant::now),
+        }
+    }
+}
+
 /// Error type for the DHT connectivity actor.
 #[derive(Debug, Error)]
 pub enum DhtConnectivityError {
@@ -111,6 +156,8 @@ pub(crate) struct DhtConnectivity {
     /// and when the dial was issued. A pool entry without a connection handle is only meaningful
     /// when paired with this: it distinguishes "still dialing" from "stale slot".
     pending_dials: HashMap<NodeId, Instant>,
+    /// Peers whose dials keep failing, and when they may be dialed again. See [`DialBackoff`].
+    dial_backoff: HashMap<NodeId, DialBackoff>,
     /// Holds references to peer connections that should be kept alive
     connection_handles: Vec<PeerConnection>,
     stats: Stats,
@@ -134,6 +181,7 @@ impl DhtConnectivity {
         Self {
             random_pool: Vec::with_capacity(pool_size),
             pending_dials: HashMap::with_capacity(pool_size),
+            dial_backoff: HashMap::new(),
             connection_handles: Vec::with_capacity(pool_size),
             config,
             peer_manager,
@@ -629,6 +677,8 @@ impl DhtConnectivity {
     }
 
     async fn handle_new_peer_connected(&mut self, conn: PeerConnection) -> Result<(), DhtConnectivityError> {
+        // The peer is reachable after all, so it starts from a clean slate the next time it fails.
+        self.dial_backoff.remove(conn.peer_node_id());
         if conn.peer_features().is_client() {
             debug!(
                 target: LOG_TARGET,
@@ -818,6 +868,7 @@ impl DhtConnectivity {
             PeerConnectFailed(node_id) => {
                 self.connection_handles.retain(|c| *c.peer_node_id() != node_id);
                 self.pending_dials.remove(&node_id);
+                self.record_dial_failure(&node_id);
                 if self.metrics_collector.clear_metrics(node_id.clone()).await.is_err() {
                     debug!(
                         target: LOG_TARGET,
@@ -951,15 +1002,60 @@ impl DhtConnectivity {
         self.random_pool.clone()
     }
 
+    /// Record a failed dial and push the peer's next eligible dial time out.
+    fn record_dial_failure(&mut self, node_id: &NodeId) {
+        let backoff = DialBackoff::next(self.dial_backoff.get(node_id).copied());
+        trace!(
+            target: LOG_TARGET,
+            "Dial to '{}' failed {} time(s) in a row; excluding it from selection for {:.0?}",
+            node_id.short_str(),
+            backoff.failures,
+            backoff.retry_after.saturating_duration_since(Instant::now()),
+        );
+        self.dial_backoff.insert(node_id.clone(), backoff);
+    }
+
+    /// Drop expired backoff entries and, if the map has grown past its cap, the entries that expire
+    /// soonest.
+    fn prune_dial_backoff(&mut self) {
+        let now = Instant::now();
+        self.dial_backoff.retain(|_, backoff| backoff.retry_after > now);
+        if self.dial_backoff.len() > MAX_DIAL_BACKOFF_ENTRIES {
+            let mut entries = self
+                .dial_backoff
+                .iter()
+                .map(|(node_id, backoff)| (node_id.clone(), backoff.retry_after))
+                .collect::<Vec<_>>();
+            entries.sort_by_key(|(_, retry_after)| *retry_after);
+            let overflow = self.dial_backoff.len().saturating_sub(MAX_DIAL_BACKOFF_ENTRIES);
+            for (node_id, _) in entries.into_iter().take(overflow) {
+                self.dial_backoff.remove(&node_id);
+            }
+        }
+    }
+
     async fn fetch_random_peers(
         &mut self,
         n: usize,
         excluded: &[NodeId],
         known_good: bool,
     ) -> Result<Vec<NodeId>, DhtConnectivityError> {
+        // Peers that have just failed us are not candidates. Re-dialling them every cycle is both
+        // futile and the write load that overwhelms the peer database — every failed dial writes the
+        // peer back.
+        self.prune_dial_backoff();
         let mut excluded = excluded.to_vec();
+        excluded.extend(self.dial_backoff.keys().cloned());
         excluded.extend(self.peer_allow_list().await?);
         let peers = self.peer_manager.random_peers(n, &excluded, None, known_good).await?;
+        if peers.is_empty() && n > 0 && !self.dial_backoff.is_empty() {
+            debug!(
+                target: LOG_TARGET,
+                "No dial candidates: {} known peer(s) are in dial backoff. Waiting for one to become eligible \
+                 rather than re-dialling peers that never resolve.",
+                self.dial_backoff.len()
+            );
+        }
         Ok(peers.into_iter().map(|p| p.node_id).collect())
     }
 

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -185,6 +185,50 @@ async fn added_pool_peers() {
     assert!(conn.handle_count() == 2 || conn.handle_count() == 3);
 }
 
+/// Dials that never resolve must back off rather than be reissued every refresh cycle.
+///
+/// A pool that never becomes healthy re-selects the same unreachable peers on every cycle, and every
+/// failed dial writes the peer back through `PeerManager::add_or_update_peer`. That write load is
+/// what saturates the peer database and, ultimately, wedges the comms actors.
+#[tokio::test]
+async fn failed_dials_are_backed_off_instead_of_reissued() {
+    let peers = repeat_with(|| create_good_standing_peer(&make_node_identity()))
+        .take(4)
+        .collect::<Vec<_>>();
+    let node_ids = peers.iter().map(|p| p.node_id.clone()).collect::<Vec<_>>();
+    let (mut dht_connectivity, _, _connectivity, _peer_manager, _node_identity, _shutdown) =
+        setup(DhtConfig::default(), make_node_identity(), peers).await;
+
+    // Every peer is a candidate to begin with.
+    let selected = dht_connectivity.fetch_random_peers(4, &[], false).await.unwrap();
+    assert_eq!(selected.len(), 4);
+
+    // Fail a dial to each of them.
+    for node_id in &node_ids {
+        dht_connectivity.record_dial_failure(node_id);
+    }
+    let selected = dht_connectivity.fetch_random_peers(4, &[], false).await.unwrap();
+    assert!(
+        selected.is_empty(),
+        "peers whose dials just failed were selected for another dial immediately: {selected:?}"
+    );
+
+    // Consecutive failures push the next attempt further out.
+    let first = *dht_connectivity.dial_backoff.get(&node_ids[0]).unwrap();
+    assert_eq!(first.failures, 1);
+    dht_connectivity.record_dial_failure(&node_ids[0]);
+    let second = *dht_connectivity.dial_backoff.get(&node_ids[0]).unwrap();
+    assert_eq!(second.failures, 2);
+    assert!(second.retry_after > first.retry_after);
+
+    // Connecting clears the backoff: the peer is reachable after all.
+    let (conn, _) = create_dummy_peer_connection(node_ids[0].clone());
+    dht_connectivity.handle_new_peer_connected(conn).await.unwrap();
+    assert!(!dht_connectivity.dial_backoff.contains_key(&node_ids[0]));
+    let selected = dht_connectivity.fetch_random_peers(4, &[], false).await.unwrap();
+    assert_eq!(selected, vec![node_ids[0].clone()]);
+}
+
 mod metrics {
     mod collector {
         use tari_comms::peer_manager::NodeId;


### PR DESCRIPTION
Every `PeerManager` method was an `async fn` with no await points that called straight into diesel/r2d2. That blocks the *worker thread*, not just the task, so a contended peer database drained the tokio worker pool one thread at a time until the comms actors stopped being scheduled: the node kept its TCP connections but could no longer dial or propagate, and only a restart recovered it. The error that surfaced was four layers away, in the outbound pipeline, reporting a deadlock in a pipeline that was nearly empty.

Root cause fix
- Add `BlockingPeerStorage`, which owns the only `PeerStorageSql` handle and exposes it solely through `call()`, dispatching to `tokio::task::spawn_blocking`. The handle is private and has no accessor, so a synchronous peer database call from `PeerManager` no longer compiles.

Supporting changes
- Scope the peer database's `PRAGMA busy_timeout` to 10s (`PEER_DATABASE_BUSY_TIMEOUT`) via new `DbConnection::connect_{url,and_migrate}_with_busy_timeout`. The shared 60s default is unchanged for every other database, including the wallet's, where losing a write is worse than waiting.
- Shed slow peer lookups in actor context: the ban check in `ConnectivityManager::handle_dial_peer`, the lookup in `ConnectionManager::dial_peer` and the dialer's peer write-back are now bounded by `PEER_LOOKUP_TIMEOUT` (5s). The query still completes on the blocking pool; the actor just stops waiting for it.
- Back off unresolvable dials in the DHT connectivity pool. Failed dials now carry per-peer exponential backoff (30s doubling to 10m), so a pool that never becomes healthy no longer re-dials the same unreachable peers every cycle - which was the write load that tipped the peer database over, since every failed dial writes back through `add_or_update_peer`.
- Make the outbound pipeline's timeout message distinguish "pipeline saturated" from "downstream actor unresponsive", using live occupancy rather than claiming a deadlock in itself.

Tests
- `peer_database_writes_do_not_park_the_runtime_worker`: on a single-worker runtime with SQLite's write lock held, a canary task must keep running. Fails with the pre-fix inline call (1 tick in 300ms).
- `select_connections_is_served_while_the_peer_database_is_slow`: the connectivity actor must keep answering while the peer database is saturated. Timed from an OS thread, because a parked worker stops the runtime's timers too. 6s with the fix, 91s without.
- `no_peer_manager_method_performs_synchronous_storage_io`: guards the invariant the compiler cannot - no sync passthrough on the storage wrapper.
- `failed_dials_are_backed_off_instead_of_reissued`.
