### PR TITLE
chore: update ootle constants

### DIFF
--- a/applications/minotari_node/src/builder.rs
+++ b/applications/minotari_node/src/builder.rs
@@ -270,10 +270,10 @@ async fn build_node_context(
     // Check for consensus constants changes before starting the node
     let consensus_tracker = ConsensusConstantsTracker::new(&app_config.base_node.data_dir);
     let current_constants = rules.consensus_constants_vec();
-    let current_height = blockchain_db
-        .get_chain_metadata()
-        .map(|o| o.best_block_height())
-        .unwrap_or_default();
+    // let current_height = blockchain_db
+    //     .get_chain_metadata()
+    //     .map(|o| o.best_block_height())
+    //     .unwrap_or_default();
 
     // bypassing for now as we will hit this, we are changing the epoch length of the ootle, but this wont impact any
     // current mainnet node if let Err(error_msg) = consensus_tracker.check_for_changes(current_constants,
@@ -281,7 +281,9 @@ async fn build_node_context(
     //     eprintln!("\n{}\n", error_msg);
     // }
     // remove this later
-    consensus_tracker.store_current(current_constants.clone())?;
+    if let Err(error_msg) = consensus_tracker.store_current(current_constants) {
+        eprintln!("\n{}\n", error_msg);
+    };
 
     let mempool_validator = TransactionFullValidator::new(
         factories.clone(),

--- a/applications/minotari_node/src/builder.rs
+++ b/applications/minotari_node/src/builder.rs
@@ -275,10 +275,11 @@ async fn build_node_context(
         .map(|o| o.best_block_height())
         .unwrap_or_default();
 
-    if let Err(error_msg) = consensus_tracker.check_for_changes(current_constants, current_height) {
-        error!(target: LOG_TARGET, "{}", error_msg);
-        eprintln!("\n{}\n", error_msg);
-    }
+    // bypassing for now as we will hit this, we are changing the epoch length of the ootle, but this wont impact any
+    // current mainnet node if let Err(error_msg) = consensus_tracker.check_for_changes(current_constants,
+    // current_height) {     error!(target: LOG_TARGET, "{}", error_msg);
+    //     eprintln!("\n{}\n", error_msg);
+    // }
 
     let mempool_validator = TransactionFullValidator::new(
         factories.clone(),

--- a/applications/minotari_node/src/builder.rs
+++ b/applications/minotari_node/src/builder.rs
@@ -280,6 +280,8 @@ async fn build_node_context(
     // current_height) {     error!(target: LOG_TARGET, "{}", error_msg);
     //     eprintln!("\n{}\n", error_msg);
     // }
+    // remove this later
+    consensus_tracker.store_current(current_constants.clone())?;
 
     let mempool_validator = TransactionFullValidator::new(
         factories.clone(),

--- a/applications/minotari_node/src/consensus_constants_tracker.rs
+++ b/applications/minotari_node/src/consensus_constants_tracker.rs
@@ -35,6 +35,7 @@ pub struct ConsensusConstantsTracker {
     storage_path: PathBuf,
 }
 
+#[allow(dead_code)]
 impl ConsensusConstantsTracker {
     pub fn new(data_dir: &Path) -> Self {
         let mut storage_path = data_dir.to_path_buf();

--- a/base_layer/transaction_components/src/consensus/consensus_constants.rs
+++ b/base_layer/transaction_components/src/consensus/consensus_constants.rs
@@ -1124,6 +1124,7 @@ impl ConsensusConstants {
         let mut con_6 = con_5.clone();
         con_6.include_c29_accumulated_difficulty_into_total = true;
         con_6.effective_from_height = 126_000;
+        con_6.vn_epoch_length = 10;
 
         let consensus_constants = vec![con_1, con_2, con_3, con_4, con_5, con_6];
         Self::with_tip004_activation(consensus_constants, MAINNET_TIP004_ACTIVATION_HEIGHT)


### PR DESCRIPTION
Description
---
uopdates the vn epoch lenght for the ootle validator nodes. This does not impact the L1 chain at all currently, so its updated with a date that has long since passed. This will trip the consensus tracker, so its disabled for. 