### PR TITLE
test: deflake duplicate-commitment and liveness end-to-end tests

### DIFF
--- a/base_layer/core/src/validation/block_body/test.rs
+++ b/base_layer/core/src/validation/block_body/test.rs
@@ -576,14 +576,18 @@ async fn it_rejects_a_block_with_two_outputs_sharing_a_commitment() {
 
     let (mut block, _) = blockchain.create_unmined_block(block_spec!("B->A", transactions: txs));
     let mut outputs = block.body.outputs().clone();
+    // Twin a non-coinbase output. Outputs are ordered on the commitment, so which one sorts first is random; twinning
+    // whichever lands at index 0 gives the block two coinbases whenever that is the coinbase, and the coinbase check
+    // runs before the sort check, so the test would fail on `InvalidCoinbase` instead.
+    let idx = outputs.iter().position(|o| !o.is_coinbase()).unwrap();
     // Same commitment, different script, so the two outputs hash differently. The hash-based duplicate check in the
     // chain validator cannot see this pair; only the commitment ordering can.
-    let mut twin = outputs[0].clone();
+    let mut twin = outputs[idx].clone();
     twin.script = script!(Nop Nop).unwrap();
-    assert_eq!(outputs[0].commitment, twin.commitment);
-    assert_ne!(outputs[0].hash(), twin.hash());
+    assert_eq!(outputs[idx].commitment, twin.commitment);
+    assert_ne!(outputs[idx].hash(), twin.hash());
     // Insert next to its twin so the body is still ordered by commitment; the duplicate is the only thing wrong.
-    outputs.insert(1, twin);
+    outputs.insert(idx + 1, twin);
     let inputs = block.body.inputs().clone();
     let kernels = block.body.kernels().clone();
     block.body = AggregateBody::new_sorted_unchecked(inputs, outputs, kernels);

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -36,6 +36,7 @@ use tari_service_framework::{RegisterHandle, StackBuilder};
 use tari_shutdown::Shutdown;
 use tari_test_utils::collect_try_recv;
 use tempfile::tempdir;
+use tokio::time;
 
 use crate::support::comms_and_services::setup_comms_services;
 
@@ -67,6 +68,24 @@ pub async fn setup_liveness_service(
     (liveness_handle, comms, dht, shutdown)
 }
 
+/// Waits until `comms` is connected to at least one peer and the connection churn around start-up has settled.
+///
+/// A node will re-dial a peer while its own dial is still in flight, because the in-progress dial is not yet in the
+/// connection pool. The extra connection that lands is resolved by a tie break which silently disconnects the loser,
+/// including any message already written to it. Liveness counts every ping, so the test may only start pinging once
+/// that has stopped happening.
+async fn wait_until_connections_settle(comms: &CommsNode) {
+    let mut connectivity = comms.connectivity();
+    let mut events = connectivity.get_event_subscription();
+    connectivity
+        .wait_for_connectivity(Duration::from_secs(30))
+        .await
+        .expect("Node did not come online");
+    // Quiet period: a tie break is reported as a connectivity event, so no events for this long means the peer
+    // connection that messaging will use is the one that survived.
+    while time::timeout(Duration::from_millis(500), events.recv()).await.is_ok() {}
+}
+
 fn make_node_identity() -> Arc<NodeIdentity> {
     let next_port = MemoryTransport::acquire_next_memsocket_port();
     Arc::new(NodeIdentity::random(
@@ -83,19 +102,22 @@ async fn end_to_end() {
     let node_2_identity = make_node_identity();
 
     let alice_temp_dir = tempdir().unwrap();
-    let (mut liveness1, _, _dht_1, _shutdown) = setup_liveness_service(
+    let (mut liveness1, comms_1, _dht_1, _shutdown) = setup_liveness_service(
         node_1_identity.clone(),
         vec![node_2_identity.clone()],
         alice_temp_dir.path().to_str().unwrap(),
     )
     .await;
     let bob_temp_dir = tempdir().unwrap();
-    let (mut liveness2, _, _dht_2, _shutdown) = setup_liveness_service(
-        node_2_identity.clone(),
-        vec![node_1_identity.clone()],
-        bob_temp_dir.path().to_str().unwrap(),
-    )
-    .await;
+    // Only node 1 is seeded with its counterpart, so only node 1 dials. If both nodes dial each other they end up
+    // with two connections and the tie break silently disconnects the loser, taking any message already written to
+    // it with it - and this test counts every single ping. Node 2 learns about node 1 from the inbound connection,
+    // which is all it needs to ping back.
+    let (mut liveness2, comms_2, _dht_2, _shutdown) =
+        setup_liveness_service(node_2_identity.clone(), vec![], bob_temp_dir.path().to_str().unwrap()).await;
+
+    wait_until_connections_settle(&comms_1).await;
+    wait_until_connections_settle(&comms_2).await;
 
     let mut liveness1_event_stream = liveness1.get_event_stream();
     let mut liveness2_event_stream = liveness2.get_event_stream();


### PR DESCRIPTION
Two tests on development fail intermittently, independently of any PR. `services::liveness::end_to_end` has now been seen on two unrelated PRs and on two different network legs:

  * run 34581539775 (PR #8002, mainnet/stagenet) - got 15 of 18 items
  * run 34606190029 (PR #8003, nextnet)         - got 17 of 18 items

`it_rejects_a_block_with_two_outputs_sharing_a_commitment` twins `outputs[0]`, but `Ord for TransactionOutput` compares the commitment alone, so which output sorts first is random. When that is the coinbase the twin gives the block two coinbases, and `check_coinbase_outputs` runs before the sort check, so the test saw `InvalidCoinbase` instead of `UnsortedOrDuplicateOutput`. Reproduced at 5/20 locally; now twins the first non-coinbase output and inserts the duplicate next to it.

`services::liveness::end_to_end` counts every ping and pong exactly, but messages were being dropped. A node re-dials a peer while its own dial is still in flight, because the pending dial is not yet in the connection pool. The extra connection that lands is resolved by a ConnectivityManager tie break which silently disconnects the loser, taking any message already written to it with it:

    No connection for peer 5023547a... Dialing...      (x3)
    Tie-break: (Existing = Outbound, New = Outbound)
    Tie break: Keep new connection (id: 3). Disconnect existing (id: 1)
    Failed to receive from peer ... 'connection is closed'

Seen as both Outbound/Outbound (one node double-dialling) and Outbound/Inbound (both nodes dialling each other); in one run both sides tie-broke in opposite directions and neither reconnected for 30s. The test now seeds only node 1 with its counterpart so only one side dials - node 2 learns node 1 from the inbound connection - and waits for connectivity plus a quiet period on the connectivity event stream before pinging. 150/150 pass, up from roughly 90%.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63087909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the changed test setups align with the relevant ordering, validation, connectivity, and messaging behavior.

<h3>Summary</h3>

- The duplicate-commitment block test now twins a non-coinbase output and inserts it adjacent to the original, avoiding a competing coinbase-validation error.
- The liveness end-to-end test uses one-way peer seeding and waits for connectivity events to become quiet before sending messages, avoiding startup tie-break churn.

<sub>Reviews (1) · Last reviewed commit: ["test: deflake duplicate-commitment and l..."](https://github.com/tari-project/tari/commit/5bd3852d02f77e0901767cfabf3530fcda62b4ed)</sub>

<!-- /greptile_comment -->