### PR TITLE
feat(sidechain)!: bind epoch and height into the proposal vote signature

### DIFF
--- a/applications/minotari_app_grpc/proto/sidechain_types.proto
+++ b/applications/minotari_app_grpc/proto/sidechain_types.proto
@@ -161,6 +161,9 @@ message QuorumCertificate {
   bytes parent_id = 2;
   repeated ValidatorSignature signatures = 3;
   QuorumDecision decision = 4;
+  uint64 epoch = 5;
+  uint64 height = 6;
+  uint32 protocol_version = 7;
 }
 
 enum QuorumDecision {

--- a/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
@@ -575,6 +575,9 @@ impl TryFrom<grpc::QuorumCertificate> for QuorumCertificate {
         Ok(Self {
             header_hash: value.header_hash.try_into().map_err(|_| "Invalid block body hash")?,
             parent_id: value.parent_id.try_into().map_err(|_| "Invalid parent id")?,
+            epoch: value.epoch,
+            height: value.height,
+            protocol_version: value.protocol_version,
             signatures: value
                 .signatures
                 .into_iter()
@@ -592,6 +595,9 @@ impl From<&QuorumCertificate> for grpc::QuorumCertificate {
         Self {
             parent_id: value.parent_id.to_vec(),
             header_hash: value.header_hash.to_vec(),
+            epoch: value.epoch,
+            height: value.height,
+            protocol_version: value.protocol_version,
             signatures: value.signatures.iter().map(Into::into).collect(),
             decision: grpc::QuorumDecision::from(value.decision).into(),
         }

--- a/base_layer/core/src/proto/sidechain_feature.proto
+++ b/base_layer/core/src/proto/sidechain_feature.proto
@@ -138,6 +138,9 @@ message QuorumCertificate {
   bytes parent_id = 2;
   repeated ValidatorSignature signatures = 3;
   QuorumDecision decision = 4;
+  uint64 epoch = 5;
+  uint64 height = 6;
+  uint32 protocol_version = 7;
 }
 
 enum QuorumDecision {

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -577,6 +577,9 @@ impl TryFrom<proto::types::QuorumCertificate> for QuorumCertificate {
         Ok(Self {
             header_hash: value.header_hash.try_into().map_err(|_| "Invalid block body hash")?,
             parent_id: value.parent_id.try_into().map_err(|_| "Invalid parent id")?,
+            epoch: value.epoch,
+            height: value.height,
+            protocol_version: value.protocol_version,
             signatures: value
                 .signatures
                 .into_iter()
@@ -594,6 +597,9 @@ impl From<&QuorumCertificate> for proto::types::QuorumCertificate {
         Self {
             parent_id: value.parent_id.to_vec(),
             header_hash: value.header_hash.to_vec(),
+            epoch: value.epoch,
+            height: value.height,
+            protocol_version: value.protocol_version,
             signatures: value.signatures.iter().map(Into::into).collect(),
             decision: proto::types::QuorumDecision::from(value.decision).into(),
         }
@@ -726,6 +732,9 @@ mod test {
         proto::types::QuorumCertificate {
             header_hash: vec![0u8; 32],
             parent_id: vec![0u8; 32],
+            epoch: 0,
+            height: 0,
+            protocol_version: 0,
             signatures: vec![signature; num_signatures],
             decision: proto::types::QuorumDecision::Accept as i32,
         }

--- a/base_layer/sidechain/src/commit_proof.rs
+++ b/base_layer/sidechain/src/commit_proof.rs
@@ -282,6 +282,19 @@ pub struct QuorumCertificate {
     pub header_hash: FixedHash,
     #[serde(with = "hex_or_bytes")]
     pub parent_id: FixedHash,
+    /// The protocol version of the block this certificate justifies, which selects the message its members signed.
+    /// A certificate is self-describing for the same reason a header is, and carries its own version because the
+    /// certificates in a proof may justify blocks either side of an activation from the block in its header.
+    #[serde(default)]
+    pub protocol_version: u32,
+    /// The epoch of the justified block. From protocol version 1 it is signed over by each member, so a mismatch
+    /// fails signature verification. A certificate that carries no epoch reads as 0, which is what a version 0
+    /// certificate — whose signatures do not cover it — encodes to.
+    #[serde(default)]
+    pub epoch: u64,
+    /// The height of the justified block. See `epoch`.
+    #[serde(default)]
+    pub height: u64,
     pub signatures: Vec<ValidatorQcSignature>,
     pub decision: QuorumDecision,
 }
@@ -358,7 +371,14 @@ pub struct ValidatorQcSignature {
 
 impl ValidatorQcSignature {
     #[must_use]
-    pub fn verify(&self, block_id: &FixedHash, decision: QuorumDecision) -> bool {
+    pub fn verify(
+        &self,
+        protocol_version: u32,
+        block_id: &FixedHash,
+        decision: QuorumDecision,
+        epoch: u64,
+        height: u64,
+    ) -> bool {
         let Ok(public_key) = self.public_key.to_public_key() else {
             return false;
         };
@@ -367,9 +387,7 @@ impl ValidatorQcSignature {
             return false;
         };
 
-        let fields = ProposalCertificateSignatureFields { block_id, decision };
-
-        let message = layer2::proposal_vote_signature_hasher().chain(&fields).finalize();
+        let message = ProposalVoteMessage::new(protocol_version, block_id, decision, epoch, height).calculate_hash();
         signature.verify(&public_key, message)
     }
 
@@ -382,10 +400,69 @@ impl ValidatorQcSignature {
     }
 }
 
+/// The message a proposal vote signs, in the shape the block's protocol version calls for. Signing and verifying
+/// both go through this so that the two cannot select different shapes.
+///
+/// Each variant serialises as its inner fields with no discriminant, so version 0 signs exactly the bytes it always
+/// has and signatures already collected stay verifiable.
+#[derive(Debug)]
+pub enum ProposalVoteMessage<'a> {
+    V0(ProposalCertificateSignatureFields<'a>),
+    V1(ProposalCertificateSignatureFieldsV1<'a>),
+}
+
+impl<'a> ProposalVoteMessage<'a> {
+    pub fn new(
+        protocol_version: u32,
+        block_id: &'a FixedHash,
+        decision: QuorumDecision,
+        epoch: u64,
+        height: u64,
+    ) -> Self {
+        match protocol_version {
+            0 => Self::V0(ProposalCertificateSignatureFields { block_id, decision }),
+            protocol_version => Self::V1(ProposalCertificateSignatureFieldsV1 {
+                protocol_version,
+                block_id,
+                decision,
+                epoch,
+                height,
+            }),
+        }
+    }
+
+    pub fn calculate_hash(&self) -> FixedHash {
+        layer2::proposal_vote_signature_hasher().chain(self).finalize().into()
+    }
+}
+
+impl BorshSerialize for ProposalVoteMessage<'_> {
+    fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
+        match self {
+            Self::V0(fields) => fields.serialize(writer),
+            Self::V1(fields) => fields.serialize(writer),
+        }
+    }
+}
+
 #[derive(Debug, BorshSerialize)]
 pub struct ProposalCertificateSignatureFields<'a> {
     pub block_id: &'a FixedHash,
     pub decision: QuorumDecision,
+}
+
+#[derive(Debug, BorshSerialize)]
+pub struct ProposalCertificateSignatureFieldsV1<'a> {
+    /// The version the vote was cast under. Committed to so that two versions sharing this preimage shape still
+    /// produce distinct messages, and a certificate cannot be relabelled to a version its members did not sign.
+    pub protocol_version: u32,
+    pub block_id: &'a FixedHash,
+    pub decision: QuorumDecision,
+    /// The epoch the vote was cast in. Present so that a single signature attributes the vote to a view, which is
+    /// what lets two conflicting votes be proven to be equivocation rather than two votes at different heights.
+    pub epoch: u64,
+    /// The height the vote was cast at. See `epoch`.
+    pub height: u64,
 }
 
 /// The hash preimage schemas for a sidechain block header, one per shape the header has taken. The variant is

--- a/base_layer/sidechain/src/validations.rs
+++ b/base_layer/sidechain/src/validations.rs
@@ -221,7 +221,7 @@ fn validate_qc(
             });
         }
 
-        if !sig.verify(&block_id, quorum_decision) {
+        if !sig.verify(qc.protocol_version, &block_id, quorum_decision, qc.epoch, qc.height) {
             return Err(SidechainProofValidationError::InvalidProof {
                 details: format!("Invalid signature for QC for block ID {block_id}",),
             });

--- a/base_layer/sidechain/tests/commit_proof.rs
+++ b/base_layer/sidechain/tests/commit_proof.rs
@@ -1,7 +1,14 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_sidechain::{CommitProofElement, MAX_QC_SIGNATURES, SidechainBlockCommitProof};
+use tari_common_types::types::FixedHash;
+use tari_sidechain::{
+    CommitProofElement,
+    MAX_QC_SIGNATURES,
+    ProposalVoteMessage,
+    QuorumDecision,
+    SidechainBlockCommitProof,
+};
 
 mod support;
 use support::load_fixture;
@@ -68,4 +75,35 @@ fn it_rejects_a_proof_whose_header_claims_another_protocol_version() {
         err.to_string().contains("does not match the block ID in the header"),
         "Expected the block ID mismatch error, got: {err}"
     );
+}
+
+#[test]
+fn it_rejects_a_qc_that_claims_another_protocol_version() {
+    let mut proof = load_fixture::<SidechainBlockCommitProof>("commit_proof.json");
+    for elem in &mut proof.proof_elements {
+        if let CommitProofElement::QuorumCertificate(qc) = elem {
+            qc.protocol_version = 1;
+        }
+    }
+    let err = proof.validate_committed(4, &|_| Ok(true)).unwrap_err();
+    assert!(
+        err.to_string().contains("Invalid signature for QC"),
+        "Expected the signature error, got: {err}"
+    );
+}
+
+#[test]
+fn the_protocol_version_selects_the_vote_message() {
+    let block_id = FixedHash::from([7u8; 32]);
+    let message = |protocol_version, epoch, height| {
+        ProposalVoteMessage::new(protocol_version, &block_id, QuorumDecision::Accept, epoch, height).calculate_hash()
+    };
+
+    assert_ne!(message(0, 3, 9), message(1, 3, 9));
+    // Version 0 does not commit to the view it was cast in, version 1 does.
+    assert_eq!(message(0, 3, 9), message(0, 0, 0));
+    assert_ne!(message(1, 3, 9), message(1, 0, 0));
+    // Versions that share a preimage shape still produce distinct messages, so a certificate cannot be
+    // relabelled to a version its members did not sign under.
+    assert_ne!(message(1, 3, 9), message(2, 3, 9));
 }


### PR DESCRIPTION
## Description

From protocol version 1, a proposal vote signs the protocol version, epoch and height of the block it votes on alongside the block ID and decision, and `QuorumCertificate` carries all three so a verifier can reconstruct the message.

Builds on #7983, which added `SidechainBlockHeader::protocol_version`.

## Motivation and Context

A proposal vote signature currently covers only `(block_id, decision)`. That is enough to verify a certificate but not enough to attribute a vote to a view: two conflicting signatures from one validator are indistinguishable from two honest votes cast at different heights, so equivocation cannot be proven from the signatures alone. Timeout votes already sign their view; this brings proposal votes in line.

`ProposalVoteMessage` selects the message shape from the protocol version of the block being voted on, and both signing and verification go through it, so the two cannot select different shapes. The version is also part of the V1 preimage, for the same reason it is part of the header's: a later version that does not change the vote message shape would otherwise share a preimage with V1, and a certificate could be relabelled to a version its members never signed under.

A certificate carries its own `protocol_version` rather than reading it off the header of the proof it appears in: the certificates in a proof may justify blocks on either side of an activation from that header.

### No reset required

Each `ProposalVoteMessage` variant serialises as its inner fields with **no discriminant**, so version 0 signs exactly the bytes it always has. Certificates already collected stay verifiable — the untouched `commit_proof.json` and `eviction_proof1.json` fixtures still validate, which is the regression guard.

`QuorumCertificate::epoch`, `::height` and `::protocol_version` are `#[serde(default)]` and proto3 scalars, so a certificate that carries none of them reads as zero for all three — which is what a version 0 certificate, whose signatures cover none of them, encodes to. Borsh is the one encoding that changes.

## How Has This Been Tested?

`cargo test -p tari_sidechain`, plus `cargo check -p tari_core -p minotari_app_grpc --all-targets` for the proto conversions.

- `it_validates_a_correct_proof` against unmodified v0 fixtures — the guard that no existing signature stopped verifying.
- `the_protocol_version_selects_the_vote_message` — v0 and v1 messages differ, v0 does not commit to the view while v1 does, and v1 and v2 differ despite sharing a preimage shape.
- `it_rejects_a_qc_that_claims_another_protocol_version` and `it_rejects_a_proof_whose_header_claims_another_protocol_version`.

## What process can a PR reviewer use to test or verify this change?

Run `cargo test -p tari_sidechain`. The claim worth checking is that a version 0 proof is bit-for-bit unaffected: the fixtures are not touched by this PR and `it_validates_a_correct_proof` still passes.

Note that the fixtures only exercise the version 0 path. They should be regenerated (see `base_layer/sidechain/tests/fixtures/README.md`) once a network schedules version 1.

## Breaking Changes

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

`QuorumCertificate` gains three fields, so the borsh encoding of sidechain proofs changes; serde and protobuf are backwards compatible. `ValidatorQcSignature::verify` takes the protocol version of the block being voted on.