### PR TITLE
feat(sidechain)!: add a protocol version to the sidechain block header

### DIFF
--- a/applications/minotari_app_grpc/proto/sidechain_types.proto
+++ b/applications/minotari_app_grpc/proto/sidechain_types.proto
@@ -144,6 +144,7 @@ message SidechainBlockHeader {
   Signature signature = 11;
   ShardGroupAccumulatedData accumulated_data = 12;
   bytes epoch_hash = 13;
+  uint32 protocol_version = 14;
 }
 
 message ShardGroup {

--- a/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
+++ b/applications/minotari_app_grpc/src/conversions/sidechain_feature.rs
@@ -457,6 +457,7 @@ impl TryFrom<grpc::SidechainBlockHeader> for SidechainBlockHeader {
         let network_byte = u8::try_from(value.network).map_err(|_| "Invalid network byte: overflows u8".to_string())?;
         Ok(Self {
             network: network_byte,
+            protocol_version: value.protocol_version,
             parent_id: value.parent_id.try_into().map_err(|_| "Invalid parent id")?,
             justify_id: value.justify_id.try_into().map_err(|_| "Invalid justify id")?,
             height: value.height,
@@ -490,6 +491,7 @@ impl From<&SidechainBlockHeader> for grpc::SidechainBlockHeader {
     fn from(value: &SidechainBlockHeader) -> Self {
         Self {
             network: u32::from(value.network),
+            protocol_version: value.protocol_version,
             parent_id: value.parent_id.to_vec(),
             justify_id: value.justify_id.to_vec(),
             height: value.height,

--- a/base_layer/core/src/proto/sidechain_feature.proto
+++ b/base_layer/core/src/proto/sidechain_feature.proto
@@ -126,6 +126,7 @@ message SidechainBlockHeader {
   bytes metadata_hash = 11;
   ShardGroupAccumulatedData accumulated_data = 12;
   bytes epoch_hash = 13;
+  uint32 protocol_version = 14;
 }
 
 message EvictAtom {

--- a/base_layer/core/src/proto/sidechain_feature.rs
+++ b/base_layer/core/src/proto/sidechain_feature.rs
@@ -451,6 +451,7 @@ impl TryFrom<proto::types::SidechainBlockHeader> for SidechainBlockHeader {
         Network::try_from(network_byte).map_err(|err| format!("Invalid network byte: {err}"))?;
         Ok(Self {
             network: network_byte,
+            protocol_version: value.protocol_version,
             parent_id: value.parent_id.try_into().map_err(|_| "Invalid parent id")?,
             justify_id: value.justify_id.try_into().map_err(|_| "Invalid justify id")?,
             height: value.height,
@@ -481,6 +482,7 @@ impl From<&SidechainBlockHeader> for proto::types::SidechainBlockHeader {
     fn from(value: &SidechainBlockHeader) -> Self {
         Self {
             network: u32::from(value.network),
+            protocol_version: value.protocol_version,
             parent_id: value.parent_id.to_vec(),
             justify_id: value.justify_id.to_vec(),
             height: value.height,

--- a/base_layer/sidechain/src/commit_proof.rs
+++ b/base_layer/sidechain/src/commit_proof.rs
@@ -185,6 +185,14 @@ impl ChainLink {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
 pub struct SidechainBlockHeader {
     pub network: u8,
+    /// The protocol version the block was produced under. A block is self-describing: [`Self::calculate_hash`]
+    /// selects its hash schema from this field alone, so this crate can hash any block it is given without knowing
+    /// the sidechain's per-network activation schedule.
+    ///
+    /// Version 0 is the version a header encodes to when the field is absent, so a proof serialised before the
+    /// field existed still deserialises into the version it was produced under.
+    #[serde(default)]
+    pub protocol_version: u32,
     #[serde(with = "hex_or_bytes")]
     pub parent_id: FixedHash,
     #[serde(with = "hex_or_bytes")]
@@ -208,19 +216,39 @@ pub struct SidechainBlockHeader {
 
 impl SidechainBlockHeader {
     pub fn calculate_hash(&self) -> FixedHash {
-        let fields = BlockHeaderHashFields::V1(BlockHeaderHashFieldsV1 {
-            network: self.network,
-            justify_id: &self.justify_id,
-            height: self.height,
-            epoch: self.epoch,
-            epoch_hash: &self.epoch_hash,
-            shard_group: self.shard_group,
-            proposed_by: self.proposed_by.as_bytes(),
-            state_merkle_root: &self.state_merkle_root,
-            command_merkle_root: &self.command_merkle_root,
-            accumulated_data: &self.accumulated_data,
-            metadata_hash: &self.metadata_hash,
-        });
+        let fields = match self.protocol_version {
+            // Protocol version 0 commits to a preimage that carries no version, so its block IDs stay reproducible.
+            0 => BlockHeaderHashFields::V1(BlockHeaderHashFieldsV1 {
+                network: self.network,
+                justify_id: &self.justify_id,
+                height: self.height,
+                epoch: self.epoch,
+                epoch_hash: &self.epoch_hash,
+                shard_group: self.shard_group,
+                proposed_by: self.proposed_by.as_bytes(),
+                state_merkle_root: &self.state_merkle_root,
+                command_merkle_root: &self.command_merkle_root,
+                accumulated_data: &self.accumulated_data,
+                metadata_hash: &self.metadata_hash,
+            }),
+            // From version 1 the version is part of the preimage, so that two versions sharing a preimage shape
+            // (a fork that changes something other than the header) still produce distinct block IDs and the
+            // version a block claims cannot be altered without invalidating it.
+            protocol_version => BlockHeaderHashFields::V2(BlockHeaderHashFieldsV2 {
+                network: self.network,
+                protocol_version,
+                justify_id: &self.justify_id,
+                height: self.height,
+                epoch: self.epoch,
+                epoch_hash: &self.epoch_hash,
+                shard_group: self.shard_group,
+                proposed_by: self.proposed_by.as_bytes(),
+                state_merkle_root: &self.state_merkle_root,
+                command_merkle_root: &self.command_merkle_root,
+                accumulated_data: &self.accumulated_data,
+                metadata_hash: &self.metadata_hash,
+            }),
+        };
 
         layer2::block_hasher().chain(&fields).finalize().into()
     }
@@ -360,14 +388,35 @@ pub struct ProposalCertificateSignatureFields<'a> {
     pub decision: QuorumDecision,
 }
 
+/// The hash preimage schemas for a sidechain block header, one per shape the header has taken. The variant is
+/// selected by [`SidechainBlockHeader::protocol_version`], so the variant index is consensus-bound: entries are
+/// append-only and never reordered.
 #[derive(Debug, BorshSerialize)]
 pub enum BlockHeaderHashFields<'a> {
     V1(BlockHeaderHashFieldsV1<'a>),
+    V2(BlockHeaderHashFieldsV2<'a>),
 }
 
 #[derive(Debug, BorshSerialize)]
 pub struct BlockHeaderHashFieldsV1<'a> {
     pub network: u8,
+    pub justify_id: &'a FixedHash,
+    pub height: u64,
+    pub epoch: u64,
+    pub epoch_hash: &'a FixedHash,
+    pub shard_group: ShardGroup,
+    pub accumulated_data: &'a ShardGroupAccumulatedData,
+    // NOTE this is borsh encoded as variable length bytes - technically should always be 32
+    pub proposed_by: &'a [u8],
+    pub state_merkle_root: &'a FixedHash,
+    pub command_merkle_root: &'a FixedHash,
+    pub metadata_hash: &'a FixedHash,
+}
+
+#[derive(Debug, BorshSerialize)]
+pub struct BlockHeaderHashFieldsV2<'a> {
+    pub network: u8,
+    pub protocol_version: u32,
     pub justify_id: &'a FixedHash,
     pub height: u64,
     pub epoch: u64,

--- a/base_layer/sidechain/tests/commit_proof.rs
+++ b/base_layer/sidechain/tests/commit_proof.rs
@@ -36,3 +36,36 @@ fn it_rejects_a_qc_with_too_many_signatures() {
         "Expected the signature-count error, got: {err}"
     );
 }
+
+#[test]
+fn a_header_that_omits_the_protocol_version_is_version_0() {
+    // The fixture has no `protocol_version` key, which is how every header serialised without one must read.
+    let proof = load_fixture::<SidechainBlockCommitProof>("commit_proof.json");
+    assert_eq!(proof.header().protocol_version, 0);
+}
+
+#[test]
+fn the_protocol_version_selects_the_hash_schema() {
+    let proof = load_fixture::<SidechainBlockCommitProof>("commit_proof.json");
+    let v0_id = proof.header().calculate_block_id();
+
+    let mut header = proof.header().clone();
+    header.protocol_version = 1;
+    let v1_id = header.calculate_block_id();
+    assert_ne!(v0_id, v1_id, "a version bump must change the block ID");
+
+    // From version 1 the version is committed to, so no two versions can share a block ID.
+    header.protocol_version = 2;
+    assert_ne!(v1_id, header.calculate_block_id());
+}
+
+#[test]
+fn it_rejects_a_proof_whose_header_claims_another_protocol_version() {
+    let mut proof = load_fixture::<SidechainBlockCommitProof>("commit_proof.json");
+    proof.header.protocol_version = 1;
+    let err = proof.validate_committed(4, &|_| Ok(true)).unwrap_err();
+    assert!(
+        err.to_string().contains("does not match the block ID in the header"),
+        "Expected the block ID mismatch error, got: {err}"
+    );
+}


### PR DESCRIPTION
## Description

Adds a `protocol_version: u32` field to `SidechainBlockHeader` and makes `calculate_hash` select its hash preimage schema from that field.

## Motivation and Context

The Ootle sidechain resolves its protocol version from a per-network activation schedule (epoch → version). That table lives on the sidechain, so today a block gives an L1 verifier no way to tell which schema it was hashed under — the verifier has to already know the schedule, and a node running a stale schedule silently hashes a post-fork block under the superseded schema and diverges instead of stopping.

Making the header self-describing moves that decision into the block itself. `tari_sidechain` can hash any block it is handed with no knowledge of the activation schedule at all, which keeps this crate free of a table it would otherwise have to track across every sidechain fork.

The window matters: once validator registration is decentralised, the header format is L1 consensus and changing it costs an L1 coordination round. The Ootle side is already taking a protocol bump, so this is the cheap moment to add it.

### Hashing

- Version 0 keeps the existing `BlockHeaderHashFieldsV1` preimage, which carries no version. Every block ID committed so far stays reproducible — the existing fixtures are unmodified by this PR and still validate.
- From version 1 the preimage is the new `BlockHeaderHashFieldsV2`, which commits to `protocol_version` itself. Committing the version explicitly (rather than relying on the variant discriminant) is what keeps it non-malleable when a fork bumps the version without changing the header shape — two such versions would otherwise share a preimage and a block ID.

`BlockHeaderHashFields` variant indices are consensus-bound and append-only.

### Compatibility

Version 0 is what a header decodes to when the field is absent, so no reset is needed to adopt this:

- **serde** — `#[serde(default)]`. The test fixtures in this PR are unchanged and have no `protocol_version` key; they deserialise as version 0 and hash exactly as before.
- **protobuf** — proto3 scalar, absent reads as 0.
- **borsh** — no equivalent notion of an absent field, so the borsh encoding of `SidechainBlockCommitProof` / `EvictionProof` does change. This is the one incompatible encoding.

## How Has This Been Tested?

`cargo test -p tari_sidechain`. The pre-existing fixtures validate unchanged, which is the regression guard that v0 hashing is byte-identical and that an absent field reads as v0. New tests cover: a header omitting the field is version 0; the version selects the schema (v0/v1/v2 IDs pairwise distinct); a proof whose header claims a different version fails block-ID validation.

`cargo check -p tari_core -p minotari_app_grpc` for the proto conversions.

## What process can a PR reviewer use to test or verify this change?

Check out the branch and run `cargo test -p tari_sidechain`. `it_validates_a_correct_proof` passing against the untouched v0 fixtures is the guard that no existing block ID changed.

## Breaking Changes

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

The borsh encoding of sidechain commit and eviction proofs changes, so a proof serialised with borsh by an older binary does not deserialise here. The serde and protobuf encodings are backwards compatible.