### PR TITLE
chore: small improvements

### DIFF
--- a/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
+++ b/base_layer/core/src/validation/aggregate_body/aggregate_body_chain_validator.rs
@@ -579,4 +579,97 @@ mod test {
         let err = validate_burn_commitment_not_in_db(&body, &db).unwrap_err();
         assert!(matches!(err, ValidationError::InvalidBurnError(_)));
     }
+
+    mod duplicated_inputs_outputs {
+        use tari_script::{ExecutionStack, StackItem, script};
+
+        use super::*;
+
+        fn output_with(commitment: CompressedCommitment, script: tari_script::TariScript) -> TransactionOutput {
+            TransactionOutput {
+                commitment,
+                script,
+                ..Default::default()
+            }
+        }
+
+        fn input_spending(output: &TransactionOutput, input_data: ExecutionStack) -> TransactionInput {
+            TransactionInput::new_current_version(
+                SpentOutput::create_from_output(output.clone()),
+                input_data,
+                Default::default(),
+            )
+        }
+
+        #[test]
+        fn it_allows_distinct_inputs_and_outputs() {
+            let outputs = vec![
+                output_with(random_commitment(), script!(Nop).unwrap()),
+                output_with(random_commitment(), script!(Nop).unwrap()),
+            ];
+            let inputs = outputs
+                .iter()
+                .map(|o| input_spending(o, ExecutionStack::default()))
+                .collect();
+            let body = AggregateBody::new_unsorted(inputs, outputs, vec![]);
+            verify_no_duplicated_inputs_outputs(&body).unwrap();
+        }
+
+        #[test]
+        fn it_rejects_two_identical_outputs() {
+            let output = output_with(random_commitment(), script!(Nop).unwrap());
+            let body = AggregateBody::new_unsorted(vec![], vec![output.clone(), output], vec![]);
+            let err = verify_no_duplicated_inputs_outputs(&body).unwrap_err();
+            assert!(matches!(err, ValidationError::UnsortedOrDuplicateOutput));
+        }
+
+        #[test]
+        fn it_rejects_duplicates_in_an_unsorted_body() {
+            // The `sorted` flag is `#[borsh(skip)]`, so a body off the wire always arrives with `sorted == false`.
+            // The check must not depend on it, and must not depend on the duplicates being adjacent either.
+            let commitment = random_commitment();
+            let duplicated = output_with(commitment, script!(Nop).unwrap());
+            let mut outputs = vec![
+                duplicated.clone(),
+                output_with(random_commitment(), script!(Nop).unwrap()),
+                output_with(random_commitment(), script!(Nop).unwrap()),
+                duplicated,
+            ];
+            outputs.reverse();
+            let body = AggregateBody::new_unsorted(vec![], outputs, vec![]);
+            assert!(!body.is_sorted());
+            let err = verify_no_duplicated_inputs_outputs(&body).unwrap_err();
+            assert!(matches!(err, ValidationError::UnsortedOrDuplicateOutput));
+        }
+
+        #[test]
+        fn it_rejects_two_inputs_spending_the_same_output_with_different_witnesses() {
+            // Exactly the shape a competing double spend takes: same output hash, different script input data. The
+            // inputs are deduplicated on the output they spend, so the differing witness must not hide the duplicate.
+            let output = output_with(random_commitment(), script!(Nop).unwrap());
+            let input = input_spending(&output, ExecutionStack::default());
+            let twin = input_spending(&output, ExecutionStack::new(vec![StackItem::Number(1)]));
+            assert_ne!(input.canonical_hash(), twin.canonical_hash());
+
+            let body = AggregateBody::new_unsorted(vec![input, twin], vec![], vec![]);
+            let err = verify_no_duplicated_inputs_outputs(&body).unwrap_err();
+            assert!(matches!(err, ValidationError::UnsortedOrDuplicateInput));
+        }
+
+        #[test]
+        fn it_does_not_catch_two_outputs_that_share_only_a_commitment() {
+            // This check deduplicates outputs by hash, so two outputs with the same commitment but different scripts
+            // hash differently and pass here. Commitment uniqueness within a body is enforced by
+            // `check_sorting_and_duplicates` in the internal consistency validator, which orders outputs on the
+            // commitment alone. This test pins the division of responsibility: if it ever starts failing, the
+            // hash-based check has been tightened and this is the weaker of the two guarantees, not a regression.
+            let commitment = random_commitment();
+            let output = output_with(commitment.clone(), script!(Nop).unwrap());
+            let twin = output_with(commitment, script!(Nop Nop).unwrap());
+            assert_ne!(output.hash(), twin.hash());
+
+            let body = AggregateBody::new_unsorted(vec![], vec![output, twin], vec![]);
+            verify_no_duplicated_inputs_outputs(&body).unwrap();
+        }
+    }
 }

