### PR TITLE
chore: fix_esme difficulty

### DIFF
--- a/base_layer/transaction_components/src/consensus/consensus_constants.rs
+++ b/base_layer/transaction_components/src/consensus/consensus_constants.rs
@@ -1415,6 +1415,9 @@ mod activation_test {
 
     /// The activation entry must differ from the rules live just below it in exactly three fields. Anything else
     /// would mean an unrelated consensus change riding along inside the TIP-RFC-MT-0004 fork.
+    ///
+    /// The entry is found by its effective height rather than by taking the last one, because a network may
+    /// schedule further changes above the fork (Esmeralda tunes the backoff cap again after activation).
     #[test]
     fn tip004_activation_entry_only_changes_the_backoff_and_the_window() {
         for network in ALL_NETWORKS.into_iter().filter(|n| *n != Network::LocalNet) {
@@ -1427,7 +1430,10 @@ mod activation_test {
             expected.pow_backoff_cap = POW_BACKOFF_CAP;
             expected.difficulty_block_window = TIP004_DIFFICULTY_BLOCK_WINDOW;
 
-            let actual = constants.last().expect("never empty");
+            let actual = constants
+                .iter()
+                .find(|c| c.effective_from_height == activation)
+                .unwrap_or_else(|| panic!("{network} has no TIP-RFC-MT-0004 activation entry at height {activation}"));
             assert_eq!(
                 *actual, expected,
                 "{network} activation entry drifted from the live rules"

--- a/base_layer/transaction_components/src/consensus/consensus_constants.rs
+++ b/base_layer/transaction_components/src/consensus/consensus_constants.rs
@@ -824,7 +824,11 @@ impl ConsensusConstants {
         con5.pow_backoff_cap = POW_BACKOFF_CAP;
         con5.difficulty_block_window = TIP004_DIFFICULTY_BLOCK_WINDOW;
 
-        vec![consensus_constants1, con2, con3, con4, con5]
+        let mut con6 = con5.clone();
+        con6.effective_from_height = 869_000;
+        con6.pow_backoff_cap = 2;
+
+        vec![consensus_constants1, con2, con3, con4, con5, con6]
     }
 
     /// *


### PR DESCRIPTION
Description
---
fixes esme difficulty by capping the backup off cap to 2. 
Esme network does not have enough mining on all chains, so the backup cap reaches the full 32x, this means the slow ci miner that mines blocks times out, and stops producing new blocks. This puts the cap at 2, to stop the difficulty reaching soo high. 


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR schedules an Esmeralda consensus update at height 869,000 to reduce the proof-of-work backoff cap from 32 to 2.
- Clones the existing Esmeralda TIP004 constants into a new activation entry.
- Appends the new entry to the network’s height-ordered consensus constants.
- The new terminal entry conflicts with an existing activation-entry regression test.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the deterministic consensus-constants test failure is resolved.

The appended Esmeralda entry becomes `constants.last()` with a cap of 2, while the existing non-LocalNet activation test requires that entry to have the global cap of 32.

**Files Needing Attention:** base_layer/transaction_components/src/consensus/consensus_constants.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| base_layer/transaction_components/src/consensus/consensus_constants.rs | Adds the Esmeralda cap reduction, but the appended entry causes the existing TIP004 activation-entry test to fail because that test assumes the final entry retains cap 32. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20tari-project%2Ftari%20PR%20%237991%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=tari-project%2Ftari&pr=7991&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abase_layer%2Ftransaction_components%2Fsrc%2Fconsensus%2Fconsensus_constants.rs%3A830%0A**New%20entry%20breaks%20activation%20test**%0A%0AWhen%20the%20consensus%20constants%20tests%20run%20for%20Esmeralda%2C%20%60constants.last%28%29%60%20now%20has%20a%20backoff%20cap%20of%202%20while%20the%20TIP004%20activation%20test%20requires%20the%20last%20entry%20to%20use%20%60POW_BACKOFF_CAP%60%20%2832%29%2C%20causing%20CI%20to%20fail.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=tari-project%2Ftari&pr=7991&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22tari-project%2Ftari%22%20on%20the%20existing%20branch%20%22sw_update_esme_constants%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22sw_update_esme_constants%22.%0A%0A%23%23%23%20Issue%201%0Abase_layer%2Ftransaction_components%2Fsrc%2Fconsensus%2Fconsensus_constants.rs%3A830%0A**New%20entry%20breaks%20activation%20test**%0A%0AWhen%20the%20consensus%20constants%20tests%20run%20for%20Esmeralda%2C%20%60constants.last%28%29%60%20now%20has%20a%20backoff%20cap%20of%202%20while%20the%20TIP004%20activation%20test%20requires%20the%20last%20entry%20to%20use%20%60POW_BACKOFF_CAP%60%20%2832%29%2C%20causing%20CI%20to%20fail.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=tari-project%2Ftari&pr=7991&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: fix\_esme difficulty"](https://github.com/tari-project/tari/commit/0ddb23ffe06f045aeaa8460f80fcec464760e238) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61262631)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->