### PR TITLE
chore: remove duplicate peer dialing logic

### DIFF
--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -179,6 +179,18 @@ pub struct P2pConfig {
     /// Default: 15 minutes
     #[serde(with = "serializers::seconds")]
     pub max_seed_peer_age: Duration,
+    /// Enable proactive (recovery) dialing in the comms connectivity manager. The DHT peer pool owns the
+    /// steady-state connection count; the proactive dialer only exists to get this node back off the floor when
+    /// the pool cannot recover unaided (cold start, total isolation). Setting this to false is the kill switch
+    /// for that subsystem.
+    /// Default: true
+    pub proactive_dialing_enabled: bool,
+    /// The connection count below which the proactive dialer is allowed to run. A *floor*, not a target - it
+    /// must stay strictly below the DHT peer pool size (`dht.num_neighbouring_nodes + dht.num_random_nodes`) or
+    /// the dialer becomes a second steady-state connection-count controller fighting the pool on the same tick.
+    /// `P2pInitializer` clamps it below the pool size and warns if this is set into conflict.
+    /// Default: 8
+    pub proactive_dialing_floor: usize,
 }
 
 impl Default for P2pConfig {
@@ -207,6 +219,8 @@ impl Default for P2pConfig {
             rpc_idle_session_timeout: Duration::from_secs(10 * 60),
             rpc_maximum_client_deadline: Duration::from_secs(10 * 60),
             max_seed_peer_age: Duration::from_secs(15 * 60),
+            proactive_dialing_enabled: true,
+            proactive_dialing_floor: 8,
         }
     }
 }

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -551,6 +551,35 @@ impl P2pInitializer {
     }
 }
 