--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use tari_common::configuration::Network;
 use tari_common_types::tari_address::TariAddress;
 use tari_node_components::blocks::BlockValidationError;
-use tari_script::{inputs, push_pubkey_script, script};
+use tari_script::{ExecutionStack, StackItem, inputs, push_pubkey_script, script};
 use tari_test_utils::unpack_enum;
 use tari_transaction_components::{
     CoinbaseBuilder,
@@ -524,6 +524,96 @@ async fn it_checks_txo_sort_order() {
         err,
         ValidationError::AggregatedBodyValidationError(AggregatedBodyValidationError::UnsortedOrDuplicateOutput)
     ));
+}
+
+/// A commitment is what the UTXO set is keyed on, so a block may never create the same commitment twice. Two outputs
+/// sharing a commitment are rejected even when nothing else about them matches, because the outputs are ordered on the
+/// commitment alone.
+#[tokio::test]
+async fn it_rejects_a_block_with_two_outputs_sharing_a_commitment() {
+    let (mut blockchain, validator) = setup(true);
+
+    let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
+
+    let schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T, 12 * T]);
+    let (txs, _) = schema_to_transaction(&[schema1], &blockchain.km);
+    let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
+
+    let (mut block, _) = blockchain.create_unmined_block(block_spec!("B->A", transactions: txs));
+    let mut outputs = block.body.outputs().clone();
+    // Same commitment, different script, so the two outputs hash differently. The hash-based duplicate check in the
+    // chain validator cannot see this pair; only the commitment ordering can.
+    let mut twin = outputs[0].clone();
+    twin.script = script!(Nop Nop).unwrap();
+    assert_eq!(outputs[0].commitment, twin.commitment);
+    assert_ne!(outputs[0].hash(), twin.hash());
+    // Insert next to its twin so the body is still ordered by commitment; the duplicate is the only thing wrong.
+    outputs.insert(1, twin);
+    let inputs = block.body.inputs().clone();
+    let kernels = block.body.kernels().clone();
+    block.body = AggregateBody::new_sorted_unchecked(inputs, outputs, kernels);
+    let block = blockchain.mine_block("A", block, Difficulty::min());
+
+    let txn = blockchain.db().db_read_access().unwrap();
+    let err = validator.validate_body(&*txn, block.block().clone()).unwrap_err();
+    assert!(matches!(
+        err,
+        ValidationError::AggregatedBodyValidationError(AggregatedBodyValidationError::UnsortedOrDuplicateOutput)
+    ));
+}
+
+/// The same output repeated verbatim is caught earlier, by the hash-based duplicate check in the chain-linked
+/// validator, which runs before the internal consistency validator.
+#[tokio::test]
+async fn it_rejects_a_block_with_a_repeated_output() {
+    let (mut blockchain, validator) = setup(true);
+
+    let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
+
+    let schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T, 12 * T]);
+    let (txs, _) = schema_to_transaction(&[schema1], &blockchain.km);
+    let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
+
+    let (mut block, _) = blockchain.create_unmined_block(block_spec!("B->A", transactions: txs));
+    let mut outputs = block.body.outputs().clone();
+    outputs.insert(1, outputs[0].clone());
+    let inputs = block.body.inputs().clone();
+    let kernels = block.body.kernels().clone();
+    block.body = AggregateBody::new_sorted_unchecked(inputs, outputs, kernels);
+    let block = blockchain.mine_block("A", block, Difficulty::min());
+
+    let txn = blockchain.db().db_read_access().unwrap();
+    let err = validator.validate_body(&*txn, block.block().clone()).unwrap_err();
+    assert!(matches!(err, ValidationError::UnsortedOrDuplicateOutput));
+}
+
+/// A block may not spend the same output twice, and swapping the script input data on the second input does not hide
+/// it: inputs are deduplicated on the output they spend, not on the input's own hash.
+#[tokio::test]
+async fn it_rejects_a_block_that_spends_the_same_output_twice() {
+    let (mut blockchain, validator) = setup(true);
+
+    let (_, coinbase_a) = blockchain.add_next_tip(block_spec!("A")).unwrap();
+
+    let schema1 = txn_schema!(from: vec![coinbase_a.clone()], to: vec![50 * T, 12 * T]);
+    let (txs, _) = schema_to_transaction(&[schema1], &blockchain.km);
+    let txs = txs.into_iter().map(|t| Arc::try_unwrap(t).unwrap()).collect::<Vec<_>>();
+
+    let (mut block, _) = blockchain.create_unmined_block(block_spec!("B->A", transactions: txs));
+    let mut inputs = block.body.inputs().clone();
+    let mut twin = inputs[0].clone();
+    twin.input_data = ExecutionStack::new(vec![StackItem::Number(1)]);
+    assert_eq!(inputs[0].output_hash(), twin.output_hash());
+    assert_ne!(inputs[0].canonical_hash(), twin.canonical_hash());
+    inputs.insert(1, twin);
+    let outputs = block.body.outputs().clone();
+    let kernels = block.body.kernels().clone();
+    block.body = AggregateBody::new_sorted_unchecked(inputs, outputs, kernels);
+    let block = blockchain.mine_block("A", block, Difficulty::min());
+
+    let txn = blockchain.db().db_read_access().unwrap();
+    let err = validator.validate_body(&*txn, block.block().clone()).unwrap_err();
+    assert!(matches!(err, ValidationError::UnsortedOrDuplicateInput));
 }
 
 #[tokio::test]

