### PR TITLE
fix: decouple liveness ping timeout from ping interval

### DIFF
--- a/base_layer/core/tests/helpers/sync.rs
+++ b/base_layer/core/tests/helpers/sync.rs
@@ -170,13 +170,15 @@ pub async fn create_network_with_multiple_nodes(
         vec![MempoolServiceConfig::default(); num_nodes],
         // Liveness auto-ping is deliberately left at its production default of `None`.
         //
-        // `LivenessService` uses `auto_ping_interval` as the in-flight TTL for each ping, and
-        // disconnects a peer after `max_allowed_ping_failures` (2) rounds. At the 100ms this used to
-        // be set to, a pong had 100ms to make it back through DHT, messaging and a runtime shared
-        // with every node in the test - so on a loaded CI runner every round failed and liveness
-        // tore down the sync peer roughly once a second, mid-sync, with
-        // "LivenessService disconnect failed peers". These tests build their `SyncPeer`s straight
-        // from the peer's blockchain db and never read liveness data, so pinging buys them nothing.
+        // Historically `LivenessService` used `auto_ping_interval` as the in-flight TTL for each ping
+        // and disconnected a peer after `max_allowed_ping_failures` (2) rounds, so the 100ms interval
+        // this helper used to set gave a pong 100ms to make it back through DHT, messaging and a
+        // runtime shared with every node in the test. On a loaded CI runner every round failed and
+        // liveness tore down the sync peer roughly once a second, mid-sync, with
+        // "LivenessService disconnect failed peers". That coupling is gone - the TTL is now
+        // `LivenessConfig::max_inflight_ttl` (30s by default), independent of the ping interval - but
+        // these tests build their `SyncPeer`s straight from the peer's blockchain db and never read
+        // liveness data, so pinging still buys them nothing.
         vec![LivenessConfig::default(); num_nodes],
         blockchain_db_configs,
         vec![P2pConfig::default(); num_nodes],

--- a/base_layer/core/tests/tests/node_state_machine.rs
+++ b/base_layer/core/tests/tests/node_state_machine.rs
@@ -87,11 +87,11 @@ async fn test_listening_lagging() {
         vec![MempoolServiceConfig::default(); 2],
         vec![
             LivenessConfig {
-                // Unlike the sync tests, these two genuinely need liveness: the chain metadata that
-                // `Listening` decides on arrives on ping-pong. But `auto_ping_interval` doubles as the
-                // in-flight TTL for each ping, and 3 expiries disconnect the peer, so 100ms gave a pong
-                // 100ms to round-trip or the peer whose metadata we are waiting for gets dropped. One
-                // second still delivers metadata well inside this test's 10s budget.
+                // Unlike the sync tests, these genuinely need liveness: the chain metadata that
+                // `Listening` decides on arrives on ping-pong. One second delivers metadata well inside
+                // this test's 10s budget. (The in-flight ping TTL is `max_inflight_ttl`, independent of
+                // this interval, so a short interval no longer risks disconnecting the peer we are
+                // waiting on.)
                 auto_ping_interval: Some(Duration::from_secs(1)),
                 ..Default::default()
             };
@@ -187,11 +187,11 @@ async fn test_listening_initial_fallen_behind() {
         vec![MempoolServiceConfig::default(); 3],
         vec![
             LivenessConfig {
-                // Unlike the sync tests, these two genuinely need liveness: the chain metadata that
-                // `Listening` decides on arrives on ping-pong. But `auto_ping_interval` doubles as the
-                // in-flight TTL for each ping, and 3 expiries disconnect the peer, so 100ms gave a pong
-                // 100ms to round-trip or the peer whose metadata we are waiting for gets dropped. One
-                // second still delivers metadata well inside this test's 10s budget.
+                // Unlike the sync tests, these genuinely need liveness: the chain metadata that
+                // `Listening` decides on arrives on ping-pong. One second delivers metadata well inside
+                // this test's 10s budget. (The in-flight ping TTL is `max_inflight_ttl`, independent of
+                // this interval, so a short interval no longer risks disconnecting the peer we are
+                // waiting on.)
                 auto_ping_interval: Some(Duration::from_secs(1)),
                 ..Default::default()
             };

--- a/base_layer/p2p/src/services/liveness/config.rs
+++ b/base_layer/p2p/src/services/liveness/config.rs
@@ -24,6 +24,12 @@ use std::time::Duration;
 
 use tari_comms::peer_manager::NodeId;
 
+/// Default maximum time an in-flight ping may go unanswered before it is counted as a failed ping.
+///
+/// This is a *timeout*, not a rate. It is deliberately kept separate from [`LivenessConfig::auto_ping_interval`]
+/// so that pinging more often does not also make the failure detector more trigger-happy.
+pub const MAX_INFLIGHT_TTL: Duration = Duration::from_secs(30);
+
 /// Configuration for liveness service
 #[derive(Debug, Clone)]
 pub struct LivenessConfig {
@@ -35,6 +41,17 @@ pub struct LivenessConfig {
     pub monitored_peers: Vec<NodeId>,
     /// Number of ping failures to tolerate before disconnecting the peer. A value of zero disables this feature.
     pub max_allowed_ping_failures: usize,
+    /// How long an in-flight ping may go unanswered before it is counted as a failed ping (Default:
+    /// [`MAX_INFLIGHT_TTL`], 30s).
+    ///
+    /// This is **independent of `auto_ping_interval`**. Ping *rate* and ping *timeout* are separate concerns:
+    /// lowering `auto_ping_interval` (e.g. for faster chain-tip detection) must not shorten the deadline a peer
+    /// has to answer. Since `max_allowed_ping_failures + 1` consecutive expiries hard-disconnect the peer, this
+    /// value should stay comfortably above the worst-case ping round-trip time under load.
+    ///
+    /// Note that expiry is evaluated lazily - a stale in-flight ping is only reaped when the *next* ping is
+    /// recorded - so the effective deadline is between this TTL and this TTL plus one `auto_ping_interval`.
+    pub max_inflight_ttl: Duration,
 }
 
 impl Default for LivenessConfig {
@@ -44,6 +61,7 @@ impl Default for LivenessConfig {
             num_peers_per_round: 8,
             monitored_peers: Default::default(),
             max_allowed_ping_failures: 2,
+            max_inflight_ttl: MAX_INFLIGHT_TTL,
         }
     }
 }

--- a/base_layer/p2p/src/services/liveness/mod.rs
+++ b/base_layer/p2p/src/services/liveness/mod.rs
@@ -36,7 +36,7 @@
 //! [PingPong]: ./messages/enum.PingPong.html
 
 pub mod config;
-pub use self::config::LivenessConfig;
+pub use self::config::{LivenessConfig, MAX_INFLIGHT_TTL};
 
 pub mod error;
 
@@ -52,7 +52,6 @@ pub use handle::{
 
 mod message;
 mod service;
-pub use service::MAX_INFLIGHT_TTL;
 
 mod state;
 pub use state::Metadata;

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -20,11 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    iter,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{iter, sync::Arc, time::Instant};
 
 use futures::{Stream, future::Either, pin_mut, stream::StreamExt};
 use log::*;
@@ -56,8 +52,6 @@ use crate::{
     services::liveness::{LivenessEvent, PingPongEvent, handle::LivenessEventSender},
     tari_message::TariMessageType,
 };
-
-pub const MAX_INFLIGHT_TTL: Duration = Duration::from_secs(30);
 
 /// Service responsible for testing Liveness of Peers.
 pub struct LivenessService<THandleStream, TPingStream> {
@@ -257,11 +251,9 @@ where
     async fn send_ping(&mut self, node_id: NodeId) -> Result<u64, LivenessError> {
         let msg = PingPongMessage::ping_with_metadata(self.state.metadata().clone());
         let nonce = msg.nonce;
-        self.state.add_inflight_ping(
-            nonce,
-            node_id.clone(),
-            self.config.auto_ping_interval.unwrap_or(MAX_INFLIGHT_TTL),
-        );
+        // The in-flight TTL is a timeout, not a rate: it must never be derived from `auto_ping_interval`.
+        self.state
+            .add_inflight_ping(nonce, node_id.clone(), self.config.max_inflight_ttl);
         debug!(target: LOG_TARGET, "Sending ping to peer '{}'", node_id.short_str(),);
 
         self.outbound_messaging
@@ -386,11 +378,9 @@ where
 
         for peer in selected_peers {
             let msg = PingPongMessage::ping_with_metadata(self.state.metadata().clone());
-            self.state.add_inflight_ping(
-                msg.nonce,
-                peer.clone(),
-                self.config.auto_ping_interval.unwrap_or(MAX_INFLIGHT_TTL),
-            );
+            // The in-flight TTL is a timeout, not a rate: it must never be derived from `auto_ping_interval`.
+            self.state
+                .add_inflight_ping(msg.nonce, peer.clone(), self.config.max_inflight_ttl);
             self.outbound_messaging
                 .send_direct_node_id(
                     peer,
@@ -416,6 +406,20 @@ where
         {
             // Liveness service is happy to be reaped — Weak handle.
             if let Ok(Some(mut conn)) = self.connectivity.get_connection(node_id.clone(), RefKind::Weak).await {
+                // A non-zero strong count means someone (e.g. block/horizon sync) is actively using this
+                // connection. The connectivity manager refuses to reap those in `reap_inactive_connections` and
+                // `minimize_connections`; liveness must not bypass that guard and abort an in-progress RPC.
+                if conn.is_strongly_held() {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Not disconnecting peer {node_id} that failed {max_allowed_ping_failures} rounds of pings \
+                         because the connection is strongly held ({} strong handles)",
+                        conn.strong_count()
+                    );
+                    continue;
+                }
+                // NOTE: whether repeated ping failures should hard-disconnect at all - as opposed to marking the
+                // peer unhealthy and letting the connectivity layer decide - is still an open question.
                 debug!(
                     target: LOG_TARGET,
                     "Disconnecting peer {node_id} that failed {max_allowed_ping_failures} rounds of pings"
@@ -461,6 +465,7 @@ mod test {
     use futures::stream;
     use tari_common_sqlite::connection::DbConnection;
     use tari_comms::{
+        connection_manager::PeerConnectionRequest,
         message::MessageTag,
         net_address::MultiaddressesWithStats,
         peer_manager::{
@@ -469,7 +474,7 @@ mod test {
             PeerFlags,
             database::{MIGRATIONS, PeerDatabaseSql},
         },
-        test_utils::mocks::create_connectivity_mock,
+        test_utils::mocks::{ConnectivityManagerMockState, create_connectivity_mock, create_dummy_peer_connection},
         types::TransportProtocol,
     };
     use tari_comms_dht::{
@@ -488,7 +493,7 @@ mod test {
     use crate::{
         create_test_peer,
         proto::liveness::MetadataKey,
-        services::liveness::{handle::LivenessHandle, state::Metadata},
+        services::liveness::{MAX_INFLIGHT_TTL, handle::LivenessHandle, state::Metadata},
     };
 
     pub fn build_peer_manager() -> Arc<PeerManager> {
@@ -718,5 +723,165 @@ mod test {
         drop(publisher);
         let msg = subscriber.recv().await;
         assert!(msg.is_err());
+    }
+
+    /// Replies `Queued` to every outbound send request so that ping rounds complete without an
+    /// outbound messaging service behind them.
+    fn spawn_outbound_ack(mut outbound_rx: mpsc::UnboundedReceiver<DhtOutboundRequest>) {
+        task::spawn(async move {
+            while let Some(DhtOutboundRequest::SendMessage(_, _, reply_tx)) = outbound_rx.recv().await {
+                let (_keep_alive, rx) = oneshot::channel();
+                let _result = reply_tx.send(SendMessageResponse::Queued(
+                    vec![MessageSendState::new(MessageTag::new(), rx)].into(),
+                ));
+            }
+        });
+    }
+
+    /// Spawns a liveness service that auto-pings a single monitored peer which never pongs back.
+    /// Returns the connectivity mock state (so disconnect attempts can be observed) and the shutdown
+    /// that keeps the service alive.
+    async fn spawn_never_ponged_liveness(
+        node_id: NodeId,
+        mut config: LivenessConfig,
+    ) -> (ConnectivityManagerMockState, Shutdown) {
+        config.monitored_peers = vec![node_id];
+        let (connectivity, mock) = create_connectivity_mock();
+        let mock_state = mock.spawn();
+
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+        spawn_outbound_ack(outbound_rx);
+
+        let (publisher, _) = broadcast::channel(200);
+        let shutdown = Shutdown::new();
+        let service = LivenessService::new(
+            config,
+            stream::empty(),
+            stream::empty(),
+            LivenessState::new(),
+            connectivity,
+            OutboundMessageRequester::new(outbound_tx),
+            publisher,
+            shutdown.to_signal(),
+            build_peer_manager(),
+        );
+        task::spawn(service.run());
+
+        (mock_state, shutdown)
+    }
+
+    fn random_node_id() -> NodeId {
+        let (_, pk) = CommsPublicKey::random_keypair(&mut rand::rng());
+        NodeId::from_key(&pk)
+    }
+
+    /// A short `auto_ping_interval` must not shorten the in-flight ping TTL. Pre-fix, the interval was
+    /// used as the TTL, so 20ms rounds meant every unanswered ping expired immediately and the peer was
+    /// disconnected after three rounds (~60ms).
+    #[tokio::test]
+    async fn short_ping_interval_does_not_shorten_inflight_ttl() {
+        let node_id = random_node_id();
+        let (mock_state, _shutdown) = spawn_never_ponged_liveness(node_id, LivenessConfig {
+            auto_ping_interval: Some(Duration::from_millis(20)),
+            max_allowed_ping_failures: 2,
+            // Left at the default 30s - far longer than this test runs for.
+            ..Default::default()
+        })
+        .await;
+
+        // ~25 ping rounds, none of them answered.
+        time::sleep(Duration::from_millis(500)).await;
+
+        // `disconnect_failed_peers` only fetches a connection once a peer is over the failure threshold,
+        // so zero `GetConnection` calls proves the failed-ping counter never got there.
+        assert_eq!(
+            mock_state.count_calls_containing("GetConnection").await,
+            0,
+            "liveness attempted a disconnect even though max_inflight_ttl had not elapsed"
+        );
+    }
+
+    /// Control for the test above: with a genuinely short `max_inflight_ttl`, failures do accumulate and a
+    /// disconnect is attempted. This is what makes the assertion above meaningful.
+    #[tokio::test]
+    async fn expired_inflight_ttl_still_disconnects() {
+        let node_id = random_node_id();
+        let (mock_state, _shutdown) = spawn_never_ponged_liveness(node_id, LivenessConfig {
+            auto_ping_interval: Some(Duration::from_millis(20)),
+            max_allowed_ping_failures: 2,
+            max_inflight_ttl: Duration::from_millis(1),
+            ..Default::default()
+        })
+        .await;
+
+        let mut attempts = 0;
+        while mock_state.count_calls_containing("GetConnection").await == 0 {
+            attempts += 1;
+            assert!(attempts <= 50, "liveness never attempted to disconnect the failed peer");
+            time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Liveness must not tear down a connection that another subsystem (e.g. block sync) is actively
+    /// holding, mirroring the `is_strongly_held` guard in the connectivity manager's reapers.
+    #[tokio::test]
+    async fn strongly_held_connections_are_not_disconnected() {
+        let node_id = random_node_id();
+        let (conn, mut conn_rx) = create_dummy_peer_connection(node_id.clone());
+        let _strong_holder = conn.clone_strong();
+
+        let (mock_state, _shutdown) = spawn_never_ponged_liveness(node_id.clone(), LivenessConfig {
+            auto_ping_interval: Some(Duration::from_millis(20)),
+            max_allowed_ping_failures: 2,
+            max_inflight_ttl: Duration::from_millis(1),
+            ..Default::default()
+        })
+        .await;
+        mock_state.add_active_connection(conn).await;
+
+        // Wait until liveness has decided this peer is failed and looked its connection up.
+        let mut attempts = 0;
+        while mock_state.count_calls_containing("GetConnection").await == 0 {
+            attempts += 1;
+            assert!(
+                attempts <= 50,
+                "liveness never considered the failed peer for disconnect"
+            );
+            time::sleep(Duration::from_millis(20)).await;
+        }
+        // Give it a few more rounds to (incorrectly) disconnect.
+        time::sleep(Duration::from_millis(200)).await;
+
+        assert!(
+            conn_rx.try_recv().is_err(),
+            "liveness disconnected a strongly held connection"
+        );
+    }
+
+    /// Control for the test above: a weakly held connection over the failure threshold is disconnected.
+    #[tokio::test]
+    async fn weakly_held_failed_connections_are_disconnected() {
+        let node_id = random_node_id();
+        let (conn, mut conn_rx) = create_dummy_peer_connection(node_id.clone());
+
+        let (mock_state, _shutdown) = spawn_never_ponged_liveness(node_id.clone(), LivenessConfig {
+            auto_ping_interval: Some(Duration::from_millis(20)),
+            max_allowed_ping_failures: 2,
+            max_inflight_ttl: Duration::from_millis(1),
+            ..Default::default()
+        })
+        .await;
+        mock_state.add_active_connection(conn).await;
+
+        let mut attempts = 0;
+        let req = loop {
+            if let Ok(req) = conn_rx.try_recv() {
+                break req;
+            }
+            attempts += 1;
+            assert!(attempts <= 50, "liveness never disconnected the failed peer");
+            time::sleep(Duration::from_millis(20)).await;
+        };
+        assert!(matches!(req, PeerConnectionRequest::Disconnect(..)));
     }
 }

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -270,7 +270,7 @@ impl AverageLatency {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::services::liveness::service::MAX_INFLIGHT_TTL;
+    use crate::services::liveness::MAX_INFLIGHT_TTL;
 
     #[test]
     fn new() {


### PR DESCRIPTION
`LivenessService` reused `auto_ping_interval` as the per-ping in-flight TTL, so configuring a faster ping rate silently tightened the failure deadline by the same factor. Three consecutive expiries hard-disconnect the peer, so a short interval (3s in the cucumber suite, 100ms in a sync test helper) turned liveness into a trigger-happy peer killer under load - including tearing down the peer an in-progress sync was using.

The inversion was that `MAX_INFLIGHT_TTL` (30s) only applied when auto-ping was *disabled*: turning the feature on at a short interval made the failure detector up to 30x more aggressive than leaving it off.

- Add `LivenessConfig::max_inflight_ttl`, defaulting to `MAX_INFLIGHT_TTL` (30s), and use it at both ping-send call sites. Rate and timeout are now independent knobs. `MAX_INFLIGHT_TTL` moves to `config.rs`; the public path `tari_p2p::services::liveness::MAX_INFLIGHT_TTL` is unchanged.
- `disconnect_failed_peers` now skips strongly held connections, mirroring the `!conn.is_strongly_held()` guard the connectivity manager already applies in `reap_inactive_connections` and `minimize_connections`. Liveness was the one reaper that bypassed it, which is what allowed it to abort a running sync.
- Tests: a short `auto_ping_interval` must not shorten the TTL or increment the failed-ping counter, plus a strongly-held-connection guard test, each with a control proving the harness can observe the disconnect.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates the liveness ping timeout from the automatic ping interval and protects strongly held connections from liveness-driven disconnection.
- Adds a 30-second default `max_inflight_ttl` and applies it to manual and automatic pings.
- Preserves the public `MAX_INFLIGHT_TTL` re-export.
- Skips failed-peer disconnection while another subsystem strongly holds the connection.
- Adds regression and control tests for timeout decoupling and connection-hold behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the timeout decoupling and strongly held connection guard consistently implemented and covered by regression controls.

The new timeout is defaulted and used by both ping paths, the existing constant’s public path remains intact, in-repository configuration construction remains compatible, and the connection guard preserves failure state for reevaluation after active use ends.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| base_layer/p2p/src/services/liveness/config.rs | Adds the independent in-flight ping timeout with a documented 30-second default. |
| base_layer/p2p/src/services/liveness/service.rs | Uses the independent timeout at both ping-send paths, protects strongly held connections, and adds focused regression tests. |
| base_layer/p2p/src/services/liveness/mod.rs | Moves the constant’s implementation location while preserving its existing public re-export path. |
| base_layer/p2p/src/services/liveness/state.rs | Updates the test import to use the preserved public constant path. |
| base_layer/core/tests/helpers/sync.rs | Updates test-helper documentation to reflect the decoupled timeout behavior. |
| base_layer/core/tests/tests/node_state_machine.rs | Updates liveness-related test comments without changing test behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: decouple liveness ping timeout from..."](https://github.com/tari-project/tari/commit/b1ba15b8f05f6716ec8ee3ab2b49f3faed9ce0ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61526527)</sub>

<!-- /greptile_comment -->