+/// Reconciles the comms proactive dialer's floor with the DHT peer pool size, returning the floor to actually
+/// configure.
+///
+/// The DHT peer pool and the proactive dialer are both closed-loop connection-count controllers running on the
+/// same tick (`connection_pool_refresh_interval` is set from `dht.connectivity.update_interval` just above).
+/// They only coexist because the dialer's floor is *strictly below* the pool's target, which makes the dialer
+/// silent whenever the pool is anywhere near healthy and leaves it to do the one job it is actually needed for:
+/// getting this node off the floor when the pool cannot recover unaided.
+///
+/// With default config that relationship holds by arithmetic (8 < 6 + 6), not by design. `num_neighbouring_nodes`
+/// and `num_random_nodes` are both live operator-settable keys, and any sum at or below the floor turns the
+/// dialer back into a co-equal steady-state controller fighting the pool - proactively dialing peers the pool
+/// then immediately disconnects as over-capacity, every refresh cycle, forever. Clamping here is what makes the
+/// relationship deliberate rather than incidental.
+fn reconcile_proactive_dialing_floor(configured_floor: usize, dht_pool_size: usize) -> usize {
+    if configured_floor < dht_pool_size {
+        return configured_floor;
+    }
+    let clamped = dht_pool_size.saturating_sub(1);
+    warn!(
+        target: LOG_TARGET,
+        "proactive_dialing_floor ({configured_floor}) >= DHT pool size ({dht_pool_size}), clamping to {clamped}. \
+         The proactive dialer is a recovery mechanism and must stay strictly below the DHT peer pool size, which \
+         owns the steady-state connection count - otherwise the two fight each other every refresh cycle. Raise \
+         dht.num_neighbouring_nodes/dht.num_random_nodes, or lower p2p.proactive_dialing_floor, to silence this."
+    );
+    clamped
+}
+
 #[async_trait]
 impl ServiceInitializer for P2pInitializer {
     async fn initialize(&mut self, context: ServiceInitializerContext) -> Result<(), ServiceInitializationError> {
@@ -578,6 +607,14 @@ impl ServiceInitializer for P2pInitializer {
             .with_reaper_min_connection_thresholds(
                 self.config.dht.num_neighbouring_nodes + self.config.dht.num_random_nodes,
             )
+            .with_proactive_dialing_enabled(config.proactive_dialing_enabled)
+            .with_proactive_dialing_floor(reconcile_proactive_dialing_floor(
+                config.proactive_dialing_floor,
+                self.config
+                    .dht
+                    .num_neighbouring_nodes
+                    .saturating_add(self.config.dht.num_random_nodes),
+            ))
             .set_self_liveness_check(config.listener_self_liveness_check_interval);
 
         if config.allow_test_addresses || config.dht.peer_validator_config.allow_test_addresses {
@@ -618,9 +655,77 @@ impl ServiceInitializer for P2pInitializer {
 mod test {
     use tari_common::configuration::Network;
     use tari_comms::connection_manager::WireMode;
+
+    use super::*;
+    use crate::P2pConfig;
+
     #[test]
     fn self_liveness_network_wire_byte_is_consistent() {
         let wire_mode = WireMode::Liveness;
         assert_eq!(wire_mode.as_byte(), Network::RESERVED_WIRE_BYTE);
+    }
+
+    /// The pool size used here is `P2pInitializer`'s own expression for it, so this test tracks the wiring
+    /// rather than a copy of it.
+    fn dht_pool_size(config: &P2pConfig) -> usize {
+        config
+            .dht
+            .num_neighbouring_nodes
+            .saturating_add(config.dht.num_random_nodes)
+    }
+
+    /// The regression this whole change exists to prevent: a DHT peer pool sized at or below the proactive
+    /// dialer's floor turns the dialer into a second steady-state connection-count controller, dialing peers
+    /// the pool immediately disconnects as over-capacity, every refresh cycle, forever. Both keys are live and
+    /// operator-settable, so the invariant has to be enforced at wire-up, not assumed.
+    #[test]
+    fn floor_is_clamped_strictly_below_a_small_dht_pool() {
+        let mut config = P2pConfig::default();
+        config.dht.num_neighbouring_nodes = 2;
+        config.dht.num_random_nodes = 2;
+
+        let pool_size = dht_pool_size(&config);
+        assert!(
+            config.proactive_dialing_floor >= pool_size,
+            "test setup is wrong: this test needs a pool size that conflicts with the default floor"
+        );
+
+        let floor = reconcile_proactive_dialing_floor(config.proactive_dialing_floor, pool_size);
+        assert!(
+            floor < pool_size,
+            "the proactive dialing floor ({floor}) must end up strictly below the DHT pool size ({pool_size})"
+        );
+    }
+
+    /// The default base node configuration must not be clamped - if it is, the default floor and the default
+    /// pool size have drifted into conflict and the arithmetic that keeps the two controllers apart no longer
+    /// holds out of the box.
+    #[test]
+    fn default_config_needs_no_clamping() {
+        let config = P2pConfig::default();
+        let pool_size = dht_pool_size(&config);
+
+        assert_eq!(
+            reconcile_proactive_dialing_floor(config.proactive_dialing_floor, pool_size),
+            config.proactive_dialing_floor,
+            "the default proactive dialing floor ({}) should already be strictly below the default DHT pool size \
+             ({pool_size})",
+            config.proactive_dialing_floor
+        );
+        assert!(config.proactive_dialing_floor < pool_size);
+    }
+
+    /// A floor exactly equal to the pool size is still a conflict - the two controllers would chase adjacent
+    /// numbers on the same tick - so the clamp is `<`, not `<=`.
+    #[test]
+    fn floor_equal_to_pool_size_is_still_clamped() {
+        assert_eq!(reconcile_proactive_dialing_floor(6, 6), 5);
+    }
+
+    /// A degenerate pool size cannot have anything strictly below it other than zero, which disables proactive
+    /// dialing entirely. That is the correct outcome and must not underflow.
+    #[test]
+    fn zero_pool_size_clamps_to_zero_without_underflowing() {
+        assert_eq!(reconcile_proactive_dialing_floor(8, 0), 0);
     }
 }

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -201,6 +201,18 @@ listener_self_liveness_check_interval = 15
 # status. Values below the 1 second minimum client deadline are floored at it. (default value = 600).
 #rpc_maximum_client_deadline = 600
 
+# Enable proactive (recovery) dialing in the comms connectivity manager. The DHT peer pool owns the steady-state
+# connection count; the proactive dialer only runs when this node has fewer than `proactive_dialing_floor`
+# connections, i.e. when the pool cannot recover unaided (cold start, total isolation, seed re-dial). Setting this
+# to false is the kill switch for that subsystem. (default value = true)
+#proactive_dialing_enabled = true
+# The connection count below which the proactive dialer is allowed to run. This is a floor, not a target: it must
+# stay strictly below the DHT peer pool size (`dht.num_neighbouring_nodes` + `dht.num_random_nodes`, 12 by
+# default) or the dialer becomes a second steady-state connection-count controller fighting the pool on the same
+# refresh tick. A floor set at or above the pool size is clamped below it at startup, with a warning.
+# (default value = 8)
+#proactive_dialing_floor = 8
+
 [base_node.p2p.transport]
 # -------------- Transport configuration --------------
 # Choose which peer address types to use and in which order to prefer them.

--- a/comms/core/src/builder/mod.rs
+++ b/comms/core/src/builder/mod.rs
@@ -315,6 +315,22 @@ impl CommsBuilder {
         self
     }
 
+    /// Enable or disable proactive (recovery) dialing. Disabling it leaves the DHT peer pool as the only thing
+    /// dialing new peers, which is fine on a node that stays connected and removes its only unaided way back
+    /// from total isolation.
+    pub fn with_proactive_dialing_enabled(mut self, enabled: bool) -> Self {
+        self.connectivity_config.proactive_dialing_enabled = enabled;
+        self
+    }
+
+    /// The connection count below which the proactive dialer is allowed to run. This is a floor, not a target -
+    /// see [`ConnectivityConfig::proactive_dialing_floor`]. It must stay strictly below the DHT peer pool size;
+    /// `P2pInitializer` clamps it to enforce that.
+    pub fn with_proactive_dialing_floor(mut self, floor: usize) -> Self {
+        self.connectivity_config.proactive_dialing_floor = floor;
+        self
+    }
+
     /// Set the transport protocols to use for communication
     /// if not provided defaults to IP4, IP6, TOR and memory address
     pub fn with_transport_protocols(mut self, protocols: Vec<TransportProtocol>) -> Self {

--- a/comms/core/src/connectivity/config.rs
+++ b/comms/core/src/connectivity/config.rs
@@ -22,6 +22,8 @@
 
 use std::time::Duration;
 
+use super::connection_stats::PeerConnectionStats;
+
 /// Connectivity actor configuration
 #[derive(Debug, Clone, Copy)]
 pub struct ConnectivityConfig {
@@ -79,6 +81,23 @@ pub struct ConnectivityConfig {
     /// Maximum seed peer age
     /// Default: 15 minutes
     pub max_seed_peer_age: Duration,
+}
+
+impl ConnectivityConfig {
+    /// Whether this peer's circuit breaker is currently open, i.e. it has failed
+    /// `circuit_breaker_failure_threshold` times in a row and has not yet waited out
+    /// `circuit_breaker_retry_interval`.
+    ///
+    /// The single definition of that question. There are two places that must not dial a circuit-broken peer -
+    /// `ConnectivityManagerActor::handle_dial_peer`, which covers every dial routed through the connectivity
+    /// actor, and `ProactiveDialer::select_dial_candidates`, whose dials go straight to the connection manager
+    /// and so never reach the actor at all. They are genuinely separate call sites; keeping the *predicate* in
+    /// one place is what stops them from drifting apart.
+    ///
+    /// A peer with no recorded stats has never failed, so it is never circuit-broken.
+    pub(crate) fn is_circuit_broken(&self, stats: Option<&PeerConnectionStats>) -> bool {
+        stats.is_some_and(|stats| !stats.should_allow_connection(self.circuit_breaker_retry_interval))
+    }
 }
 
 impl Default for ConnectivityConfig {

--- a/comms/core/src/connectivity/config.rs
+++ b/comms/core/src/connectivity/config.rs
@@ -52,10 +52,16 @@ pub struct ConnectivityConfig {
     /// The closest number of peer connections to maintain; connections above the threshold will be removed
     /// (default: disabled)
     pub maintain_n_closest_connections_only: Option<usize>,
-    /// Target number of active peer connections to maintain
+    /// The connection count below which the proactive dialer is allowed to run. This is a *floor*, not a target:
+    /// steady-state connection count is owned by the DHT peer pool, and the proactive dialer exists only to get a
+    /// node back off the floor when the pool cannot recover unaided (cold start, total isolation, seed re-dial).
+    ///
+    /// It must therefore stay strictly below the DHT pool size (`num_neighbouring_nodes + num_random_nodes`), or
+    /// the dialer becomes a second steady-state connection-count controller fighting the pool on the same tick.
+    /// `P2pInitializer` clamps it to enforce that.
     /// Default: 8
-    pub target_connection_count: usize,
-    /// Enable proactive peer dialing to maintain target connections
+    pub proactive_dialing_floor: usize,
+    /// Enable proactive peer dialing to recover from a connection count below `proactive_dialing_floor`
     /// Default: true
     pub proactive_dialing_enabled: bool,
     /// Multiplier for calculating how many peers to dial based on success rate
@@ -87,7 +93,7 @@ impl Default for ConnectivityConfig {
             connection_tie_break_linger: Duration::from_secs(2),
             expire_peer_last_seen_duration: Duration::from_secs(24 * 60 * 60),
             maintain_n_closest_connections_only: None,
-            target_connection_count: 8,
+            proactive_dialing_floor: 8,
             proactive_dialing_enabled: true,
             dialing_multiplier: 2.5,
             success_rate_tracking_window: Duration::from_secs(5 * 60),

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -429,6 +429,31 @@ impl ConnectivityManagerActor {
                 return;
             },
         }
+
+        // Per-peer circuit breaker. `handle_dial_peer` is the single chokepoint every dial passes
+        // through, so this is the only place the breaker can cover DHT-originated dials as well as
+        // the proactive dialer's own - previously it was consulted only inside the dialer's
+        // candidate filter, which is why the DHT could re-dial a peer that had just failed
+        // `circuit_breaker_failure_threshold` times in a row.
+        //
+        // It applies to *speculative* dials only: `reply_tx: None` together with `RefKind::Weak` is
+        // exactly what `ConnectivityRequester::request_many_dials` sends (the pool refresh) and is
+        // never what an explicit `dial_peer` from sync or RPC sends. An explicit dial names a peer
+        // some other subsystem specifically needs, and must never be circuit-broken.
+        let is_speculative_dial = reply_tx.is_none() && matches!(ref_kind, RefKind::Weak);
+        if is_speculative_dial &&
+            let Some(stats) = self.connection_stats.get(&node_id) &&
+            !stats.should_allow_connection(self.config.circuit_breaker_retry_interval)
+        {
+            debug!(
+                target: LOG_TARGET,
+                "Skipping speculative dial to peer {} - its circuit breaker is open ({})",
+                node_id.short_str(),
+                stats
+            );
+            return;
+        }
+
         match self.pool.get(&node_id) {
             // The connection pool may temporarily contain a connection that is not connected so we need to check this.
             Some(state) if state.is_connected() => {
@@ -530,19 +555,44 @@ impl ConnectivityManagerActor {
     }
 
     async fn refresh_connection_pool(&mut self, task_id: u64) -> Result<(), ConnectivityError> {
+        // The DHT pool size this node was wired for. Both comms-side ceilings are set from
+        // `num_neighbouring_nodes + num_random_nodes` by `P2pInitializer`, so either one reports the number the
+        // DHT's own status line calls the "peer pool" - printing it here is what lets the two log targets be
+        // read against each other instead of against each other's absence.
+        let dht_pool_size = self
+            .config
+            .maintain_n_closest_connections_only
+            .unwrap_or(self.config.reaper_min_connection_threshold);
+        let num_connected_nodes = self.pool.count_connected_nodes();
+        let floor = self.config.proactive_dialing_floor;
+        // Decided once, here, so the single status line below and the branch it describes cannot disagree.
+        let dialer_state = if !self.config.proactive_dialing_enabled {
+            "disabled"
+        } else if num_connected_nodes < floor {
+            "ARMED"
+        } else {
+            "idle"
+        };
+
         info!(
             target: LOG_TARGET,
-            "CONNECTIVITY_REFRESH: Performing connection pool cleanup/refresh ({}). (#Peers = {}, #Connected={}, #Failed={}, #Disconnected={}, \
-             #Clients={})",
+            "CONNECTIVITY_REFRESH: Performing connection pool cleanup/refresh ({}). (#Peers = {}, \
+             #ConnectedNodes(incl. inbound)={}, #Failed={}, #Disconnected={}, #Clients={}, DHT pool size={}, \
+             proactive dialer={} (floor {}))",
             task_id,
             self.pool.count_entries(),
-            self.pool.count_connected_nodes(),
+            num_connected_nodes,
             self.pool.count_failed(),
             self.pool.count_disconnected(),
-            self.pool.count_connected_clients()
+            self.pool.count_connected_clients(),
+            dht_pool_size,
+            dialer_state,
+            floor,
         );
 
         self.clean_connection_pool();
+        // Deliberately outside the proactive-dialing gate below: aging seed connections out is unconditional,
+        // only the seed *re-dial* path (inside `execute_proactive_dialing`) is gated on the floor.
         self.disconnect_seed_peers(task_id).await;
 
         if self.config.is_connection_reaping_enabled {
@@ -552,31 +602,21 @@ impl ConnectivityManagerActor {
             self.maintain_n_closest_peer_connections_only(threshold, task_id).await;
         }
 
-        // Execute proactive dialing logic (if enabled)
-        debug!(
-            target: LOG_TARGET,
-            "({}) Proactive dialing config check: enabled={}, target_connections={}",
-            task_id,
-            self.config.proactive_dialing_enabled,
-            self.config.target_connection_count
-        );
-
-        if self.config.proactive_dialing_enabled {
-            debug!(
+        // Proactive dialing is a *recovery* mechanism, not a steady-state connection-count controller - the DHT
+        // peer pool owns that. Gate it here, at the call site, rather than relying on the dialer's own early
+        // return: the constraint that keeps the two loops from fighting is "this floor stays below the DHT pool
+        // size", and it should be legible where the decision is made.
+        //
+        // Re-read the connection count rather than reusing the one above: the reaping and minimize-connections
+        // passes in between may have dropped connections, and a node that has just been pushed below the floor
+        // should recover on this tick, not the next one.
+        if self.config.proactive_dialing_enabled &&
+            self.pool.count_connected_nodes() < floor &&
+            let Err(err) = self.execute_proactive_dialing(task_id).await
+        {
+            warn!(
                 target: LOG_TARGET,
-                "({task_id}) Executing proactive dialing logic"
-            );
-            if let Err(err) = self.execute_proactive_dialing(task_id).await {
-                warn!(
-                    target: LOG_TARGET,
-                    "({task_id}) Proactive dialing failed: {err:?}"
-                );
-            }
-        } else {
-            debug!(
-                target: LOG_TARGET,
-                "({task_id}) Proactive dialing disabled in configuration"
-
+                "({task_id}) Proactive dialing failed: {err:?}"
             );
         }
 
@@ -1486,10 +1526,10 @@ impl ConnectivityManagerActor {
     async fn execute_proactive_dialing(&mut self, task_id: u64) -> Result<(), ConnectivityError> {
         debug!(
             target: LOG_TARGET,
-            "({}) Starting proactive dialing execution - current connections: {}, target: {}",
+            "({}) Starting proactive dialing execution - current connections: {}, floor: {}",
             task_id,
             self.pool.count_connected_nodes(),
-            self.config.target_connection_count
+            self.config.proactive_dialing_floor
         );
 
         // First, clean up old health data to keep metrics accurate
@@ -1882,5 +1922,144 @@ mod retry_ban_persistence_tests {
             peer_manager.is_peer_banned(&node_id).await.unwrap(),
             "a retry whose tracked entry is unchanged must actually persist the ban"
         );
+    }
+}
+
+#[cfg(test)]
+mod speculative_dial_circuit_breaker_tests {
+    use tari_shutdown::Shutdown;
+    use tokio::sync::broadcast;
+
+    use super::*;
+    use crate::{
+        connection_manager::ConnectionManagerRequest,
+        peer_manager::{PeerFeatures, create_test_peer},
+        test_utils::{node_identity::build_node_identity, peer_manager::build_peer_manager},
+    };
+
+    /// Builds a bare `ConnectivityManagerActor` plus the receiving end of its connection manager request
+    /// channel. The receiver is held directly rather than going through `ConnectionManagerMock` so the
+    /// assertions below are synchronous - "was a `DialPeer` request produced by this call?" is answered by
+    /// `try_recv`, with no sleeping or racing against a spawned mock task.
+    fn setup(
+        peer_manager: Arc<PeerManager>,
+    ) -> (
+        ConnectivityManagerActor,
+        mpsc::Receiver<ConnectionManagerRequest>,
+        Shutdown,
+    ) {
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+        let (cm_tx, cm_rx) = mpsc::channel(10);
+        let (cm_event_tx, _) = broadcast::channel(10);
+        let connection_manager = ConnectionManagerRequester::new(cm_tx, cm_event_tx);
+        let shutdown = Shutdown::new();
+        let (_request_tx, request_rx) = mpsc::channel(1);
+        let (event_tx, _event_rx) = broadcast::channel(10);
+        let config = ConnectivityConfig::default();
+        let proactive_dialer = ProactiveDialer::new(config, connection_manager.clone(), peer_manager.clone());
+
+        let actor = ConnectivityManagerActor {
+            config,
+            status: ConnectivityStatus::Initializing,
+            request_rx,
+            connection_manager,
+            node_identity,
+            peer_manager,
+            event_tx,
+            connection_stats: HashMap::new(),
+            pool: ConnectionPool::new(),
+            shutdown_signal: shutdown.to_signal(),
+            #[cfg(feature = "metrics")]
+            uptime: Some(Instant::now()),
+            allow_list: vec![],
+            proactive_dialer,
+            seeds: vec![],
+            ban_persist_retry_permits: Arc::new(Semaphore::new(MAX_CONCURRENT_BAN_PERSIST_RETRIES)),
+        };
+
+        (actor, cm_rx, shutdown)
+    }
+
+    /// Drives a peer's stats to a tripped (open) circuit breaker the same way the actor itself does, via
+    /// consecutive recorded failures at the configured threshold.
+    fn trip_circuit_breaker(actor: &mut ConnectivityManagerActor, node_id: &NodeId) {
+        let threshold = actor.config.circuit_breaker_failure_threshold;
+        let stats = actor.connection_stats.entry(node_id.clone()).or_default();
+        for _ in 0..threshold {
+            stats.set_connection_failed_with_threshold(threshold);
+        }
+        assert!(
+            !stats.should_allow_connection(actor.config.circuit_breaker_retry_interval),
+            "test setup is wrong: the circuit breaker did not open after {threshold} consecutive failures"
+        );
+    }
+
+    /// `reply_tx: None` + `RefKind::Weak` is exactly and only what `ConnectivityRequester::request_many_dials`
+    /// sends, whose sole caller in the workspace is the DHT peer pool refresh. Those dials are speculative -
+    /// nobody is waiting on them and no subsystem named the peer - so a peer whose breaker is open must be
+    /// skipped rather than re-dialed on every refresh tick.
+    #[tokio::test]
+    async fn speculative_dial_to_a_circuit_broken_peer_is_skipped() {
+        let this_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let peer_manager = build_peer_manager(&this_peer).unwrap();
+        let target_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let node_id = target_peer.node_id.clone();
+        peer_manager.add_or_update_peer(target_peer).await.unwrap();
+
+        let (mut actor, mut cm_rx, _shutdown) = setup(peer_manager);
+        trip_circuit_breaker(&mut actor, &node_id);
+
+        actor.handle_dial_peer(node_id.clone(), RefKind::Weak, None).await;
+
+        assert!(
+            cm_rx.try_recv().is_err(),
+            "a speculative dial to a circuit-broken peer must not reach the connection manager"
+        );
+    }
+
+    /// The other half of the discriminator, and the one with the blast radius: an explicit dial (block sync, an
+    /// RPC client, anything holding a `reply_tx`) names a peer some subsystem specifically needs, and must go
+    /// through regardless of the breaker. Getting this wrong silently breaks sync.
+    #[tokio::test]
+    async fn explicit_dial_to_a_circuit_broken_peer_still_goes_through() {
+        let this_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let peer_manager = build_peer_manager(&this_peer).unwrap();
+        let target_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let node_id = target_peer.node_id.clone();
+        peer_manager.add_or_update_peer(target_peer).await.unwrap();
+
+        let (mut actor, mut cm_rx, _shutdown) = setup(peer_manager);
+        trip_circuit_breaker(&mut actor, &node_id);
+
+        let (reply_tx, _reply_rx) = oneshot::channel();
+        actor
+            .handle_dial_peer(node_id.clone(), RefKind::Strong, Some(reply_tx))
+            .await;
+
+        match cm_rx.try_recv() {
+            Ok(ConnectionManagerRequest::DialPeer { node_id: dialed, .. }) => assert_eq!(dialed, node_id),
+            other => panic!("an explicit dial must never be circuit-broken, got {other:?}"),
+        }
+    }
+
+    /// A speculative dial to a peer with no failure history - the overwhelmingly common case for the pool
+    /// refresh - must still be dialed. Without this, the test above would also pass if the new check simply
+    /// dropped every speculative dial.
+    #[tokio::test]
+    async fn speculative_dial_to_a_healthy_peer_still_goes_through() {
+        let this_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let peer_manager = build_peer_manager(&this_peer).unwrap();
+        let target_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let node_id = target_peer.node_id.clone();
+        peer_manager.add_or_update_peer(target_peer).await.unwrap();
+
+        let (mut actor, mut cm_rx, _shutdown) = setup(peer_manager);
+
+        actor.handle_dial_peer(node_id.clone(), RefKind::Weak, None).await;
+
+        match cm_rx.try_recv() {
+            Ok(ConnectionManagerRequest::DialPeer { node_id: dialed, .. }) => assert_eq!(dialed, node_id),
+            other => panic!("a speculative dial to a healthy peer must go through, got {other:?}"),
+        }
     }
 }

--- a/comms/core/src/connectivity/manager.rs
+++ b/comms/core/src/connectivity/manager.rs
@@ -430,26 +430,31 @@ impl ConnectivityManagerActor {
             },
         }
 
-        // Per-peer circuit breaker. `handle_dial_peer` is the single chokepoint every dial passes
-        // through, so this is the only place the breaker can cover DHT-originated dials as well as
-        // the proactive dialer's own - previously it was consulted only inside the dialer's
-        // candidate filter, which is why the DHT could re-dial a peer that had just failed
+        // Per-peer circuit breaker, for dials that reach this actor. That is every dial routed through
+        // `ConnectivityRequester` - notably the DHT peer pool's `request_many_dials`, which previously
+        // bypassed the breaker entirely and could therefore re-dial a peer that had just failed
         // `circuit_breaker_failure_threshold` times in a row.
         //
-        // It applies to *speculative* dials only: `reply_tx: None` together with `RefKind::Weak` is
-        // exactly what `ConnectivityRequester::request_many_dials` sends (the pool refresh) and is
-        // never what an explicit `dial_peer` from sync or RPC sends. An explicit dial names a peer
-        // some other subsystem specifically needs, and must never be circuit-broken.
+        // It is *not* the only dial path in comms: `ProactiveDialer::dial_peers_concurrently` calls
+        // `ConnectionManagerRequester::try_send_dial_peer` directly and never passes through here, so it
+        // keeps its own breaker check in `select_dial_candidates`. Both sites ask the same question via
+        // `ConnectivityConfig::is_circuit_broken` so the two cannot drift apart, but they remain two
+        // call sites - this is not a single chokepoint for all dials.
+        //
+        // Here it applies to *speculative* dials only: `reply_tx: None` together with `RefKind::Weak` is
+        // exactly what `ConnectivityRequester::request_many_dials` sends (the pool refresh) and is never
+        // what an explicit `dial_peer` sends. Both halves of that test matter - `RefKind::Weak` alone is
+        // not enough, because the ordinary messaging and RPC dial paths ask for `Weak` handles too and
+        // are explicit (they carry a `reply_tx`). An explicit dial names a peer some other subsystem
+        // specifically needs, and must never be circuit-broken.
         let is_speculative_dial = reply_tx.is_none() && matches!(ref_kind, RefKind::Weak);
-        if is_speculative_dial &&
-            let Some(stats) = self.connection_stats.get(&node_id) &&
-            !stats.should_allow_connection(self.config.circuit_breaker_retry_interval)
-        {
+        let stats = self.connection_stats.get(&node_id);
+        if is_speculative_dial && self.config.is_circuit_broken(stats) {
             debug!(
                 target: LOG_TARGET,
                 "Skipping speculative dial to peer {} - its circuit breaker is open ({})",
                 node_id.short_str(),
-                stats
+                stats.map(ToString::to_string).unwrap_or_default()
             );
             return;
         }
@@ -555,6 +560,18 @@ impl ConnectivityManagerActor {
     }
 
     async fn refresh_connection_pool(&mut self, task_id: u64) -> Result<(), ConnectivityError> {
+        self.clean_connection_pool();
+        // Deliberately outside the proactive-dialing gate below: aging seed connections out is unconditional,
+        // only the seed *re-dial* path (inside `execute_proactive_dialing`) is gated on the floor.
+        self.disconnect_seed_peers(task_id).await;
+
+        if self.config.is_connection_reaping_enabled {
+            self.reap_inactive_connections(task_id).await;
+        }
+        if let Some(threshold) = self.config.maintain_n_closest_connections_only {
+            self.maintain_n_closest_peer_connections_only(threshold, task_id).await;
+        }
+
         // The DHT pool size this node was wired for. Both comms-side ceilings are set from
         // `num_neighbouring_nodes + num_random_nodes` by `P2pInitializer`, so either one reports the number the
         // DHT's own status line calls the "peer pool" - printing it here is what lets the two log targets be
@@ -563,12 +580,20 @@ impl ConnectivityManagerActor {
             .config
             .maintain_n_closest_connections_only
             .unwrap_or(self.config.reaper_min_connection_threshold);
-        let num_connected_nodes = self.pool.count_connected_nodes();
         let floor = self.config.proactive_dialing_floor;
-        // Decided once, here, so the single status line below and the branch it describes cannot disagree.
+
+        // Read the connection count exactly once, here, and use that one value for both the status line and
+        // the gate below. It has to be read *after* the cleanup, seed-disconnect, reaping and
+        // minimize-connections passes above, all of which can drop connections: a count taken before them
+        // could say "idle" in the log while the gate, acting on the real post-cleanup count, dials anyway on
+        // that same tick - which is precisely the two-logs-disagreeing-on-one-tick confusion this status line
+        // exists to end. Reading it after also means a node just pushed below the floor recovers on this tick
+        // rather than the next.
+        let num_connected_nodes = self.pool.count_connected_nodes();
+        let should_dial = self.config.proactive_dialing_enabled && num_connected_nodes < floor;
         let dialer_state = if !self.config.proactive_dialing_enabled {
             "disabled"
-        } else if num_connected_nodes < floor {
+        } else if should_dial {
             "ARMED"
         } else {
             "idle"
@@ -576,7 +601,7 @@ impl ConnectivityManagerActor {
 
         info!(
             target: LOG_TARGET,
-            "CONNECTIVITY_REFRESH: Performing connection pool cleanup/refresh ({}). (#Peers = {}, \
+            "CONNECTIVITY_REFRESH: Performed connection pool cleanup/refresh ({}). (#Peers = {}, \
              #ConnectedNodes(incl. inbound)={}, #Failed={}, #Disconnected={}, #Clients={}, DHT pool size={}, \
              proactive dialer={} (floor {}))",
             task_id,
@@ -590,30 +615,11 @@ impl ConnectivityManagerActor {
             floor,
         );
 
-        self.clean_connection_pool();
-        // Deliberately outside the proactive-dialing gate below: aging seed connections out is unconditional,
-        // only the seed *re-dial* path (inside `execute_proactive_dialing`) is gated on the floor.
-        self.disconnect_seed_peers(task_id).await;
-
-        if self.config.is_connection_reaping_enabled {
-            self.reap_inactive_connections(task_id).await;
-        }
-        if let Some(threshold) = self.config.maintain_n_closest_connections_only {
-            self.maintain_n_closest_peer_connections_only(threshold, task_id).await;
-        }
-
         // Proactive dialing is a *recovery* mechanism, not a steady-state connection-count controller - the DHT
         // peer pool owns that. Gate it here, at the call site, rather than relying on the dialer's own early
         // return: the constraint that keeps the two loops from fighting is "this floor stays below the DHT pool
         // size", and it should be legible where the decision is made.
-        //
-        // Re-read the connection count rather than reusing the one above: the reaping and minimize-connections
-        // passes in between may have dropped connections, and a node that has just been pushed below the floor
-        // should recover on this tick, not the next one.
-        if self.config.proactive_dialing_enabled &&
-            self.pool.count_connected_nodes() < floor &&
-            let Err(err) = self.execute_proactive_dialing(task_id).await
-        {
+        if should_dial && let Err(err) = self.execute_proactive_dialing(task_id).await {
             warn!(
                 target: LOG_TARGET,
                 "({task_id}) Proactive dialing failed: {err:?}"
@@ -2039,6 +2045,40 @@ mod speculative_dial_circuit_breaker_tests {
         match cm_rx.try_recv() {
             Ok(ConnectionManagerRequest::DialPeer { node_id: dialed, .. }) => assert_eq!(dialed, node_id),
             other => panic!("an explicit dial must never be circuit-broken, got {other:?}"),
+        }
+    }
+
+    /// The discriminator's most consequential case, and the one the two tests above do *not* pin between
+    /// them. `ConnectivityRequester::dial_peer` always sends `reply_tx: Some(..)` whatever `RefKind` it is
+    /// given, and the ordinary messaging and RPC dial paths both ask for `RefKind::Weak`
+    /// (`protocol/messaging/outbound.rs` and `protocol/rpc/context.rs`) - so `Weak` + `Some(reply_tx)` is the
+    /// dominant explicit-dial shape in production, not `Strong`.
+    ///
+    /// If the check ever regressed to testing `ref_kind` alone and dropped the `reply_tx.is_none()` half,
+    /// every other test in this module would still pass while every RPC and messaging dial to a peer with a
+    /// tripped breaker was silently dropped. This is that test.
+    #[tokio::test]
+    async fn explicit_weak_dial_to_a_circuit_broken_peer_still_goes_through() {
+        let this_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let peer_manager = build_peer_manager(&this_peer).unwrap();
+        let target_peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);
+        let node_id = target_peer.node_id.clone();
+        peer_manager.add_or_update_peer(target_peer).await.unwrap();
+
+        let (mut actor, mut cm_rx, _shutdown) = setup(peer_manager);
+        trip_circuit_breaker(&mut actor, &node_id);
+
+        let (reply_tx, _reply_rx) = oneshot::channel();
+        actor
+            .handle_dial_peer(node_id.clone(), RefKind::Weak, Some(reply_tx))
+            .await;
+
+        match cm_rx.try_recv() {
+            Ok(ConnectionManagerRequest::DialPeer { node_id: dialed, .. }) => assert_eq!(dialed, node_id),
+            other => panic!(
+                "a Weak dial carrying a reply_tx is explicit (this is what messaging and RPC send) and must never be \
+                 circuit-broken, got {other:?}"
+            ),
         }
     }
 

--- a/comms/core/src/connectivity/proactive_dialer.rs
+++ b/comms/core/src/connectivity/proactive_dialer.rs
@@ -72,23 +72,27 @@ impl ProactiveDialer {
         }
 
         let current_connections = pool.count_connected_nodes();
-        let target = self.config.target_connection_count;
+        let floor = self.config.proactive_dialing_floor;
 
         // Update metrics
 
-        if current_connections >= target {
+        // The call site in `refresh_connection_pool` already makes this decision; this is a backstop for any
+        // other caller, not the gate. Keep both: the gate belongs at the call site so it is visible there.
+        if current_connections >= floor {
             debug!(
                 target: LOG_TARGET,
-                "({task_id}) Current connections ({current_connections}) meet or exceed target ({target}), no proactive dialing needed",
+                "({task_id}) Current connections ({current_connections}) are at or above the proactive dialing floor \
+                 ({floor}), no proactive dialing needed",
             );
 
             return Ok(0);
         }
 
-        let needed = target.saturating_sub(current_connections);
+        let needed = floor.saturating_sub(current_connections);
         debug!(
             target: LOG_TARGET,
-            "({task_id}) Proactive dialing: need {needed} more connections ({current_connections}/{target})",
+            "({task_id}) Proactive dialing: need {needed} more connections to reach the floor \
+             ({current_connections}/{floor})",
 
         );
 

--- a/comms/core/src/connectivity/proactive_dialer.rs
+++ b/comms/core/src/connectivity/proactive_dialer.rs
@@ -221,10 +221,11 @@ impl ProactiveDialer {
         let mut final_candidates = Vec::new();
         for peer in candidates {
             // The SQL query already filtered for communication nodes, non-banned, non-deleted
-            // Just need to check circuit breaker state
-            if let Some(stats) = connection_stats.get(&peer.node_id) &&
-                !stats.should_allow_connection(self.config.circuit_breaker_retry_interval)
-            {
+            // Just need to check circuit breaker state. These dials go straight to the connection manager
+            // via `try_send_dial_peer` and never reach `ConnectivityManagerActor::handle_dial_peer`, so this
+            // check cannot be dropped in favour of the one there - but it asks the same question through the
+            // same predicate so the two cannot disagree.
+            if self.config.is_circuit_broken(connection_stats.get(&peer.node_id)) {
                 trace!(
                     target: LOG_TARGET,
                     "({}) Skipping peer {} due to circuit breaker",

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -317,10 +317,14 @@ impl DhtConnectivity {
             .random_pool
             .iter()
             .partition::<Vec<_>, _>(|peer| self.connection_handles.iter().any(|c| c.peer_node_id() == *peer));
+        // Both numbers below are pool-scoped on purpose, and both are labelled as such. `comms::connectivity`
+        // reports `#ConnectedNodes(incl. inbound)` on the same tick, which counts every connected node peer -
+        // inbound connections the DHT pool never selected included - so the two targets legitimately disagree
+        // and only read as contradictory when one of them does not say what it is counting.
         debug!(
             target: LOG_TARGET,
-            "DHT connectivity status: {}peer pool: {}/{} ({} connected, last refreshed {}), active DHT connections: \
-             {}/{}",
+            "DHT connectivity status: {}peer pool: {}/{} ({} connected, last refreshed {}), pool connection \
+             handles held: {}/{}",
             self.cooldown_in_effect
                 .map(|ts| format!(
                     "COOLDOWN({:.2?} remaining) ",


### PR DESCRIPTION
1. The reconciled status line could lie about what happened on its own tick.
   `dialer_state` was computed from a connection count snapshotted *before*
   `clean_connection_pool`, `disconnect_seed_peers`, reaping and
   minimize-connections ran, any of which can drop connections, while the gate
   below deliberately re-read the count. So the line could print
   `proactive dialer=idle` and then dial anyway a few statements later -
   reproducing the exact "two numbers disagree on one tick" confusion this line
   was added to end. The count is now read once, after all the cleanup passes,
   and that single value feeds both the log line and the gate. The message moves
   with it and is reworded from "Performing" to "Performed", since every number
   in it is now post-cleanup.

2. Pin the discriminator's dominant real-world shape.
   `ConnectivityRequester::dial_peer` always sends `reply_tx: Some(..)` whatever
   `RefKind` it is handed, and both ordinary explicit dial paths - messaging
   (`protocol/messaging/outbound.rs`) and RPC (`protocol/rpc/context.rs`) - ask
   for `RefKind::Weak`. So `Weak` + `Some(reply_tx)` is the common explicit dial,
   not `Strong`, and no existing test covered it: a regression to testing
   `ref_kind` alone would have left all three passing while silently
   circuit-breaking every RPC and messaging dial. Verified by making exactly that
   mutation - the three old tests still passed and only the new one failed.

3. Stop claiming single-chokepoint coverage that does not exist, and remove the
   duplicate predicate that made the claim tempting. `handle_dial_peer` is the
   chokepoint for dials routed through the connectivity actor, but
   `ProactiveDialer::dial_peers_concurrently` calls `try_send_dial_peer` directly
   and never passes through it, so the dialer's own candidate filter is load
   bearing and cannot be removed. Rather than leave two independent
   implementations, both now ask through `ConnectivityConfig::is_circuit_broken`
   so the two call sites cannot drift apart, and the comments describe the actual
   scope.