--- a/base_layer/transaction_components/src/transaction_components/transaction_output.rs
+++ b/base_layer/transaction_components/src/transaction_components/transaction_output.rs
@@ -277,7 +277,16 @@ impl TransactionOutput {
         // NOTE: The metadata signature must also be verified elsewhere
         let e_bytes = self.get_metadata_signature_challenge();
         // Now we can perform the balance proof
-        let e = PrivateKey::from_uniform_bytes(&e_bytes).unwrap();
+        // `get_metadata_signature_challenge` returns exactly the 64 bytes wide reduction needs, so this cannot
+        // currently fail. Map it rather than unwrap so that a future change to the challenge width surfaces as an
+        // invalid range proof instead of taking the node down.
+        let e = PrivateKey::from_uniform_bytes(&e_bytes).map_err(|e| RangeProofError::InvalidRangeProof {
+            reason: format!(
+                "Could not construct the metadata signature challenge scalar for commitment {}: {}",
+                self.commitment.to_hex(),
+                e
+            ),
+        })?;
         let value_as_private_key = PrivateKey::from(self.minimum_value_promise.as_u64());
         let commit_nonce_a = PrivateKey::default(); // This is the deterministic nonce `r_a` of zero
         if self.metadata_signature.u_a() == &(commit_nonce_a + e * value_as_private_key) {

--- a/base_layer/transaction_components/src/validation/aggregate_body/aggregate_body_internal_validator.rs
+++ b/base_layer/transaction_components/src/validation/aggregate_body/aggregate_body_internal_validator.rs
@@ -650,6 +650,115 @@ mod test {
         assert!(check_total_burned(&body2).is_err());
     }
 
+    /// `is_all_unique_and_sorted` is what makes an output commitment unique within a body: `Ord for
+    /// TransactionOutput` compares nothing but the commitment, so two outputs sharing a commitment compare `Equal`
+    /// and the check rejects them no matter what the rest of the output looks like. The same holds for inputs, which
+    /// are ordered on the hash of the output they spend.
+    mod duplicate_commitments {
+        use tari_script::{ExecutionStack, StackItem};
+
+        use super::*;
+        use crate::transaction_components::SpentOutput;
+
+        fn utxo(key_manager: &KeyManager) -> TransactionOutput {
+            let (output, _, _) = test_helpers::create_utxo(
+                100.into(),
+                key_manager,
+                &OutputFeatures::default(),
+                &script!(Nop).unwrap(),
+                &Covenant::default(),
+                0.into(),
+            );
+            output
+        }
+
+        fn input_spending(output: &TransactionOutput, input_data: ExecutionStack) -> TransactionInput {
+            TransactionInput::new_current_version(
+                SpentOutput::create_from_output(output.clone()),
+                input_data,
+                Default::default(),
+            )
+        }
+
+        #[test]
+        fn it_accepts_distinct_output_commitments() {
+            let key_manager = KeyManager::new_random().unwrap();
+            let mut outputs = vec![utxo(&key_manager), utxo(&key_manager), utxo(&key_manager)];
+            outputs.sort();
+            let body = AggregateBody::new_sorted_unchecked(Vec::new(), outputs, Vec::new());
+            check_sorting_and_duplicates(&body).unwrap();
+        }
+
+        #[test]
+        fn it_rejects_two_identical_outputs() {
+            let key_manager = KeyManager::new_random().unwrap();
+            let output = utxo(&key_manager);
+            let body = AggregateBody::new_sorted_unchecked(Vec::new(), vec![output.clone(), output], Vec::new());
+            assert!(matches!(
+                check_sorting_and_duplicates(&body),
+                Err(AggregatedBodyValidationError::UnsortedOrDuplicateOutput)
+            ));
+        }
+
+        #[test]
+        fn it_rejects_two_outputs_sharing_a_commitment() {
+            let key_manager = KeyManager::new_random().unwrap();
+            let output = utxo(&key_manager);
+            // Same commitment, different canonical hash. A duplicate check keyed on the output hash would wave this
+            // pair through; only the commitment ordering catches it. The commitment is what the UTXO set is keyed on,
+            // so letting both into a block would put two entries under one key.
+            let mut twin = output.clone();
+            twin.script = script!(Nop Nop).unwrap();
+            assert_eq!(output.commitment, twin.commitment);
+            assert_ne!(output.hash(), twin.hash());
+
+            let body = AggregateBody::new_sorted_unchecked(Vec::new(), vec![output.clone(), twin.clone()], Vec::new());
+            assert!(matches!(
+                check_sorting_and_duplicates(&body),
+                Err(AggregatedBodyValidationError::UnsortedOrDuplicateOutput)
+            ));
+
+            // The order the two are presented in must not matter.
+            let body = AggregateBody::new_sorted_unchecked(Vec::new(), vec![twin, output], Vec::new());
+            assert!(matches!(
+                check_sorting_and_duplicates(&body),
+                Err(AggregatedBodyValidationError::UnsortedOrDuplicateOutput)
+            ));
+        }
+
+        #[test]
+        fn it_rejects_a_duplicate_commitment_hidden_among_distinct_outputs() {
+            let key_manager = KeyManager::new_random().unwrap();
+            let mut outputs = vec![utxo(&key_manager), utxo(&key_manager), utxo(&key_manager)];
+            outputs.sort();
+            // Re-insert the middle output next to itself so the body stays sorted; only the duplicate breaks it.
+            outputs.insert(1, outputs[1].clone());
+            let body = AggregateBody::new_sorted_unchecked(Vec::new(), outputs, Vec::new());
+            assert!(matches!(
+                check_sorting_and_duplicates(&body),
+                Err(AggregatedBodyValidationError::UnsortedOrDuplicateOutput)
+            ));
+        }
+
+        #[test]
+        fn it_rejects_two_inputs_spending_the_same_output() {
+            let key_manager = KeyManager::new_random().unwrap();
+            let output = utxo(&key_manager);
+            let input = input_spending(&output, ExecutionStack::default());
+            // A competing double spend differs only in its witness, which `canonical_hash` distinguishes but `Ord`
+            // deliberately does not.
+            let twin = input_spending(&output, ExecutionStack::new(vec![StackItem::Number(1)]));
+            assert_eq!(input.output_hash(), twin.output_hash());
+            assert_ne!(input.canonical_hash(), twin.canonical_hash());
+
+            let body = AggregateBody::new_sorted_unchecked(vec![input, twin], Vec::new(), Vec::new());
+            assert!(matches!(
+                check_sorting_and_duplicates(&body),
+                Err(AggregatedBodyValidationError::UnsortedOrDuplicateInput)
+            ));
+        }
+    }
+
     mod transaction_ordering {
         use super::*;
 


### PR DESCRIPTION
Description
---
adds two small improvements to not get false alarms about security
* test for duplicate commentments
* not use unwrap in rangeproof verification 

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62626134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no concrete correctness or security regressions identified.

<h3>Summary</h3>

- Maps metadata challenge scalar-conversion failures to `InvalidRangeProof`.
- Tests hash-based duplicate detection in the chain validator.
- Tests commitment/output-hash uniqueness in internal and full block validation.

<sub>Reviews (1) · Last reviewed commit: ["test(validation): cover duplicate commit..."](https://github.com/tari-project/tari/commit/21e05d235abff99ef43d6ddc20cc4d7c010b9a40)</sub>

<!-- /greptile_comment -->