### PR TITLE
fix(node): panic hook no longer kills the node; bound `page` on sync_utxos_by_block (GHSA-4r27 follow-up)

### DIFF
--- a/applications/minotari_node/src/main.rs
+++ b/applications/minotari_node/src/main.rs
@@ -101,13 +101,10 @@ fn format_system_time(time: SystemTime) -> String {
     naive.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
-/// Application entry point
-fn main() {
-    #[cfg(feature = "dhat-heap")]
-    let dhat_profiler = dhat::Profiler::new_heap();
-    #[cfg(feature = "dhat-heap")]
-    println!("\n\nDHAT: Profiling enabled. Run `dhat-heap` to view the results.\n\n");
-
+/// Installs the global panic hook. See the policy comment inside: a panic on any
+/// single task must never terminate the whole node (GHSA-4r27-mpgm-hx3h follow-up,
+/// tari-project/special_contributions#17).
+fn install_panic_hook() {
     panic::set_hook(Box::new(|panic_info| {
         let location = panic_info
             .location()
@@ -130,17 +127,62 @@ fn main() {
         };
 
         error!(target: "minotari::base_node", "Panic occurred at {location}: {message}");
-
-        // Optionally, write a custom message directly to the file
-        let mut file = File::create("minotari-node-panic.log").unwrap();
-        file.write_all(format!("Panic at {location}: {message}").as_bytes())
-            .unwrap();
-        // if cfg!(debug_assertions) {
-        // In debug mode, we want to see the panic message
         eprintln!("Panic occurred at {location}: {message}");
-        std::process::exit(500);
-        // }
+
+        // Optionally, write a custom message directly to the file. Deliberately
+        // non-panicking: an unwrap inside a panic hook would double-panic and abort.
+        if let Ok(mut file) = File::create("minotari-node-panic.log") {
+            let _ = file.write_all(format!("Panic at {location}: {message}").as_bytes());
+        }
+
+        // Policy (see GHSA-4r27-mpgm-hx3h and tari-project/special_contributions#17):
+        // the hook must NOT call std::process::exit. The node runs many independent
+        // tasks (P2P, gRPC, HTTP request handlers, mining) and a panic on any single
+        // task — e.g. one unauthenticated HTTP request — must unwind that task only,
+        // not kill the whole process. A panic on the main thread still terminates the
+        // process through normal unwinding, so genuinely fatal failures still crash
+        // loudly. Do not reintroduce process::exit here.
     }));
+}
+
+#[cfg(test)]
+mod panic_hook_tests {
+    use super::install_panic_hook;
+
+    /// Regression test for the GHSA-4r27-mpgm-hx3h follow-up
+    /// (tari-project/special_contributions#17, acceptance criterion 3): a panic on a
+    /// request-handler-style task must NOT kill the process. With the old hook
+    /// (unconditional `std::process::exit(500)`), this test terminates the whole test
+    /// runner instead of passing.
+    #[test]
+    fn panic_on_a_task_does_not_kill_the_process() {
+        let _ = std::fs::remove_file("minotari-node-panic.log");
+        install_panic_hook();
+
+        let unwind_result = std::panic::catch_unwind(|| {
+            panic!("synthetic handler panic (GHSA-4r27 follow-up regression test)");
+        });
+
+        // Reaching this line at all proves the hook did not exit the process.
+        assert!(
+            unwind_result.is_err(),
+            "the panic must still unwind (and be caught), not abort"
+        );
+        assert!(
+            std::path::Path::new("minotari-node-panic.log").exists(),
+            "the hook must still write minotari-node-panic.log"
+        );
+        let _ = std::fs::remove_file("minotari-node-panic.log");
+    }
+}
+
+/// Application entry point
+fn main() {
+    install_panic_hook();
+    #[cfg(feature = "dhat-heap")]
+    let dhat_profiler = dhat::Profiler::new_heap();
+    #[cfg(feature = "dhat-heap")]
+    println!("\n\nDHAT: Profiling enabled. Run `dhat-heap` to view the results.\n\n");
 
     if let Err(err) = main_inner() {
         eprintln!("{err:?}");

--- a/base_layer/transaction_components/src/rpc/models/sync_utxos_by_block.rs
+++ b/base_layer/transaction_components/src/rpc/models/sync_utxos_by_block.rs
@@ -11,7 +11,13 @@ pub struct SyncUtxosByBlockRequest {
     #[validate(minimum = 1)]
     #[validate(maximum = 2000)]
     pub limit: u64,
+    // Bounded per tari-project/special_contributions#17 (GHSA-4r27-mpgm-hx3h
+    // follow-up): an unbounded `page` multiplied by `limit` previously overflowed and,
+    // via the old panic hook, killed the node. `request.validate()` runs in
+    // `fetch_utxos` before any handler work, so an over-ceiling `page` is rejected
+    // there. Ceiling = u32::MAX, far above any plausible chain height.
     #[validate(minimum = 0)]
+    #[validate(maximum = 4294967295)]
     pub page: u64,
     #[serde(default)]
     pub exclude_spent: bool,
@@ -141,4 +147,33 @@ pub struct MinimalUtxoSyncInfo {
     pub commitment: Vec<u8>,
     pub encrypted_data: Vec<u8>,
     pub sender_offset_public_key: Vec<u8>,
+}
+
+#[cfg(test)]
+mod page_validation_tests {
+    use super::SyncUtxosByBlockRequest;
+    use serde_valid::Validate;
+
+    fn request_with_page(page: u64) -> SyncUtxosByBlockRequest {
+        SyncUtxosByBlockRequest {
+            start_header_hash: vec![0u8; 32],
+            limit: 1,
+            page,
+            exclude_spent: false,
+            exclude_inputs: false,
+            version: 0,
+        }
+    }
+
+    /// tari-project/special_contributions#17 acceptance criterion 1: an over-ceiling
+    /// `page` must be rejected by validation rather than reaching the handler.
+    #[test]
+    fn page_over_ceiling_is_rejected_by_validation() {
+        assert!(request_with_page(4294967296).validate().is_err());
+    }
+
+    #[test]
+    fn page_at_ceiling_is_accepted() {
+        assert!(request_with_page(4294967295).validate().is_ok());
+    }
 }


### PR DESCRIPTION
Follow-up to GHSA-4r27-mpgm-hx3h and tari-project/special_contributions#17 (closed in late
August, but both code-side items are still open on `development` at 59009d4). Two commits:

## 1. Panic hook no longer kills the node — `applications/minotari_node/src/main.rs`

The global panic hook ends in an unconditional `std::process::exit(500)` — the
`if cfg!(debug_assertions)` guard around it is commented out. Because the hook runs for
panics on *any* thread, a panic on a single Axum request-handler task — which would
otherwise unwind harmlessly and return a 500 — takes the whole process down: P2P, gRPC,
mining, everything. That is the amplification that turned one unauthenticated
`GET /sync_utxos_by_block` overflow into full node death in GHSA-4r27-mpgm-hx3h.

The hook now logs (tracing + stderr), writes `minotari-node-panic.log` — without
`unwrap()`, since an unwrap inside a panic hook can double-panic and abort — and lets the
panicking task unwind. A panic on the main thread still terminates the process through
normal unwinding, so genuinely fatal failures still crash loudly. The chosen policy is
documented in a comment in the hook so it does not silently regress again
(acceptance criterion 2).

Regression test included (acceptance criterion 3): with the old hook, the test kills the
entire test runner instead of passing.

## 2. `page` is bounded — `base_layer/transaction_components/src/rpc/models/sync_utxos_by_block.rs`

`page` currently carries only `#[validate(minimum = 0)]`. Adds
`#[validate(maximum = 4294967295)]` (u32::MAX, far above any plausible chain height).
`request.validate()` runs in `fetch_utxos` (`base_node/rpc/query_service.rs:187`) before
any handler work, so an over-ceiling `page` is rejected by validation rather than reaching
the handler (acceptance criterion 1), with tests.

## Follow-up

Item 3 of #17 (no auth on the wallet-query HTTP service, default `0.0.0.0` binding) is
split out as requested: see 7998.

*The arithmetic fix itself already landed in #7961 — this PR closes the remaining class:
the hook that converts any panic into process death, and the unbounded `page` that fed it.*


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62473468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with one non-blocking test-portability issue involving an unwritable working directory.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapplications%2Fminotari_node%2Fsrc%2Fmain.rs%3A171-174%0AIf%20the%20test%20runs%20with%20an%20unwritable%20current%20directory%2C%20the%20hook%20correctly%20ignores%20the%20failed%20best-effort%20log%20creation%2C%20but%20this%20assertion%20still%20requires%20the%20file%20to%20exist%2C%20causing%20the%20regression%20test%20to%20fail%20despite%20the%20intended%20unwind%20behavior%20working%20correctly.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=tari-project%2Ftari&pr=7999&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Test requires optional panic log** <a href="https://github.com/tari-project/tari/pull/7999#discussion_r3976095070">▶</a>

<h3>Summary</h3>

- Extracts panic-hook installation, makes panic-log writes non-panicking, and adds a regression test for task-local unwinding.
- Adds maximum-page validation and boundary tests for `SyncUtxosByBlockRequest`.

<sub>Reviews (1) · Last reviewed commit: ["fix(core): bound \`page\` on SyncUtxosByBl..."](https://github.com/tari-project/tari/commit/4f7f9ca855ce928230607750c088f6850f6a5e72)</sub>

<!-- /greptile_comment -->